### PR TITLE
feat(backend/stigmer-server-ts): port the McpServer connect/OAuth slice (D4 #19)

### DIFF
--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -27,6 +27,7 @@ import { registerAgentExecutionServices } from "../domain/agentexecution/control
 import { newArtifactStorage } from "../artifactstorage/artifact-storage.js";
 import { StreamBroker } from "../domain/agentexecution/stream-broker.js";
 import { newExecutionEngineStateProvider } from "../temporal/agentexecution/engine-client.js";
+import { newMcpServerEngineStateProvider } from "../temporal/mcpserver/engine-client.js";
 import { newAgentExecutionWorkerFactory } from "../temporal/agentexecution/worker.js";
 import { TemporalManager } from "../temporal/manager.js";
 import { loadServerPayloadCodecs } from "../temporal/payload-codec.js";
@@ -284,15 +285,42 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     secretService,
     logger,
   );
-  // OAuth-managed token access for the EC builder's injection (server.go
-  // 732–735); rides the environment in-process client so encryption,
-  // validation, and audit ride the environment pipeline.
-  const managedEnvService = new ManagedEnvironmentService({
-    getSecretValue: (input) =>
-      requireInProcess().executionEnvironmentReader.getSecretValue(input),
-    updateVariables: (request) =>
-      requireInProcess().executionEnvironmentReader.updateVariables(request),
+  // The managed-environment lifecycle — OAuth token access for the EC
+  // builder's injection (server.go 732–735) plus the create/delete halves
+  // the connect/OAuth slice mints and tears environments with (#19).
+  // Rides the environment in-process client so encryption, validation,
+  // and audit ride the environment pipeline. ONE instance shared by
+  // agentexecution and mcpserver — Go builds two, both stateless over the
+  // same client, so sharing is behavior-identical.
+  const managedEnvService = new ManagedEnvironmentService(
+    {
+      getSecretValue: (input) =>
+        requireInProcess().executionEnvironmentReader.getSecretValue(input),
+      updateVariables: (request) =>
+        requireInProcess().executionEnvironmentReader.updateVariables(request),
+      create: (environment) =>
+        requireInProcess().executionEnvironmentReader.create(environment),
+      delete: (input) =>
+        requireInProcess().executionEnvironmentReader.delete(input),
+    },
+    logger,
+  );
+  // The mcpserver connect-engine provider — the same manager-backed
+  // request-time idiom as executionEngineState above; the connect lanes
+  // start the RUNNER's workflow, so no worker factory is added here.
+  const mcpServerEngineState = newMcpServerEngineStateProvider({
+    manager: temporalManager,
+    config: temporalConfig,
+    logger,
   });
+  // WARN-degrade, not boot-fatal (Go server.go:722-729): every OAuth RPC
+  // except initiateOAuthConnect works without the redirect URI, and
+  // initiate refuses with the pinned FailedPrecondition copy.
+  if (config.oauthRedirectUri === "") {
+    logger.warn(
+      "STIGMER_OAUTH_REDIRECT_URI is not set — OAuth Connect flows for MCP servers are unavailable (initiateOAuthConnect will refuse)",
+    );
+  }
   // The SAME `routes` function registers every service on BOTH the serving
   // router and the in-process router transport (createInProcessClients).
   // Handlers are stateless over the same store, so the two routers behave
@@ -419,9 +447,40 @@ export function composeServer(options: ComposeOptions): ComposedServer {
           requireInProcess().workflowExecutionContextCreator,
       },
     });
-    // CRUD slice only (D4 #9) — Go's constructor takes exactly the store
-    // for this slice; the connect/OAuth deps arrive with #19.
-    registerMcpServerServices(router, { store, logger });
+    // The whole surface: the CRUD slice (D4 #9) plus the connect/OAuth
+    // slice (D4 #19). All connect deps are wired unconditionally per the
+    // composition-root idiom — engine availability is the modeled state
+    // the provider answers at request time, and the managed-env service
+    // has no Temporal dependency (DB-1, sub-project 20260825.02).
+    registerMcpServerServices(router, {
+      store,
+      logger,
+      connect: {
+        store,
+        logger,
+        engineState: mcpServerEngineState,
+        environmentReader: {
+          list: (request) =>
+            requireInProcess().executionEnvironmentReader.list(request),
+          getSecretValue: (input) =>
+            requireInProcess().executionEnvironmentReader.getSecretValue(input),
+        },
+        executionContext: {
+          create: (ec) =>
+            requireInProcess().connectExecutionContextClient.create(ec),
+          delete: (input) =>
+            requireInProcess().connectExecutionContextClient.delete(input),
+        },
+        runnerAuth: runnerAuthService,
+        managedEnv: managedEnvService,
+        // The SAME grant-store instance agentexecution's session-time
+        // token injection reads (Go server.go:732-735 shares it too).
+        oauthGrants: store.oauthGrants,
+        pendingOAuthStates: store.pendingOAuthStates,
+        secretService,
+        oauthRedirectUri: config.oauthRedirectUri,
+      },
+    });
     registerSkillServices(router, {
       store,
       logger,

--- a/backend/services/stigmer-server-ts/src/boot/config.ts
+++ b/backend/services/stigmer-server-ts/src/boot/config.ts
@@ -88,6 +88,14 @@ export interface ServerConfig {
   readonly gitHubOAuthClientId: string;
   readonly gitHubOAuthClientSecret: string;
   /**
+   * The OAuth callback URL for the McpServer OAuth Connect flows
+   * (STIGMER_OAUTH_REDIRECT_URI; Go config.go OAuthRedirectURI). Unset is
+   * a WARN at wiring time, not a boot failure — every RPC except
+   * initiateOAuthConnect works without it, and initiate refuses with a
+   * FailedPrecondition naming the variable (the pinned copy).
+   */
+  readonly oauthRedirectUri: string;
+  /**
    * Skill artifact storage root (STORAGE_PATH; Go defaultStoragePath
    * ~/.stigmer/storage). Artifacts live at {storagePath}/skills/,
    * upload staging at {storagePath}/skills-staging/ — byte-identical to
@@ -196,6 +204,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
       "STIGMER_GITHUB_CLIENT_SECRET",
       DEFAULT_GITHUB_OAUTH_CLIENT_SECRET,
     ),
+    oauthRedirectUri: envString(env, "STIGMER_OAUTH_REDIRECT_URI", ""),
   };
 }
 

--- a/backend/services/stigmer-server-ts/src/boot/inprocess.ts
+++ b/backend/services/stigmer-server-ts/src/boot/inprocess.ts
@@ -49,6 +49,7 @@ import type {
   ExecutionContextCreator,
   SessionLoader,
 } from "../domain/agentexecution/create-execution-context-step.js";
+import type { ConnectExecutionContextClient } from "../domain/mcpserver/connect.js";
 import type { ManagedEnvironmentClient } from "../domain/mcpserver/oauth/managed-env.js";
 import type { AgentInstanceCreator } from "../domain/session/steps.js";
 import type { WorkflowInstanceCreator } from "../domain/workflow/steps.js";
@@ -79,13 +80,21 @@ export interface InProcessClients {
   readonly executionSessionLoader: SessionLoader;
   readonly executionSessionCreator: SessionCreator;
   /**
-   * Reads for the EC builder plus the secret rewrite the OAuth pre-flight
-   * refresh needs (ManagedEnvironmentClient) — one surface, every call
-   * through the full chain.
+   * Reads for the EC builder plus the full managed-environment lifecycle
+   * (ManagedEnvironmentClient): the secret rewrite the OAuth pre-flight
+   * refresh needs (#17) and the create/delete edges the connect/OAuth
+   * slice mints and tears managed environments with (#19) — one surface,
+   * every call through the full chain.
    */
   readonly executionEnvironmentReader: EnvironmentReader &
     ManagedEnvironmentClient;
   readonly executionContextCreator: ExecutionContextCreator;
+  /**
+   * The connect lanes' ephemeral-EC lifecycle (server.go 693–705: the
+   * mcpserver controller's executioncontext client) — create before the
+   * discovery workflow starts, delete when the operation settles.
+   */
+  readonly connectExecutionContextClient: ConnectExecutionContextClient;
   // The workflowexecution edges (server.go 636–642: the controller's
   // workflowinstance/executioncontext clients and the two HITL forwarding
   // interfaces satisfied by the agentexecution controller).
@@ -202,9 +211,15 @@ export function createInProcessClients(
       list: (request) => environmentQuery.list(request),
       getSecretValue: (input) => environmentQuery.getSecretValue(input),
       updateVariables: (request) => environmentCommand.updateVariables(request),
+      create: (environment) => environmentCommand.create(environment),
+      delete: (input) => environmentCommand.delete(input),
     },
     executionContextCreator: {
       create: (ec) => executionContextCommand.create(ec),
+    },
+    connectExecutionContextClient: {
+      create: (ec) => executionContextCommand.create(ec),
+      delete: (input) => executionContextCommand.delete(input),
     },
     // The workflowexecution edges. CreateAsSystem semantics per the
     // workflow edge above: create under the process-global operator

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/connect.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/connect.test.ts
@@ -1,0 +1,597 @@
+/**
+ * Pins the connect lanes against Go's connect_test.go +
+ * start_connect_test.go, at the handler layer with a REAL sqlite store
+ * and a fake engine (the seam the temporal side implements): the budget
+ * guards, the failure→gRPC mapping table (#239/#243/#478), the
+ * connect_status bookkeeping (attach skips CONNECTING; results and the
+ * terminal phase ride ONE atomic write; failure_code in CamelCase),
+ * tool-approval preserve-on-empty, the ephemeral EC lifecycle, and
+ * startConnect's two-layer idempotency + dead-runner warning.
+ *
+ * The wire-level halves are pinned by
+ * mcpserver-connect.conformance.test.ts on local-ts-execution.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { ConnectInputSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { ConnectPhase } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SecretService } from "../../../encryption/encryption.js";
+import { RunnerAuthService } from "../../../runnerauth/runnerauth.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import {
+  ASYNC_CONNECT_TIMEOUT,
+  CONNECT_TIMEOUT,
+  buildConnectFailureMessage,
+  connect,
+  startBestEffortConnect,
+} from "../connect.js";
+import type { McpServerConnectDeps } from "../connect.js";
+import { RUNNER_QUEUE_WARNING, startConnect } from "../start-connect.js";
+import type {
+  ConnectRunOutcome,
+  ConnectWorkflowInput,
+  ConnectWorkflowOutput,
+  McpServerConnectEngine,
+} from "../engine.js";
+import { MCP_SERVER_ENGINE_DISCONNECTED } from "../engine.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+// Deterministic key so runner-token minting is enabled (the mint arm).
+vi.stubEnv("STIGMER_RUNNER_TOKEN_KEY", Buffer.alloc(32, 8).toString("base64"));
+
+const OK_OUTPUT: ConnectWorkflowOutput = {
+  tools: [
+    { name: "search", description: "find things", input_schema: { type: "object" } },
+  ],
+  resource_templates: [
+    { uri_template: "file://{path}", name: "files", description: "", mime_type: "" },
+  ],
+  tool_approvals: [
+    { tool_name: "search", requires_approval: true, message: "gated", from_destructive_hint: false },
+  ],
+};
+
+interface FakeEngineOptions {
+  outcome?: ConnectRunOutcome;
+  attached?: boolean;
+  running?: boolean;
+  pollers?: boolean | undefined;
+}
+
+interface FakeEngine extends McpServerConnectEngine {
+  readonly startedInputs: ConnectWorkflowInput[];
+  readonly startedTimeouts: number[];
+}
+
+function fakeEngine(options: FakeEngineOptions = {}): FakeEngine {
+  const startedInputs: ConnectWorkflowInput[] = [];
+  const startedTimeouts: number[] = [];
+  return {
+    startedInputs,
+    startedTimeouts,
+    async startOrAttachConnect(mcpServerId, input, runTimeoutMs) {
+      startedInputs.push(input);
+      startedTimeouts.push(runTimeoutMs);
+      return {
+        workflowId: `stigmer/mcp-server/connect/${mcpServerId}`,
+        attached: options.attached ?? false,
+        result: async () => options.outcome ?? { ok: true, output: OK_OUTPUT },
+      };
+    },
+    async isConnectRunRunning() {
+      return options.running ?? false;
+    },
+    async hasRunnerQueuePollers() {
+      return options.pollers;
+    },
+  };
+}
+
+interface Harness {
+  deps: McpServerConnectDeps;
+  engine: FakeEngine;
+  ecCreates: number;
+  ecDeletes: string[];
+}
+
+let dir: string;
+let store: SqliteStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "mcpserver-connect-test-"));
+  store = SqliteStore.open(path.join(dir, "test.db"));
+});
+
+afterEach(() => {
+  store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function makeHarness(options: FakeEngineOptions = {}): Harness {
+  const engine = fakeEngine(options);
+  const harness: Harness = {
+    engine,
+    ecCreates: 0,
+    ecDeletes: [],
+    deps: {
+      store,
+      logger: silentLogger,
+      engineState: () => ({ connected: true, engine }),
+      environmentReader: {
+        list: async () => {
+          throw new Error("no personal environment in this harness");
+        },
+        getSecretValue: async () => {
+          throw new Error("no secrets in this harness");
+        },
+      },
+      executionContext: {
+        create: async () => {
+          harness.ecCreates += 1;
+          return create(ExecutionContextSchema, {
+            metadata: { id: `ectx_${harness.ecCreates}` },
+          });
+        },
+        delete: async (input) => {
+          harness.ecDeletes.push(String(input.resourceId ?? ""));
+          return create(ExecutionContextSchema);
+        },
+      },
+      runnerAuth: RunnerAuthService.fromEnv(),
+      // A fake managed-env client backed by nothing: the refresh
+      // pre-flight arms that need it are exercised in the handshake
+      // composed test; here every read throws, which the pre-flight
+      // treats as its silent-skip arm (oss#863).
+      managedEnv: {
+        readSecretValue: async () => {
+          throw new Error("no managed env in this harness");
+        },
+        updateSecrets: async () => {},
+        createManagedEnvironment: async () => "env_1",
+        deleteManagedEnvironment: async () => {},
+        // Structural stand-in for the class instance.
+      } as unknown as McpServerConnectDeps["managedEnv"],
+      oauthGrants: store.oauthGrants,
+      pendingOAuthStates: store.pendingOAuthStates,
+      secretService: SecretService.create(undefined),
+      oauthRedirectUri: "http://127.0.0.1:8234/auth/oauth/callback",
+    },
+  };
+  return harness;
+}
+
+let counter = 0;
+async function seedServer(overrides?: {
+  stdio?: boolean;
+  env?: boolean;
+}): Promise<McpServer> {
+  counter += 1;
+  const id = `mcps_test_${counter}`;
+  const server = create(McpServerSchema, {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "McpServer",
+    metadata: {
+      id,
+      name: `Test Server ${counter}`,
+      slug: `test-server-${counter}`,
+      org: "acme",
+    },
+    spec: {
+      description: "seeded",
+      serverType:
+        overrides?.stdio === false
+          ? { case: "http", value: { url: "https://mcp.example.com/mcp" } }
+          : { case: "stdio", value: { command: "npx", args: ["-y", "@x/mcp"] } },
+      ...(overrides?.env === true
+        ? { env: { API_KEY: { isSecret: true, optional: false } } }
+        : {}),
+    },
+  });
+  await store.saveResource(ApiResourceKind.mcp_server, id, McpServerSchema, server);
+  return server;
+}
+
+function connectInput(mcpServerId: string, runtimeEnv?: Record<string, { value: string; isSecret: boolean }>) {
+  return create(ConnectInputSchema, {
+    mcpServerId,
+    org: "acme",
+    ...(runtimeEnv !== undefined ? { runtimeEnv } : {}),
+  });
+}
+
+async function expectConnectError(
+  promise: Promise<unknown>,
+  code: Code,
+  messageFragment: string | RegExp,
+): Promise<ConnectError> {
+  try {
+    await promise;
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    const connectError = error as ConnectError;
+    expect(connectError.code).toBe(code);
+    if (typeof messageFragment === "string") {
+      expect(connectError.rawMessage).toContain(messageFragment);
+    } else {
+      expect(connectError.rawMessage).toMatch(messageFragment);
+    }
+    return connectError;
+  }
+  throw new Error("expected the promise to reject");
+}
+
+describe("budget guards (Go connect_test.go:339, start_connect_test.go:202)", () => {
+  it("the sync budget covers stdio cold-start + the classification floor (#243)", () => {
+    expect(CONNECT_TIMEOUT.ms).toBeGreaterThanOrEqual(270_000 + 120_000);
+  });
+
+  it("the async backstop exceeds the sync budget", () => {
+    expect(ASYNC_CONNECT_TIMEOUT.ms).toBeGreaterThan(CONNECT_TIMEOUT.ms);
+  });
+
+  it("the Go duration labels match the budgets (the DEADLINE_EXCEEDED copy)", () => {
+    expect(CONNECT_TIMEOUT.goLabel).toBe("7m0s");
+    expect(ASYNC_CONNECT_TIMEOUT.goLabel).toBe("1h0m0s");
+  });
+});
+
+describe("connect (blocking lane)", () => {
+  it("refuses with Go's byte-pinned copy while the engine is disconnected", async () => {
+    const harness = makeHarness();
+    harness.deps = { ...harness.deps, engineState: () => MCP_SERVER_ENGINE_DISCONNECTED };
+    const server = await seedServer();
+    await expectConnectError(
+      connect(harness.deps, connectInput(server.metadata!.id)),
+      Code.FailedPrecondition,
+      "connect is not available: Temporal not configured",
+    );
+  });
+
+  const guards: Array<[string, { id: string; org: string }, string]> = [
+    ["empty mcp_server_id", { id: "", org: "acme" }, "mcp_server_id is required"],
+    ["empty org", { id: "mcps_x", org: "" }, "org is required for connect"],
+  ];
+  it.each(guards)("rejects %s", async (_label, args, message) => {
+    const harness = makeHarness();
+    await expectConnectError(
+      connect(
+        harness.deps,
+        create(ConnectInputSchema, { mcpServerId: args.id, org: args.org }),
+      ),
+      Code.InvalidArgument,
+      message,
+    );
+  });
+
+  it("answers NotFound for an unknown server", async () => {
+    const harness = makeHarness();
+    await expectConnectError(
+      connect(harness.deps, connectInput("mcps_missing")),
+      Code.NotFound,
+      "mcp_server not found: mcps_missing",
+    );
+  });
+
+  it("persists capabilities + gates + SUCCEEDED in one record and returns the updated resource", async () => {
+    const harness = makeHarness();
+    const server = await seedServer();
+    const result = await connect(harness.deps, connectInput(server.metadata!.id));
+
+    expect(result.status?.discoveredCapabilities?.tools).toHaveLength(1);
+    expect(result.status?.discoveredCapabilities?.tools[0]?.name).toBe("search");
+    expect(result.status?.discoveredCapabilities?.tools[0]?.inputSchema).toEqual({
+      type: "object",
+    });
+    expect(result.status?.toolApprovals).toHaveLength(1);
+    expect(result.status?.connectStatus?.phase).toBe(ConnectPhase.succeeded);
+    expect(result.status?.connectStatus?.failureCode).toBe("");
+    // The sync lane passes the 420s budget to the engine.
+    expect(harness.engine.startedTimeouts[0]).toBe(CONNECT_TIMEOUT.ms);
+  });
+
+  it("preserves existing tool approvals when a reconnect returns none (a degraded runner cannot disarm gates)", async () => {
+    const harness = makeHarness();
+    const server = await seedServer();
+    await connect(harness.deps, connectInput(server.metadata!.id));
+
+    const emptyHarness = makeHarness({
+      outcome: { ok: true, output: { tools: [{ name: "other" }] } },
+    });
+    const second = await connect(
+      emptyHarness.deps,
+      connectInput(server.metadata!.id),
+    );
+    // Capabilities: overwritten. Gates: preserved.
+    expect(second.status?.discoveredCapabilities?.tools[0]?.name).toBe("other");
+    expect(second.status?.toolApprovals).toHaveLength(1);
+    expect(second.status?.toolApprovals[0]?.toolName).toBe("search");
+  });
+
+  it("creates the ephemeral EC from runtime_env, mints the decrypt token, and deletes the EC after settle", async () => {
+    const harness = makeHarness();
+    const server = await seedServer();
+    await connect(
+      harness.deps,
+      connectInput(server.metadata!.id, {
+        API_KEY: { value: "k", isSecret: true },
+      }),
+    );
+    expect(harness.ecCreates).toBe(1);
+    expect(harness.ecDeletes).toEqual(["ectx_1"]);
+    const input = harness.engine.startedInputs[0];
+    expect(input?.execution_context_id).toMatch(/^connect-mcps_test_/);
+    // oss#535: the decrypt-lane token rides the payload.
+    expect(input?.execution_context_token).toBeTruthy();
+  });
+
+  it("skips EC creation entirely for an env-less server", async () => {
+    const harness = makeHarness();
+    const server = await seedServer();
+    await connect(harness.deps, connectInput(server.metadata!.id));
+    expect(harness.ecCreates).toBe(0);
+    expect(harness.engine.startedInputs[0]?.execution_context_id).toBeUndefined();
+  });
+
+  it("refuses with the [key] list when required credentials have no personal environment", async () => {
+    const harness = makeHarness();
+    harness.deps = {
+      ...harness.deps,
+      environmentReader: {
+        list: async () => ({ totalCount: 0, items: [] }) as never,
+        getSecretValue: async () => {
+          throw new Error("unreachable");
+        },
+      },
+    };
+    const server = await seedServer({ env: true });
+    await expectConnectError(
+      connect(harness.deps, connectInput(server.metadata!.id)),
+      Code.FailedPrecondition,
+      "personal environment not found for org 'acme'; save required credentials first: [API_KEY]",
+    );
+  });
+
+  it("skips the CONNECTING write when attached to an in-flight run", async () => {
+    const server = await seedServer();
+    // Seed a CONNECTING record with a sentinel started_at second.
+    const before = await startConnectSeedConnecting(server.metadata!.id);
+    const harness = makeHarness({ attached: true });
+    await connect(harness.deps, connectInput(server.metadata!.id));
+    const after = await store.getResource(
+      ApiResourceKind.mcp_server,
+      server.metadata!.id,
+      McpServerSchema,
+    );
+    // The settle (same-write) fired, but the starting lane's started_at
+    // survived — the attach skipped persistConnectStarting.
+    expect(after.status?.connectStatus?.startedAt?.seconds).toBe(before);
+  });
+});
+
+/** Seeds a CONNECTING record and returns its started_at seconds. */
+async function startConnectSeedConnecting(mcpServerId: string): Promise<bigint> {
+  const { persistConnectStarting } = await import("../connect-status.js");
+  const persisted = await persistConnectStarting(
+    store,
+    mcpServerId,
+    `stigmer/mcp-server/connect/${mcpServerId}`,
+    "",
+  );
+  return persisted.status!.connectStatus!.startedAt!.seconds;
+}
+
+describe("connect failure mapping (Go awaitConnectWorkflow, #239/#243/#478)", () => {
+  it("application failure → FailedPrecondition with the stdio variant naming --dry-run", async () => {
+    const harness = makeHarness({
+      outcome: { ok: false, failure: { kind: "application", message: "spawn npx ENOENT" } },
+    });
+    const server = await seedServer();
+    const error = await expectConnectError(
+      connect(harness.deps, connectInput(server.metadata!.id)),
+      Code.FailedPrecondition,
+      `connect failed for MCP server '${server.metadata!.name}': spawn npx ENOENT. This is a stdio server launched ` +
+        "by your local runner — verify the command is installed and its arguments " +
+        "and environment variables are correct. Preview discovery locally with: " +
+        `stigmer connect mcp-server ${server.metadata!.slug} --dry-run`,
+    );
+    // The failure also settles connect_status with the CamelCase code name.
+    const after = await store.getResource(
+      ApiResourceKind.mcp_server,
+      server.metadata!.id,
+      McpServerSchema,
+    );
+    expect(after.status?.connectStatus?.phase).toBe(ConnectPhase.failed);
+    expect(after.status?.connectStatus?.failureCode).toBe("FailedPrecondition");
+    expect(after.status?.connectStatus?.failureMessage).toBe(error.rawMessage);
+    expect(after.status?.connectStatus?.warning).toBe("");
+  });
+
+  it("application failure → the HTTP variant for non-stdio servers", async () => {
+    const harness = makeHarness({
+      outcome: { ok: false, failure: { kind: "application", message: "401" } },
+    });
+    const server = await seedServer({ stdio: false });
+    await expectConnectError(
+      connect(harness.deps, connectInput(server.metadata!.id)),
+      Code.FailedPrecondition,
+      "Check that the server URL is reachable and your credentials are valid.",
+    );
+  });
+
+  it("passes a 'requires OAuth' message through verbatim (the stable marker)", async () => {
+    const oauthMessage =
+      "MCP server 'X' requires OAuth sign-in. Connect it from the server page.";
+    const harness = makeHarness({
+      outcome: { ok: false, failure: { kind: "application", message: oauthMessage } },
+    });
+    const server = await seedServer();
+    const error = await expectConnectError(
+      connect(harness.deps, connectInput(server.metadata!.id)),
+      Code.FailedPrecondition,
+      oauthMessage,
+    );
+    expect(error.rawMessage).toBe(oauthMessage);
+  });
+
+  it("timeout → DeadlineExceeded naming the 7m0s budget (#243)", async () => {
+    const harness = makeHarness({
+      outcome: { ok: false, failure: { kind: "timeout" } },
+    });
+    const server = await seedServer();
+    await expectConnectError(
+      connect(harness.deps, connectInput(server.metadata!.id)),
+      Code.DeadlineExceeded,
+      `connect did not complete within the 7m0s budget for MCP server '${server.metadata!.id}' — ` +
+        "if this repeats, check that your runner is running and healthy",
+    );
+  });
+
+  it("service-not-found → Unavailable", async () => {
+    const harness = makeHarness({
+      outcome: { ok: false, failure: { kind: "service-not-found" } },
+    });
+    const server = await seedServer();
+    await expectConnectError(
+      connect(harness.deps, connectInput(server.metadata!.id)),
+      Code.Unavailable,
+      `connect service temporarily unavailable for MCP server '${server.metadata!.id}'`,
+    );
+  });
+
+  it("other → Internal WITH the classified cause on the wire (the #478 exception)", async () => {
+    const harness = makeHarness({
+      outcome: { ok: false, failure: { kind: "other", message: "history lost" } },
+    });
+    const server = await seedServer();
+    const error = await expectConnectError(
+      connect(harness.deps, connectInput(server.metadata!.id)),
+      Code.Internal,
+      "history lost",
+    );
+    expect(error.rawMessage).toContain(
+      `connect failed for MCP server '${server.metadata!.name}'`,
+    );
+  });
+});
+
+describe("buildConnectFailureMessage", () => {
+  it("names the server and slug for the stdio variant", async () => {
+    const server = await seedServer();
+    expect(buildConnectFailureMessage(server, "boom")).toContain(
+      `stigmer connect mcp-server ${server.metadata!.slug} --dry-run`,
+    );
+  });
+});
+
+describe("startConnect (async lane)", () => {
+  it("fast path: a live CONNECTING run returns immediately, before any EC exists", async () => {
+    const server = await seedServer({ env: true });
+    await startConnectSeedConnecting(server.metadata!.id);
+    const harness = makeHarness({ running: true });
+    const result = await startConnect(harness.deps, connectInput(server.metadata!.id));
+    expect(result.metadata?.id).toBe(server.metadata!.id);
+    expect(harness.ecCreates).toBe(0);
+    expect(harness.engine.startedInputs).toHaveLength(0);
+  });
+
+  it("records CONNECTING with the dead-runner warning when no pollers answer", async () => {
+    const harness = makeHarness({ pollers: false });
+    const server = await seedServer();
+    const result = await startConnect(harness.deps, connectInput(server.metadata!.id));
+    expect(result.status?.connectStatus?.phase).toBe(ConnectPhase.connecting);
+    expect(result.status?.connectStatus?.warning).toBe(RUNNER_QUEUE_WARNING);
+    // The async lane passes the 60-minute backstop budget.
+    expect(harness.engine.startedTimeouts[0]).toBe(ASYNC_CONNECT_TIMEOUT.ms);
+    // The detached settle lands SUCCEEDED and clears the warning.
+    await vi.waitFor(async () => {
+      const after = await store.getResource(
+        ApiResourceKind.mcp_server,
+        server.metadata!.id,
+        McpServerSchema,
+      );
+      expect(after.status?.connectStatus?.phase).toBe(ConnectPhase.succeeded);
+      expect(after.status?.connectStatus?.warning).toBe("");
+      expect(after.status?.discoveredCapabilities?.tools).toHaveLength(1);
+    });
+  });
+
+  const noWarning: Array<[string, boolean | undefined]> = [
+    ["a live poller", true],
+    ["an unanswerable probe (fail-open)", undefined],
+  ];
+  it.each(noWarning)("records no warning for %s", async (_label, pollers) => {
+    const harness = makeHarness({ pollers });
+    const server = await seedServer();
+    const result = await startConnect(harness.deps, connectInput(server.metadata!.id));
+    expect(result.status?.connectStatus?.warning).toBe("");
+  });
+
+  it("attach path: deletes the just-created EC and returns the re-read resource", async () => {
+    const server = await seedServer();
+    const harness = makeHarness({ attached: true });
+    const result = await startConnect(
+      harness.deps,
+      connectInput(server.metadata!.id, { K: { value: "v", isSecret: false } }),
+    );
+    expect(result.metadata?.id).toBe(server.metadata!.id);
+    expect(harness.ecCreates).toBe(1);
+    await vi.waitFor(() => expect(harness.ecDeletes).toEqual(["ectx_1"]));
+  });
+});
+
+describe("startBestEffortConnect (apply tail)", () => {
+  it("returns silently while the engine is disconnected (Go's nil-client no-op)", async () => {
+    const harness = makeHarness();
+    const engine = harness.engine;
+    harness.deps = { ...harness.deps, engineState: () => MCP_SERVER_ENGINE_DISCONNECTED };
+    const server = await seedServer();
+    await startBestEffortConnect(harness.deps, server);
+    expect(engine.startedInputs).toHaveLength(0);
+  });
+
+  it("skips servers with env declarations (no caller identity in the background)", async () => {
+    const harness = makeHarness();
+    const server = await seedServer({ env: true });
+    await startBestEffortConnect(harness.deps, server);
+    expect(harness.engine.startedInputs).toHaveLength(0);
+  });
+
+  it("connects an env-less server and persists the result", async () => {
+    const harness = makeHarness();
+    const server = await seedServer();
+    await startBestEffortConnect(harness.deps, server);
+    const after = await store.getResource(
+      ApiResourceKind.mcp_server,
+      server.metadata!.id,
+      McpServerSchema,
+    );
+    expect(after.status?.connectStatus?.phase).toBe(ConnectPhase.succeeded);
+    expect(after.status?.discoveredCapabilities?.tools).toHaveLength(1);
+  });
+
+  it("never throws when the server was deleted mid-connect", async () => {
+    const harness = makeHarness();
+    const server = await seedServer();
+    await store.deleteResource(ApiResourceKind.mcp_server, server.metadata!.id);
+    await expect(
+      startBestEffortConnect(harness.deps, server),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/connect.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/connect.test.ts
@@ -38,6 +38,7 @@ import {
   startBestEffortConnect,
 } from "../connect.js";
 import type { McpServerConnectDeps } from "../connect.js";
+import { ManagedEnvironmentService } from "../oauth/managed-env.js";
 import { RUNNER_QUEUE_WARNING, startConnect } from "../start-connect.js";
 import type {
   ConnectRunOutcome,
@@ -155,19 +156,27 @@ function makeHarness(options: FakeEngineOptions = {}): Harness {
         },
       },
       runnerAuth: RunnerAuthService.fromEnv(),
-      // A fake managed-env client backed by nothing: the refresh
+      // The REAL service over a client backed by nothing: the refresh
       // pre-flight arms that need it are exercised in the handshake
       // composed test; here every read throws, which the pre-flight
       // treats as its silent-skip arm (oss#863).
-      managedEnv: {
-        readSecretValue: async () => {
-          throw new Error("no managed env in this harness");
+      managedEnv: new ManagedEnvironmentService(
+        {
+          getSecretValue: async () => {
+            throw new Error("no managed env in this harness");
+          },
+          updateVariables: async () => {
+            throw new Error("no managed env in this harness");
+          },
+          create: async () => {
+            throw new Error("no managed env in this harness");
+          },
+          delete: async () => {
+            throw new Error("no managed env in this harness");
+          },
         },
-        updateSecrets: async () => {},
-        createManagedEnvironment: async () => "env_1",
-        deleteManagedEnvironment: async () => {},
-        // Structural stand-in for the class instance.
-      } as unknown as McpServerConnectDeps["managedEnv"],
+        silentLogger,
+      ),
       oauthGrants: store.oauthGrants,
       pendingOAuthStates: store.pendingOAuthStates,
       secretService: SecretService.create(undefined),

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/oauth-handshake.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/oauth-handshake.test.ts
@@ -1,0 +1,587 @@
+/**
+ * Pins the OAuth handshake against Go's initiate_oauth_connect.go +
+ * complete_oauth_connect.go + disconnect_oauth.go +
+ * get_oauth_grant_status.go (initiate_vendor_refusal_test.go +
+ * oauth_connect_secrets_test.go coverage) — through the REAL stack: a
+ * composed server on an ephemeral port, a native gRPC client, a live
+ * mock authorization server (RFC 8414 discovery + RFC 7591 DCR +
+ * authorize pre-flight + token endpoint), and the real environment
+ * domain behind the managed-env lifecycle.
+ *
+ * DB-1 (sub-project 20260825.02): this composed server has NO Temporal
+ * behind it, and completeOAuthConnect works anyway — the ratified,
+ * disclosed divergence from Go's composition gate. connect/startConnect
+ * refuse with the byte-pinned engine-unavailable copy on the same boot.
+ */
+import { createServer } from "node:http";
+import type { Server } from "node:http";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
+import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
+import { OAuthConnectionHealth } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { OAuthAppSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import {
+  TokenEndpointAuthMethod,
+  VendorApprovalStatus,
+} from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const REDIRECT_URI = "http://127.0.0.1:8234/auth/oauth/callback";
+const ORG = "acme";
+
+// ---------------------------------------------------------------------------
+// A minimal mock authorization server: discovery + DCR + authorize
+// pre-flight + token exchange. Programmable per test via `levers`.
+// ---------------------------------------------------------------------------
+
+interface MockAsLevers {
+  omitRegistrationEndpoint?: boolean;
+  tokenStatus?: number;
+  tokenBody?: unknown;
+}
+
+class MockAuthorizationServer {
+  private server: Server | undefined;
+  private baseUrl = "";
+  levers: MockAsLevers = {};
+  tokenRequests: URLSearchParams[] = [];
+
+  async start(): Promise<string> {
+    this.server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", this.baseUrl);
+      if (url.pathname === "/.well-known/oauth-authorization-server") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            issuer: this.baseUrl,
+            authorization_endpoint: `${this.baseUrl}/authorize`,
+            token_endpoint: `${this.baseUrl}/token`,
+            ...(this.levers.omitRegistrationEndpoint === true
+              ? {}
+              : { registration_endpoint: `${this.baseUrl}/register` }),
+            scopes_supported: ["read", "write"],
+            code_challenge_methods_supported: ["S256"],
+          }),
+        );
+        return;
+      }
+      if (url.pathname === "/register" && req.method === "POST") {
+        res.writeHead(201, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ client_id: "dcr-client-1" }));
+        return;
+      }
+      if (url.pathname === "/authorize") {
+        // The pre-flight probe: 200 = healthy login page, fail-open.
+        res.writeHead(200);
+        res.end("login page");
+        return;
+      }
+      if (url.pathname === "/token" && req.method === "POST") {
+        let body = "";
+        req.on("data", (chunk: Buffer) => (body += chunk.toString()));
+        req.on("end", () => {
+          this.tokenRequests.push(new URLSearchParams(body));
+          res.writeHead(this.levers.tokenStatus ?? 200, {
+            "Content-Type": "application/json",
+          });
+          res.end(
+            JSON.stringify(
+              this.levers.tokenBody ?? {
+                access_token: "at-fresh",
+                token_type: "bearer",
+                expires_in: 3600,
+                refresh_token: "rt-fresh",
+              },
+            ),
+          );
+        });
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    await new Promise<void>((resolve) =>
+      this.server!.listen(0, "127.0.0.1", resolve),
+    );
+    const address = this.server!.address();
+    if (address === null || typeof address === "string") {
+      throw new Error("mock AS failed to bind");
+    }
+    this.baseUrl = `http://127.0.0.1:${address.port}`;
+    return this.baseUrl;
+  }
+
+  reset(): void {
+    this.levers = {};
+    this.tokenRequests = [];
+  }
+
+  async stop(): Promise<void> {
+    await new Promise<void>((resolve) => this.server?.close(() => resolve()));
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+type CommandClient = Client<typeof McpServerCommandController>;
+type QueryClient = Client<typeof McpServerQueryController>;
+
+let server: ComposedServer;
+let command: CommandClient;
+let query: QueryClient;
+let mockAs: MockAuthorizationServer;
+let asBaseUrl: string;
+let dir: string;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "mcpserver-oauth-handshake-"));
+  mockAs = new MockAuthorizationServer();
+  asBaseUrl = await mockAs.start();
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      // No engine: 127.0.0.1:1 is deterministically closed (the composed
+      // CRUD harness idiom) — which is exactly the DB-1 arm under test.
+      TEMPORAL_HOST_PORT: "127.0.0.1:1",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      STORAGE_PATH: path.join(dir, "storage"),
+      STIGMER_OAUTH_REDIRECT_URI: REDIRECT_URI,
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  command = createClient(McpServerCommandController, transport);
+  query = createClient(McpServerQueryController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  await mockAs.stop();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+let counter = 0;
+async function applyServer(overrides?: {
+  vendorSlug?: string;
+  oauthOnly?: boolean;
+  noAuth?: boolean;
+}): Promise<string> {
+  counter += 1;
+  const applied = await command.apply({
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "McpServer",
+    metadata: { name: `OAuth Server ${counter}`, org: ORG },
+    spec: {
+      description: "handshake test server",
+      serverType: {
+        case: "http" as const,
+        value: { url: `${asBaseUrl}/mcp` },
+      },
+      ...(overrides?.noAuth === true
+        ? {}
+        : {
+            auth: {
+              targetEnvVar: "EXAMPLE_TOKEN",
+              ...(overrides?.vendorSlug !== undefined
+                ? {
+                    oauthAppRef: {
+                      org: ORG,
+                      slug: overrides.vendorSlug,
+                      kind: ApiResourceKind.oauth_app,
+                    },
+                  }
+                : {}),
+              ...(overrides?.oauthOnly === true ? { oauthOnly: true } : {}),
+            },
+          }),
+    },
+  });
+  return applied.metadata!.id;
+}
+
+async function seedOAuthApp(
+  slug: string,
+  approvalStatus: VendorApprovalStatus,
+): Promise<void> {
+  const app = create(OAuthAppSchema, {
+    apiVersion: "iam.stigmer.ai/v1",
+    kind: "OAuthApp",
+    metadata: { id: `oap_${slug}`, name: slug, slug, org: ORG },
+    spec: {
+      provider: "exampleco",
+      clientId: "vendor-client-1",
+      clientSecret: "vendor-secret",
+      authorizationUrl: `${asBaseUrl}/authorize`,
+      tokenUrl: `${asBaseUrl}/token`,
+      scopes: ["vendor.read"],
+      vendorApprovalStatus: approvalStatus,
+      tokenEndpointAuthMethod: TokenEndpointAuthMethod.CLIENT_SECRET_POST,
+    },
+  });
+  await server.store.saveResource(
+    ApiResourceKind.oauth_app,
+    app.metadata!.id,
+    OAuthAppSchema,
+    app,
+  );
+}
+
+async function expectCode(
+  promise: Promise<unknown>,
+  code: Code,
+  fragment: string,
+): Promise<ConnectError> {
+  try {
+    await promise;
+  } catch (error) {
+    const connectError = ConnectError.from(error);
+    expect(connectError.code).toBe(code);
+    expect(connectError.rawMessage).toContain(fragment);
+    return connectError;
+  }
+  throw new Error("expected the RPC to fail");
+}
+
+describe("engine-unavailable connect refusals (the DB-1 counterpart)", () => {
+  it("connect refuses FailedPrecondition on a Temporal-less server (byte-pinned copy)", async () => {
+    const id = await applyServer({ noAuth: true });
+    await expectCode(
+      command.connect({ mcpServerId: id, org: ORG }),
+      Code.FailedPrecondition,
+      "connect is not available: Temporal not configured",
+    );
+  });
+
+  it("startConnect refuses identically", async () => {
+    const id = await applyServer({ noAuth: true });
+    await expectCode(
+      command.startConnect({ mcpServerId: id, org: ORG }),
+      Code.FailedPrecondition,
+      "connect is not available: Temporal not configured",
+    );
+  });
+});
+
+describe("initiateOAuthConnect", () => {
+  it("rejects an empty mcp_server_id (protovalidate answers before the handler guard — same order as Go)", async () => {
+    await expectCode(
+      command.initiateOAuthConnect({ mcpServerId: "", org: ORG }),
+      Code.InvalidArgument,
+      "mcp_server_id: value is required [required]",
+    );
+  });
+
+  it("answers NotFound for an unknown server", async () => {
+    await expectCode(
+      command.initiateOAuthConnect({ mcpServerId: "mcps_ghost", org: ORG }),
+      Code.NotFound,
+      "mcp_server not found: mcps_ghost",
+    );
+  });
+
+  it("refuses a server without an auth block", async () => {
+    const id = await applyServer({ noAuth: true });
+    await expectCode(
+      command.initiateOAuthConnect({ mcpServerId: id, org: ORG }),
+      Code.FailedPrecondition,
+      `MCP server '${id}' does not have an auth block configured`,
+    );
+  });
+
+  it("DCR arm: discovers, registers, and returns a sorted S256 authorization URL", async () => {
+    mockAs.reset();
+    const id = await applyServer();
+    const output = await command.initiateOAuthConnect({
+      mcpServerId: id,
+      org: ORG,
+    });
+
+    const url = new URL(output.authorizationUrl);
+    expect(`${url.origin}${url.pathname}`).toBe(`${asBaseUrl}/authorize`);
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBe("dcr-client-1");
+    expect(url.searchParams.get("redirect_uri")).toBe(REDIRECT_URI);
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+    expect(url.searchParams.get("code_challenge")).toBeTruthy();
+    expect(url.searchParams.get("state")).toBe(output.state);
+    // Scope fallback to the discovered scopes_supported (space-joined).
+    expect(url.searchParams.get("scope")).toBe("read write");
+    // Go url.Values.Encode() sorts keys — the raw query is ordered.
+    const keys = [...url.searchParams.keys()];
+    expect(keys).toEqual([...keys].sort());
+    expect(output.scopes).toEqual(["read", "write"]);
+    expect(output.providerName).toBe(`OAuth Server ${counter}`);
+  });
+
+  it("DCR arm: refuses a provider that advertises no registration_endpoint", async () => {
+    mockAs.reset();
+    mockAs.levers.omitRegistrationEndpoint = true;
+    const id = await applyServer();
+    await expectCode(
+      command.initiateOAuthConnect({ mcpServerId: id, org: ORG }),
+      Code.FailedPrecondition,
+      "does not advertise a registration_endpoint for DCR",
+    );
+    mockAs.reset();
+  });
+
+  const refusals: Array<[string, VendorApprovalStatus, boolean, string]> = [
+    [
+      "PENDING with the manual-token alternative",
+      VendorApprovalStatus.PENDING,
+      false,
+      "OAuth sign-in is unavailable: the platform's OAuth app for 'exampleco' is pending approval by the vendor. Please enter a token manually instead.",
+    ],
+    [
+      "REJECTED with the manual-token alternative",
+      VendorApprovalStatus.REJECTED,
+      false,
+      "OAuth sign-in is unavailable: the platform's OAuth app for 'exampleco' is rejected by the vendor. Please enter a token manually instead.",
+    ],
+    [
+      "PENDING with the oauth_only BYOA alternative (#412)",
+      VendorApprovalStatus.PENDING,
+      true,
+      "OAuth sign-in is unavailable: the platform's OAuth app for 'exampleco' is pending approval by the vendor. This server only accepts OAuth sign-in; an org admin can configure your own OAuth app instead.",
+    ],
+  ];
+  it.each(refusals)("vendor arm refuses %s", async (_label, status, oauthOnly, copy) => {
+    const slug = `vendor-${status}-${oauthOnly ? "only" : "manual"}`;
+    await seedOAuthApp(slug, status);
+    const id = await applyServer({ vendorSlug: slug, oauthOnly });
+    const error = await expectCode(
+      command.initiateOAuthConnect({ mcpServerId: id, org: ORG }),
+      Code.FailedPrecondition,
+      copy,
+    );
+    expect(error.rawMessage).toBe(copy);
+  });
+
+  it("vendor arm answers NotFound for an unresolvable oauth_app_ref", async () => {
+    const id = await applyServer({ vendorSlug: "no-such-app" });
+    await expectCode(
+      command.initiateOAuthConnect({ mcpServerId: id, org: ORG }),
+      Code.NotFound,
+      "oauth_app not found: no-such-app",
+    );
+  });
+
+  it("vendor arm (APPROVED): builds the URL from the OAuthApp's endpoints and scopes", async () => {
+    await seedOAuthApp("vendor-ok", VendorApprovalStatus.APPROVED);
+    const id = await applyServer({ vendorSlug: "vendor-ok" });
+    const output = await command.initiateOAuthConnect({
+      mcpServerId: id,
+      org: ORG,
+    });
+    const url = new URL(output.authorizationUrl);
+    expect(url.searchParams.get("client_id")).toBe("vendor-client-1");
+    expect(url.searchParams.get("scope")).toBe("vendor.read");
+    expect(output.providerName).toBe("exampleco");
+  });
+});
+
+describe("completeOAuthConnect → grant → disconnect (the full lifecycle)", () => {
+  it("guards its inputs (proto rules answer first, exactly as on Go)", async () => {
+    await expectCode(
+      command.completeOAuthConnect({ mcpServerId: "", state: "s", authorizationCode: "c" }),
+      Code.InvalidArgument,
+      "mcp_server_id: value is required [required]",
+    );
+    await expectCode(
+      command.completeOAuthConnect({ mcpServerId: "m", state: "", authorizationCode: "c" }),
+      Code.InvalidArgument,
+      "state:",
+    );
+    await expectCode(
+      command.completeOAuthConnect({ mcpServerId: "m", state: "s", authorizationCode: "" }),
+      Code.InvalidArgument,
+      "authorization_code:",
+    );
+  });
+
+  it("refuses an unknown or already-consumed state (single-use atomicity)", async () => {
+    await expectCode(
+      command.completeOAuthConnect({
+        mcpServerId: "mcps_x",
+        state: "never-issued",
+        authorizationCode: "c",
+      }),
+      Code.FailedPrecondition,
+      "no pending OAuth state found for the given state parameter (expired or already used)",
+    );
+  });
+
+  it("refuses a state minted for a different server", async () => {
+    mockAs.reset();
+    const id = await applyServer();
+    const initiated = await command.initiateOAuthConnect({
+      mcpServerId: id,
+      org: ORG,
+    });
+    await expectCode(
+      command.completeOAuthConnect({
+        mcpServerId: "mcps_other",
+        state: initiated.state,
+        authorizationCode: "c",
+      }),
+      Code.FailedPrecondition,
+      "state parameter does not match the requested mcp_server_id",
+    );
+  });
+
+  it("maps a token-exchange failure to Unavailable (the pinned mapping)", async () => {
+    mockAs.reset();
+    const id = await applyServer();
+    const initiated = await command.initiateOAuthConnect({
+      mcpServerId: id,
+      org: ORG,
+    });
+    mockAs.levers.tokenStatus = 400;
+    mockAs.levers.tokenBody = { error: "invalid_grant" };
+    await expectCode(
+      command.completeOAuthConnect({
+        mcpServerId: id,
+        state: initiated.state,
+        authorizationCode: "bad-code",
+      }),
+      Code.Unavailable,
+      "token exchange failed:",
+    );
+    mockAs.reset();
+  });
+
+  it("exchanges the code, stores tokens in a managed environment, grants, reuses on re-connect, disconnects", async () => {
+    mockAs.reset();
+    const id = await applyServer();
+
+    // First connect.
+    const initiated = await command.initiateOAuthConnect({
+      mcpServerId: id,
+      org: ORG,
+    });
+    const completed = await command.completeOAuthConnect({
+      mcpServerId: id,
+      state: initiated.state,
+      authorizationCode: "auth-code-1",
+    });
+    expect(completed.connected).toBe(true);
+    expect(completed.targetEnvVar).toBe("EXAMPLE_TOKEN");
+
+    // The exchange presented the DCR public client with PKCE (no secret).
+    const tokenRequest = mockAs.tokenRequests[0];
+    expect(tokenRequest?.get("grant_type")).toBe("authorization_code");
+    expect(tokenRequest?.get("client_id")).toBe("dcr-client-1");
+    expect(tokenRequest?.get("redirect_uri")).toBe(REDIRECT_URI);
+    expect(tokenRequest?.get("code_verifier")).toBeTruthy();
+    expect(tokenRequest?.has("client_secret")).toBe(false);
+
+    // The grant is queryable and HEALTHY; the refresh-token env var is
+    // stamped unconditionally (oss#863's precondition, ported as-is).
+    const status = await query.getOAuthGrantStatus({ resourceId: id, org: ORG });
+    expect(status.connected).toBe(true);
+    expect(status.targetEnvVar).toBe("EXAMPLE_TOKEN");
+    expect(status.authMethod).toBe("mcp_oauth");
+    expect(status.connectionHealth).toBe(
+      OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY,
+    );
+
+    const grant = await server.store.oauthGrants.find("", id, ORG);
+    expect(grant?.refreshTokenEnvVar).toBe("EXAMPLE_TOKEN_REFRESH_TOKEN");
+    const firstEnvId = grant?.environmentId ?? "";
+    expect(firstEnvId).not.toBe("");
+
+    // Re-connect reuses the managed environment.
+    const again = await command.initiateOAuthConnect({ mcpServerId: id, org: ORG });
+    await command.completeOAuthConnect({
+      mcpServerId: id,
+      state: again.state,
+      authorizationCode: "auth-code-2",
+    });
+    const regrant = await server.store.oauthGrants.find("", id, ORG);
+    expect(regrant?.environmentId).toBe(firstEnvId);
+
+    // Disconnect tears down grant + environment; a second disconnect is
+    // the idempotent no-grant arm.
+    const disconnected = await command.disconnectOAuth({ resourceId: id, org: ORG });
+    expect(disconnected.disconnected).toBe(true);
+    expect(await server.store.oauthGrants.find("", id, ORG)).toBeUndefined();
+    const againDisconnected = await command.disconnectOAuth({
+      resourceId: id,
+      org: ORG,
+    });
+    expect(againDisconnected.disconnected).toBe(false);
+
+    // NO_GRANT after teardown.
+    const after = await query.getOAuthGrantStatus({ resourceId: id, org: ORG });
+    expect(after.connected).toBe(false);
+    expect(after.connectionHealth).toBe(
+      OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_NO_GRANT,
+    );
+  });
+});
+
+describe("getOAuthGrantStatus", () => {
+  it("guards its inputs (proto rules answer first, exactly as on Go)", async () => {
+    await expectCode(
+      query.getOAuthGrantStatus({ resourceId: "", org: ORG }),
+      Code.InvalidArgument,
+      "resource_id: value is required [required]",
+    );
+    await expectCode(
+      query.getOAuthGrantStatus({ resourceId: "x", org: "" }),
+      Code.InvalidArgument,
+      "org:",
+    );
+  });
+
+  it("claims TOKEN_EXPIRED_REFRESHABLE for an expired grant with a stamped refresh var — oss#863, pinned as-is", async () => {
+    await server.store.oauthGrants.upsert({
+      identityAccountId: "",
+      resourceId: "mcps_expired",
+      resourceKind: "mcp_server",
+      orgId: ORG,
+      // Expired well past the 60s buffer.
+      accessTokenExpiresAt: Math.floor(Date.now() / 1000) - 3600,
+      clientId: "c",
+      authMethod: "mcp_oauth",
+      tokenEndpoint: `${asBaseUrl}/token`,
+      accessTokenEnvVar: "T",
+      // Stamped unconditionally by complete — even when no refresh token
+      // was ever issued, which is exactly the filed defect.
+      refreshTokenEnvVar: "T_REFRESH_TOKEN",
+      environmentId: "env_x",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    const status = await query.getOAuthGrantStatus({
+      resourceId: "mcps_expired",
+      org: ORG,
+    });
+    expect(status.connectionHealth).toBe(
+      OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED_REFRESHABLE,
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/oauth-handshake.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/oauth-handshake.test.ts
@@ -541,6 +541,29 @@ describe("completeOAuthConnect → grant → disconnect (the full lifecycle)", (
       OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_NO_GRANT,
     );
   });
+
+  it("refuses a REPLAYED state after a successful complete (single-use atomicity at the wire)", async () => {
+    mockAs.reset();
+    const id = await applyServer();
+    const initiated = await command.initiateOAuthConnect({
+      mcpServerId: id,
+      org: ORG,
+    });
+    await command.completeOAuthConnect({
+      mcpServerId: id,
+      state: initiated.state,
+      authorizationCode: "auth-code-replay-1",
+    });
+    await expectCode(
+      command.completeOAuthConnect({
+        mcpServerId: id,
+        state: initiated.state,
+        authorizationCode: "auth-code-replay-2",
+      }),
+      Code.FailedPrecondition,
+      "no pending OAuth state found for the given state parameter (expired or already used)",
+    );
+  });
 });
 
 describe("getOAuthGrantStatus", () => {
@@ -582,6 +605,31 @@ describe("getOAuthGrantStatus", () => {
     });
     expect(status.connectionHealth).toBe(
       OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED_REFRESHABLE,
+    );
+  });
+
+  it("answers TOKEN_EXPIRED only for a grant WITHOUT a refresh var — unreachable through the real flow (oss#863)", async () => {
+    await server.store.oauthGrants.upsert({
+      identityAccountId: "",
+      resourceId: "mcps_expired_norefresh",
+      resourceKind: "mcp_server",
+      orgId: ORG,
+      accessTokenExpiresAt: Math.floor(Date.now() / 1000) - 3600,
+      clientId: "c",
+      authMethod: "mcp_oauth",
+      tokenEndpoint: `${asBaseUrl}/token`,
+      accessTokenEnvVar: "T",
+      refreshTokenEnvVar: "",
+      environmentId: "env_x",
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    const status = await query.getOAuthGrantStatus({
+      resourceId: "mcps_expired_norefresh",
+      org: ORG,
+    });
+    expect(status.connectionHealth).toBe(
+      OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED,
     );
   });
 });

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/seal-unseal.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/__tests__/seal-unseal.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Pins the pending-state seal/unseal seams against Go's
+ * oauth_connect_secrets_test.go with encryption ENABLED (the composed
+ * handshake test runs the disabled/plaintext arm): code_verifier always
+ * encrypted at rest, client_secret only when non-empty — NEVER
+ * ciphertext-of-empty, so emptiness keeps meaning "public client"
+ * (oss#394) — and unseal restores the exact plaintexts. A sealed row on a
+ * keyless deployment fails loudly before any token-exchange attempt.
+ */
+import { describe, expect, it } from "vitest";
+
+import { SecretService } from "../../../encryption/encryption.js";
+import { createLogger } from "../../../boot/logger.js";
+import type { PendingOAuthState } from "../../../store/interface.js";
+import { sealPendingOAuthState } from "../initiate-oauth-connect.js";
+import { unsealPendingOAuthState } from "../complete-oauth-connect.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const enabled = SecretService.create(Buffer.alloc(32, 7));
+const disabled = SecretService.create(undefined);
+
+function pendingState(overrides?: Partial<PendingOAuthState>): PendingOAuthState {
+  return {
+    state: "state-1",
+    codeVerifier: "verifier-plaintext",
+    clientId: "client-1",
+    clientSecret: "vendor-secret",
+    tokenEndpoint: "https://auth.example.com/token",
+    mcpServerId: "mcps_1",
+    identityAccountId: "",
+    targetEnvVar: "TOKEN",
+    authMethod: "vendor_oauth",
+    tokenAuthMethod: "client_secret_basic",
+    redirectUri: "http://cb",
+    org: "acme",
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+describe("sealPendingOAuthState (enabled encryption)", () => {
+  it("encrypts the code_verifier and a non-empty client_secret at rest", () => {
+    const sealed = sealPendingOAuthState(enabled, silentLogger, pendingState());
+    expect(sealed.codeVerifier).toMatch(/^enc:v1:/);
+    expect(sealed.clientSecret).toMatch(/^enc:v1:/);
+    // Everything else rides unchanged.
+    expect(sealed.tokenEndpoint).toBe("https://auth.example.com/token");
+  });
+
+  it("keeps the DCR path's empty client_secret EMPTY — never ciphertext-of-empty (oss#394)", () => {
+    const sealed = sealPendingOAuthState(
+      enabled,
+      silentLogger,
+      pendingState({ clientSecret: "", authMethod: "mcp_oauth" }),
+    );
+    expect(sealed.codeVerifier).toMatch(/^enc:v1:/);
+    expect(sealed.clientSecret).toBe("");
+  });
+
+  it("passes plaintext through with disabled encryption (the WARN-degrade posture)", () => {
+    const sealed = sealPendingOAuthState(disabled, silentLogger, pendingState());
+    expect(sealed.codeVerifier).toBe("verifier-plaintext");
+    expect(sealed.clientSecret).toBe("vendor-secret");
+  });
+});
+
+describe("unsealPendingOAuthState", () => {
+  it("round-trips the sealed secrets back to their exact plaintexts", () => {
+    const sealed = sealPendingOAuthState(enabled, silentLogger, pendingState());
+    const unsealed = unsealPendingOAuthState(enabled, sealed);
+    expect(unsealed.codeVerifier).toBe("verifier-plaintext");
+    expect(unsealed.clientSecret).toBe("vendor-secret");
+  });
+
+  it("passes legacy plaintext rows through unchanged (pre-sealing shapes)", () => {
+    const unsealed = unsealPendingOAuthState(enabled, pendingState());
+    expect(unsealed.codeVerifier).toBe("verifier-plaintext");
+    expect(unsealed.clientSecret).toBe("vendor-secret");
+  });
+
+  it("fails loudly on a sealed row when the key has vanished (before any token exchange)", () => {
+    const sealed = sealPendingOAuthState(enabled, silentLogger, pendingState());
+    expect(() => unsealPendingOAuthState(disabled, sealed)).toThrow(
+      /^failed to decrypt code_verifier: /,
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/complete-oauth-connect.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/complete-oauth-connect.ts
@@ -1,0 +1,309 @@
+/**
+ * completeOAuthConnect — ports
+ * pkg/domain/mcpserver/controller/complete_oauth_connect.go: finish the
+ * OAuth flow by exchanging the authorization code for tokens, storing
+ * them in a managed environment, and creating an OAuthGrant record. On
+ * re-connect (same user + server + org already has a grant with an
+ * environment ID), the existing managed environment is reused — only its
+ * secrets are updated with the fresh tokens.
+ *
+ * DB-1 (owner-ratified, sub-project 20260825.02): the managed-env service
+ * is wired unconditionally here, so this RPC serves on a Temporal-less
+ * server where Go's composition gate refuses ("managed environment
+ * service not initialized" — a wiring artifact CW-1 deliberately did NOT
+ * pin). Disclosed divergence; the Go-side issue files at wrap-up.
+ *
+ * Proven by mcpserver-connect.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts-execution) and
+ * __tests__/complete-oauth-connect.test.ts.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import type { EnvironmentValue as EnvironmentSpecValue } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import { EnvironmentValueSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type {
+  CompleteOAuthConnectInput,
+  CompleteOAuthConnectOutput,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { CompleteOAuthConnectOutputSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { SecretService } from "../../encryption/encryption.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+  unavailableError,
+} from "../../pipeline/errors.js";
+import type { PendingOAuthState } from "../../store/interface.js";
+import type { McpServerConnectDeps } from "./connect.js";
+import { exchangeCode } from "./oauth/token.js";
+
+export async function completeOAuthConnect(
+  deps: McpServerConnectDeps,
+  input: CompleteOAuthConnectInput,
+): Promise<CompleteOAuthConnectOutput> {
+  const mcpServerId = input.mcpServerId;
+  if (mcpServerId === "") {
+    throw invalidArgumentError("mcp_server_id is required");
+  }
+
+  const stateParam = input.state;
+  if (stateParam === "") {
+    throw invalidArgumentError("state is required");
+  }
+
+  const code = input.authorizationCode;
+  if (code === "") {
+    throw invalidArgumentError("authorization_code is required");
+  }
+
+  // Load and validate pending state (atomically consumed).
+  let pendingState: PendingOAuthState | undefined;
+  try {
+    pendingState = await deps.pendingOAuthStates.getAndDelete(stateParam);
+  } catch (error) {
+    throw internalError(error, "failed to load pending OAuth state");
+  }
+  if (pendingState === undefined) {
+    throw failedPreconditionError(
+      "no pending OAuth state found for the given state parameter (expired or already used)",
+    );
+  }
+
+  if (pendingState.mcpServerId !== mcpServerId) {
+    throw failedPreconditionError(
+      "state parameter does not match the requested mcp_server_id",
+    );
+  }
+
+  // Unseal the handshake secrets that initiateOAuthConnect sealed at rest
+  // (oss#394), at the last moment before their only use. The row was
+  // consumed by getAndDelete (single-use is atomic), so a decryption
+  // failure costs the user one re-initiate — the same posture as the
+  // expiry refusal; the error message points them there.
+  try {
+    pendingState = unsealPendingOAuthState(deps.secretService, pendingState);
+  } catch (error) {
+    deps.logger.error("Failed to decrypt pending OAuth state secrets", {
+      mcp_server_id: mcpServerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(
+      error,
+      "failed to decrypt OAuth handshake secrets — please retry the connect flow",
+    );
+  }
+
+  // Exchange authorization code for tokens. Failure maps to UNAVAILABLE —
+  // the pinned (unusual) Go mapping, complete_oauth_connect.go:96.
+  let tokenResponse;
+  try {
+    tokenResponse = await exchangeCode(
+      pendingState.tokenEndpoint,
+      code,
+      pendingState.redirectUri,
+      pendingState.codeVerifier,
+      pendingState.clientId,
+      pendingState.clientSecret,
+      pendingState.tokenAuthMethod,
+    );
+  } catch (error) {
+    throw unavailableError(
+      `token exchange failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  // Load the MCP server for the auth block metadata and name.
+  let mcpServer: McpServer;
+  try {
+    mcpServer = await deps.store.getResource(
+      ApiResourceKind.mcp_server,
+      mcpServerId,
+      McpServerSchema,
+    );
+  } catch {
+    throw notFoundError("mcp_server", mcpServerId);
+  }
+
+  let org = pendingState.org;
+  if (org === "") {
+    org = mcpServer.metadata?.org ?? "";
+  }
+
+  // Resolve the managed environment: reuse from an existing grant or
+  // create new.
+  const managedEnvId = await resolveOrCreateManagedEnvironment(
+    deps,
+    pendingState.identityAccountId,
+    mcpServerId,
+    org,
+    mcpServer.metadata?.name ?? "",
+  );
+
+  // Build token variables (plaintext — the environment pipeline encrypts).
+  const tokenVars: { [key: string]: EnvironmentSpecValue } = {
+    [pendingState.targetEnvVar]: create(EnvironmentValueSchema, {
+      value: tokenResponse.accessToken,
+      isSecret: true,
+    }),
+  };
+
+  const refreshTokenEnvVar = `${pendingState.targetEnvVar}_REFRESH_TOKEN`;
+  if (tokenResponse.refreshToken !== "") {
+    tokenVars[refreshTokenEnvVar] = create(EnvironmentValueSchema, {
+      value: tokenResponse.refreshToken,
+      isSecret: true,
+    });
+  }
+
+  try {
+    await deps.managedEnv.updateSecrets(managedEnvId, tokenVars);
+  } catch (error) {
+    throw internalError(
+      error,
+      "failed to store OAuth tokens in managed environment",
+    );
+  }
+
+  let expiresAt = 0;
+  if (tokenResponse.expiresIn > 0) {
+    expiresAt = Math.floor(Date.now() / 1000) + tokenResponse.expiresIn;
+  }
+
+  // Create or update the OAuthGrant record. RefreshTokenEnvVar is set
+  // UNCONDITIONALLY — even when no refresh token was issued — which is
+  // exactly why evaluateHealth's TOKEN_EXPIRED arm is unreachable through
+  // the real flow: the filed defect oss#863, ported as-is (parity, not a
+  // fix).
+  try {
+    await deps.oauthGrants.upsert({
+      identityAccountId: pendingState.identityAccountId,
+      resourceId: mcpServerId,
+      resourceKind: "mcp_server",
+      orgId: org,
+      accessTokenExpiresAt: expiresAt,
+      clientId: pendingState.clientId,
+      authMethod: pendingState.authMethod,
+      tokenEndpoint: pendingState.tokenEndpoint,
+      accessTokenEnvVar: pendingState.targetEnvVar,
+      refreshTokenEnvVar,
+      environmentId: managedEnvId,
+      createdAt: 0,
+      updatedAt: 0,
+    });
+  } catch (error) {
+    throw internalError(error, "failed to create OAuth grant record");
+  }
+
+  const auth = mcpServer.spec?.auth;
+
+  deps.logger.info(
+    "OAuth Connect completed: tokens stored in managed environment",
+    {
+      mcp_server_id: mcpServerId,
+      auth_method: pendingState.authMethod,
+      target_env_var: pendingState.targetEnvVar,
+      managed_env_id: managedEnvId,
+      expires_at: expiresAt,
+      has_refresh_token: tokenResponse.refreshToken !== "",
+    },
+  );
+
+  return create(CompleteOAuthConnectOutputSchema, {
+    connected: true,
+    targetEnvVar: pendingState.targetEnvVar,
+    tokenLifetimeHint: auth?.tokenLifetimeHint ?? "",
+  });
+}
+
+/**
+ * Decrypts the secrets sealPendingOAuthState encrypted before the row
+ * rested (oss#394) — the read seam paired with the write seam in
+ * initiate-oauth-connect.ts.
+ *
+ * decrypt() dispatches on the value's own enc:v1: prefix and passes
+ * plaintext through unchanged, which quietly covers every legacy shape:
+ * rows written before the sealing release, rows written while encryption
+ * was disabled, and the DCR path's deliberately empty client secret. No
+ * migration — the table turns over in 10 minutes.
+ *
+ * A sealed row on a deployment whose key has since vanished fails here
+ * (loudly, before any token-exchange attempt) rather than sending
+ * ciphertext to the vendor's token endpoint.
+ */
+export function unsealPendingOAuthState(
+  secretService: SecretService,
+  state: PendingOAuthState,
+): PendingOAuthState {
+  let verifier: string;
+  try {
+    verifier = secretService.decrypt(state.codeVerifier);
+  } catch (error) {
+    throw new Error(
+      `failed to decrypt code_verifier: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  let secret: string;
+  try {
+    secret = secretService.decrypt(state.clientSecret);
+  } catch (error) {
+    throw new Error(
+      `failed to decrypt client_secret: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  return { ...state, codeVerifier: verifier, clientSecret: secret };
+}
+
+/**
+ * Reuses the managed environment an existing OAuthGrant points to
+ * (re-connect case), or creates a new one (Go
+ * resolveOrCreateManagedEnvironment).
+ */
+async function resolveOrCreateManagedEnvironment(
+  deps: McpServerConnectDeps,
+  identityAccountId: string,
+  mcpServerId: string,
+  org: string,
+  mcpServerName: string,
+): Promise<string> {
+  let existingGrant;
+  try {
+    existingGrant = await deps.oauthGrants.find(
+      identityAccountId,
+      mcpServerId,
+      org,
+    );
+  } catch (error) {
+    deps.logger.warn(
+      "Failed to look up existing OAuth grant (non-fatal, will create new managed env)",
+      {
+        mcp_server_id: mcpServerId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+
+  if (existingGrant !== undefined && existingGrant.environmentId !== "") {
+    deps.logger.info("Reusing existing managed environment for OAuth re-connect", {
+      mcp_server_id: mcpServerId,
+      environment_id: existingGrant.environmentId,
+    });
+    return existingGrant.environmentId;
+  }
+
+  const envName = `OAuth: ${mcpServerName}`;
+  try {
+    return await deps.managedEnv.createManagedEnvironment(envName, org);
+  } catch (error) {
+    throw internalError(
+      error,
+      "failed to create managed environment for OAuth tokens",
+    );
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/connect-status.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/connect-status.ts
@@ -1,0 +1,302 @@
+/**
+ * Connect-status bookkeeping and result persistence — ports the
+ * persistence family shared by all three connect lanes:
+ * persistConnectResult / settleConnectStatus / convertToDiscovered-
+ * Capabilities / convertToToolApprovals / setToolApprovalsFromConnect
+ * (connect.go:733-889) and persistConnectStarting / persistConnectFailure
+ * (start_connect.go:212-285). One module because these helpers are the
+ * shared bookkeeping BOTH connect.ts and start-connect.ts consume — Go's
+ * single package makes the split invisible; in ESM this placement keeps
+ * the handler modules cycle-free.
+ *
+ * Proven by mcpserver-connect.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts-execution).
+ */
+import { create } from "@bufbuild/protobuf";
+import type { JsonObject } from "@bufbuild/protobuf";
+import { timestampNow } from "@bufbuild/protobuf/wkt";
+import type { ConnectError } from "@connectrpc/connect";
+
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { ToolApprovalPolicy } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/spec_pb";
+import { ToolApprovalPolicySchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/spec_pb";
+import type {
+  DiscoveredCapabilities,
+  McpServerStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+import {
+  ConnectPhase,
+  ConnectStatusSchema,
+  DiscoveredCapabilitiesSchema,
+  DiscoveredResourceTemplateSchema,
+  DiscoveredToolSchema,
+  McpServerStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { grpcCodeName } from "../../pipeline/errors.js";
+import type { Store } from "../../store/interface.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { ConnectWorkflowOutput } from "./engine.js";
+
+/**
+ * Converts the workflow output to the proto DiscoveredCapabilities
+ * message (Go convertToDiscoveredCapabilities).
+ *
+ * protobuf-es represents google.protobuf.Struct fields as JsonObject, so
+ * the runner's schema object assigns directly — Go's soft
+ * structpb.NewStruct error arm has no TS equivalent (the value arrived
+ * through JSON and is representable by construction).
+ *
+ * Watch item (oss#862, ratified DB-3): Go persists the Struct with
+ * SORTED JSON keys while this path keeps the runner's insertion order —
+ * the runner's reconnect signature compares stringified schemas, so
+ * ordering feeds the filed carry-forward defect. The conformance suite
+ * pins only the wire-stable contract (capabilities + gates survive
+ * reconnect), which both orderings satisfy.
+ */
+export function convertToDiscoveredCapabilities(
+  output: ConnectWorkflowOutput,
+): DiscoveredCapabilities {
+  const capabilities = create(DiscoveredCapabilitiesSchema, {
+    lastDiscoveredAt: timestampNow(),
+  });
+
+  for (const t of output.tools ?? []) {
+    const tool = create(DiscoveredToolSchema, {
+      name: t.name ?? "",
+      description: t.description ?? "",
+    });
+    if (t.input_schema !== undefined) {
+      tool.inputSchema = t.input_schema as JsonObject;
+    }
+    capabilities.tools.push(tool);
+  }
+
+  for (const rt of output.resource_templates ?? []) {
+    capabilities.resourceTemplates.push(
+      create(DiscoveredResourceTemplateSchema, {
+        uriTemplate: rt.uri_template ?? "",
+        name: rt.name ?? "",
+        description: rt.description ?? "",
+        mimeType: rt.mime_type ?? "",
+      }),
+    );
+  }
+
+  return capabilities;
+}
+
+/**
+ * Converts the classifier output to the ToolApprovalPolicy list (Go
+ * convertToToolApprovals). Presence in the list means "requires
+ * approval" — there is no boolean on the proto — so any entry explicitly
+ * marked requires_approval=false is dropped. Mirrors the Cloud (Java)
+ * StoreConnectResults converter so both editions persist identical
+ * classifier output.
+ */
+export function convertToToolApprovals(
+  output: ConnectWorkflowOutput,
+): ToolApprovalPolicy[] {
+  const approvals: ToolApprovalPolicy[] = [];
+  for (const a of output.tool_approvals ?? []) {
+    if (a.requires_approval !== true || (a.tool_name ?? "") === "") {
+      continue;
+    }
+    approvals.push(
+      create(ToolApprovalPolicySchema, {
+        toolName: a.tool_name,
+        message: a.message ?? "",
+        fromDestructiveHint: a.from_destructive_hint ?? false,
+      }),
+    );
+  }
+  return approvals;
+}
+
+/**
+ * Writes the freshly classified tool approvals onto the status, returning
+ * how many were applied (Go setToolApprovalsFromConnect).
+ *
+ * Overwrite-on-reconnect: a new non-empty result replaces the prior list
+ * so a reclassification takes effect. Preserve-on-empty: an empty result
+ * leaves the existing list untouched, so a degraded or older runner that
+ * returns nothing can never silently disarm previously persisted approval
+ * gates.
+ */
+export function setToolApprovalsFromConnect(
+  status: McpServerStatus,
+  output: ConnectWorkflowOutput,
+): number {
+  const approvals = convertToToolApprovals(output);
+  if (approvals.length > 0) {
+    status.toolApprovals = approvals;
+  }
+  return approvals.length;
+}
+
+/**
+ * Records the terminal phase of a connect operation on the status,
+ * preserving the start-time fields (started_at) the starting lane
+ * recorded (Go settleConnectStatus). failure is the mapped gRPC error for
+ * a failed operation, undefined for success; its code and message land
+ * verbatim on the status so polling clients render the same
+ * classification blocking callers get as an RPC error.
+ *
+ * The start-time warning is cleared either way: it is a CONNECTING-phase
+ * advisory ("no worker appears to be polling"), and a settled operation
+ * has disproven it.
+ */
+export function settleConnectStatus(
+  mcpStatus: McpServerStatus,
+  workflowId: string,
+  failure: ConnectError | undefined,
+): void {
+  let cs = mcpStatus.connectStatus;
+  if (cs === undefined) {
+    // The operation was started by a lane that could not record
+    // CONNECTING (a failed best-effort status write, or a legacy
+    // in-flight run from before this field existed). Settle with what is
+    // known.
+    cs = create(ConnectStatusSchema);
+    mcpStatus.connectStatus = cs;
+  }
+  cs.workflowId = workflowId;
+  cs.finishedAt = timestampNow();
+  cs.warning = "";
+  if (failure === undefined) {
+    cs.phase = ConnectPhase.succeeded;
+    cs.failureCode = "";
+    cs.failureMessage = "";
+    return;
+  }
+  cs.phase = ConnectPhase.failed;
+  cs.failureCode = grpcCodeName(failure.code);
+  cs.failureMessage = failure.rawMessage;
+}
+
+/**
+ * Writes the connect workflow's output onto the McpServer status as a
+ * single atomic read-modify-write, returning the updated resource and the
+ * number of tool-approval gates applied (Go persistConnectResult).
+ *
+ * This is the one place connect output lands on the resource — the
+ * blocking Connect path, the async StartConnect path, and the best-effort
+ * auto-connect path all route through it. The atomic updateResource is
+ * deliberate: the background writes can land long after the triggering
+ * RPC returned, so a plain read-modify-write would risk clobbering a
+ * concurrent update (a manual reconnect or an edit) made in that window.
+ *
+ * The result fields follow the deliberate Phase-6 asymmetry, unchanged:
+ * discovered_capabilities is a point-in-time snapshot, overwritten on
+ * every connect; tool_approvals are safety-critical gates (see
+ * setToolApprovalsFromConnect). The connect_status settle rides the same
+ * atomic write so pollers can never observe results without the terminal
+ * phase (or vice versa).
+ *
+ * Throws ResourceNotFoundError if the resource was deleted between the
+ * connect trigger and its completion (a real case for the background
+ * paths); callers decide how to react.
+ */
+export async function persistConnectResult(
+  store: Store,
+  mcpServerId: string,
+  workflowId: string,
+  output: ConnectWorkflowOutput,
+): Promise<{ persisted: McpServer; toolApprovalCount: number }> {
+  let toolApprovalCount = 0;
+  const persisted = await store.updateResource(
+    ApiResourceKind.mcp_server,
+    mcpServerId,
+    McpServerSchema,
+    (mcpServer) => {
+      if (mcpServer.status === undefined) {
+        mcpServer.status = create(McpServerStatusSchema);
+      }
+      mcpServer.status.discoveredCapabilities =
+        convertToDiscoveredCapabilities(output);
+      toolApprovalCount = setToolApprovalsFromConnect(mcpServer.status, output);
+      settleConnectStatus(mcpServer.status, workflowId, undefined);
+    },
+  );
+  return { persisted, toolApprovalCount };
+}
+
+/**
+ * Records a freshly started connect operation as the resource's
+ * connect_status (phase CONNECTING), replacing whatever previous
+ * operation's record was there (Go persistConnectStarting). Returns the
+ * updated resource — the payload StartConnect answers with.
+ */
+export async function persistConnectStarting(
+  store: Store,
+  mcpServerId: string,
+  workflowId: string,
+  warning: string,
+): Promise<McpServer> {
+  return store.updateResource(
+    ApiResourceKind.mcp_server,
+    mcpServerId,
+    McpServerSchema,
+    (mcpServer) => {
+      if (mcpServer.status === undefined) {
+        mcpServer.status = create(McpServerStatusSchema);
+      }
+      mcpServer.status.connectStatus = create(ConnectStatusSchema, {
+        phase: ConnectPhase.connecting,
+        workflowId,
+        startedAt: timestampNow(),
+        warning,
+      });
+    },
+  );
+}
+
+/**
+ * Settles connect_status as FAILED with the mapped gRPC classification of
+ * the given error (Go persistConnectFailure). Never propagates its own
+ * failure: every caller has already surfaced the connect failure on its
+ * own channel (RPC error or log), and a resource deleted mid-operation is
+ * expected.
+ */
+export async function persistConnectFailure(
+  store: Store,
+  logger: Logger,
+  mcpServerId: string,
+  failure: ConnectError,
+): Promise<void> {
+  try {
+    await store.updateResource(
+      ApiResourceKind.mcp_server,
+      mcpServerId,
+      McpServerSchema,
+      (mcpServer) => {
+        if (mcpServer.status === undefined) {
+          mcpServer.status = create(McpServerStatusSchema);
+        }
+        settleConnectStatus(
+          mcpServer.status,
+          mcpServer.status.connectStatus?.workflowId ?? "",
+          failure,
+        );
+      },
+    );
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      logger.info(
+        "Skipping connect failure persistence: MCP server deleted before connect settled",
+        { mcp_server_id: mcpServerId },
+      );
+      return;
+    }
+    logger.warn(
+      "Failed to record connect failure on connect_status (non-fatal)",
+      {
+        mcp_server_id: mcpServerId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/connect.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/connect.ts
@@ -1,0 +1,1160 @@
+/**
+ * McpServer connect (blocking lane) + the shared connect machinery —
+ * ports pkg/domain/mcpserver/controller/connect.go: the Connect RPC,
+ * prepareConnect (OAuth refresh pre-flight, ephemeral ExecutionContext,
+ * decrypt-lane token minting), environment resolution, the workflow
+ * failure→gRPC mapping, and apply's best-effort auto-connect tail. The
+ * async lane lives in start-connect.ts; the connect_status persistence
+ * family in connect-status.ts.
+ *
+ * Discovery runs on the RUNNER: this module starts the runner's
+ * stigmer/mcp-server/connect workflow through the engine seam
+ * (engine.ts) and never registers a worker.
+ *
+ * Proven by mcpserver-connect.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts-execution) and __tests__/connect.test.ts.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { randomUUID } from "node:crypto";
+
+import type {
+  EnvironmentList,
+  EnvironmentSecretValueInputSchema,
+  ListEnvironmentsRequestSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/environment/v1/io_pb";
+import type {
+  EnvironmentValue as EnvironmentSpecValue,
+  EnvVarDeclaration,
+} from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import { EnvironmentValueSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
+import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+import type { ExecutionValue } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
+import { ExecutionValueSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { ConnectInput } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import type { ApiResourceDeleteInputSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { TokenEndpointAuthMethod } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import {
+  failedPreconditionError,
+  internalError,
+  notFoundError,
+  invalidArgumentError,
+  unavailableError,
+} from "../../pipeline/errors.js";
+import type { RunnerAuthService } from "../../runnerauth/runnerauth.js";
+import type {
+  OAuthGrantStore,
+  PendingOAuthStateStore,
+  Store,
+} from "../../store/interface.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import { resolveOAuthAppRef } from "../oauthapp/refresolution.js";
+import {
+  persistConnectFailure,
+  persistConnectResult,
+  persistConnectStarting,
+} from "./connect-status.js";
+import type {
+  ConnectRun,
+  ConnectRunFailure,
+  ConnectWorkflowInput,
+  McpServerEngineStateProvider,
+} from "./engine.js";
+import { refreshTokenIfExpired } from "./oauth/refresh.js";
+import {
+  TOKEN_AUTH_METHOD_BASIC,
+  TOKEN_AUTH_METHOD_POST,
+} from "./oauth/token.js";
+import type { ManagedEnvironmentService } from "./oauth/managed-env.js";
+
+/**
+ * A connect budget: the workflow run timeout in milliseconds plus its Go
+ * time.Duration String() rendering — the DEADLINE_EXCEEDED copy names the
+ * budget that fired, and the string must match Go's %s byte-for-byte.
+ */
+export interface ConnectBudget {
+  readonly ms: number;
+  readonly goLabel: string;
+}
+
+/**
+ * The connect workflow's WorkflowRunTimeout — the total budget for
+ * discovery + tool-approval classification. Sized from the runner's own
+ * bounds (issue #243): the 270s stdio init allowance (STDIO_INIT_TIMEOUT_MS
+ * in activities/discover-mcp-server.ts — a first run may download and
+ * compile packages via npx/uvx/go run) + the 120s classification floor
+ * (classifyWithTimeout in workflows/connect-mcp-server.ts) + margin for
+ * tool listing and persistence. Anything smaller makes the runner's
+ * cold-start allowance — and its actionable timeout error — unreachable by
+ * construction, which is exactly how the pre-#243 45s value killed every
+ * heavy stdio connect.
+ *
+ * Deliberately NOT sized for classification retries (maximumAttempts: 2)
+ * or >~160-tool stdio servers, whose budgets scale past any flat ceiling —
+ * async/pollable discovery is the cure for those, not a longer wait.
+ *
+ * Trade-off, accepted: this is also the bound on "no runner ever picked up
+ * the task", so a connect against a dead runner now waits the full budget
+ * before DEADLINE_EXCEEDED. The local daemon supervises the runner
+ * (crash-restart), making that state pathological rather than designed; a
+ * CLI --timeout remains the caller's soft bound.
+ */
+export const CONNECT_TIMEOUT: ConnectBudget = {
+  ms: 420_000,
+  goLabel: "7m0s",
+};
+
+/**
+ * The WorkflowRunTimeout for connects started through the async lane
+ * (startConnect), where no client blocks on the result and the ceiling is
+ * a backstop rather than anyone's wait.
+ *
+ * Sized generously above the activity budgets that do the real
+ * budget-keeping (discovery hard-bounded at 600s; classification scales
+ * max(120, (n/40+1)*60)s with up to 2 attempts): one hour covers the
+ * discovery bound plus two classification attempts for servers up to
+ * ~800 tools — well past anything in the wild. Beyond that a flat
+ * backstop becomes the limiting factor again; if such a server ever
+ * exists, the ceiling should turn into a value derived from the
+ * discovered tool count, not a bigger constant.
+ *
+ * The dead-runner concern that shaped CONNECT_TIMEOUT does not apply
+ * here: the async lane surfaces "no worker is polling" as a start-time
+ * warning on ConnectStatus instead of making a client wait to find out.
+ */
+export const ASYNC_CONNECT_TIMEOUT: ConnectBudget = {
+  ms: 60 * 60 * 1000,
+  goLabel: "1h0m0s",
+};
+
+/**
+ * Added to a budget to bound a settle task's wait on the workflow result.
+ * The workflow's own WorkflowRunTimeout is the deadline that should fire
+ * first; this slightly longer bound is only a backstop so a settle task
+ * can never hang if Temporal becomes unreachable (Go
+ * bestEffortConnectGetBuffer).
+ */
+export const BEST_EFFORT_CONNECT_GET_BUFFER_MS = 15_000;
+
+/** The label selecting the user's personal environment (connect.go:74). */
+export const PERSONAL_ENV_LABEL = "stigmer.ai/personal";
+
+/**
+ * The narrow environment read surface the connect lanes consume for
+ * personal-environment resolution — satisfied by the composition root's
+ * in-process clients (DD-002: full interceptor traversal).
+ */
+export interface ConnectEnvironmentReader {
+  list(
+    request: MessageInitShape<typeof ListEnvironmentsRequestSchema>,
+  ): Promise<EnvironmentList>;
+  getSecretValue(
+    input: MessageInitShape<typeof EnvironmentSecretValueInputSchema>,
+  ): Promise<EnvironmentSpecValue>;
+}
+
+/**
+ * The ExecutionContext lifecycle surface for the ephemeral connect EC —
+ * Go's downstream executioncontext client (create + delete).
+ */
+export interface ConnectExecutionContextClient {
+  create(
+    executionContext: MessageInitShape<typeof ExecutionContextSchema>,
+  ): Promise<ExecutionContext>;
+  delete(
+    input: MessageInitShape<typeof ApiResourceDeleteInputSchema>,
+  ): Promise<ExecutionContext>;
+}
+
+/**
+ * Dependencies of the connect/OAuth slice — Go's optional
+ * SetConnectDependencies/SetOAuthDependencies fields, made REQUIRED
+ * constructor-style parameters per the composition-root idiom
+ * (guidelines §4): "Temporal is down" is the engine-state provider's
+ * modeled state, never a missing dependency. Ratified DB-1 consequence:
+ * the OAuth RPCs (managed-env service included) work on a Temporal-less
+ * server where Go's composition gate refuses completeOAuthConnect —
+ * disclosed, deliberately unpinned divergence.
+ */
+export interface McpServerConnectDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly engineState: McpServerEngineStateProvider;
+  readonly environmentReader: ConnectEnvironmentReader;
+  readonly executionContext: ConnectExecutionContextClient;
+  readonly runnerAuth: RunnerAuthService;
+  readonly managedEnv: ManagedEnvironmentService;
+  readonly oauthGrants: OAuthGrantStore;
+  readonly pendingOAuthStates: PendingOAuthStateStore;
+  readonly secretService: SecretService;
+  readonly oauthRedirectUri: string;
+}
+
+/**
+ * Everything prepareConnect resolves for a connect lane: the slim
+ * workflow input plus the ephemeral EC coordinates for cleanup.
+ */
+interface PreparedConnect {
+  readonly workflowInput: ConnectWorkflowInput;
+  readonly ecResourceId: string;
+  readonly executionId: string;
+}
+
+/**
+ * Connect — triggers server-side MCP discovery and tool approval
+ * classification via the runner's Temporal workflow, blocking until the
+ * operation settles (Go Connect, connect.go:165).
+ *
+ * Lifecycle: prepareConnect → start-or-attach → record CONNECTING (the
+ * same bookkeeping the async lane does, so observers see one consistent
+ * record regardless of which lane ran) → block on the result → persist
+ * capabilities + classifier output + terminal phase atomically → delete
+ * the ExecutionContext. Prefer startConnect for interactive clients: this
+ * RPC's response can outlive browser transport limits.
+ */
+export async function connect(
+  deps: McpServerConnectDeps,
+  input: ConnectInput,
+): Promise<McpServer> {
+  const engineState = deps.engineState();
+  if (!engineState.connected) {
+    throw failedPreconditionError(
+      "connect is not available: Temporal not configured",
+    );
+  }
+
+  const mcpServerId = input.mcpServerId;
+  if (mcpServerId === "") {
+    throw invalidArgumentError("mcp_server_id is required");
+  }
+  if (input.org === "") {
+    throw invalidArgumentError("org is required for connect");
+  }
+
+  let mcpServer: McpServer;
+  try {
+    mcpServer = await deps.store.getResource(
+      ApiResourceKind.mcp_server,
+      mcpServerId,
+      McpServerSchema,
+    );
+  } catch {
+    throw notFoundError("mcp_server", mcpServerId);
+  }
+
+  const prepared = await prepareConnect(deps, mcpServer, input);
+
+  try {
+    let run: ConnectRun;
+    try {
+      run = await engineState.engine.startOrAttachConnect(
+        mcpServerId,
+        prepared.workflowInput,
+        CONNECT_TIMEOUT.ms,
+      );
+    } catch (error) {
+      deps.logger.error("Failed to start MCP connect workflow", {
+        mcp_server_id: mcpServerId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw internalError(error, "failed to start connect workflow");
+    }
+
+    // Record the operation on connect_status. Skipped when attached: the
+    // lane that started the run already recorded it, and overwriting
+    // would reset its started_at. Best-effort — the blocking caller
+    // learns the outcome from this RPC's response either way.
+    if (!run.attached) {
+      try {
+        await persistConnectStarting(deps.store, mcpServerId, run.workflowId, "");
+      } catch (error) {
+        deps.logger.warn(
+          "Failed to record CONNECTING on connect_status (non-fatal)",
+          {
+            mcp_server_id: mcpServerId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    }
+
+    // Bounded even on the blocking lane: Go's wait rides the RPC context
+    // (unbounded when Temporal dies mid-await); here the budget+buffer
+    // race answers Internal instead of hanging the handler forever —
+    // unreachable while Temporal is alive, disclosed as a bounded-wait
+    // delta.
+    const outcome = await run.result(
+      CONNECT_TIMEOUT.ms + BEST_EFFORT_CONNECT_GET_BUFFER_MS,
+    );
+    if (!outcome.ok) {
+      const failure = mapConnectFailure(
+        deps.logger,
+        mcpServer,
+        run.workflowId,
+        outcome.failure,
+        CONNECT_TIMEOUT,
+      );
+      await persistConnectFailure(deps.store, deps.logger, mcpServerId, failure);
+      throw failure;
+    }
+
+    // Persist discovered capabilities + the connect-time classifier
+    // output (layer 1 of the approval policy chain) atomically. The
+    // freshly-read, updated resource is returned to the caller.
+    let persisted: McpServer;
+    let toolApprovalCount: number;
+    try {
+      ({ persisted, toolApprovalCount } = await persistConnectResult(
+        deps.store,
+        mcpServerId,
+        run.workflowId,
+        outcome.output,
+      ));
+    } catch (error) {
+      throw internalError(error, "failed to save mcp server after connect");
+    }
+
+    deps.logger.info("MCP server connect completed and stored", {
+      mcp_server_id: mcpServerId,
+      tools: persisted.status?.discoveredCapabilities?.tools.length ?? 0,
+      resource_templates:
+        persisted.status?.discoveredCapabilities?.resourceTemplates.length ?? 0,
+      tool_approvals: toolApprovalCount,
+    });
+
+    return persisted;
+  } finally {
+    if (prepared.ecResourceId !== "") {
+      await deleteConnectExecutionContext(
+        deps,
+        prepared.ecResourceId,
+        prepared.executionId,
+      );
+    }
+  }
+}
+
+/**
+ * The caller-context half of a connect: the OAuth refresh pre-flight,
+ * ephemeral ExecutionContext creation, and decrypt-lane token minting
+ * (Go prepareConnect).
+ *
+ * Both the blocking (connect) and async (startConnect) lanes run this
+ * synchronously inside the RPC handler, because everything here needs the
+ * caller's identity: OAuth refresh and personal-environment resolution
+ * read the caller's grant and secrets, which a background task has no
+ * request context to do (the same constraint that scopes
+ * startBestEffortConnect to env-less servers).
+ */
+export async function prepareConnect(
+  deps: McpServerConnectDeps,
+  mcpServer: McpServer,
+  input: ConnectInput,
+): Promise<PreparedConnect> {
+  const mcpServerId = mcpServer.metadata?.id ?? "";
+  const callerOrg = input.org;
+
+  // Pre-flight: refresh expired OAuth tokens before env resolution. Only
+  // applies when runtime_env is empty and the MCP server has an auth
+  // block with an existing OAuthGrant. Tokens are refreshed in the
+  // grant's managed environment.
+  if (Object.keys(input.runtimeEnv).length === 0) {
+    await refreshOAuthTokenIfNeeded(deps, mcpServer, callerOrg);
+  }
+
+  const executionId = `connect-${mcpServerId}-${randomUUID().slice(0, 8)}`;
+
+  const ecResourceId = await createConnectExecutionContext(
+    deps,
+    mcpServer,
+    executionId,
+    callerOrg,
+    input.runtimeEnv,
+  );
+
+  const workflowInput: ConnectWorkflowInput = {
+    mcp_server_id: mcpServerId,
+    ...(ecResourceId !== "" ? { execution_context_id: executionId } : {}),
+  };
+
+  // Mint the decrypt-lane token for the EC just created (oss#535) — see
+  // the engine.ts ConnectWorkflowInput doc for why this rides the
+  // payload. Minting failure degrades, not fails: discovery of a server
+  // with declared credentials will refuse the redacted read with an
+  // actionable error, and credential-less servers connect fine without
+  // the token.
+  if (ecResourceId !== "" && deps.runnerAuth.isEnabled()) {
+    try {
+      const minted = deps.runnerAuth.mint(executionId, 0);
+      return {
+        workflowInput: {
+          ...workflowInput,
+          execution_context_token: minted.token,
+        },
+        ecResourceId,
+        executionId,
+      };
+    } catch (error) {
+      deps.logger.warn(
+        "Failed to mint connect EC token — discovery will read redacted credentials",
+        {
+          execution_id: executionId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
+
+  return { workflowInput, ecResourceId, executionId };
+}
+
+/**
+ * Builds and persists an ephemeral ExecutionContext for the connect
+ * activity (Go createConnectExecutionContext).
+ *
+ * When runtime_env is provided, the values are used directly (one-time
+ * use). When runtime_env is empty, variables are resolved from two
+ * sources: OAuth-managed variables from the grant's managed environment,
+ * the remainder from the user's personal environment. Returns "" when the
+ * MCP server has no env declarations and no runtime_env.
+ */
+async function createConnectExecutionContext(
+  deps: McpServerConnectDeps,
+  mcpServer: McpServer,
+  executionId: string,
+  callerOrg: string,
+  runtimeEnv: { [key: string]: ExecutionValue },
+): Promise<string> {
+  let ecData: { [key: string]: ExecutionValue };
+
+  if (Object.keys(runtimeEnv).length > 0) {
+    ecData = runtimeEnv;
+    deps.logger.info(
+      "Using runtime_env for connect ExecutionContext (one-time use)",
+      {
+        execution_id: executionId,
+        runtime_env_count: Object.keys(runtimeEnv).length,
+      },
+    );
+  } else {
+    const envDecls = mcpServer.spec?.env ?? {};
+    if (Object.keys(envDecls).length === 0) {
+      deps.logger.debug(
+        "MCP server has no env declarations — skipping ExecutionContext creation",
+        { execution_id: executionId },
+      );
+      return "";
+    }
+
+    const mcpServerId = mcpServer.metadata?.id ?? "";
+
+    // Split resolution: OAuth vars from managed env, rest from personal.
+    const { oauthVars, remainingDecls } = await resolveOAuthVarsFromManagedEnv(
+      deps,
+      mcpServerId,
+      callerOrg,
+      envDecls,
+    );
+
+    let personalVars: { [key: string]: ExecutionValue } = {};
+    if (Object.keys(remainingDecls).length > 0) {
+      personalVars = await resolveFromPersonalEnvironment(
+        deps,
+        callerOrg,
+        remainingDecls,
+      );
+    }
+
+    ecData = { ...personalVars, ...oauthVars };
+
+    deps.logger.info("Resolved env vars for connect ExecutionContext", {
+      execution_id: executionId,
+      oauth_count: Object.keys(oauthVars).length,
+      personal_count: Object.keys(personalVars).length,
+    });
+  }
+
+  if (Object.keys(ecData).length === 0) {
+    return "";
+  }
+
+  let created: ExecutionContext;
+  try {
+    created = await deps.executionContext.create(
+      create(ExecutionContextSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "ExecutionContext",
+        metadata: {
+          name: `exec-ctx-${executionId}`,
+          org: callerOrg,
+        },
+        spec: {
+          executionId,
+          data: ecData,
+        },
+      }),
+    );
+  } catch (error) {
+    throw internalError(error, "failed to create connect ExecutionContext");
+  }
+
+  const resourceId = created.metadata?.id ?? "";
+  deps.logger.info("Created ephemeral ExecutionContext for MCP connect", {
+    execution_context_id: resourceId,
+    execution_id: executionId,
+    data_entries: Object.keys(ecData).length,
+  });
+
+  return resourceId;
+}
+
+/**
+ * Reads OAuth-managed variables from the grant's managed environment and
+ * returns them along with the remaining declarations that still need the
+ * personal environment (Go resolveOAuthVarsFromManagedEnv). If no grant
+ * exists or reads fail, all declarations are returned as "remaining" —
+ * the personal-env fallback Go takes on the same arms.
+ */
+async function resolveOAuthVarsFromManagedEnv(
+  deps: McpServerConnectDeps,
+  mcpServerId: string,
+  org: string,
+  envDecls: { [key: string]: EnvVarDeclaration },
+): Promise<{
+  oauthVars: { [key: string]: ExecutionValue };
+  remainingDecls: { [key: string]: EnvVarDeclaration };
+}> {
+  let grant;
+  try {
+    grant = await deps.oauthGrants.find("", mcpServerId, org);
+  } catch {
+    // A grant-store read failure falls through to the personal env,
+    // exactly Go's err-folded arm.
+    return { oauthVars: {}, remainingDecls: envDecls };
+  }
+  if (grant === undefined || grant.environmentId === "") {
+    return { oauthVars: {}, remainingDecls: envDecls };
+  }
+
+  const oauthKey = grant.accessTokenEnvVar;
+  if (!(oauthKey in envDecls)) {
+    return { oauthVars: {}, remainingDecls: envDecls };
+  }
+
+  let tokenValue = "";
+  try {
+    tokenValue = await deps.managedEnv.readSecretValue(
+      grant.environmentId,
+      oauthKey,
+    );
+  } catch (error) {
+    deps.logger.warn(
+      "Failed to read OAuth token from managed environment — falling back to personal env",
+      {
+        mcp_server_id: mcpServerId,
+        oauth_key: oauthKey,
+        managed_env_id: grant.environmentId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return { oauthVars: {}, remainingDecls: envDecls };
+  }
+  if (tokenValue === "") {
+    deps.logger.warn(
+      "Failed to read OAuth token from managed environment — falling back to personal env",
+      {
+        mcp_server_id: mcpServerId,
+        oauth_key: oauthKey,
+        managed_env_id: grant.environmentId,
+      },
+    );
+    return { oauthVars: {}, remainingDecls: envDecls };
+  }
+
+  const remainingDecls: { [key: string]: EnvVarDeclaration } = {};
+  for (const [k, v] of Object.entries(envDecls)) {
+    if (k !== oauthKey) {
+      remainingDecls[k] = v;
+    }
+  }
+
+  deps.logger.debug("Resolved OAuth token from managed environment", {
+    mcp_server_id: mcpServerId,
+    oauth_key: oauthKey,
+    managed_env_id: grant.environmentId,
+  });
+
+  return {
+    oauthVars: {
+      [oauthKey]: create(ExecutionValueSchema, {
+        value: tokenValue,
+        isSecret: true,
+      }),
+    },
+    remainingDecls,
+  };
+}
+
+/**
+ * Reads environment variables from the user's personal environment
+ * (labeled stigmer.ai/personal=true; Go resolveFromPersonalEnvironment).
+ * Required variables (optional=false, the default) must be present;
+ * optional variables are included when available but silently skipped
+ * when missing.
+ */
+async function resolveFromPersonalEnvironment(
+  deps: McpServerConnectDeps,
+  org: string,
+  envDecls: { [key: string]: EnvVarDeclaration },
+): Promise<{ [key: string]: ExecutionValue }> {
+  const requiredKeys: string[] = [];
+  for (const [k, decl] of Object.entries(envDecls)) {
+    if (!decl.optional) {
+      requiredKeys.push(k);
+    }
+  }
+
+  let listResponse: EnvironmentList;
+  try {
+    listResponse = await deps.environmentReader.list({
+      org,
+      labels: { [PERSONAL_ENV_LABEL]: "true" },
+    });
+  } catch (error) {
+    throw internalError(error, "failed to list personal environments");
+  }
+  if (listResponse.totalCount === 0 || listResponse.items.length === 0) {
+    if (requiredKeys.length === 0) {
+      return {};
+    }
+    // Go renders the key list with %v — bracketed, space-separated.
+    throw failedPreconditionError(
+      `personal environment not found for org '${org}'; save required credentials first: [${requiredKeys.join(" ")}]`,
+    );
+  }
+
+  const personalEnv = listResponse.items[0];
+  const personalEnvId = personalEnv?.metadata?.id ?? "";
+  const storedKeys = new Set(Object.keys(personalEnv?.spec?.data ?? {}));
+
+  const result: { [key: string]: ExecutionValue } = {};
+  const missing: string[] = [];
+
+  for (const [key, decl] of Object.entries(envDecls)) {
+    if (!storedKeys.has(key)) {
+      if (decl.optional) {
+        deps.logger.debug(
+          "Optional env var not in personal environment — skipping",
+          { key },
+        );
+        continue;
+      }
+      missing.push(key);
+      continue;
+    }
+
+    let secretValue: EnvironmentSpecValue;
+    try {
+      secretValue = await deps.environmentReader.getSecretValue({
+        environmentId: personalEnvId,
+        key,
+      });
+    } catch (error) {
+      deps.logger.warn("Failed to get secret value from personal environment", {
+        key,
+        personal_env_id: personalEnvId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      if (decl.optional) {
+        continue;
+      }
+      missing.push(key);
+      continue;
+    }
+    if (secretValue.value === "") {
+      if (decl.optional) {
+        continue;
+      }
+      missing.push(key);
+      continue;
+    }
+
+    result[key] = create(ExecutionValueSchema, {
+      value: secretValue.value,
+      isSecret: decl.isSecret,
+    });
+  }
+
+  if (missing.length > 0) {
+    throw failedPreconditionError(
+      `missing required credentials in personal environment: [${missing.join(" ")}]`,
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Removes the ephemeral ExecutionContext after the connect workflow
+ * completes (Go deleteConnectExecutionContext). Failures are logged but
+ * not propagated, since the result is already stored.
+ */
+export async function deleteConnectExecutionContext(
+  deps: McpServerConnectDeps,
+  resourceId: string,
+  executionId: string,
+): Promise<void> {
+  try {
+    await deps.executionContext.delete({ resourceId });
+  } catch (error) {
+    deps.logger.warn("Failed to delete connect ExecutionContext (non-fatal)", {
+      resource_id: resourceId,
+      execution_id: executionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  deps.logger.debug("Deleted ephemeral connect ExecutionContext", {
+    resource_id: resourceId,
+    execution_id: executionId,
+  });
+}
+
+/**
+ * Maps a classified connect-run failure to the gRPC status the connect
+ * contract promises (Go awaitConnectWorkflow's switch, connect.go:661-694).
+ * budget is the WorkflowRunTimeout the run was started with, named in the
+ * DEADLINE_EXCEEDED message so the error reports the ceiling that
+ * actually fired.
+ */
+export function mapConnectFailure(
+  logger: Logger,
+  mcpServer: McpServer,
+  workflowId: string,
+  failure: ConnectRunFailure,
+  budget: ConnectBudget,
+): ConnectError {
+  const mcpServerId = mcpServer.metadata?.id ?? "";
+  logger.error("MCP connect workflow failed", {
+    workflow_id: workflowId,
+    mcp_server_id: mcpServerId,
+    failure_kind: failure.kind,
+  });
+
+  switch (failure.kind) {
+    case "application":
+      // FAILED_PRECONDITION, not INTERNAL (issue #239): an application
+      // error from the connect workflow means the TARGET server (or its
+      // credentials/config) refused the connect — the runner's message
+      // is crafted for the user, and clients render FAILED_PRECONDITION
+      // messages verbatim while (correctly) hiding INTERNAL detail.
+      return failedPreconditionError(
+        buildConnectFailureMessage(mcpServer, failure.message),
+      );
+    case "timeout":
+      // Name the budget that fired (issue #243): the runner's own bounds
+      // fail earlier with specific, actionable errors, so reaching this
+      // ceiling usually means the runner never served the task at all.
+      return new ConnectError(
+        `connect did not complete within the ${budget.goLabel} budget for MCP server '${mcpServerId}' — ` +
+          "if this repeats, check that your runner is running and healthy",
+        Code.DeadlineExceeded,
+      );
+    case "service-not-found":
+      return unavailableError(
+        `connect service temporarily unavailable for MCP server '${mcpServerId}'`,
+      );
+    case "other": {
+      // Deliberate exception to the "internal causes stay off the wire"
+      // rule (stigmer/stigmer#478): the cause here is the runner's own
+      // CLASSIFIED, user-facing connect-failure text, not raw server
+      // internals — so the message rides the wire, NOT the sanitized
+      // internalError helper. Connect failures are user-debugged
+      // configuration problems; the classified cause is the product.
+      return new ConnectError(
+        buildConnectFailureMessage(mcpServer, failure.message),
+        Code.Internal,
+      );
+    }
+    default: {
+      const exhaustive: never = failure;
+      throw new Error(`unhandled connect failure ${String(exhaustive)}`);
+    }
+  }
+}
+
+/**
+ * Builds a user-facing, transport-aware connect failure message (Go
+ * buildConnectFailureMessage), replacing the raw ExceptionGroup/TaskGroup
+ * text that told users nothing.
+ *
+ * In the OSS/local edition the local runner spawns stdio servers on the
+ * user's own machine, so a stdio failure is usually a missing command or
+ * bad args/environment — and previewing discovery locally with --dry-run
+ * is the fastest way to diagnose it. HTTP servers fail on reachability or
+ * credentials.
+ */
+export function buildConnectFailureMessage(
+  mcpServer: McpServer,
+  cause: string,
+): string {
+  const name = mcpServer.metadata?.name ?? "";
+  // The runner classifies a 401 OAuth challenge into a self-contained,
+  // user-facing message (see runner mcp-oauth-detect.ts). It already
+  // names the server and tells the user to sign in, so pass it through
+  // verbatim rather than wrapping it with a generic "check your
+  // credentials" suffix that would contradict it. The "requires OAuth"
+  // phrase is the stable marker.
+  if (cause.includes("requires OAuth")) {
+    return cause;
+  }
+  if (mcpServer.spec?.serverType.case === "stdio") {
+    const slug = mcpServer.metadata?.slug ?? "";
+    return (
+      `connect failed for MCP server '${name}': ${cause}. This is a stdio server launched ` +
+      "by your local runner — verify the command is installed and its arguments " +
+      "and environment variables are correct. Preview discovery locally with: " +
+      `stigmer connect mcp-server ${slug} --dry-run`
+    );
+  }
+  return (
+    `connect failed for MCP server '${name}': ${cause}. Check that the server URL is ` +
+    "reachable and your credentials are valid."
+  );
+}
+
+/**
+ * Checks whether the MCP server has an auth block with an existing
+ * OAuthGrant, and if the access token is expired, refreshes it using the
+ * refresh token from the grant's managed environment (Go
+ * refreshOAuthTokenIfNeeded) — the pre-flight that ensures the connect
+ * workflow (and agent execution) always sees a fresh token.
+ */
+export async function refreshOAuthTokenIfNeeded(
+  deps: McpServerConnectDeps,
+  mcpServer: McpServer,
+  callerOrg: string,
+): Promise<void> {
+  const auth = mcpServer.spec?.auth;
+  if (auth === undefined) {
+    return;
+  }
+
+  const mcpServerId = mcpServer.metadata?.id ?? "";
+
+  // OSS mode: single user, empty identity_account_id. Org comes from the
+  // caller's active org (matches how the grant was stored).
+  let grant;
+  try {
+    grant = await deps.oauthGrants.find("", mcpServerId, callerOrg);
+  } catch (error) {
+    deps.logger.warn("Failed to load OAuth grant for pre-flight check (non-fatal)", {
+      mcp_server_id: mcpServerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  if (grant === undefined) {
+    return;
+  }
+
+  if (grant.environmentId === "") {
+    deps.logger.warn(
+      "OAuth grant has no managed environment ID — user must re-authenticate via OAuth Connect",
+      { mcp_server_id: mcpServerId },
+    );
+    return;
+  }
+
+  let refreshTokenValue: string;
+  try {
+    refreshTokenValue = await deps.managedEnv.readSecretValue(
+      grant.environmentId,
+      grant.refreshTokenEnvVar,
+    );
+  } catch (error) {
+    // Silent skip, ported as-is (oss#863's second half): a failed
+    // refresh-token read proceeds with the stale token instead of
+    // failing fast with the re-authenticate message — which is why
+    // refresh.ts's empty-token error is unreachable through this path.
+    deps.logger.debug(
+      "No refresh token found in managed environment (may not be OAuth-connected)",
+      {
+        mcp_server_id: mcpServerId,
+        refresh_token_var: grant.refreshTokenEnvVar,
+        managed_env_id: grant.environmentId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return;
+  }
+
+  // For vendor OAuth, the client_secret and its token-endpoint auth
+  // method come from the OAuthApp. For DCR, both are empty (public
+  // client).
+  let clientSecret = "";
+  let tokenAuthMethod = "";
+  if (grant.authMethod === "vendor_oauth") {
+    try {
+      ({ clientSecret, tokenAuthMethod } = await loadOAuthAppClientCredentials(
+        deps,
+        mcpServer,
+      ));
+    } catch (error) {
+      deps.logger.warn("Failed to load OAuthApp client secret for refresh", {
+        mcp_server_id: mcpServerId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  let result;
+  try {
+    result = await refreshTokenIfExpired(
+      grant,
+      refreshTokenValue,
+      clientSecret,
+      tokenAuthMethod,
+      deps.logger,
+    );
+  } catch (error) {
+    throw failedPreconditionError(
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  if (!result.refreshed) {
+    return;
+  }
+
+  // Write refreshed tokens to the grant's managed environment.
+  const tokenVars: { [key: string]: EnvironmentSpecValue } = {
+    [grant.accessTokenEnvVar]: create(EnvironmentValueSchema, {
+      value: result.newAccessToken,
+      isSecret: true,
+    }),
+  };
+  if (result.newRefreshToken !== refreshTokenValue) {
+    tokenVars[grant.refreshTokenEnvVar] = create(EnvironmentValueSchema, {
+      value: result.newRefreshToken,
+      isSecret: true,
+    });
+  }
+
+  try {
+    await deps.managedEnv.updateSecrets(grant.environmentId, tokenVars);
+  } catch (error) {
+    throw internalError(
+      error,
+      "failed to update refreshed tokens in managed environment",
+    );
+  }
+
+  try {
+    await deps.oauthGrants.upsert({
+      ...grant,
+      accessTokenExpiresAt: result.newExpiresAt,
+    });
+  } catch (error) {
+    deps.logger.warn("Failed to update OAuth grant after refresh (non-fatal)", {
+      mcp_server_id: mcpServerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
+ * Loads the decrypted client_secret and the token-endpoint auth method
+ * from the referenced OAuthApp for vendor OAuth token refresh (Go
+ * loadOAuthAppClientCredentials). The method is read LIVE (not
+ * snapshotted on the grant) so an admin correcting a misconfigured
+ * OAuthApp fixes refreshes immediately.
+ *
+ * Resolution goes through refresolution — the same lookup the initiate
+ * path used when the grant was minted — so the refresh always runs
+ * against the credentials the user actually signed in with (the old
+ * slug-only scan could load a same-slug app from a different org,
+ * stigmer/stigmer#584).
+ */
+export async function loadOAuthAppClientCredentials(
+  deps: McpServerConnectDeps,
+  mcpServer: McpServer,
+): Promise<{ clientSecret: string; tokenAuthMethod: string }> {
+  const ref = mcpServer.spec?.auth?.oauthAppRef;
+  if (ref === undefined || ref.slug === "") {
+    return { clientSecret: "", tokenAuthMethod: "" };
+  }
+
+  let app;
+  try {
+    app = await resolveOAuthAppRef(deps.store, ref, deps.logger);
+  } catch (error) {
+    throw new Error(
+      `failed to list oauth apps: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (app === undefined) {
+    throw new Error(`OAuthApp '${ref.slug}' not found`);
+  }
+
+  const tokenAuthMethod = tokenAuthMethodFromSpec(
+    app.spec?.tokenEndpointAuthMethod ?? TokenEndpointAuthMethod.UNSPECIFIED,
+  );
+
+  let secret = app.spec?.clientSecret ?? "";
+  if (deps.secretService.isEncrypted(secret)) {
+    secret = deps.secretService.decrypt(secret);
+  }
+  return { clientSecret: secret, tokenAuthMethod };
+}
+
+/**
+ * Maps the OAuthAppSpec enum onto the oauth package's RFC 8414 strings
+ * (Go tokenAuthMethodFromSpec). UNSPECIFIED means Basic — every OAuthApp
+ * created before the field existed authenticated via HTTP Basic.
+ */
+export function tokenAuthMethodFromSpec(
+  method: TokenEndpointAuthMethod,
+): string {
+  if (method === TokenEndpointAuthMethod.CLIENT_SECRET_POST) {
+    return TOKEN_AUTH_METHOD_POST;
+  }
+  return TOKEN_AUTH_METHOD_BASIC;
+}
+
+/**
+ * Runs the connect workflow for a freshly applied MCP server and persists
+ * its discovered capabilities + classifier tool-approvals (Go
+ * StartBestEffortConnect). Apply launches it fire-and-forget: every
+ * failure is logged, never propagated. Persistence is shared with the
+ * synchronous connect path via persistConnectResult, so auto-connect and
+ * manual connect store byte-identical results.
+ *
+ * A disconnected engine returns SILENTLY — byte parity with Go's
+ * nil-temporalClient no-op (connect.go:1048). Servers that declare env
+ * vars are skipped: creating an ExecutionContext requires the caller's
+ * request context (for personal environment resolution), which a
+ * background task does not have. If the server is deleted before the
+ * workflow completes, persistence is skipped — expected for best-effort.
+ */
+export async function startBestEffortConnect(
+  deps: McpServerConnectDeps,
+  mcpServer: McpServer,
+): Promise<void> {
+  const engineState = deps.engineState();
+  if (!engineState.connected) {
+    return;
+  }
+
+  const envKeys = Object.keys(mcpServer.spec?.env ?? {}).length;
+  if (envKeys > 0) {
+    deps.logger.debug(
+      "Skipping best-effort auto-connect: MCP server has env declarations (requires manual connect)",
+      {
+        mcp_server_id: mcpServer.metadata?.id ?? "",
+        env_keys: envKeys,
+      },
+    );
+    return;
+  }
+
+  const mcpServerId = mcpServer.metadata?.id ?? "";
+
+  let run: ConnectRun;
+  try {
+    run = await engineState.engine.startOrAttachConnect(
+      mcpServerId,
+      { mcp_server_id: mcpServerId },
+      CONNECT_TIMEOUT.ms,
+    );
+  } catch (error) {
+    deps.logger.warn("Failed to start best-effort connect workflow (non-fatal)", {
+      mcp_server_id: mcpServerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+
+  // Record CONNECTING like the other lanes so an observer of a freshly
+  // applied server sees the auto-connect in progress rather than
+  // nothing. Skipped when attached (the starting lane's record stands);
+  // failures stay non-fatal like everything else on this path.
+  if (!run.attached) {
+    try {
+      await persistConnectStarting(deps.store, mcpServerId, run.workflowId, "");
+    } catch (error) {
+      deps.logger.warn(
+        "Failed to record CONNECTING for best-effort connect (non-fatal)",
+        {
+          mcp_server_id: mcpServerId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
+
+  const outcome = await run.result(
+    CONNECT_TIMEOUT.ms + BEST_EFFORT_CONNECT_GET_BUFFER_MS,
+  );
+  if (!outcome.ok) {
+    deps.logger.warn(
+      "Best-effort connect workflow did not complete (non-fatal)",
+      {
+        workflow_id: run.workflowId,
+        mcp_server_id: mcpServerId,
+        failure_kind: outcome.failure.kind,
+      },
+    );
+    await persistConnectFailure(
+      deps.store,
+      deps.logger,
+      mcpServerId,
+      internalError(
+        new Error(`connect run failed: ${outcome.failure.kind}`),
+        "best-effort connect did not complete",
+      ),
+    );
+    return;
+  }
+
+  let persisted: McpServer;
+  let toolApprovalCount: number;
+  try {
+    ({ persisted, toolApprovalCount } = await persistConnectResult(
+      deps.store,
+      mcpServerId,
+      run.workflowId,
+      outcome.output,
+    ));
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      deps.logger.info(
+        "Skipping best-effort connect persistence: MCP server deleted before connect completed",
+        { mcp_server_id: mcpServerId },
+      );
+      return;
+    }
+    deps.logger.warn("Failed to persist best-effort connect result (non-fatal)", {
+      mcp_server_id: mcpServerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+
+  deps.logger.info("Best-effort auto-connect completed and stored", {
+    workflow_id: run.workflowId,
+    mcp_server_id: mcpServerId,
+    tools: persisted.status?.discoveredCapabilities?.tools.length ?? 0,
+    resource_templates:
+      persisted.status?.discoveredCapabilities?.resourceTemplates.length ?? 0,
+    tool_approvals: toolApprovalCount,
+  });
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/controller.ts
@@ -1,30 +1,32 @@
 /**
- * McpServer controller — ports pkg/domain/mcpserver/controller's CRUD
- * slice (D4 entry #9): the declarative MCP server surface. Registered
- * methods: apply/create/update/delete/updateVisibility on the command
- * side; get/getByReference on the query side; plus the three org-OAuth
- * RPCs as PERMANENT UNIMPLEMENTED stubs (below).
+ * McpServer controller — ports pkg/domain/mcpserver/controller whole:
+ * the CRUD slice (D4 entry #9) and the connect/OAuth slice (D4 entry
+ * #19). Registered methods: apply/create/update/delete/updateVisibility +
+ * connect/startConnect/initiateOAuthConnect/completeOAuthConnect/
+ * disconnectOAuth on the command side; get/getByReference/
+ * getOAuthGrantStatus on the query side; plus the three org-OAuth RPCs as
+ * PERMANENT UNIMPLEMENTED stubs (below).
  *
- * The connect/OAuth slice (connect, startConnect, initiateOAuthConnect,
- * completeOAuthConnect, disconnectOAuth, getOAuthGrantStatus) arrives
- * with #19 — those methods stay unregistered here; connect-es answers
- * them Unimplemented with its own generated text. Go's constructor takes
- * only the store for exactly this slice; its connect/OAuth deps are
- * optional setters. The interim gap is DISCLOSED, not uniform
- * "unported" lag: Go wires the OAuth deps unconditionally (server.go:718),
- * so getOAuthGrantStatus, completeOAuthConnect, and disconnectOAuth give
- * real answers on Go today (grant-status even answers NO_GRANT with a nil
- * store), and connect/startConnect answer FailedPrecondition on a
- * Temporal-less Go rather than Unimplemented. Clients treating
- * Unimplemented as capability-absent (the SDK's posture) degrade
- * gracefully; the surfaces themselves return with #19.
+ * The connect/OAuth slice lives in sibling modules named for their Go
+ * files (connect.ts, start-connect.ts, initiate-oauth-connect.ts,
+ * complete-oauth-connect.ts, disconnect-oauth.ts,
+ * get-oauth-grant-status.ts; shared status bookkeeping in
+ * connect-status.ts). They are plain handlers — Go uses no pipeline for
+ * this slice — over the McpServerConnectDeps the composition root wires.
+ * Engine availability is the modeled state: connect/startConnect refuse
+ * FailedPrecondition while disconnected; the OAuth RPCs serve
+ * unconditionally (DB-1, sub-project 20260825.02 — Go's Temporal-gated
+ * managed-env wiring is a disclosed, deliberately unpinned composition
+ * artifact).
  *
  * Versus Stigmer Cloud, OSS excludes the Authorize, CreateIamPolicies,
  * and Publish steps (no multi-tenant auth, IAM/FGA, or event publishing).
  *
  * Proven by mcpserver.conformance.test.ts +
- * agent-mcpserver-references.conformance.test.ts
- * (CONFORMANCE_TARGET=local-ts) and __tests__/mcpserver.test.ts.
+ * agent-mcpserver-references.conformance.test.ts +
+ * mcpserver-oauth.conformance.test.ts (CONFORMANCE_TARGET=local-ts),
+ * mcpserver-connect.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts-execution), and __tests__/.
  */
 import { Code, ConnectError } from "@connectrpc/connect";
 import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
@@ -72,7 +74,14 @@ import {
   newValidateVisibilityUpdateStep,
 } from "../../pipeline/steps/validate-visibility.js";
 import type { Store } from "../../store/interface.js";
+import { completeOAuthConnect } from "./complete-oauth-connect.js";
+import { connect, startBestEffortConnect } from "./connect.js";
+import type { McpServerConnectDeps } from "./connect.js";
+import { disconnectOAuth } from "./disconnect-oauth.js";
+import { getOAuthGrantStatus } from "./get-oauth-grant-status.js";
+import { initiateOAuthConnect } from "./initiate-oauth-connect.js";
 import { mcpServerSearchExtractor } from "./search-extractor.js";
+import { startConnect } from "./start-connect.js";
 import {
   newEnrichOAuthStatusStep,
   newValidateDefaultEnabledToolsStep,
@@ -81,6 +90,8 @@ import {
 export interface McpServerControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The connect/OAuth slice's dependencies (D4 #19). */
+  readonly connect: McpServerConnectDeps;
 }
 
 /** Registers both mcpserver services on the router (routes stage). */
@@ -94,6 +105,11 @@ export function registerMcpServerServices(
     update: (server, ctx) => update(deps, server, ctx),
     updateVisibility: (input, ctx) => updateVisibility(deps, input, ctx),
     delete: (input, ctx) => deleteMcpServer(deps, input, ctx),
+    connect: (input) => connect(deps.connect, input),
+    startConnect: (input) => startConnect(deps.connect, input),
+    initiateOAuthConnect: (input) => initiateOAuthConnect(deps.connect, input),
+    completeOAuthConnect: (input) => completeOAuthConnect(deps.connect, input),
+    disconnectOAuth: (input) => disconnectOAuth(deps.connect, input),
     setOrgOAuthApp: () => {
       throw orgOAuthAppUnimplemented("SetOrgOAuthApp");
     },
@@ -104,6 +120,7 @@ export function registerMcpServerServices(
   router.service(McpServerQueryController, {
     get: (id, ctx) => get(deps, id, ctx),
     getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    getOAuthGrantStatus: (input) => getOAuthGrantStatus(deps.connect, input),
     getOrgOAuthApp: () => {
       throw orgOAuthAppUnimplemented("GetOrgOAuthApp");
     },
@@ -193,12 +210,11 @@ async function update(
  * Apply — kubectl-style create-or-update: a minimal probe pipeline
  * decides existence, then delegates with the ORIGINAL request message.
  *
- * Go's tail fires `go StartBestEffortConnect(result)` here — auto
- * discovery through the runner's Temporal workflow. That call is a SILENT
- * no-op when connect dependencies are absent (connect.go:1046: nil
- * temporalClient returns immediately), which is this server's exact state
- * until #19 wires the connect slice — so its absence here IS byte-parity,
- * not an approximation. #19 adds the seam.
+ * The tail fires startBestEffortConnect on the result — Go's
+ * `go StartBestEffortConnect(result)` (apply.go:76), auto discovery
+ * through the runner's connect workflow. Fire-and-forget on purpose: the
+ * gRPC response must not wait on a discovery run; a disconnected engine
+ * makes it a silent no-op (byte parity with Go's nil-client return).
  */
 async function apply(
   deps: McpServerControllerDeps,
@@ -220,9 +236,20 @@ async function apply(
       "apply operation failed to determine create vs update",
     );
   }
-  return shouldCreate
-    ? createMcpServer(deps, server, ctx)
-    : update(deps, server, ctx);
+  const result = shouldCreate
+    ? await createMcpServer(deps, server, ctx)
+    : await update(deps, server, ctx);
+
+  // startBestEffortConnect's arms never throw by design; the catch is
+  // the process-safety net an unhandled rejection would pierce.
+  void startBestEffortConnect(deps.connect, result).catch((error: unknown) => {
+    deps.logger.warn("Best-effort connect task failed unexpectedly", {
+      mcp_server_id: result.metadata?.id ?? "",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+
+  return result;
 }
 
 /**

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/disconnect-oauth.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/disconnect-oauth.ts
@@ -1,0 +1,91 @@
+/**
+ * disconnectOAuth — ports
+ * pkg/domain/mcpserver/controller/disconnect_oauth.go: tear down a user's
+ * OAuth connection for an MCP server. Deletes the OAuthGrant record and
+ * its associated managed environment (which holds the access and refresh
+ * tokens); the MCP server definition is unchanged.
+ *
+ * Idempotent: no grant for the (caller, resource_id, org) tuple returns
+ * disconnected=false without error — race conditions, retries after
+ * partial failures, and desired-state semantics all rely on it.
+ *
+ * Delete order: managed environment first (eliminates secrets), then
+ * grant record (metadata only). If grant deletion fails after environment
+ * deletion, the orphaned grant is harmless metadata pointing to a deleted
+ * environment.
+ *
+ * Proven by mcpserver-oauth.conformance.test.ts (guards + no-grant
+ * idempotence, CONFORMANCE_TARGET=local-ts) and
+ * mcpserver-connect.conformance.test.ts (teardown,
+ * CONFORMANCE_TARGET=local-ts-execution).
+ */
+import { create } from "@bufbuild/protobuf";
+
+import type {
+  DisconnectOAuthInput,
+  DisconnectOAuthOutput,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { DisconnectOAuthOutputSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+
+import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
+import type { McpServerConnectDeps } from "./connect.js";
+
+export async function disconnectOAuth(
+  deps: McpServerConnectDeps,
+  input: DisconnectOAuthInput,
+): Promise<DisconnectOAuthOutput> {
+  const resourceId = input.resourceId;
+  if (resourceId === "") {
+    throw invalidArgumentError("resource_id is required");
+  }
+  const org = input.org;
+  if (org === "") {
+    throw invalidArgumentError("org is required");
+  }
+
+  // OSS mode: single user, empty identity_account_id.
+  let grant;
+  try {
+    grant = await deps.oauthGrants.find("", resourceId, org);
+  } catch (error) {
+    throw internalError(error, "failed to look up OAuth grant");
+  }
+
+  if (grant === undefined) {
+    deps.logger.debug("No OAuth grant to disconnect", {
+      resource_id: resourceId,
+      org,
+    });
+    return create(DisconnectOAuthOutputSchema, { disconnected: false });
+  }
+
+  const envId = grant.environmentId;
+  if (envId !== "") {
+    try {
+      await deps.managedEnv.deleteManagedEnvironment(envId);
+    } catch (error) {
+      deps.logger.warn(
+        "Failed to delete managed environment — may already be deleted",
+        {
+          resource_id: resourceId,
+          environment_id: envId,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
+
+  try {
+    await deps.oauthGrants.delete("", resourceId, org);
+  } catch (error) {
+    throw internalError(error, "failed to delete OAuth grant");
+  }
+
+  deps.logger.info("OAuth connection disconnected", {
+    resource_id: resourceId,
+    org,
+    env_deleted: envId !== "",
+  });
+
+  return create(DisconnectOAuthOutputSchema, { disconnected: true });
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/engine.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/engine.ts
@@ -1,0 +1,176 @@
+/**
+ * McpServer connect-engine seam — the domain's view of the Temporal client
+ * operations the connect lanes need (Go holds these as optional fields on
+ * McpServerController, set by SetConnectDependencies; here availability is
+ * the modeled engine state, the same idiom as agentexecution's engine.ts
+ * and workflowexecution's engine.ts — guidelines §4).
+ *
+ * The engine does NOT run a worker: the connect workflow
+ * (stigmer/mcp-server/connect) is the RUNNER's — this server only starts,
+ * attaches to, and awaits runs of it. The temporal-side implementation
+ * lands in src/temporal/mcpserver/engine-client.ts; tests fake this
+ * interface directly.
+ *
+ * Failure classification (ConnectRunFailure) mirrors the error taxonomy
+ * Go's awaitConnectWorkflow switches on (connect.go:661-694). The engine
+ * classifies; the DOMAIN owns the gRPC codes and user-facing copy the
+ * classes map to — the split keeps Temporal error types out of handler
+ * code.
+ */
+
+/**
+ * The connect workflow's input — matches the runner's
+ * ConnectMcpServerWorkflowInput (Go connectWorkflowInput). Snake_case keys
+ * are the Temporal JSON payload wire contract; ids-only except
+ * execution_context_token, the ONE deliberate exception (oss#535): the EC
+ * read RPC redacts secrets unless the caller presents an execution-scoped
+ * runner token, and the discovery activity has no execution of its own to
+ * exchange for one — the capability travels with the work item. It is a
+ * decrypt-lane discriminator, not a secret value: short-TTL, bound to
+ * this connect flow's ephemeral EC (deleted when the handler returns),
+ * and useless once either expires.
+ */
+export interface ConnectWorkflowInput {
+  readonly mcp_server_id: string;
+  readonly execution_context_id?: string;
+  readonly execution_context_token?: string;
+}
+
+/**
+ * The connect workflow's result — mirrors the runner's
+ * ConnectMcpServerWorkflowOutput (Go connectWorkflowOutput). Every field
+ * the runner emits must have a home here: a missing field is silently
+ * dropped during JSON deserialization, which is exactly how
+ * tool_approvals used to be lost.
+ */
+export interface ConnectWorkflowOutput {
+  readonly tools?: DiscoveredToolResult[];
+  readonly resource_templates?: DiscoveredResourceTemplateResult[];
+  /**
+   * Per-tool approval policies produced by the connect-time classifier —
+   * layer 1 of the approval policy chain. The classifier returns only the
+   * gated tools, but each entry still carries requires_approval so a
+   * future runner that emits non-gated entries is handled defensively at
+   * conversion time.
+   */
+  readonly tool_approvals?: ToolApprovalResult[];
+}
+
+export interface DiscoveredToolResult {
+  readonly name?: string;
+  readonly description?: string;
+  readonly input_schema?: Record<string, unknown>;
+}
+
+export interface DiscoveredResourceTemplateResult {
+  readonly uri_template?: string;
+  readonly name?: string;
+  readonly description?: string;
+  readonly mime_type?: string;
+}
+
+export interface ToolApprovalResult {
+  readonly tool_name?: string;
+  readonly requires_approval?: boolean;
+  readonly message?: string;
+  /**
+   * True when the connect-time tightener force-gated this tool from its
+   * destructiveHint annotation (not the classifier) — persisted to
+   * ToolApprovalPolicy.from_destructive_hint so the runner attributes the
+   * gate to the annotation rather than the classifier default.
+   */
+  readonly from_destructive_hint?: boolean;
+}
+
+/**
+ * How a connect run failed, in Go awaitConnectWorkflow's taxonomy:
+ * - "application": the workflow itself failed with the runner's crafted,
+ *   user-facing message (Go temporal.ApplicationError).
+ * - "timeout": the WorkflowRunTimeout elapsed (Go temporal.TimeoutError).
+ * - "service-not-found": Temporal no longer knows the run (Go
+ *   serviceerror.NotFound).
+ * - "other": everything else; message carries the error's own text (Go's
+ *   default arm, err.Error()).
+ */
+export type ConnectRunFailure =
+  | { readonly kind: "application"; readonly message: string }
+  | { readonly kind: "timeout" }
+  | { readonly kind: "service-not-found" }
+  | { readonly kind: "other"; readonly message: string };
+
+export type ConnectRunOutcome =
+  | { readonly ok: true; readonly output: ConnectWorkflowOutput }
+  | { readonly ok: false; readonly failure: ConnectRunFailure };
+
+/** A started-or-attached connect run (Go client.WorkflowRun). */
+export interface ConnectRun {
+  readonly workflowId: string;
+  /**
+   * True when the deterministic workflow ID reported an in-flight run and
+   * this handle attached to it instead of starting a new one — the lanes
+   * skip the CONNECTING write in that case so the starting lane's
+   * started_at survives.
+   */
+  readonly attached: boolean;
+  /**
+   * Blocks until the run settles and classifies the outcome. The
+   * workflow's own WorkflowRunTimeout is the deadline that should fire
+   * first; raceTimeoutMs (budget + a small buffer on the background
+   * lanes) is only a backstop so a settle task can never hang if Temporal
+   * becomes unreachable — Go's bounded background contexts.
+   */
+  result(raceTimeoutMs?: number): Promise<ConnectRunOutcome>;
+}
+
+/** The Temporal client operations the connect lanes consume. */
+export interface McpServerConnectEngine {
+  /**
+   * Starts the connect workflow on the runner queue, or attaches to the
+   * in-flight run when the deterministic workflow ID reports one already
+   * running (Go startOrAttachConnectWorkflow). Throws on any other start
+   * failure — the lanes map that to Internal "failed to start connect
+   * workflow".
+   */
+  startOrAttachConnect(
+    mcpServerId: string,
+    input: ConnectWorkflowInput,
+    runTimeoutMs: number,
+  ): Promise<ConnectRun>;
+
+  /**
+   * Whether the recorded connect workflow is still running (Go
+   * isConnectRunRunning). Errors — including a run Temporal no longer
+   * knows — report false: the caller falls through to a fresh start,
+   * where the AlreadyStarted refusal is the authoritative answer.
+   */
+  isConnectRunRunning(workflowId: string): Promise<boolean>;
+
+  /**
+   * Whether any worker is polling the runner task queue (Go
+   * runnerQueueWarning's DescribeTaskQueue probe). `undefined` when the
+   * question cannot be answered — an unreachable Temporal should not cry
+   * wolf on an operation that is about to fail loudly anyway.
+   */
+  hasRunnerQueuePollers(): Promise<boolean | undefined>;
+}
+
+/** Engine availability as an explicit modeled state (guidelines §4). */
+export type McpServerEngineState =
+  | { readonly connected: true; readonly engine: McpServerConnectEngine }
+  | { readonly connected: false };
+
+/**
+ * The disconnected state: no Temporal behind this server (never
+ * connected since boot). Connect/startConnect refuse with Go's
+ * byte-pinned FailedPrecondition; the OAuth RPCs work fully — the
+ * ratified DB-1 split (sub-project 20260825.02).
+ */
+export const MCP_SERVER_ENGINE_DISCONNECTED: McpServerEngineState =
+  Object.freeze({ connected: false });
+
+/**
+ * A provider rather than a value: consumers observe the CURRENT state at
+ * request time, never a boot-time snapshot — reconnects propagate
+ * automatically (the #18 engine-state idiom).
+ */
+export type McpServerEngineStateProvider = () => McpServerEngineState;

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/get-oauth-grant-status.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/get-oauth-grant-status.ts
@@ -1,0 +1,92 @@
+/**
+ * getOAuthGrantStatus — ports
+ * pkg/domain/mcpserver/controller/get_oauth_grant_status.go: whether the
+ * authenticated user has an active OAuth grant for the specified MCP
+ * server in the given org. Returns grant metadata (connected status,
+ * token expiry, auth method, connection health) without exposing secret
+ * token values; the frontend renders the OAuth state in the MCP server
+ * detail page and session composer from it. In OSS mode the
+ * identity_account_id is always empty (single-user).
+ *
+ * Proven by mcpserver-oauth.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts) and
+ * __tests__/get-oauth-grant-status.test.ts.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import type {
+  GetOAuthGrantStatusInput,
+  GetOAuthGrantStatusOutput,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import {
+  GetOAuthGrantStatusOutputSchema,
+  OAuthConnectionHealth,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+
+import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
+import type { OAuthGrant } from "../../store/interface.js";
+import type { McpServerConnectDeps } from "./connect.js";
+import { REFRESH_EXPIRY_BUFFER_SECONDS } from "./oauth/refresh.js";
+
+export async function getOAuthGrantStatus(
+  deps: McpServerConnectDeps,
+  input: GetOAuthGrantStatusInput,
+): Promise<GetOAuthGrantStatusOutput> {
+  if (input.resourceId === "") {
+    throw invalidArgumentError("resource_id is required");
+  }
+  if (input.org === "") {
+    throw invalidArgumentError("org is required");
+  }
+
+  let grant: OAuthGrant | undefined;
+  try {
+    grant = await deps.oauthGrants.find("", input.resourceId, input.org);
+  } catch (error) {
+    throw internalError(error, "failed to look up OAuth grant");
+  }
+
+  if (grant === undefined) {
+    return create(GetOAuthGrantStatusOutputSchema, {
+      connected: false,
+      connectionHealth: OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_NO_GRANT,
+    });
+  }
+
+  return create(GetOAuthGrantStatusOutputSchema, {
+    connected: true,
+    accessTokenExpiresAt: BigInt(grant.accessTokenExpiresAt),
+    targetEnvVar: grant.accessTokenEnvVar,
+    authMethod: grant.authMethod,
+    connectionHealth: evaluateHealth(grant),
+  });
+}
+
+/**
+ * Determines the health of an OAuth connection from locally available
+ * grant metadata (Go evaluateHealth). Uses the same 60-second expiry
+ * buffer as oauth/refresh.ts so the UX signal matches execution behavior.
+ *
+ * Ported bug, as-is (oss#863): "refreshable" keys off
+ * refreshTokenEnvVar != "" — but completeOAuthConnect sets that field
+ * unconditionally, so TOKEN_EXPIRED is unreachable through the real flow
+ * and an expired grant always claims refreshable even when no refresh
+ * token was ever issued. The conformance suite pins this behavior;
+ * fixing it is a both-editions change tracked on the issue.
+ */
+export function evaluateHealth(grant: OAuthGrant): OAuthConnectionHealth {
+  if (grant.accessTokenExpiresAt === 0) {
+    return OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY;
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+  if (now < grant.accessTokenExpiresAt - REFRESH_EXPIRY_BUFFER_SECONDS) {
+    return OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_HEALTHY;
+  }
+
+  if (grant.refreshTokenEnvVar !== "") {
+    return OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED_REFRESHABLE;
+  }
+
+  return OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED;
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/initiate-oauth-connect.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/initiate-oauth-connect.ts
@@ -1,0 +1,461 @@
+/**
+ * initiateOAuthConnect — ports
+ * pkg/domain/mcpserver/controller/initiate_oauth_connect.go: start the
+ * OAuth authorization flow for an MCP server. For DCR servers (no
+ * oauth_app_ref): discover the authorization server, register a client
+ * via RFC 7591, generate PKCE, pre-flight the authorize endpoint, return
+ * the auth URL. For vendor OAuth servers: load the OAuthApp for client
+ * credentials and build the auth URL from its endpoints.
+ *
+ * Proven by mcpserver-oauth.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts) and
+ * __tests__/initiate-oauth-connect.test.ts.
+ */
+import { create } from "@bufbuild/protobuf";
+import { randomBytes } from "node:crypto";
+
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type {
+  InitiateOAuthConnectInput,
+  InitiateOAuthConnectOutput,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { InitiateOAuthConnectOutputSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import {
+  TokenEndpointAuthMethod,
+  VendorApprovalStatus,
+} from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PendingOAuthState } from "../../store/interface.js";
+import { resolveOAuthAppRef } from "../oauthapp/refresolution.js";
+import { tokenAuthMethodFromSpec } from "./connect.js";
+import type { McpServerConnectDeps } from "./connect.js";
+import { generatePkce } from "./oauth/pkce.js";
+import type { PkcePair } from "./oauth/pkce.js";
+import { discoverAuthorizationServer } from "./oauth/discovery.js";
+import { registerClient } from "./oauth/dcr.js";
+import { preflightAuthorize } from "./oauth/preflight.js";
+import type { AuthorizeRejection } from "./oauth/preflight.js";
+
+export async function initiateOAuthConnect(
+  deps: McpServerConnectDeps,
+  input: InitiateOAuthConnectInput,
+): Promise<InitiateOAuthConnectOutput> {
+  if (deps.oauthRedirectUri === "") {
+    throw failedPreconditionError(
+      "OAuth Connect is not configured: STIGMER_OAUTH_REDIRECT_URI is not set",
+    );
+  }
+
+  const mcpServerId = input.mcpServerId;
+  if (mcpServerId === "") {
+    throw invalidArgumentError("mcp_server_id is required");
+  }
+
+  let mcpServer: McpServer;
+  try {
+    mcpServer = await deps.store.getResource(
+      ApiResourceKind.mcp_server,
+      mcpServerId,
+      McpServerSchema,
+    );
+  } catch {
+    throw notFoundError("mcp_server", mcpServerId);
+  }
+
+  const auth = mcpServer.spec?.auth;
+  if (auth === undefined) {
+    throw failedPreconditionError(
+      `MCP server '${mcpServerId}' does not have an auth block configured`,
+    );
+  }
+
+  const pkcePair = generatePkce();
+  const stateParam = generateState();
+
+  const oauthAppRef = auth.oauthAppRef;
+  const isDcr = oauthAppRef === undefined || oauthAppRef.slug === "";
+  const result = isDcr
+    ? await initiateDcr(deps, mcpServer, pkcePair, stateParam)
+    : await initiateVendorOAuth(deps, mcpServer, pkcePair, stateParam);
+  const authMethod = isDcr ? "mcp_oauth" : "vendor_oauth";
+
+  const pendingState: PendingOAuthState = {
+    state: stateParam,
+    codeVerifier: pkcePair.codeVerifier,
+    clientId: result.clientId,
+    clientSecret: result.clientSecret,
+    tokenEndpoint: result.tokenEndpoint,
+    mcpServerId,
+    // OSS mode: single user, no identity account.
+    identityAccountId: "",
+    targetEnvVar: auth.targetEnvVar,
+    authMethod,
+    tokenAuthMethod: result.tokenAuthMethod,
+    redirectUri: deps.oauthRedirectUri,
+    org: input.org,
+    createdAt: 0,
+  };
+
+  // Fail-closed: an encryption error fails the request; plaintext never
+  // reaches the store.
+  let sealed: PendingOAuthState;
+  try {
+    sealed = sealPendingOAuthState(deps.secretService, deps.logger, pendingState);
+  } catch (error) {
+    throw internalError(error, "failed to encrypt OAuth handshake secrets");
+  }
+
+  try {
+    await deps.pendingOAuthStates.save(sealed);
+  } catch (error) {
+    throw internalError(error, "failed to save pending OAuth state");
+  }
+
+  deps.logger.info("Initiated OAuth Connect flow", {
+    mcp_server_id: mcpServerId,
+    auth_method: authMethod,
+    provider: result.providerName,
+  });
+
+  return create(InitiateOAuthConnectOutputSchema, {
+    authorizationUrl: result.authorizationUrl,
+    state: stateParam,
+    scopes: result.scopes,
+    providerName: result.providerName,
+  });
+}
+
+interface InitiateResult {
+  readonly authorizationUrl: string;
+  readonly providerName: string;
+  readonly scopes: string[];
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly tokenEndpoint: string;
+  /** RFC 8414 string; set on the vendor OAuth arm only. */
+  readonly tokenAuthMethod: string;
+}
+
+async function initiateDcr(
+  deps: McpServerConnectDeps,
+  mcpServer: McpServer,
+  pkcePair: PkcePair,
+  stateParam: string,
+): Promise<InitiateResult> {
+  // Resolve the URL for OAuth authorization server discovery. Priority:
+  // auth.discovery_url > http.url — discovery_url enables DCR for stdio
+  // servers that have no HTTP URL.
+  let serverUrl = mcpServer.spec?.auth?.discoveryUrl ?? "";
+  if (serverUrl === "") {
+    const serverType = mcpServer.spec?.serverType;
+    if (serverType?.case === "http") {
+      serverUrl = serverType.value.url;
+    }
+  }
+  if (serverUrl === "") {
+    throw failedPreconditionError(
+      `DCR requires a discoverable URL. MCP server '${mcpServer.metadata?.id ?? ""}' has no http.url and no auth.discovery_url. ` +
+        "Set auth.discovery_url for stdio servers, oauth_app_ref for vendor OAuth, or switch to HTTP transport",
+    );
+  }
+
+  let metadata;
+  try {
+    metadata = await discoverAuthorizationServer(serverUrl);
+  } catch (error) {
+    throw failedPreconditionError(
+      `OAuth authorization server discovery failed for ${serverUrl}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (metadata.registrationEndpoint === "") {
+    throw failedPreconditionError(
+      `MCP server at ${serverUrl} does not advertise a registration_endpoint for DCR`,
+    );
+  }
+
+  const clientName = `Stigmer (${mcpServer.metadata?.name ?? ""})`;
+  let dcrResponse;
+  try {
+    dcrResponse = await registerClient(
+      metadata.registrationEndpoint,
+      deps.oauthRedirectUri,
+      clientName,
+    );
+  } catch (error) {
+    throw failedPreconditionError(
+      `DCR registration failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  let scopes = mcpServer.spec?.auth?.scopeHints ?? [];
+  if (scopes.length === 0 && metadata.scopesSupported.length > 0) {
+    scopes = metadata.scopesSupported;
+  }
+
+  const authUrl = buildAuthorizationUrl(
+    metadata.authorizationEndpoint,
+    dcrResponse.clientId,
+    deps.oauthRedirectUri,
+    pkcePair.codeChallenge,
+    stateParam,
+    scopes,
+    "scope",
+  );
+
+  // Some providers accept DCR for any redirect URI but enforce a
+  // redirect-host allowlist at the authorization endpoint; without this
+  // pre-flight the rejection would surface only as a vendor error page
+  // inside the popup, which never redirects back (stigmer/stigmer#235).
+  // Fail-open by contract: only a definite rejection blocks initiate.
+  let rejection: AuthorizeRejection | undefined;
+  try {
+    rejection = await preflightAuthorize(authUrl);
+  } catch (probeError) {
+    deps.logger.debug("authorize pre-flight probe inconclusive; proceeding", {
+      mcp_server_id: mcpServer.metadata?.id ?? "",
+      error: probeError instanceof Error ? probeError.message : String(probeError),
+    });
+  }
+  if (rejection !== undefined) {
+    deps.logger.warn(
+      "authorization endpoint rejected the sign-in request pre-flight",
+      {
+        status_code: rejection.statusCode,
+        mcp_server_id: mcpServer.metadata?.id ?? "",
+        body_snippet: rejection.bodySnippet,
+      },
+    );
+    throw failedPreconditionError(
+      dcrRejectionMessage(
+        mcpServer.metadata?.name ?? "",
+        deps.oauthRedirectUri,
+        rejection,
+      ),
+    );
+  }
+
+  return {
+    authorizationUrl: authUrl,
+    providerName: mcpServer.metadata?.name ?? "",
+    scopes,
+    clientId: dcrResponse.clientId,
+    clientSecret: "",
+    tokenEndpoint: metadata.tokenEndpoint,
+    tokenAuthMethod: "",
+  };
+}
+
+async function initiateVendorOAuth(
+  deps: McpServerConnectDeps,
+  mcpServer: McpServer,
+  pkcePair: PkcePair,
+  stateParam: string,
+): Promise<InitiateResult> {
+  const ref = mcpServer.spec?.auth?.oauthAppRef;
+
+  let oauthApp;
+  try {
+    oauthApp = await resolveOAuthAppRef(deps.store, ref, deps.logger);
+  } catch (error) {
+    throw internalError(error, "failed to list oauth apps");
+  }
+  if (oauthApp === undefined) {
+    throw notFoundError("oauth_app", ref?.slug ?? "");
+  }
+
+  const approvalStatus = oauthApp.spec?.vendorApprovalStatus;
+  if (
+    approvalStatus === VendorApprovalStatus.PENDING ||
+    approvalStatus === VendorApprovalStatus.REJECTED
+  ) {
+    const statusLabel =
+      approvalStatus === VendorApprovalStatus.REJECTED
+        ? "rejected"
+        : "pending approval";
+    // The suggested alternative must be one that can actually work:
+    // oauth_only endpoints reject static tokens, so recommending manual
+    // entry there sends the user down a dead end (stigmer/stigmer#412).
+    const alternative = mcpServer.spec?.auth?.oauthOnly
+      ? "This server only accepts OAuth sign-in; an org admin can configure your own OAuth app instead."
+      : "Please enter a token manually instead.";
+    throw failedPreconditionError(
+      `OAuth sign-in is unavailable: the platform's OAuth app for '${oauthApp.spec?.provider ?? ""}' is ${statusLabel} by the vendor. ${alternative}`,
+    );
+  }
+
+  let clientSecret = oauthApp.spec?.clientSecret ?? "";
+  if (deps.secretService.isEncrypted(clientSecret)) {
+    try {
+      clientSecret = deps.secretService.decrypt(clientSecret);
+    } catch (error) {
+      throw internalError(error, "failed to decrypt OAuthApp client secret");
+    }
+  }
+
+  const scopes = oauthApp.spec?.scopes ?? [];
+  const authUrl = buildAuthorizationUrl(
+    oauthApp.spec?.authorizationUrl ?? "",
+    oauthApp.spec?.clientId ?? "",
+    deps.oauthRedirectUri,
+    pkcePair.codeChallenge,
+    stateParam,
+    scopes,
+    oauthApp.spec?.scopeParameterName ?? "",
+  );
+
+  return {
+    authorizationUrl: authUrl,
+    providerName: oauthApp.spec?.provider ?? "",
+    scopes,
+    clientId: oauthApp.spec?.clientId ?? "",
+    clientSecret,
+    tokenEndpoint: oauthApp.spec?.tokenUrl ?? "",
+    tokenAuthMethod: tokenAuthMethodFromSpec(
+      oauthApp.spec?.tokenEndpointAuthMethod ??
+        TokenEndpointAuthMethod.UNSPECIFIED,
+    ),
+  };
+}
+
+/**
+ * Builds the authorization URL (Go buildAuthorizationURL). Parameters are
+ * rendered SORTED by key — Go's url.Values.Encode() sorts, and the
+ * conformance suite asserts the exact parameter set — with
+ * form-urlencoding (spaces as +, both editions).
+ */
+export function buildAuthorizationUrl(
+  authEndpoint: string,
+  clientId: string,
+  redirectUri: string,
+  codeChallenge: string,
+  state: string,
+  scopes: string[],
+  scopeParamName: string,
+): string {
+  const scopeParam = scopeParamName === "" ? "scope" : scopeParamName;
+
+  const params = new URLSearchParams({
+    response_type: "code",
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    state,
+  });
+  if (scopes.length > 0) {
+    params.set(scopeParam, scopes.join(" "));
+  }
+  params.sort();
+
+  const separator = authEndpoint.includes("?") ? "&" : "?";
+  return authEndpoint + separator + params.toString();
+}
+
+/**
+ * Renders the user-facing copy for a pre-flight authorize rejection (Go
+ * dcrRejectionMessage). The wording is hedged — a 400 can in principle
+ * have other causes — but leads with the redirect-host allowlist because
+ * it is the only cause observed in the wild (Canva, stigmer/stigmer#235),
+ * and it names this deployment's callback host so self-hosted operators
+ * can act on it. Surfaces which render initiate errors pass this text
+ * through verbatim (getUserMessage in @stigmer/sdk), so it must stand on
+ * its own for an end user.
+ */
+export function dcrRejectionMessage(
+  providerName: string,
+  redirectUri: string,
+  rejection: AuthorizeRejection,
+): string {
+  let callbackHost = redirectUri;
+  try {
+    const parsed = new URL(redirectUri);
+    if (parsed.host !== "") {
+      callbackHost = parsed.host;
+    }
+  } catch {
+    // Keep the raw URI when it does not parse — Go's err-tolerant arm.
+  }
+  let message =
+    `${providerName} rejected the sign-in request before showing a login page (HTTP ${rejection.statusCode}). ` +
+    `The most common cause is a redirect-host allowlist: this deployment's OAuth callback host (${callbackHost}) ` +
+    "is not on the provider's approved list. Self-hosted deployments with a localhost callback are typically unaffected.";
+  if (rejection.vendorDetail !== "") {
+    message += " Provider detail: " + rejection.vendorDetail;
+  }
+  return message;
+}
+
+/** 32 random bytes, base64url — CSRF state (Go generateState). */
+function generateState(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+/**
+ * Encrypts the two real secrets in the pending row — code_verifier (every
+ * flow) and client_secret (vendor flow) — before they rest in SQLite, so
+ * handshake secrets never leak through filesystem backups of the database
+ * (oss#394; ports stigmer-cloud#294). The store itself stays a
+ * byte-faithful adapter; this call site is the single write seam.
+ *
+ * The row is a self-contained SNAPSHOT, never an alias of the OAuthApp's
+ * stored ciphertext: initiateVendorOAuth decrypts the app's secret
+ * (failing loudly if the key is unavailable), and the seal re-encrypts
+ * that plaintext with a fresh nonce. The token exchange must use the
+ * credentials the authorization code was minted for, not whatever a later
+ * resolution of the OAuthApp would return.
+ *
+ * The DCR path's empty client secret stays empty — never
+ * ciphertext-of-"" — so completeOAuthConnect and the token exchange keep
+ * seeing the emptiness that means "public client".
+ *
+ * Disabled encryption (no key configured) passes plaintext through with a
+ * WARN, matching the deployment-wide posture for environment, OAuthApp
+ * and ChannelApp secrets under the same key. A real encryption error
+ * while enabled throws so the caller fails the request instead of
+ * persisting plaintext.
+ */
+export function sealPendingOAuthState(
+  secretService: SecretService,
+  logger: Logger,
+  state: PendingOAuthState,
+): PendingOAuthState {
+  if (!secretService.isEnabled()) {
+    logger.warn(
+      "Encryption disabled: pending OAuth state secrets will be stored in plaintext",
+    );
+    return state;
+  }
+
+  let sealedVerifier: string;
+  try {
+    sealedVerifier = secretService.encrypt(state.codeVerifier);
+  } catch (error) {
+    throw new Error(
+      `failed to encrypt code_verifier: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  let sealedSecret = state.clientSecret;
+  if (state.clientSecret !== "") {
+    try {
+      sealedSecret = secretService.encrypt(state.clientSecret);
+    } catch (error) {
+      throw new Error(
+        `failed to encrypt client_secret: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  return { ...state, codeVerifier: sealedVerifier, clientSecret: sealedSecret };
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/dcr.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/dcr.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Pins RFC 7591 Dynamic Client Registration against Go oauth/dcr.go: the
+ * public-client request shape (token_endpoint_auth_method "none" — MCP
+ * OAuth uses PKCE, and the empty secret keeps meaning "public client",
+ * oss#394), 200/201 acceptance, the 256-byte error-body truncation, and
+ * the missing-client_id refusal.
+ */
+import { describe, expect, it } from "vitest";
+
+import { registerClient } from "../dcr.js";
+
+describe("registerClient", () => {
+  it("registers a public client with the exact RFC 7591 request shape", async () => {
+    let requestBody: Record<string, unknown> = {};
+    const response = await registerClient(
+      "https://auth.example.com/register",
+      "http://127.0.0.1:8234/auth/oauth/callback",
+      "Stigmer (Example Server)",
+      async (_url, init) => {
+        requestBody = JSON.parse(String(init?.body)) as Record<string, unknown>;
+        return new Response(
+          JSON.stringify({ client_id: "dcr-client-1", client_name: "Stigmer (Example Server)" }),
+          { status: 201 },
+        );
+      },
+    );
+    expect(requestBody).toEqual({
+      redirect_uris: ["http://127.0.0.1:8234/auth/oauth/callback"],
+      client_name: "Stigmer (Example Server)",
+      grant_types: ["authorization_code"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+    });
+    expect(response.clientId).toBe("dcr-client-1");
+    expect(response.clientSecret).toBe("");
+  });
+
+  it("accepts HTTP 200 as well as 201 (real providers answer both)", async () => {
+    const response = await registerClient(
+      "https://auth.example.com/register",
+      "http://cb",
+      "Stigmer (X)",
+      async () =>
+        new Response(JSON.stringify({ client_id: "ok-200" }), { status: 200 }),
+    );
+    expect(response.clientId).toBe("ok-200");
+  });
+
+  it("refuses a non-2xx with the truncated body (256-byte cap)", async () => {
+    const longBody = "x".repeat(300);
+    await expect(
+      registerClient(
+        "https://auth.example.com/register",
+        "http://cb",
+        "Stigmer (X)",
+        async () => new Response(longBody, { status: 400 }),
+      ),
+    ).rejects.toThrow(
+      `DCR at https://auth.example.com/register returned HTTP 400: ${"x".repeat(256)}...`,
+    );
+  });
+
+  it("refuses a 201 whose body has no client_id", async () => {
+    await expect(
+      registerClient(
+        "https://auth.example.com/register",
+        "http://cb",
+        "Stigmer (X)",
+        async () => new Response(JSON.stringify({}), { status: 201 }),
+      ),
+    ).rejects.toThrow(
+      "DCR response from https://auth.example.com/register is missing client_id",
+    );
+  });
+
+  it("wraps a network failure with the DCR-request prefix", async () => {
+    await expect(
+      registerClient(
+        "https://auth.example.com/register",
+        "http://cb",
+        "Stigmer (X)",
+        async () => {
+          throw new Error("socket hang up");
+        },
+      ),
+    ).rejects.toThrow(
+      "DCR request to https://auth.example.com/register failed: socket hang up",
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/discovery.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/discovery.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Pins RFC 8414 discovery against Go oauth/discovery.go: the well-known
+ * URI lives at the URL ORIGIN (not under the server's path), S256 support
+ * is mandatory when advertised, and every error message is text initiate
+ * embeds in its FailedPrecondition copy — asserted verbatim.
+ */
+import { describe, expect, it } from "vitest";
+
+import { buildWellKnownUrl, discoverAuthorizationServer } from "../discovery.js";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const VALID_METADATA = {
+  issuer: "https://auth.example.com",
+  authorization_endpoint: "https://auth.example.com/authorize",
+  token_endpoint: "https://auth.example.com/token",
+  registration_endpoint: "https://auth.example.com/register",
+  scopes_supported: ["read", "write"],
+  code_challenge_methods_supported: ["S256"],
+};
+
+describe("buildWellKnownUrl", () => {
+  it("builds at the origin, dropping the server path (Linear-style URL)", () => {
+    expect(buildWellKnownUrl("https://mcp.linear.app/mcp")).toBe(
+      "https://mcp.linear.app/.well-known/oauth-authorization-server",
+    );
+  });
+
+  it("preserves a non-default port in the origin", () => {
+    expect(buildWellKnownUrl("http://127.0.0.1:8931/api/v2")).toBe(
+      "http://127.0.0.1:8931/.well-known/oauth-authorization-server",
+    );
+  });
+
+  const invalid: Array<[string, string, string]> = [
+    [
+      "a non-http(s) scheme",
+      "ftp://example.com",
+      'invalid server URL for discovery: unsupported scheme "ftp": only http and https are supported',
+    ],
+  ];
+  it.each(invalid)("rejects %s", (_label, url, message) => {
+    expect(() => buildWellKnownUrl(url)).toThrow(message);
+  });
+
+  it("rejects an unparseable URL with the Go prefix", () => {
+    expect(() => buildWellKnownUrl("::::")).toThrow(
+      /^invalid server URL for discovery: /,
+    );
+  });
+});
+
+describe("discoverAuthorizationServer", () => {
+  it("parses valid metadata and sends Accept: application/json to the origin well-known URI", async () => {
+    let requestedUrl = "";
+    let accept = "";
+    const metadata = await discoverAuthorizationServer(
+      "https://mcp.example.com/mcp",
+      async (url, init) => {
+        requestedUrl = String(url);
+        accept = (init?.headers as Record<string, string>)["Accept"] ?? "";
+        return jsonResponse(200, VALID_METADATA);
+      },
+    );
+    expect(requestedUrl).toBe(
+      "https://mcp.example.com/.well-known/oauth-authorization-server",
+    );
+    expect(accept).toBe("application/json");
+    expect(metadata.authorizationEndpoint).toBe(
+      "https://auth.example.com/authorize",
+    );
+    expect(metadata.tokenEndpoint).toBe("https://auth.example.com/token");
+    expect(metadata.registrationEndpoint).toBe(
+      "https://auth.example.com/register",
+    );
+    expect(metadata.scopesSupported).toEqual(["read", "write"]);
+  });
+
+  it("refuses a non-200 with the MCP Authorization hint (Go copy, verbatim)", async () => {
+    await expect(
+      discoverAuthorizationServer("https://mcp.example.com/mcp", async () =>
+        jsonResponse(404, {}),
+      ),
+    ).rejects.toThrow(
+      "authorization server discovery failed: https://mcp.example.com/.well-known/oauth-authorization-server returned HTTP 404 (expected 200). " +
+        "This MCP server may not support the MCP Authorization specification",
+    );
+  });
+
+  const missingEndpoint: Array<[string, Record<string, unknown>, string]> = [
+    [
+      "authorization_endpoint",
+      { ...VALID_METADATA, authorization_endpoint: undefined },
+      "is missing authorization_endpoint",
+    ],
+    [
+      "token_endpoint",
+      { ...VALID_METADATA, token_endpoint: undefined },
+      "is missing token_endpoint",
+    ],
+  ];
+  it.each(missingEndpoint)(
+    "refuses metadata without %s",
+    async (_label, body, fragment) => {
+      await expect(
+        discoverAuthorizationServer("https://mcp.example.com/mcp", async () =>
+          jsonResponse(200, body),
+        ),
+      ).rejects.toThrow(fragment);
+    },
+  );
+
+  it("refuses a server that advertises methods without S256 (Go %v list rendering)", async () => {
+    await expect(
+      discoverAuthorizationServer("https://mcp.example.com/mcp", async () =>
+        jsonResponse(200, {
+          ...VALID_METADATA,
+          code_challenge_methods_supported: ["plain"],
+        }),
+      ),
+    ).rejects.toThrow(
+      "does not support S256 PKCE (supports: [plain]). S256 is required by the MCP Authorization specification",
+    );
+  });
+
+  it("accepts a server that advertises NO methods (list absent = unconstrained)", async () => {
+    const metadata = await discoverAuthorizationServer(
+      "https://mcp.example.com/mcp",
+      async () =>
+        jsonResponse(200, {
+          ...VALID_METADATA,
+          code_challenge_methods_supported: undefined,
+        }),
+    );
+    expect(metadata.codeChallengeMethodsSupported).toEqual([]);
+  });
+
+  it("wraps a network failure with the discovery-request prefix", async () => {
+    await expect(
+      discoverAuthorizationServer("https://mcp.example.com/mcp", async () => {
+        throw new Error("connect ECONNREFUSED");
+      }),
+    ).rejects.toThrow(/^discovery request to .* failed: connect ECONNREFUSED$/);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/pkce.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/pkce.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Pins PKCE pair generation against Go oauth/pkce.go: 32-byte base64url
+ * verifier (no padding), S256 challenge = base64url(SHA-256(verifier)) —
+ * RFC 7636 / OAuth 2.1 shape the mock authorization server verifies at
+ * the token exchange.
+ */
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import { generatePkce } from "../pkce.js";
+
+describe("generatePkce", () => {
+  it("produces a 43-char base64url verifier (32 bytes, no padding)", () => {
+    const pair = generatePkce();
+    expect(pair.codeVerifier).toHaveLength(43);
+    expect(pair.codeVerifier).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("derives the challenge as base64url(SHA-256(verifier)) — S256", () => {
+    const pair = generatePkce();
+    const expected = createHash("sha256")
+      .update(pair.codeVerifier)
+      .digest()
+      .toString("base64url");
+    expect(pair.codeChallenge).toBe(expected);
+  });
+
+  it("generates a fresh pair on every call", () => {
+    const a = generatePkce();
+    const b = generatePkce();
+    expect(a.codeVerifier).not.toBe(b.codeVerifier);
+    expect(a.codeChallenge).not.toBe(b.codeChallenge);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/preflight.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/preflight.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Pins the authorize pre-flight probe against Go oauth/preflight.go
+ * (stigmer/stigmer#235): ONLY HTTP 400 classifies as blocked (RFC 6749
+ * §4.1.2.1's no-redirect rejection); 2xx/3xx/403/503 fail open (bot walls
+ * answer server-side GETs while real browsers pass); redirects are never
+ * followed; vendor detail comes from an RFC-shaped JSON body only.
+ */
+import { describe, expect, it } from "vitest";
+
+import { preflightAuthorize } from "../preflight.js";
+
+describe("preflightAuthorize", () => {
+  it("classifies HTTP 400 with an RFC-shaped body as a rejection with vendor detail", async () => {
+    const rejection = await preflightAuthorize(
+      "https://auth.example.com/authorize?x=1",
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: "invalid_request",
+            error_description: "redirect_uri not allowed",
+          }),
+          { status: 400 },
+        ),
+    );
+    expect(rejection).toBeDefined();
+    expect(rejection?.statusCode).toBe(400);
+    expect(rejection?.vendorDetail).toBe("redirect_uri not allowed");
+  });
+
+  it("falls back to the RFC error field when error_description is absent", async () => {
+    const rejection = await preflightAuthorize(
+      "https://auth.example.com/authorize",
+      async () =>
+        new Response(JSON.stringify({ error: "invalid_request" }), {
+          status: 400,
+        }),
+    );
+    expect(rejection?.vendorDetail).toBe("invalid_request");
+  });
+
+  it("yields empty vendor detail for an HTML error page (the Canva case) but keeps the snippet", async () => {
+    const rejection = await preflightAuthorize(
+      "https://auth.example.com/authorize",
+      async () => new Response("<html>Nope</html>", { status: 400 }),
+    );
+    expect(rejection?.vendorDetail).toBe("");
+    expect(rejection?.bodySnippet).toBe("<html>Nope</html>");
+  });
+
+  const failOpen: Array<[number]> = [[200], [302], [403], [503]];
+  it.each(failOpen)("fails open on HTTP %d", async (status) => {
+    const rejection = await preflightAuthorize(
+      "https://auth.example.com/authorize",
+      async () => new Response("whatever", { status }),
+    );
+    expect(rejection).toBeUndefined();
+  });
+
+  it("requests with redirect: manual — the first response alone classifies", async () => {
+    let redirectMode = "";
+    await preflightAuthorize("https://auth.example.com/authorize", async (_url, init) => {
+      redirectMode = init?.redirect ?? "";
+      return new Response("", { status: 302 });
+    });
+    expect(redirectMode).toBe("manual");
+  });
+
+  it("propagates network errors to the caller (Go's (nil, err) fail-open diagnostics)", async () => {
+    await expect(
+      preflightAuthorize("https://auth.example.com/authorize", async () => {
+        throw new Error("ETIMEDOUT");
+      }),
+    ).rejects.toThrow("ETIMEDOUT");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/token-exchange.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/__tests__/token-exchange.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Pins the authorization-code exchange against Go oauth/token.go
+ * (token_test.go): the grant parameter set, EXACTLY ONE secret channel
+ * per request (RFC 6749 §2.3 — Basic default, form-body for
+ * client_secret_post, neither for public clients), the Slack V2
+ * authed_user promotion, the 256-byte error truncation, and the
+ * missing-access_token refusal. The refresh half is pinned by
+ * token-refresh.test.ts (#17).
+ */
+import { describe, expect, it } from "vitest";
+
+import { exchangeCode } from "../token.js";
+
+interface CapturedRequest {
+  body: URLSearchParams;
+  authorization: string;
+}
+
+function capturingFetch(
+  responseBody: unknown,
+  captured: CapturedRequest[],
+  status = 200,
+): typeof fetch {
+  return async (_url, init) => {
+    captured.push({
+      body: new URLSearchParams(String(init?.body)),
+      authorization:
+        (init?.headers as Record<string, string>)["Authorization"] ?? "",
+    });
+    return new Response(JSON.stringify(responseBody), { status });
+  };
+}
+
+const TOKENS = { access_token: "at-1", token_type: "bearer", expires_in: 3600 };
+
+describe("exchangeCode", () => {
+  it("sends the authorization_code grant with PKCE parameters", async () => {
+    const captured: CapturedRequest[] = [];
+    await exchangeCode(
+      "https://auth.example.com/token",
+      "code-1",
+      "http://cb",
+      "verifier-1",
+      "client-1",
+      "",
+      "",
+      capturingFetch(TOKENS, captured),
+    );
+    const body = captured[0]?.body;
+    expect(body?.get("grant_type")).toBe("authorization_code");
+    expect(body?.get("code")).toBe("code-1");
+    expect(body?.get("redirect_uri")).toBe("http://cb");
+    expect(body?.get("code_verifier")).toBe("verifier-1");
+    expect(body?.get("client_id")).toBe("client-1");
+  });
+
+  it("public client (DCR): no Authorization header, no client_secret in the body", async () => {
+    const captured: CapturedRequest[] = [];
+    await exchangeCode(
+      "https://auth.example.com/token",
+      "c",
+      "http://cb",
+      "v",
+      "client-1",
+      "",
+      "",
+      capturingFetch(TOKENS, captured),
+    );
+    expect(captured[0]?.authorization).toBe("");
+    expect(captured[0]?.body.has("client_secret")).toBe(false);
+  });
+
+  it("confidential client, default method: secret rides Basic ONLY", async () => {
+    const captured: CapturedRequest[] = [];
+    await exchangeCode(
+      "https://auth.example.com/token",
+      "c",
+      "http://cb",
+      "v",
+      "client-1",
+      "s3cret",
+      "",
+      capturingFetch(TOKENS, captured),
+    );
+    expect(captured[0]?.authorization).toBe(
+      `Basic ${Buffer.from("client-1:s3cret").toString("base64")}`,
+    );
+    expect(captured[0]?.body.has("client_secret")).toBe(false);
+  });
+
+  it("client_secret_post: secret rides the form body ONLY", async () => {
+    const captured: CapturedRequest[] = [];
+    await exchangeCode(
+      "https://auth.example.com/token",
+      "c",
+      "http://cb",
+      "v",
+      "client-1",
+      "s3cret",
+      "client_secret_post",
+      capturingFetch(TOKENS, captured),
+    );
+    expect(captured[0]?.authorization).toBe("");
+    expect(captured[0]?.body.get("client_secret")).toBe("s3cret");
+  });
+
+  it("promotes Slack's authed_user token over the top-level bot token", async () => {
+    const response = await exchangeCode(
+      "https://auth.example.com/token",
+      "c",
+      "http://cb",
+      "v",
+      "client-1",
+      "",
+      "",
+      capturingFetch(
+        {
+          access_token: "xoxb-bot",
+          token_type: "bot",
+          authed_user: {
+            access_token: "xoxp-user",
+            token_type: "user",
+            scope: "chat:write",
+          },
+        },
+        [],
+      ),
+    );
+    expect(response.accessToken).toBe("xoxp-user");
+    expect(response.tokenType).toBe("user");
+    expect(response.scope).toBe("chat:write");
+  });
+
+  it("refuses a non-200 with the truncated body", async () => {
+    await expect(
+      exchangeCode(
+        "https://auth.example.com/token",
+        "c",
+        "http://cb",
+        "v",
+        "client-1",
+        "",
+        "",
+        capturingFetch({ error: "invalid_grant" }, [], 400),
+      ),
+    ).rejects.toThrow(
+      'token endpoint https://auth.example.com/token returned HTTP 400: {"error":"invalid_grant"}',
+    );
+  });
+
+  it("refuses a 200 whose body has no access_token", async () => {
+    await expect(
+      exchangeCode(
+        "https://auth.example.com/token",
+        "c",
+        "http://cb",
+        "v",
+        "client-1",
+        "",
+        "",
+        capturingFetch({ token_type: "bearer" }, []),
+      ),
+    ).rejects.toThrow(
+      "token response from https://auth.example.com/token is missing access_token",
+    );
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/dcr.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/dcr.ts
@@ -1,0 +1,92 @@
+/**
+ * RFC 7591 Dynamic Client Registration — ports
+ * pkg/domain/mcpserver/oauth/dcr.go. Registers a PUBLIC client
+ * (token_endpoint_auth_method "none"): MCP OAuth uses PKCE instead of a
+ * client secret, and an empty secret is what keeps the pending state's
+ * "never ciphertext-of-empty" rule meaningful (oss#394).
+ * Proven by mcpserver-oauth.conformance.test.ts (CONFORMANCE_TARGET=local-ts).
+ */
+import { truncateBody } from "./truncate-body.js";
+
+/** Dynamic Client Registration response per RFC 7591 (Go DCRResponse). */
+export interface DcrResponse {
+  clientId: string;
+  clientSecret: string;
+  clientName: string;
+  tokenEndpointAuthMethod: string;
+}
+
+/** Go's dcrHTTPClient 15s timeout — a named constant per guidelines. */
+export const DCR_REQUEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Performs OAuth Dynamic Client Registration at the given registration
+ * endpoint (Go RegisterClient). The returned client_id is stored in the
+ * user's OAuthGrant for subsequent token operations. Accepts 200 or 201
+ * (RFC says 201; real providers answer both).
+ */
+export async function registerClient(
+  registrationEndpoint: string,
+  redirectUri: string,
+  clientName: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DcrResponse> {
+  const requestBody = JSON.stringify({
+    redirect_uris: [redirectUri],
+    client_name: clientName,
+    grant_types: ["authorization_code"],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+  });
+
+  let response: Response;
+  try {
+    response = await fetchImpl(registrationEndpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: requestBody,
+      signal: AbortSignal.timeout(DCR_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    throw new Error(
+      `DCR request to ${registrationEndpoint} failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const body = await response.text();
+  if (response.status !== 201 && response.status !== 200) {
+    throw new Error(
+      `DCR at ${registrationEndpoint} returned HTTP ${response.status}: ${truncateBody(body)}`,
+    );
+  }
+
+  let raw: {
+    client_id?: string;
+    client_secret?: string;
+    client_name?: string;
+    token_endpoint_auth_method?: string;
+  };
+  try {
+    raw = JSON.parse(body) as typeof raw;
+  } catch (error) {
+    throw new Error(
+      `failed to parse DCR response: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if ((raw.client_id ?? "") === "") {
+    throw new Error(
+      `DCR response from ${registrationEndpoint} is missing client_id`,
+    );
+  }
+
+  return {
+    clientId: raw.client_id as string,
+    clientSecret: raw.client_secret ?? "",
+    clientName: raw.client_name ?? "",
+    tokenEndpointAuthMethod: raw.token_endpoint_auth_method ?? "",
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/discovery.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/discovery.ts
@@ -1,0 +1,142 @@
+/**
+ * RFC 8414 authorization-server discovery — ports
+ * pkg/domain/mcpserver/oauth/discovery.go. The well-known URI lives at the
+ * URL ORIGIN (scheme + host), not under the server's path — a Linear-style
+ * MCP URL like https://mcp.linear.app/mcp discovers at
+ * https://mcp.linear.app/.well-known/oauth-authorization-server.
+ * Proven by mcpserver-oauth.conformance.test.ts (CONFORMANCE_TARGET=local-ts).
+ */
+
+/**
+ * OAuth 2.0 Authorization Server Metadata discovered via RFC 8414
+ * (Go AuthServerMetadata). Field names keep the RFC's snake_case on the
+ * wire; this interface is the parsed camelCase view.
+ */
+export interface AuthServerMetadata {
+  issuer: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint: string;
+  scopesSupported: string[];
+  codeChallengeMethodsSupported: string[];
+}
+
+/** Go's discoveryHTTPClient 10s timeout — a named constant per guidelines. */
+export const DISCOVERY_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Fetches the OAuth Authorization Server Metadata from the MCP server's
+ * .well-known endpoint per RFC 8414 (Go DiscoverAuthorizationServer).
+ * Throws with Go's message text on non-200, unparseable metadata, missing
+ * endpoints, or an S256-less server — initiate embeds these messages in
+ * its FailedPrecondition copy, so the text is contract.
+ */
+export async function discoverAuthorizationServer(
+  serverUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<AuthServerMetadata> {
+  const wellKnownUrl = buildWellKnownUrl(serverUrl);
+
+  let response: Response;
+  try {
+    response = await fetchImpl(wellKnownUrl, {
+      method: "GET",
+      headers: { Accept: "application/json" },
+      signal: AbortSignal.timeout(DISCOVERY_REQUEST_TIMEOUT_MS),
+    });
+  } catch (error) {
+    throw new Error(
+      `discovery request to ${wellKnownUrl} failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (response.status !== 200) {
+    // Drain the body so the connection can be reused; the status alone
+    // classifies the failure.
+    await response.text();
+    throw new Error(
+      `authorization server discovery failed: ${wellKnownUrl} returned HTTP ${response.status} (expected 200). ` +
+        "This MCP server may not support the MCP Authorization specification",
+    );
+  }
+
+  let raw: {
+    issuer?: string;
+    authorization_endpoint?: string;
+    token_endpoint?: string;
+    registration_endpoint?: string;
+    scopes_supported?: string[];
+    code_challenge_methods_supported?: string[];
+  };
+  try {
+    raw = (await response.json()) as typeof raw;
+  } catch (error) {
+    throw new Error(
+      `failed to parse authorization server metadata: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const metadata: AuthServerMetadata = {
+    issuer: raw.issuer ?? "",
+    authorizationEndpoint: raw.authorization_endpoint ?? "",
+    tokenEndpoint: raw.token_endpoint ?? "",
+    registrationEndpoint: raw.registration_endpoint ?? "",
+    scopesSupported: raw.scopes_supported ?? [],
+    codeChallengeMethodsSupported: raw.code_challenge_methods_supported ?? [],
+  };
+
+  validateMetadata(metadata, wellKnownUrl);
+  return metadata;
+}
+
+/**
+ * Constructs the .well-known URL from the MCP server URL (Go
+ * buildWellKnownURL). Per RFC 8414, the well-known URI is at the origin.
+ */
+export function buildWellKnownUrl(serverUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(serverUrl);
+  } catch (error) {
+    throw new Error(
+      `invalid server URL for discovery: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const scheme = parsed.protocol.replace(/:$/, "");
+  if (scheme !== "http" && scheme !== "https") {
+    throw new Error(
+      `invalid server URL for discovery: unsupported scheme "${scheme}": only http and https are supported`,
+    );
+  }
+  if (parsed.host === "") {
+    throw new Error("invalid server URL for discovery: server URL has no host");
+  }
+
+  const origin = `${scheme}://${parsed.host}`;
+  return `${origin.replace(/\/+$/, "")}/.well-known/oauth-authorization-server`;
+}
+
+function validateMetadata(m: AuthServerMetadata, sourceUrl: string): void {
+  if (m.authorizationEndpoint === "") {
+    throw new Error(
+      `authorization server at ${sourceUrl} is missing authorization_endpoint`,
+    );
+  }
+  if (m.tokenEndpoint === "") {
+    throw new Error(
+      `authorization server at ${sourceUrl} is missing token_endpoint`,
+    );
+  }
+  if (
+    m.codeChallengeMethodsSupported.length > 0 &&
+    !m.codeChallengeMethodsSupported.includes("S256")
+  ) {
+    // Go renders the supported list with %v — space-separated in
+    // brackets; matched exactly because initiate forwards this text.
+    throw new Error(
+      `authorization server at ${sourceUrl} does not support S256 PKCE (supports: [${m.codeChallengeMethodsSupported.join(" ")}]). ` +
+        "S256 is required by the MCP Authorization specification",
+    );
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/managed-env.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/managed-env.ts
@@ -1,11 +1,11 @@
 /**
- * Managed-environment access — ports the slice of
- * pkg/domain/mcpserver/oauth/managed_env.go the agentexecution EC builder
- * consumes (#17): reading and rewriting OAuth token secrets through the
+ * Managed-environment access — ports pkg/domain/mcpserver/oauth/
+ * managed_env.go whole: reading and rewriting OAuth token secrets (#17's
+ * EC-builder slice) plus creating and deleting the managed environments
+ * themselves (#19's connect/OAuth slice). Every operation rides the
  * environment domain's in-process client, so encryption, validation, and
- * audit ride the environment pipeline automatically. The
- * create/delete-managed-environment halves arrive with the connect/OAuth
- * sub-project (#19), which owns the flows that mint managed environments.
+ * audit come from the environment pipeline automatically (DD-002: full
+ * interceptor traversal on every internal call).
  */
 import { create } from "@bufbuild/protobuf";
 
@@ -16,7 +16,11 @@ import {
   UpdateEnvironmentVariablesRequestSchema,
 } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/io_pb";
 import type { Environment } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { ApiResourceDeleteInputSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
 import type { MessageInitShape } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../../boot/logger.js";
 
 /** The label marking system-managed OAuth-token environments. */
 export const MANAGED_ENV_LABEL = "stigmer.ai/managed";
@@ -33,10 +37,76 @@ export interface ManagedEnvironmentClient {
   updateVariables(
     request: MessageInitShape<typeof UpdateEnvironmentVariablesRequestSchema>,
   ): Promise<Environment>;
+  create(
+    environment: MessageInitShape<typeof EnvironmentSchema>,
+  ): Promise<Environment>;
+  delete(
+    input: MessageInitShape<typeof ApiResourceDeleteInputSchema>,
+  ): Promise<Environment>;
 }
 
 export class ManagedEnvironmentService {
-  constructor(private readonly client: ManagedEnvironmentClient) {}
+  constructor(
+    private readonly client: ManagedEnvironmentClient,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Creates a new system-managed environment with the
+   * stigmer.ai/managed=true label and returns its resource id (Go
+   * CreateManagedEnvironment). The environment goes through the standard
+   * create pipeline, which handles id generation, slug resolution,
+   * timestamps, and search indexing.
+   */
+  async createManagedEnvironment(name: string, org: string): Promise<string> {
+    let created: Environment;
+    try {
+      created = await this.client.create(
+        create(EnvironmentSchema, {
+          apiVersion: "agentic.stigmer.ai/v1",
+          kind: "Environment",
+          metadata: {
+            name,
+            org,
+            labels: { [MANAGED_ENV_LABEL]: "true" },
+          },
+        }),
+      );
+    } catch (error) {
+      throw new Error(
+        `failed to create managed environment: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    const envId = created.metadata?.id ?? "";
+    this.logger.info("Created managed environment for OAuth token storage", {
+      environment_id: envId,
+      name,
+      org,
+    });
+    return envId;
+  }
+
+  /**
+   * Deletes a managed environment and all its secrets (Go
+   * DeleteManagedEnvironment). Non-fatal callers should catch errors —
+   * the environment may already be deleted (concurrent disconnects or
+   * partial-failure retries).
+   */
+  async deleteManagedEnvironment(environmentId: string): Promise<void> {
+    try {
+      await this.client.delete(
+        create(ApiResourceDeleteInputSchema, { resourceId: environmentId }),
+      );
+    } catch (error) {
+      throw new Error(
+        `failed to delete managed environment ${environmentId}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    this.logger.info("Deleted managed environment", {
+      environment_id: environmentId,
+    });
+  }
 
   /**
    * Retrieves a single decrypted secret value from a managed environment

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/pkce.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/pkce.ts
@@ -1,0 +1,28 @@
+/**
+ * PKCE pair generation — ports pkg/domain/mcpserver/oauth/pkce.go.
+ * Always S256: RFC 7636 and OAuth 2.1 require it, and initiate refuses
+ * authorization servers that do not support it (discovery.ts).
+ */
+import { createHash, randomBytes } from "node:crypto";
+
+/** A PKCE code verifier and its corresponding S256 challenge. */
+export interface PkcePair {
+  codeVerifier: string;
+  codeChallenge: string;
+}
+
+/**
+ * Creates a cryptographically random PKCE pair using the S256 method.
+ *
+ * The code verifier is a 32-byte random value encoded as base64url (no
+ * padding). The code challenge is the SHA-256 hash of the verifier, also
+ * base64url-encoded.
+ */
+export function generatePkce(): PkcePair {
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256")
+    .update(verifier)
+    .digest()
+    .toString("base64url");
+  return { codeVerifier: verifier, codeChallenge: challenge };
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/preflight.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/preflight.ts
@@ -1,0 +1,107 @@
+/**
+ * Authorization-endpoint pre-flight probe — ports
+ * pkg/domain/mcpserver/oauth/preflight.go.
+ *
+ * Some providers (e.g. Canva) accept Dynamic Client Registration for any
+ * redirect URI but enforce a redirect-host allowlist at the authorization
+ * endpoint. The rejection then surfaces only inside the OAuth popup, on a
+ * vendor error page that never redirects back — so the connect flow never
+ * learns it failed (stigmer/stigmer#235). This probe moves that discovery
+ * to initiate time, where it can fail fast with an honest error.
+ *
+ * Classification is deliberately narrow — blocked means HTTP 400, nothing
+ * else. RFC 6749 §4.1.2.1 requires an invalid-redirect rejection to be
+ * shown at the authorization server without redirecting, which providers
+ * implement as a 400. Everything else fails open (undefined, possibly
+ * after a diagnostic error): bot-protection layers answer server-side
+ * GETs with 403/503 while real browsers pass, and treating those as
+ * blocked would turn healthy providers into false dead ends. A fail-open
+ * miss merely preserves today's behavior; a false positive would break a
+ * working connect flow.
+ *
+ * The probe is side-effect-free: state and PKCE parameters are opaque to
+ * the authorization server at this point, and nothing is consumed until
+ * the callback leg, which the probe never reaches.
+ */
+import { truncateBody } from "./truncate-body.js";
+
+/**
+ * A definite refusal from an authorization endpoint, observed before any
+ * browser was involved (Go AuthorizeRejection).
+ */
+export interface AuthorizeRejection {
+  /** The HTTP status the authorization endpoint returned. */
+  statusCode: number;
+  /**
+   * The provider's own explanation, extracted from an RFC 6749-shaped
+   * JSON error body (error_description, falling back to error). Empty
+   * when the body is HTML or otherwise unparseable.
+   */
+  vendorDetail: string;
+  /** A truncated copy of the raw response body, for logs. */
+  bodySnippet: string;
+}
+
+/**
+ * Go's preflightHTTPClient 4s timeout: this probe sits on the user-facing
+ * initiate path, after discovery and DCR round trips.
+ */
+export const PREFLIGHT_REQUEST_TIMEOUT_MS = 4_000;
+
+/**
+ * Error pages are small; anything longer is noise (Go's LimitReader cap).
+ */
+const PREFLIGHT_BODY_READ_CAP = 4096;
+
+/**
+ * Probes an authorization URL server-side and reports whether the
+ * provider will refuse it before ever showing a login page (Go
+ * PreflightAuthorize). Redirects are deliberately not followed: a healthy
+ * authorization endpoint answers a fresh GET with either a login/consent
+ * page (2xx) or a redirect into the vendor's login flow (3xx), and the
+ * first response alone is enough to classify.
+ */
+export async function preflightAuthorize(
+  authorizationUrl: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<AuthorizeRejection | undefined> {
+  // Network errors propagate to the caller, who treats them as
+  // fail-open diagnostics — exactly Go's (nil, err) contract.
+  const response = await fetchImpl(authorizationUrl, {
+    method: "GET",
+    redirect: "manual",
+    signal: AbortSignal.timeout(PREFLIGHT_REQUEST_TIMEOUT_MS),
+  });
+
+  if (response.status !== 400) {
+    // Drain so the socket is reusable; the status alone classifies.
+    await response.text().catch(() => "");
+    return undefined;
+  }
+
+  const body = (await response.text()).slice(0, PREFLIGHT_BODY_READ_CAP);
+
+  return {
+    statusCode: response.status,
+    vendorDetail: extractVendorDetail(body),
+    bodySnippet: truncateBody(body),
+  };
+}
+
+/**
+ * Pulls the provider's own words from an RFC 6749-shaped JSON error body
+ * (Go extractVendorDetail). HTML error pages (Canva's case) yield "" —
+ * scraping prose out of markup is not worth the fragility.
+ */
+function extractVendorDetail(body: string): string {
+  let parsed: { error?: string; error_description?: string };
+  try {
+    parsed = JSON.parse(body) as typeof parsed;
+  } catch {
+    return "";
+  }
+  if ((parsed.error_description ?? "") !== "") {
+    return parsed.error_description as string;
+  }
+  return parsed.error ?? "";
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/token.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/token.ts
@@ -1,9 +1,10 @@
 /**
- * OAuth token-endpoint client — ports the refresh slice of
- * pkg/domain/mcpserver/oauth/token.go (D4 #17 consumes the pre-flight
- * refresh; ExchangeCode and the DCR/discovery/PKCE machinery arrive with
- * the connect/OAuth sub-project, #19).
+ * OAuth token-endpoint client — ports pkg/domain/mcpserver/oauth/token.go
+ * whole: the pre-flight refresh (#17) and the authorization-code exchange
+ * (#19). Proven by mcpserver-oauth.conformance.test.ts and the Class B
+ * mcpserver-connect suite.
  */
+import { truncateBody } from "./truncate-body.js";
 
 /** Token-endpoint response (Go TokenResponse). */
 export interface TokenResponse {
@@ -24,6 +25,39 @@ export const TOKEN_AUTH_METHOD_POST = "client_secret_post";
 
 /** Go's tokenHTTPClient 15s timeout — a named constant per guidelines. */
 export const TOKEN_REQUEST_TIMEOUT_MS = 15_000;
+
+/**
+ * Exchanges an authorization code for tokens using the
+ * authorization_code grant with PKCE (Go ExchangeCode). For public
+ * clients (DCR), clientSecret is empty; for confidential clients (vendor
+ * OAuth) tokenAuthMethod selects how the secret is presented.
+ */
+export async function exchangeCode(
+  tokenEndpoint: string,
+  code: string,
+  redirectUri: string,
+  codeVerifier: string,
+  clientId: string,
+  clientSecret: string,
+  tokenAuthMethod: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<TokenResponse> {
+  const params = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    code_verifier: codeVerifier,
+    client_id: clientId,
+  });
+  return doTokenRequest(
+    tokenEndpoint,
+    params,
+    clientId,
+    clientSecret,
+    tokenAuthMethod,
+    fetchImpl,
+  );
+}
 
 /**
  * Exchanges a refresh token for a new access token (refresh_token
@@ -150,10 +184,4 @@ async function doTokenRequest(
     );
   }
   return tokenResponse;
-}
-
-/** Bounded error detail — Go truncateBody's 256-byte cap, verbatim. */
-function truncateBody(body: string): string {
-  const MAX = 256;
-  return body.length <= MAX ? body : `${body.slice(0, MAX)}...`;
 }

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/truncate-body.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/oauth/truncate-body.ts
@@ -1,0 +1,11 @@
+/**
+ * Bounded HTTP-body snippets for error messages and rejection records —
+ * ports pkg/domain/mcpserver/oauth/dcr.go's package-level truncateBody,
+ * shared by the DCR, preflight, and token modules exactly as in Go.
+ */
+
+/** Go truncateBody's 256-byte cap, verbatim. */
+export function truncateBody(body: string): string {
+  const MAX = 256;
+  return body.length <= MAX ? body : `${body.slice(0, MAX)}...`;
+}

--- a/backend/services/stigmer-server-ts/src/domain/mcpserver/start-connect.ts
+++ b/backend/services/stigmer-server-ts/src/domain/mcpserver/start-connect.ts
@@ -1,0 +1,295 @@
+/**
+ * McpServer startConnect (async lane) — ports
+ * pkg/domain/mcpserver/controller/start_connect.go: begin a connect
+ * operation and return without waiting for it (stigmer/stigmer#425).
+ *
+ * Everything that needs the caller's identity — OAuth refresh pre-flight,
+ * personal-environment resolution, ExecutionContext creation, token
+ * minting — runs synchronously here via prepareConnect, exactly as in the
+ * blocking connect. Only awaiting the workflow moves to a detached settle
+ * task, which records the terminal connect_status and cleans up the
+ * ExecutionContext when the run finishes. Clients poll
+ * get/getByReference until connect_status reaches a terminal phase.
+ *
+ * Idempotent while an operation is in flight, at two layers: a fast path
+ * (a live CONNECTING record whose workflow Temporal reports as running
+ * returns immediately, before any ExecutionContext is created) and the
+ * authoritative deterministic-workflow-ID refusal, turned into the same
+ * attach semantics. A CONNECTING record whose run is NOT running (the
+ * backend restarted before its awaiter could settle, or Temporal lost the
+ * run) is not reconciled in place — the fresh start below overwrites it,
+ * which is both the repair and the caller's intent.
+ *
+ * Proven by mcpserver-connect.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts-execution) and
+ * __tests__/start-connect.test.ts.
+ */
+import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import type { ConnectInput } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { ConnectPhase } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import {
+  persistConnectFailure,
+  persistConnectResult,
+  persistConnectStarting,
+} from "./connect-status.js";
+import {
+  ASYNC_CONNECT_TIMEOUT,
+  BEST_EFFORT_CONNECT_GET_BUFFER_MS,
+  deleteConnectExecutionContext,
+  mapConnectFailure,
+  prepareConnect,
+} from "./connect.js";
+import type { McpServerConnectDeps } from "./connect.js";
+import type { ConnectRun, McpServerConnectEngine } from "./engine.js";
+
+/**
+ * The dead-runner advisory recorded on connect_status when no worker is
+ * polling the runner task queue at start time (Go runnerQueueWarning's
+ * copy — rendered verbatim by the SDK).
+ */
+export const RUNNER_QUEUE_WARNING =
+  "no runner appears to be polling the task queue — the connect will wait " +
+  "for one to come up (start your local runner if it is not running)";
+
+export async function startConnect(
+  deps: McpServerConnectDeps,
+  input: ConnectInput,
+): Promise<McpServer> {
+  const engineState = deps.engineState();
+  if (!engineState.connected) {
+    throw failedPreconditionError(
+      "connect is not available: Temporal not configured",
+    );
+  }
+
+  const mcpServerId = input.mcpServerId;
+  if (mcpServerId === "") {
+    throw invalidArgumentError("mcp_server_id is required");
+  }
+  if (input.org === "") {
+    throw invalidArgumentError("org is required for connect");
+  }
+
+  let mcpServer: McpServer;
+  try {
+    mcpServer = await deps.store.getResource(
+      ApiResourceKind.mcp_server,
+      mcpServerId,
+      McpServerSchema,
+    );
+  } catch {
+    throw notFoundError("mcp_server", mcpServerId);
+  }
+
+  const connectStatus = mcpServer.status?.connectStatus;
+  if (connectStatus?.phase === ConnectPhase.connecting) {
+    if (
+      await engineState.engine.isConnectRunRunning(connectStatus.workflowId)
+    ) {
+      deps.logger.info("StartConnect attached to in-flight connect operation", {
+        mcp_server_id: mcpServerId,
+        workflow_id: connectStatus.workflowId,
+      });
+      return mcpServer;
+    }
+  }
+
+  const prepared = await prepareConnect(deps, mcpServer, input);
+
+  // Taken before the start so the advisory describes the queue the run is
+  // about to join. Warn-only by design: a worker may be booting (the
+  // pre-flight has a startup false-negative race), so the operation
+  // proceeds either way and the poller renders the warning as context.
+  const warning = await runnerQueueWarning(engineState.engine);
+
+  let run: ConnectRun;
+  try {
+    run = await engineState.engine.startOrAttachConnect(
+      mcpServerId,
+      prepared.workflowInput,
+      ASYNC_CONNECT_TIMEOUT.ms,
+    );
+  } catch (error) {
+    if (prepared.ecResourceId !== "") {
+      await deleteConnectExecutionContext(
+        deps,
+        prepared.ecResourceId,
+        prepared.executionId,
+      );
+    }
+    deps.logger.error("Failed to start MCP connect workflow", {
+      mcp_server_id: mcpServerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw internalError(error, "failed to start connect workflow");
+  }
+
+  if (run.attached) {
+    // Lost the residual race to another lane: its run and CONNECTING
+    // record stand, and the ExecutionContext prepared here is unused.
+    if (prepared.ecResourceId !== "") {
+      await deleteConnectExecutionContext(
+        deps,
+        prepared.ecResourceId,
+        prepared.executionId,
+      );
+    }
+    try {
+      return await deps.store.getResource(
+        ApiResourceKind.mcp_server,
+        mcpServerId,
+        McpServerSchema,
+      );
+    } catch {
+      throw notFoundError("mcp_server", mcpServerId);
+    }
+  }
+
+  let persisted: McpServer;
+  try {
+    persisted = await persistConnectStarting(
+      deps.store,
+      mcpServerId,
+      run.workflowId,
+      warning,
+    );
+  } catch (error) {
+    // The workflow is already running; hand it to the background settler
+    // (which copes with a deleted resource) but fail the RPC honestly —
+    // a caller that cannot observe CONNECTING cannot poll.
+    detachSettle(deps, mcpServer, run, prepared);
+    throw internalError(error, "failed to record connect operation");
+  }
+
+  detachSettle(deps, mcpServer, run, prepared);
+
+  return persisted;
+}
+
+/**
+ * Launches the settle task fire-and-forget (Go's `go settleConnectAsync`).
+ * settleConnectAsync's own arms never reject; the catch here is the
+ * process-safety net an unhandled rejection would otherwise pierce.
+ */
+function detachSettle(
+  deps: McpServerConnectDeps,
+  mcpServer: McpServer,
+  run: ConnectRun,
+  prepared: { readonly ecResourceId: string; readonly executionId: string },
+): void {
+  void settleConnectAsync(
+    deps,
+    mcpServer,
+    run,
+    prepared.ecResourceId,
+    prepared.executionId,
+  ).catch((error: unknown) => {
+    deps.logger.warn("Async connect settle task failed unexpectedly", {
+      mcp_server_id: mcpServer.metadata?.id ?? "",
+      error: error instanceof Error ? error.message : String(error),
+    });
+  });
+}
+
+/**
+ * Awaits a connect workflow off the request path, records the terminal
+ * connect_status (with results on success), and cleans up the ephemeral
+ * ExecutionContext (Go settleConnectAsync).
+ *
+ * The bounded wait follows the startBestEffortConnect pattern: the
+ * workflow's own WorkflowRunTimeout is the deadline that should fire
+ * first; the slightly longer backstop only guarantees the settle task can
+ * never hang if Temporal becomes unreachable. If this process dies before
+ * settling, the CONNECTING record goes stale; the next startConnect
+ * overwrites it (the orphan contract on ConnectStatus). Never throws —
+ * every failure lands on connect_status or the log.
+ */
+async function settleConnectAsync(
+  deps: McpServerConnectDeps,
+  mcpServer: McpServer,
+  run: ConnectRun,
+  ecResourceId: string,
+  executionId: string,
+): Promise<void> {
+  const mcpServerId = mcpServer.metadata?.id ?? "";
+  try {
+    const outcome = await run.result(
+      ASYNC_CONNECT_TIMEOUT.ms + BEST_EFFORT_CONNECT_GET_BUFFER_MS,
+    );
+
+    if (!outcome.ok) {
+      const failure = mapConnectFailure(
+        deps.logger,
+        mcpServer,
+        run.workflowId,
+        outcome.failure,
+        ASYNC_CONNECT_TIMEOUT,
+      );
+      await persistConnectFailure(deps.store, deps.logger, mcpServerId, failure);
+      return;
+    }
+
+    let persisted: McpServer;
+    let toolApprovalCount: number;
+    try {
+      ({ persisted, toolApprovalCount } = await persistConnectResult(
+        deps.store,
+        mcpServerId,
+        run.workflowId,
+        outcome.output,
+      ));
+    } catch (error) {
+      if (error instanceof ResourceNotFoundError) {
+        deps.logger.info(
+          "Skipping async connect persistence: MCP server deleted before connect completed",
+          { mcp_server_id: mcpServerId },
+        );
+        return;
+      }
+      deps.logger.warn("Failed to persist async connect result", {
+        mcp_server_id: mcpServerId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return;
+    }
+
+    deps.logger.info("Async MCP server connect completed and stored", {
+      workflow_id: run.workflowId,
+      mcp_server_id: mcpServerId,
+      tools: persisted.status?.discoveredCapabilities?.tools.length ?? 0,
+      resource_templates:
+        persisted.status?.discoveredCapabilities?.resourceTemplates.length ?? 0,
+      tool_approvals: toolApprovalCount,
+    });
+  } finally {
+    if (ecResourceId !== "") {
+      await deleteConnectExecutionContext(deps, ecResourceId, executionId);
+    }
+  }
+}
+
+/**
+ * The dead-runner advisory for connect_status, or "" when a worker is
+ * polling the runner task queue — or when the question cannot be answered
+ * (an unreachable Temporal should not cry wolf on an operation that is
+ * about to fail loudly anyway; Go runnerQueueWarning).
+ */
+async function runnerQueueWarning(
+  engine: McpServerConnectEngine,
+): Promise<string> {
+  const hasPollers = await engine.hasRunnerQueuePollers();
+  if (hasPollers === undefined || hasPollers) {
+    return "";
+  }
+  return RUNNER_QUEUE_WARNING;
+}

--- a/backend/services/stigmer-server-ts/src/pipeline/errors.ts
+++ b/backend/services/stigmer-server-ts/src/pipeline/errors.ts
@@ -81,6 +81,16 @@ const GRPC_CODE_NAMES: Readonly<Record<Code, string>> = {
 };
 
 /**
+ * grpc-go's codes.Code.String() name for a connect Code — for surfaces
+ * that persist the code NAME rather than raise it (McpServer
+ * connect_status.failure_code copies the blocking RPC's classification in
+ * CamelCase form per status.proto's field doc).
+ */
+export function grpcCodeName(code: Code): string {
+  return GRPC_CODE_NAMES[code];
+}
+
+/**
  * Reproduces the wire message grpc-go's status.FromError manufactures for
  * %w-wrapped status errors: when Go wraps a downstream in-process client
  * error with fmt.Errorf("%s: %w", ...), PipelineError.GRPCStatus's

--- a/backend/services/stigmer-server-ts/src/temporal/mcpserver/engine-client.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/mcpserver/engine-client.ts
@@ -1,0 +1,273 @@
+/**
+ * McpServerConnectEngine over the Temporal client — the temporal-side
+ * implementation of the domain seam (src/domain/mcpserver/engine.ts),
+ * porting the client operations Go's McpServerController holds directly:
+ * startOrAttachConnectWorkflow (connect.go:599), isConnectRunRunning and
+ * DescribeTaskQueue (start_connect.go:181-210), and run.Get's error
+ * taxonomy (connect.go:646-698 — classification here, gRPC copy in the
+ * domain).
+ *
+ * No worker: the connect workflow is the RUNNER's; this module only
+ * starts, attaches to, describes, and awaits runs. The engine-state
+ * provider follows #18's idiom exactly (engine-client.ts precedent): it
+ * reads the manager's CURRENT client at request time and memoizes the
+ * engine per client instance, so reconnects propagate automatically.
+ *
+ * Proven by mcpserver-connect.conformance.test.ts
+ * (CONFORMANCE_TARGET=local-ts-execution).
+ */
+import type { Client } from "@temporalio/client";
+import { WorkflowFailedError, WorkflowNotFoundError } from "@temporalio/client";
+import type { WorkflowHandle } from "@temporalio/client";
+import {
+  ApplicationFailure,
+  TimeoutFailure,
+  WorkflowExecutionAlreadyStartedError,
+} from "@temporalio/common";
+// Default-imported: @temporalio/proto is CommonJS, and Node's ESM loader
+// cannot statically detect its `temporal` named export (the runtime
+// throws SyntaxError on the named form even though tsc accepts it).
+import temporalProto from "@temporalio/proto";
+
+import type { Logger } from "../../boot/logger.js";
+import type { AgentExecutionTemporalConfig } from "../../domain/agentexecution/temporal/config.js";
+import type {
+  ConnectRun,
+  ConnectRunFailure,
+  ConnectRunOutcome,
+  ConnectWorkflowInput,
+  ConnectWorkflowOutput,
+  McpServerConnectEngine,
+  McpServerEngineState,
+  McpServerEngineStateProvider,
+} from "../../domain/mcpserver/engine.js";
+import { MCP_SERVER_ENGINE_DISCONNECTED } from "../../domain/mcpserver/engine.js";
+import type { TemporalManager } from "../manager.js";
+import { CONNECT_WORKFLOW_NAME, connectWorkflowIdFor } from "./names.js";
+
+export interface McpServerEngineDeps {
+  readonly client: Client;
+  readonly config: AgentExecutionTemporalConfig;
+  readonly logger: Logger;
+}
+
+export class TemporalMcpServerConnectEngine implements McpServerConnectEngine {
+  constructor(private readonly deps: McpServerEngineDeps) {}
+
+  async startOrAttachConnect(
+    mcpServerId: string,
+    input: ConnectWorkflowInput,
+    runTimeoutMs: number,
+  ): Promise<ConnectRun> {
+    const { client, config, logger } = this.deps;
+    const workflowId = connectWorkflowIdFor(mcpServerId);
+    // MCP connect is not session-scoped (it discovers tools at the server
+    // level), so it always routes to the default runner queue regardless
+    // of routing mode (connect.go:642-645).
+    const runnerQueue = config.runnerQueue;
+
+    let handle: WorkflowHandle;
+    let attached = false;
+    try {
+      handle = await client.workflow.start(CONNECT_WORKFLOW_NAME, {
+        workflowId,
+        taskQueue: runnerQueue,
+        workflowRunTimeout: runTimeoutMs,
+        args: [input],
+      });
+    } catch (error) {
+      if (error instanceof WorkflowExecutionAlreadyStartedError) {
+        logger.info("Connect workflow already in flight — attaching to it", {
+          workflow_id: workflowId,
+          mcp_server_id: mcpServerId,
+        });
+        handle = client.workflow.getHandle(workflowId);
+        attached = true;
+      } else {
+        throw error;
+      }
+    }
+
+    if (!attached) {
+      logger.info("Started MCP connect workflow", {
+        workflow_id: workflowId,
+        mcp_server_id: mcpServerId,
+        runner_queue: runnerQueue,
+      });
+    }
+
+    return {
+      workflowId,
+      attached,
+      result: (raceTimeoutMs?: number) =>
+        awaitRunOutcome(handle, raceTimeoutMs),
+    };
+  }
+
+  async isConnectRunRunning(workflowId: string): Promise<boolean> {
+    if (workflowId === "") {
+      return false;
+    }
+    try {
+      const description = await this.deps.client.workflow
+        .getHandle(workflowId)
+        .describe();
+      return description.status.name === "RUNNING";
+    } catch {
+      return false;
+    }
+  }
+
+  async hasRunnerQueuePollers(): Promise<boolean | undefined> {
+    const { client, config, logger } = this.deps;
+    try {
+      const response = await client.workflowService.describeTaskQueue({
+        namespace: client.options.namespace,
+        taskQueue: { name: config.runnerQueue },
+        taskQueueType:
+          temporalProto.temporal.api.enums.v1.TaskQueueType
+            .TASK_QUEUE_TYPE_WORKFLOW,
+      });
+      return (response.pollers?.length ?? 0) > 0;
+    } catch (error) {
+      logger.debug("Could not describe runner task queue for connect pre-flight", {
+        runner_queue: config.runnerQueue,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+}
+
+/**
+ * Awaits a run and classifies its settle into the seam's taxonomy —
+ * run.Get's errors.As switch (connect.go:661-694), one arm per Temporal
+ * failure class. raceTimeoutMs mirrors Go's bounded background contexts:
+ * the classification for a fired backstop is Go's ctx text, so the
+ * settle paths render the same failure they would have logged there.
+ */
+async function awaitRunOutcome(
+  handle: WorkflowHandle,
+  raceTimeoutMs: number | undefined,
+): Promise<ConnectRunOutcome> {
+  const resultPromise = handle
+    .result()
+    .then((output): ConnectRunOutcome => {
+      // The runner returns the output object directly; a null (crashed
+      // codec path etc.) classifies as an empty result rather than a
+      // crash — persistConnectResult's preserve-on-empty then applies.
+      return { ok: true, output: (output ?? {}) as ConnectWorkflowOutput };
+    })
+    .catch((error: unknown): ConnectRunOutcome => {
+      return { ok: false, failure: classifyRunError(error) };
+    });
+
+  if (raceTimeoutMs === undefined) {
+    return resultPromise;
+  }
+
+  let backstop: NodeJS.Timeout | undefined;
+  const backstopPromise = new Promise<ConnectRunOutcome>((resolve) => {
+    backstop = setTimeout(() => {
+      // Go's expired background context makes run.Get return
+      // "context deadline exceeded", which lands in the default
+      // (Internal) arm — same text, same classification.
+      resolve({
+        ok: false,
+        failure: { kind: "other", message: "context deadline exceeded" },
+      });
+    }, raceTimeoutMs);
+  });
+
+  try {
+    return await Promise.race([resultPromise, backstopPromise]);
+  } finally {
+    if (backstop !== undefined) {
+      clearTimeout(backstop);
+    }
+  }
+}
+
+function classifyRunError(error: unknown): ConnectRunFailure {
+  if (error instanceof WorkflowFailedError) {
+    // Walk the WHOLE cause chain, not just the direct cause: a workflow
+    // failed by an activity arrives as WorkflowFailedError →
+    // ActivityFailure → ApplicationFailure, and Go's errors.As unwraps
+    // the same chain to find the runner's ApplicationError (whose message
+    // is the classified, user-facing text — the intermediate
+    // ActivityFailure's "Activity task failed" is NOT the contract).
+    // Pinned by the mcpserver-connect suite's unreachable-server arm.
+    let application: ApplicationFailure | undefined;
+    let timeout: TimeoutFailure | undefined;
+    let cause: unknown = error.cause;
+    while (cause !== undefined && cause !== null) {
+      if (application === undefined && cause instanceof ApplicationFailure) {
+        application = cause;
+      }
+      if (timeout === undefined && cause instanceof TimeoutFailure) {
+        timeout = cause;
+      }
+      cause = (cause as { cause?: unknown }).cause;
+    }
+    // Go's switch order: the application arm wins when both match.
+    if (application !== undefined) {
+      // The runner's crafted, user-facing message (issue #239 arm).
+      return { kind: "application", message: application.message };
+    }
+    if (timeout !== undefined) {
+      // The WorkflowRunTimeout elapsed (issue #243 arm).
+      return { kind: "timeout" };
+    }
+    return {
+      kind: "other",
+      message:
+        error.cause?.message !== undefined && error.cause.message !== ""
+          ? error.cause.message
+          : error.message,
+    };
+  }
+  if (error instanceof WorkflowNotFoundError) {
+    // Go serviceerror.NotFound — the run vanished (e.g. Temporal data
+    // loss); the domain maps this to Unavailable.
+    return { kind: "service-not-found" };
+  }
+  return {
+    kind: "other",
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+/**
+ * Builds the provider compose hands the mcpserver registration.
+ * Availability parity per the manager's contract: disconnected ONLY until
+ * the first successful connect; afterwards the engine wraps the manager's
+ * CURRENT client, stale-during-outage included — operations then fail
+ * exactly as Go's stale-client operations do.
+ */
+export function newMcpServerEngineStateProvider(deps: {
+  readonly manager: TemporalManager;
+  readonly config: AgentExecutionTemporalConfig;
+  readonly logger: Logger;
+}): McpServerEngineStateProvider {
+  let memo: { client: Client; state: McpServerEngineState } | undefined;
+  return () => {
+    const client = deps.manager.getClient();
+    if (client === undefined) {
+      return MCP_SERVER_ENGINE_DISCONNECTED;
+    }
+    if (memo === undefined || memo.client !== client) {
+      memo = {
+        client,
+        state: {
+          connected: true,
+          engine: new TemporalMcpServerConnectEngine({
+            client,
+            config: deps.config,
+            logger: deps.logger,
+          }),
+        },
+      };
+    }
+    return memo.state;
+  };
+}

--- a/backend/services/stigmer-server-ts/src/temporal/mcpserver/names.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/mcpserver/names.ts
@@ -1,0 +1,23 @@
+/**
+ * McpServer connect workflow wire identifiers — cross-edition constants
+ * copied character-for-character from Go (connect.go:31-32, 584-586).
+ * Renaming one is a wire protocol break (guidelines §2).
+ */
+
+/** The runner's connect workflow type (Go connectWorkflowName). */
+export const CONNECT_WORKFLOW_NAME = "stigmer/mcp-server/connect";
+
+/**
+ * The deterministic workflow ID for a server's connect operation (Go
+ * connectWorkflowID). One ID per server (no random suffix) makes Temporal
+ * itself the authority on "is a connect already running": a second start
+ * while one is in flight is refused with WorkflowExecutionAlreadyStarted,
+ * which the lanes turn into attach semantics — concurrent connects share
+ * one discovery run instead of racing duplicate workflows against the
+ * same server. A new run under the same ID is allowed once the previous
+ * one closes (the SDK's default reuse policy), which is what a reconnect
+ * is.
+ */
+export function connectWorkflowIdFor(mcpServerId: string): string {
+  return `${CONNECT_WORKFLOW_NAME}/${mcpServerId}`;
+}

--- a/test/conformance/src/targets/local-ts-execution.ts
+++ b/test/conformance/src/targets/local-ts-execution.ts
@@ -50,6 +50,11 @@ export class LocalTsExecutionTarget implements TargetProfile {
     // provisions is the agent/workflow execution engine, not a channel
     // delivery runtime — the refusal posture is identical to local-ts.
     channelMessaging: false,
+    // The org-OAuth-app (BYOA) surface is UNIMPLEMENTED on OSS by design
+    // (stigmer/stigmer#558) — identical to every local target. This line
+    // was the CW-1→#18 merge-coordination item (whichever PR merged
+    // second adds it); it landed here with #19.
+    orgOAuthAppConfiguration: false,
   };
 
   private temporal: RunningTemporal | undefined;

--- a/test/conformance/src/targets/local-ts-execution.ts
+++ b/test/conformance/src/targets/local-ts-execution.ts
@@ -50,20 +50,11 @@ export class LocalTsExecutionTarget implements TargetProfile {
     // provisions is the agent/workflow execution engine, not a channel
     // delivery runtime — the refusal posture is identical to local-ts.
     channelMessaging: false,
-<<<<<<< HEAD
-    // The org-OAuth-app (BYOA) surface is UNIMPLEMENTED on OSS by design
-    // (stigmer/stigmer#558) — identical to every local target. This line
-    // was the CW-1→#18 merge-coordination item (whichever PR merged
-    // second adds it); it landed here with #19.
-    orgOAuthAppConfiguration: false,
-||||||| 69f3d7e32
-=======
     // The org BYOA lane is UNIMPLEMENTED on OSS by design (stigmer#558) —
     // the suite pins the three refusals here. This line was CW-1's (#11)
     // merge-coordination ask of whichever execution PR merged second; #18
     // merged second and missed it — restored by D4 #21's pre-flight.
     orgOAuthAppConfiguration: false,
->>>>>>> origin/main
   };
 
   private temporal: RunningTemporal | undefined;

--- a/test/conformance/vitest.local-ts-execution.config.ts
+++ b/test/conformance/vitest.local-ts-execution.config.ts
@@ -17,12 +17,17 @@
 //   half needs the #20/#21 engine; the file was split for exactly this
 //   roster — sub-project 20260824.03 brief #3), and open-computer-use
 //   (the STIGMER_DESKTOP_TESTS opt-in gate — CI-inert exactly as on the
-//   Go target). DEFERRED to #9 mcpserver-crud (sub-project 20260824.03
-//   DD-002, owner-ratified): agentexecution-approval (the HITL matrix),
-//   mcp.harness.smoke, and mcp-caller-identity register McpServer
-//   resources as their tool surface — a domain this server serves only
-//   once #9 ports it. #9's PR rosters them and carries the "HITL matrix
-//   green" acceptance.
+//   Go target). #18 deferred agentexecution-approval (the HITL matrix),
+//   mcp.harness.smoke, and mcp-caller-identity "to #9's PR" — but #9 had
+//   already merged when #18's roster landed, so the handoff fell between
+//   the parallel sessions; #19 absorbed them (below).
+//   #19 (2026-08-25, sp.mcpserver-connect-oauth): mcpserver-connect —
+//   the CW-1 Class B slice (connect/startConnect discovery through the
+//   runner's workflow, handshake completion, refresh-on-connect) — plus
+//   the three suites orphaned above (owner-ratified DB-2): they need
+//   only #9's McpServer CRUD + #18's engine ("create only — no
+//   connect/discovery step"), and this entry carries the "HITL matrix
+//   green" acceptance #18 reassigned.
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -35,6 +40,10 @@ export default defineConfig({
       "src/suites-execution/open-computer-use.conformance.test.ts",
       "src/suites-execution/session-immutability.conformance.test.ts",
       "src/suites-execution/envmerge-agent.conformance.test.ts",
+      "src/suites-execution/agentexecution-approval.conformance.test.ts",
+      "src/suites-execution/mcp.harness.smoke.test.ts",
+      "src/suites-execution/mcp-caller-identity.conformance.test.ts",
+      "src/suites-execution/mcpserver-connect.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts-execution.ts"],
     env: {

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -56,6 +56,12 @@
 //     Layer-1 arms, and the artifact file-server disposition lane). The
 //     oauthapp suite's delete-block test drives McpServer create/delete,
 //     so it rosters here only after #9 (McpServer CRUD) merged.
+//   - mcpserver-oauth — sub-project #19 (sp.mcpserver-connect-oauth; the
+//     CW-1 Class A slice: initiate guards + the DCR arm against the mock
+//     authorization server + the vendor arm's byte-pinned refusals +
+//     grant-free reads + the three org-OAuth UNIMPLEMENTED pins. The
+//     handshake-completion lanes run Class B on local-ts-execution —
+//     CW-1's execution-time DB-1 amendment).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -83,6 +89,7 @@ export default defineConfig({
       "src/suites/platform.conformance.test.ts",
       "src/suites/github.conformance.test.ts",
       "src/suites/artifact.conformance.test.ts",
+      "src/suites/mcpserver-oauth.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary

Ports the last unported domain surface to the TS server (stigmer-cloud program 20260822.01, D4 entry #19): McpServer `connect`/`startConnect` (tool discovery through the runner's `stigmer/mcp-server/connect` workflow) and the per-user OAuth credential lifecycle (`initiateOAuthConnect`/`completeOAuthConnect`/`disconnectOAuth`/`getOAuthGrantStatus`), plus apply's best-effort auto-connect tail. Proven by CW-1's suites: `mcpserver-oauth` (24) joins the `local-ts` roster, `mcpserver-connect` (20) joins `local-ts-execution`.

## Changes

- `src/domain/mcpserver/oauth/` completed: `pkce`/`discovery`/`dcr`/`preflight`/`truncate-body` new; `token.ts` gains `exchangeCode`; `managed-env.ts` gains the create/delete halves.
- Six RPC handlers as Go-file-mirroring modules (`connect`, `start-connect`, `connect-status`, `initiate-oauth-connect`, `complete-oauth-connect`, `disconnect-oauth`, `get-oauth-grant-status`); all Go budgets, byte-pinned copy, and error-code mappings preserved (420s/60m budgets with Go duration labels in the DeadlineExceeded copy, token-exchange→Unavailable, the #478 Internal-with-classified-cause exception, `failure_code` in CamelCase).
- The connect-engine seam: `src/domain/mcpserver/engine.ts` + `src/temporal/mcpserver/{names,engine-client}.ts` — client start/attach/await + DescribeTaskQueue (dead-runner warning) over the TemporalManager provider idiom. No new worker: the connect workflow is the runner's.
- Boot: `STIGMER_OAUTH_REDIRECT_URI` (WARN-degrade), compose wiring with the grant store shared with agentexecution's session-time injection, in-process environment create/delete + EC delete edges (DD-002 full-chain traversal).
- Conformance: rosters `mcpserver-oauth` (local-ts) and `mcpserver-connect` (local-ts-execution); absorbs the three #18-orphaned execution suites (`agentexecution-approval`, `mcp.harness.smoke`, `mcp-caller-identity` — owner-ratified DB-2, closing #18's reassigned "HITL matrix green" acceptance); fixes main's live TS2741 (`orgOAuthAppConfiguration: false` on the local-ts-execution target — the CW-1→#18 coordination line PR #873 missed).
- 91 new unit/composed tests, incl. the full handshake through a composed server against a live mock authorization server.

## Parity disclosures (for the register)

1. **Temporal-less `completeOAuthConnect` serves** (owner-ratified DB-1): Go refuses via its composition gate ("managed environment service not initialized" — built only inside the Temporal-gated `SetConnectDependencies`); CW-1 deliberately did NOT pin that wiring artifact. The TS composition root wires the managed-env service unconditionally. Go-side issue to file: the service has no conceptual Temporal dependency.
2. **Struct key ordering** (ratified DB-3 watch item): discovered-tool `input_schema` persists with the runner's insertion order (protobuf-es JsonObject) vs Go's sorted structpb JSON — feeds the filed carry-forward defect oss#862 either way; the suite pins only the wire-stable contract, which both orderings satisfy.
3. **Bounded sync wait**: the blocking connect races the workflow result against budget+15s; Go's wait is unbounded when Temporal dies mid-await. Unreachable while Temporal lives (the run timeout settles first); after 435s of dead Temporal the TS server answers Internal where Go hangs.
4. **Unreachable Internal arms dropped**: Go's "failed to generate PKCE pair"/"failed to generate state parameter" guard `crypto/rand` error returns; `node:crypto.randomBytes` throws only on entropy exhaustion and would surface as a generic Internal. Likewise Go's nil-dep guard shapes (initiate/complete "dependencies not initialized", disconnect/grant-status nil-store arms) are unreachable under the composition-root idiom.
5. **Query-encoding characters**: `URLSearchParams` and Go's `url.Values.Encode()` differ on `~`/`*` percent-encoding; parameter ORDER is matched (sorted) and every value in practice (base64url, URLs) encodes identically.
6. **Proto-required guards**: protovalidate answers `mcp_server_id`/`resource_id` emptiness before the handler guards — identical to Go (same rules, same interceptor order); the ported handler guards remain as defense-in-depth.
7. **oss#862 and oss#863 ported as-is** with issue-linked comments (the unconditional `RefreshTokenEnvVar` stamp, the unreachable TOKEN_EXPIRED arm, the refresh-token-read silent skip).

## Panel (run directly in-session; both reviewer subagents died to model limits)

- 1 BLOCKING parity fix caught by CW-1's unreachable-server pin: the failure classifier read only `WorkflowFailedError.cause` — a workflow failed by an activity nests `ActivityFailure → ApplicationFailure`, so the arm mapped to Internal "Activity task failed" instead of FailedPrecondition with the runner's classified text. Fixed with Go's `errors.As` chain-walk semantics.
- 1 boot fix: `@temporalio/proto` is CJS; the named `temporal` import passes tsc but throws at ESM runtime — default-import form.
- Quality hardening: honest managed-env fake (real service over a throwing client, no `as unknown as`), enabled-encryption seal/unseal pins (fail-closed, never-ciphertext-of-empty, keyless-deployment loud failure), wire-level state-replay arm, the TOKEN_EXPIRED store-seeded arm. Mechanical byte-string sweep of all pinned copy against Go: all present.

## Test plan

- `tsc --noEmit` clean (server; `test/conformance` down to main's 3 pre-existing errors — the TS2741 fixed).
- Server unit suite: **1394 passed** (91 new).
- `local-ts`: **24 suites, 453 passed / 1 pre-existing skip** — `mcpserver-oauth` first-run green (post-#16 merge tree).
- `local-ts-execution`: **11 suites, 87 passed / 1 opt-in skip** — `mcpserver-connect` 20/20; the DB-2 trio green.
- `local-go`: **492 / 1 skip** and `local-go-execution`: **159 / 2 skips** — baselines exact, regression-free.
- dist + slim bundles boot-verified.

Made with [Cursor](https://cursor.com)