### PR TITLE
feat(backend/stigmer-server-ts): port the Schedule domain and clock (D4 #22)

### DIFF
--- a/backend/services/stigmer-server-ts/scripts/capture-schedule-replay-histories.ts
+++ b/backend/services/stigmer-server-ts/scripts/capture-schedule-replay-histories.ts
@@ -1,0 +1,110 @@
+/**
+ * Captures schedule/tick workflow histories for the replay determinism
+ * gate — the OD-6 go-forward discipline the schedule domain itself
+ * originated (Go tick_history_capture_test.go): any change to the tick's
+ * logic must replay committed histories green, or be gated with patched().
+ * Histories are REGENERATED only when no producing release is still
+ * supported.
+ *
+ * The three scenarios mirror Go's gold masters name-for-name
+ * (tick-completed-run, tick-skipped-disabled, tick-start-failed) —
+ * captured fresh here because Go histories cannot replay against the TS
+ * SDK. Mock data only — safe to commit. Writes proto-JSON to
+ * src/temporal/schedule/__tests__/replay-histories/.
+ *
+ * Usage: npx tsx scripts/capture-schedule-replay-histories.ts
+ * (requires the `temporal` CLI on PATH — same as the workflow tests)
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import proto from "@temporalio/proto";
+import { TestWorkflowEnvironment } from "@temporalio/testing";
+import { Worker } from "@temporalio/worker";
+
+const TASK_QUEUE = "schedule-replay-capture";
+const WORKFLOWS_PATH = fileURLToPath(
+  new URL("../src/temporal/schedule/workflows/index.ts", import.meta.url),
+);
+const OUT_DIR = fileURLToPath(
+  new URL("../src/temporal/schedule/__tests__/replay-histories", import.meta.url),
+);
+
+// Scenario scripting mirrors the tick workflow tests' double.
+let tickOutcome = "FIRED";
+let runStart: Record<string, unknown> = {};
+let pollResult = "COMPLETED";
+
+const activities = {
+  "stigmer/schedule/record-tick": async () => tickOutcome,
+  "stigmer/schedule/start-run": async () => runStart,
+  "stigmer/schedule/poll-phase": async () => pollResult,
+  "stigmer/schedule/record-success": async () => {},
+  "stigmer/schedule/record-failure": async () => ({
+    consecutiveFailures: 1,
+    paused: false,
+  }),
+};
+
+async function main(): Promise<void> {
+  mkdirSync(OUT_DIR, { recursive: true });
+  const env = await TestWorkflowEnvironment.createLocal();
+  const worker = await Worker.create({
+    connection: env.nativeConnection,
+    taskQueue: TASK_QUEUE,
+    workflowsPath: WORKFLOWS_PATH,
+    activities,
+  });
+  const runPromise = worker.run();
+
+  async function capture(name: string): Promise<void> {
+    const handle = await env.client.workflow.start("schedule/tick", {
+      taskQueue: TASK_QUEUE,
+      // The artifact's workflow-id shape with an RFC-3339 fire suffix —
+      // the tick's tier-2 nominal derivation, exactly what a real fire
+      // replays.
+      workflowId: `schedule/tick/sch-replay-2026-08-25T09:30:00Z-${name}`,
+      args: ["sch-replay"],
+    });
+    await handle.result();
+    const history = await handle.fetchHistory();
+    // protobufjs' OWN toJSON/fromObject round-trip — see
+    // capture-replay-histories.ts for why not the SDK's historyToJSON.
+    const json = proto.temporal.api.history.v1.History.fromObject(history).toJSON();
+    writeFileSync(`${OUT_DIR}/${name}.json`, JSON.stringify(json, null, 2) + "\n");
+    console.log(`captured ${name}.json`);
+  }
+
+  // 1. The tracked happy path: FIRED → STARTED → poll COMPLETED → the
+  //    success reset (Go tick-completed-run.json).
+  tickOutcome = "FIRED";
+  runStart = {
+    outcome: "STARTED",
+    executionId: "aex-replay",
+    trackingTimeoutMinutes: 60,
+    failureReason: "",
+  };
+  pollResult = "COMPLETED";
+  await capture("tick-completed-run");
+
+  // 2. The revalidation decline (Go tick-skipped-disabled.json).
+  tickOutcome = "SKIPPED_DISABLED";
+  await capture("tick-skipped-disabled");
+
+  // 3. The start failure: FIRED → TARGET_MISSING → the single-attempt
+  //    failure record (Go tick-start-failed.json).
+  tickOutcome = "FIRED";
+  runStart = {
+    outcome: "TARGET_MISSING",
+    executionId: "",
+    trackingTimeoutMinutes: 60,
+    failureReason: "target agent acme/gone not found",
+  };
+  await capture("tick-start-failed");
+
+  worker.shutdown();
+  await runPromise.catch(() => {});
+  await env.teardown();
+}
+
+await main();
+process.exit(0);

--- a/backend/services/stigmer-server-ts/scripts/capture-schedule-replay-histories.ts
+++ b/backend/services/stigmer-server-ts/scripts/capture-schedule-replay-histories.ts
@@ -57,13 +57,16 @@ async function main(): Promise<void> {
   const runPromise = worker.run();
 
   async function capture(name: string): Promise<void> {
+    // The artifact's workflow-id shape with an RFC-3339 fire suffix — the
+    // tick's tier-2 nominal derivation, exactly what a real fire replays:
+    // workflowId = artifactId(scheduleId) + "-" + fireTime, so the
+    // scenario name rides the SCHEDULE id and the suffix stays a pure
+    // timestamp the tier-2 parser accepts.
+    const scheduleId = `sch-replay-${name}`;
     const handle = await env.client.workflow.start("schedule/tick", {
       taskQueue: TASK_QUEUE,
-      // The artifact's workflow-id shape with an RFC-3339 fire suffix —
-      // the tick's tier-2 nominal derivation, exactly what a real fire
-      // replays.
-      workflowId: `schedule/tick/sch-replay-2026-08-25T09:30:00Z-${name}`,
-      args: ["sch-replay"],
+      workflowId: `schedule/tick/${scheduleId}-2026-08-25T09:30:00Z`,
+      args: [scheduleId],
     });
     await handle.result();
     const history = await handle.fetchHistory();

--- a/backend/services/stigmer-server-ts/src/boot/compose.ts
+++ b/backend/services/stigmer-server-ts/src/boot/compose.ts
@@ -30,6 +30,15 @@ import { newExecutionEngineStateProvider } from "../temporal/agentexecution/engi
 import { newAgentExecutionWorkerFactory } from "../temporal/agentexecution/worker.js";
 import { TemporalManager } from "../temporal/manager.js";
 import { loadServerPayloadCodecs } from "../temporal/payload-codec.js";
+import type { Client as TemporalClient } from "@temporalio/client";
+
+import { ScheduleArtifact } from "../temporal/schedule/artifact.js";
+import { newScheduleConfigFromEnv } from "../temporal/schedule/config.js";
+import { ScheduleReconciler } from "../temporal/schedule/reconciler.js";
+import { RunStarter } from "../temporal/schedule/run-starter.js";
+import { ScheduleSyncer } from "../temporal/schedule/syncer.js";
+import { newScheduleWorkerFactory } from "../temporal/schedule/worker.js";
+import { registerScheduleServices } from "../domain/schedule/controller.js";
 import { RuntimeResolutionService } from "../domain/environment/resolution/resolution.js";
 import { ManagedEnvironmentService } from "../domain/mcpserver/oauth/managed-env.js";
 import { registerAgentInstanceServices } from "../domain/agentinstance/controller.js";
@@ -208,9 +217,45 @@ export function composeServer(options: ComposeOptions): ComposedServer {
   const workflowExecutionStreamBroker = new WorkflowExecutionStreamBroker(
     logger,
   );
+  // Stage: schedule clock (#22) — Go server.go 578–592 injection order:
+  // config → artifact → syncer → run starter → (worker below) →
+  // reconciler. The client provider closes over `temporalManager`,
+  // declared just below — legal and deliberate: the manager's factory list
+  // must include the schedule worker at construction, while the syncer and
+  // reconciler only READ the client at call time, long after boot (a call
+  // before initialization would throw loudly, the composition-root idiom).
+  const scheduleTemporalConfig = newScheduleConfigFromEnv();
+  const scheduleClientProvider = (): TemporalClient | undefined =>
+    temporalManager.getClient();
+  const scheduleArtifact = new ScheduleArtifact(scheduleTemporalConfig);
+  const scheduleSyncer = new ScheduleSyncer(
+    scheduleClientProvider,
+    store,
+    scheduleArtifact,
+    logger,
+  );
+  // Every fire enters the FULL execution create pipeline through the
+  // in-process agentexecution client (Go server.go 581: the RunStarter's
+  // ExecutionCreator edge).
+  const scheduleRunStarter = new RunStarter({
+    store,
+    config: scheduleTemporalConfig,
+    executions: {
+      create: (execution) =>
+        requireInProcess().scheduleExecutionCreator.create(execution),
+    },
+    logger,
+  });
+  const scheduleReconciler = new ScheduleReconciler(
+    scheduleClientProvider,
+    store,
+    scheduleSyncer,
+    scheduleTemporalConfig,
+    logger,
+  );
   // The manager owns the connection lifecycle; the agent-execution worker
-  // is the first factory (workflow-execution and the schedule clock
-  // append theirs in #21/#22 — Go createWorkers' list).
+  // is the first factory, the schedule clock's the second (Go
+  // createWorkers' list; workflow-execution appends with #21).
   const temporalManager = new TemporalManager({
     hostPort: config.temporalHostPort,
     namespace: config.temporalNamespace,
@@ -222,6 +267,13 @@ export function composeServer(options: ComposeOptions): ComposedServer {
         logger,
         broker: agentExecutionStreamBroker,
         temporalConfig,
+      }),
+      newScheduleWorkerFactory({
+        store,
+        config: scheduleTemporalConfig,
+        syncer: scheduleSyncer,
+        runStarter: scheduleRunStarter,
+        logger,
       }),
     ],
   });
@@ -358,6 +410,18 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     registerChannelMessageServices(router);
     registerChannelConversationServices(router);
     registerChannelAppServices(router, { store, logger, secretService });
+    // Schedule registers between channelapp and memory (Go server.go
+    // 417 → 426 → 436). The clock and runner ride constant providers —
+    // production wiring always has both (Go SetClock/SetRunner beside the
+    // manager); the provider SHAPE exists for embedded/test assemblies
+    // that skip Temporal wiring, where undefined degrades per DD-015 D-A.
+    registerScheduleServices(router, {
+      store,
+      logger,
+      modelRegistry: modelRegistryStore,
+      clock: () => scheduleSyncer,
+      runner: () => scheduleRunStarter,
+    });
     registerMemoryServices(router, { store, logger });
     registerAgentExecutionServices(router, {
       store,
@@ -493,6 +557,11 @@ export function composeServer(options: ComposeOptions): ComposedServer {
         await temporalManager.startWorkers();
       }
       temporalManager.startHealthMonitor();
+      // Schedule reconciliation: an immediate boot pass (the dev server may
+      // have restarted with empty state while the daemon was down), the
+      // periodic loop, and the reconnect kick — Go server.go 763–764.
+      const kickScheduleReconcile = scheduleReconciler.startReconciliation();
+      temporalManager.addReconnectHook(kickScheduleReconcile);
       // Artifact storage must be reachable and writable before the server
       // answers (Go server.go boots-fatal on the same probe).
       await artifactStorage.health();
@@ -525,6 +594,10 @@ export function composeServer(options: ComposeOptions): ComposedServer {
       healthState.setOverall(ServingStatus.NOT_SERVING);
       modelRegistryStore.stopRefresh();
       await artifactFileServer?.shutdown();
+      // The reconciler stops before the manager: a pass mid-flight may
+      // still call through the manager's client, and nothing may fire
+      // after shutdown (the #18 close-race lesson).
+      await scheduleReconciler.stop();
       // Workers stop before the transport drains: an in-flight activity
       // may still write through the store, which closes LAST.
       await temporalManager.close();

--- a/backend/services/stigmer-server-ts/src/boot/inprocess.ts
+++ b/backend/services/stigmer-server-ts/src/boot/inprocess.ts
@@ -68,6 +68,7 @@ import type { AgentExecutionFileDecisionForwarder } from "../domain/workflowexec
 import type { ParentWorkflowLoader } from "../domain/workflowinstance/steps.js";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import type { OrphanDeleter } from "../domain/project/reconcile.js";
+import type { ScheduleExecutionCreator } from "../temporal/schedule/run-starter.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
 import type { Logger } from "./logger.js";
 
@@ -111,6 +112,14 @@ export interface InProcessClients {
    * the same interceptor chain as an external delete.
    */
   readonly projectOrphanDeleter: OrphanDeleter;
+  /**
+   * The schedule clock's fire edge (server.go 581: the RunStarter's
+   * in-process agentexecution client): every fire — cron tick or manual
+   * trigger — enters the FULL execution create pipeline, so session
+   * auto-create, execution context, launch gates, and workflow start all
+   * run exactly as for an external create.
+   */
+  readonly scheduleExecutionCreator: ScheduleExecutionCreator;
 }
 
 /**
@@ -252,6 +261,12 @@ export function createInProcessClients(
     workflowExecutionFileDecisionForwarder: {
       submitFileDecision: (input) =>
         agentExecutionCommand.submitFileDecision(input),
+    },
+    // The schedule clock's fire edge — the plain Create RPC under the
+    // process-global operator identity (Go's ExecutionCreator; OSS has no
+    // caller identity by design, DD-015 D-G).
+    scheduleExecutionCreator: {
+      create: (execution) => agentExecutionCommand.create(execution),
     },
     // The project reconciler's delete routing — Go's
     // ResourceDeleterAdapter.Delete switch (execution_engine.go:75-92).

--- a/backend/services/stigmer-server-ts/src/domain/schedule/__tests__/cron.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/__tests__/cron.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Pins the lexical cron/timezone validation matrix against Go's
+ * cron_test.go — the shared rejection matrix is pinned by unit tests in
+ * both editions (and in the cloud Java edition), because every message is
+ * cross-edition byte contract.
+ */
+import { Code, ConnectError } from "@connectrpc/connect";
+import { describe, expect, it } from "vitest";
+
+import {
+  isLoadableTimeZone,
+  validateScheduleCron,
+  validateScheduleTimeZone,
+} from "../cron.js";
+
+function refusal(run: () => void): ConnectError {
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error("expected a refusal");
+}
+
+describe("validateScheduleCron — accepted grammar", () => {
+  it.each([
+    "* * * * *",
+    "0 9 * * *",
+    "*/5 * * * *",
+    "0 9 * * MON-FRI",
+    "30 8 1,15 * *",
+    "0 0 1 Jan *",
+    "@hourly",
+    "@daily",
+    "@weekly",
+    "@monthly",
+    "@yearly",
+  ])("accepts %j", (cron) => {
+    expect(() => validateScheduleCron(cron)).not.toThrow();
+  });
+
+  it("accepts fields separated by runs of whitespace (Go strings.Fields)", () => {
+    expect(() => validateScheduleCron("0  9   *  *  *")).not.toThrow();
+  });
+});
+
+describe("validateScheduleCron — rejection matrix (byte-pinned copy)", () => {
+  it("rejects a CRON_TZ= prefix", () => {
+    const err = refusal(() => validateScheduleCron("CRON_TZ=UTC 0 9 * * *"));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(
+      "spec.cron must not carry a timezone prefix (CRON_TZ=/TZ=) — spec.time_zone is the single timezone authority",
+    );
+  });
+
+  it("rejects a TZ= prefix", () => {
+    const err = refusal(() => validateScheduleCron("TZ=UTC 0 9 * * *"));
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+
+  it("rejects a trailing comment", () => {
+    const err = refusal(() => validateScheduleCron("0 9 * * * # daily"));
+    expect(err.rawMessage).toBe("spec.cron must not contain a comment (#)");
+  });
+
+  it("rejects @every intervals", () => {
+    const err = refusal(() => validateScheduleCron("@every 5m"));
+    expect(err.rawMessage).toBe(
+      "spec.cron must be a calendar expression — @every intervals are not supported",
+    );
+  });
+
+  it.each(["@annually", "@midnight", "@reboot"])(
+    "rejects the nonstandard shorthand %j with the supported list",
+    (cron) => {
+      const err = refusal(() => validateScheduleCron(cron));
+      expect(err.rawMessage).toBe(
+        `spec.cron shorthand "${cron}" is not supported — use @hourly, @daily, @weekly, @monthly, or @yearly, or a 5-field cron expression`,
+      );
+    },
+  );
+
+  it.each([
+    ["0 9 * *", 4],
+    ["0 9 * * * *", 6],
+    ["0 9 * * * * 2026", 7],
+    ["", 0],
+  ])("rejects %j with the field count %i", (cron, count) => {
+    const err = refusal(() => validateScheduleCron(cron));
+    expect(err.rawMessage).toBe(
+      `spec.cron must have exactly 5 fields (minute hour day-of-month month day-of-week); got ${count}`,
+    );
+  });
+
+  it("rejects '?' via the field character set", () => {
+    const err = refusal(() => validateScheduleCron("? 9 * * *"));
+    expect(err.rawMessage).toBe(
+      `spec.cron field "?" contains unsupported characters — allowed: digits, names, '*', ',', '-', '/'`,
+    );
+  });
+
+  it("rejects '1#3' via the comment check (the '#' rule fires first, as in Go)", () => {
+    const err = refusal(() => validateScheduleCron("1#3 9 * * *"));
+    expect(err.rawMessage).toBe("spec.cron must not contain a comment (#)");
+  });
+
+  it("accepts bare letters like 'L' lexically (Go's charset allows name letters; Temporal refuses downstream at artifact create)", () => {
+    // Deliberate Go-parity: the character class exists for month/day NAMES
+    // (Jan, MON) and incidentally passes single letters — the lexical
+    // validator is a grammar restriction, not a cron parser (DD-009 C-4).
+    expect(() => validateScheduleCron("L 9 * * *")).not.toThrow();
+    expect(() => validateScheduleCron("W 9 * * *")).not.toThrow();
+  });
+});
+
+describe("validateScheduleTimeZone", () => {
+  it.each(["UTC", "Asia/Kolkata", "America/New_York", "Europe/Berlin"])(
+    "accepts the IANA zone %j",
+    (zone) => {
+      expect(() => validateScheduleTimeZone(zone)).not.toThrow();
+    },
+  );
+
+  it("accepts the empty zone (Go LoadLocation('') is UTC)", () => {
+    expect(() => validateScheduleTimeZone("")).not.toThrow();
+  });
+
+  it("rejects 'Local' explicitly (nondeterministic across replicas; Java never resolves it)", () => {
+    const err = refusal(() => validateScheduleTimeZone("Local"));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(
+      'spec.time_zone "Local" is not a valid IANA time zone (e.g. "Asia/Kolkata")',
+    );
+  });
+
+  it.each(["Not/AZone", "Mars/Olympus", "gibberish"])(
+    "rejects the unknown zone %j with the byte-pinned copy",
+    (zone) => {
+      const err = refusal(() => validateScheduleTimeZone(zone));
+      expect(err.rawMessage).toBe(
+        `spec.time_zone "${zone}" is not a valid IANA time zone (e.g. "Asia/Kolkata")`,
+      );
+    },
+  );
+
+  it("rejects a case variant of a canonical zone (Go's tzdata lookup is case-sensitive)", () => {
+    // ICU resolves "america/new_york" case-insensitively; Go's file lookup
+    // does not — the canonical-set guard restores Go's refusal (cron.ts
+    // isLoadableTimeZone). Case variants of ALIAS names (e.g.
+    // "asia/kolkata" where ICU's canonical is Asia/Calcutta) remain a
+    // disclosed residual divergence — the guard can only see ICU's
+    // canonical list.
+    expect(isLoadableTimeZone("america/new_york")).toBe(false);
+    expect(() => validateScheduleTimeZone("america/new_york")).toThrow();
+  });
+
+  it("accepts genuine alias/link zones as Go does", () => {
+    // "US/Pacific" is a tzdata link and "Asia/Kolkata" an ICU alias of
+    // Asia/Calcutta; Go's tzdata and ICU both resolve them.
+    expect(isLoadableTimeZone("US/Pacific")).toBe(true);
+    expect(isLoadableTimeZone("Asia/Kolkata")).toBe(true);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/domain/schedule/__tests__/schedule.composed.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/__tests__/schedule.composed.test.ts
@@ -452,6 +452,47 @@ describe("queries — list, getByAgent, listRuns", () => {
     const err = await refusal(() => query.listRuns({ scheduleId: "sch_missing" }));
     expect(err.code).toBe(Code.NotFound);
   });
+
+  it("listRuns pages newest-first with 1-indexed pages (fire-identity rows via the ledger)", async () => {
+    const created = await command.create(scheduleInput({ name: "Paged Runs", slug: "paged-runs" }));
+    const id = created.metadata?.id ?? "";
+    // Three fires with distinct nominal times, inserted through the store
+    // (a trigger's nominal is "now", so real fires within one second would
+    // upsert the same row — the ledger key IS the fire identity).
+    for (const hour of ["09", "10", "11"]) {
+      await server.store.upsertScheduleRun({
+        scheduleId: id,
+        org: "acme",
+        nominalFireTime: `2026-08-25T${hour}:00:00Z`,
+        origin: "cron",
+        outcome: "completed",
+        reason: "",
+        executionId: "aex_paged",
+        recordedAt: `2026-08-25T${hour}:00:00Z`,
+        completedAt: `2026-08-25T${hour}:30:00Z`,
+      });
+    }
+
+    const pageOne = await query.listRuns({ scheduleId: id, pageInfo: { size: 2, num: 1 } });
+    expect(pageOne.totalCount).toBe(3);
+    expect(pageOne.items).toHaveLength(2);
+    // Newest first: 11:00 then 10:00.
+    expect(pageOne.items[0]?.nominalFireTime?.seconds).toBe(
+      BigInt(Date.parse("2026-08-25T11:00:00Z") / 1000),
+    );
+
+    const pageTwo = await query.listRuns({ scheduleId: id, pageInfo: { size: 2, num: 2 } });
+    expect(pageTwo.items).toHaveLength(1);
+    expect(pageTwo.items[0]?.nominalFireTime?.seconds).toBe(
+      BigInt(Date.parse("2026-08-25T09:00:00Z") / 1000),
+    );
+
+    // A zero/absent page reads as the first (1-indexed contract).
+    const defaulted = await query.listRuns({ scheduleId: id, pageInfo: { size: 2, num: 0 } });
+    expect(defaulted.items[0]?.nominalFireTime?.seconds).toBe(
+      pageOne.items[0]?.nominalFireTime?.seconds,
+    );
+  });
 });
 
 describe("delete — teardown posture and the ledger cascade", () => {

--- a/backend/services/stigmer-server-ts/src/domain/schedule/__tests__/schedule.composed.test.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/__tests__/schedule.composed.test.ts
@@ -1,0 +1,484 @@
+/**
+ * Pins the schedule domain against Go's schedule_test.go and
+ * trigger_test.go — through the REAL stack: a composed server on an
+ * ephemeral port, a native gRPC client, the full interceptor chain, the
+ * REAL in-process agentexecution create pipeline behind the trigger, and
+ * a deterministically-closed Temporal port (the arming steps must degrade,
+ * never refuse — DD-015 D-A).
+ *
+ * The load-bearing pins the conformance suite does NOT own:
+ *   - status preservation across apply-as-update (the auto-pause can never
+ *     be clobbered declaratively) and the update graft's status honesty;
+ *   - resume's atomic latch+streak clear, its idempotent no-write no-op,
+ *     and the pause→resume round trip;
+ *   - the trigger's two-level contract with the REAL launch gates: with no
+ *     engine behind the server the fire happens and honestly reports the
+ *     EnsureEngineAvailable refusal — never a gRPC error;
+ *   - the fire ledger: manual rows, cascade on delete, listRuns paging.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { create, toBinary, fromBinary } from "@bufbuild/protobuf";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import { AgentQueryController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/query_pb";
+import { ScheduleCommandController } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/command_pb";
+import { ScheduleQueryController } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/query_pb";
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ScheduleStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/status_pb";
+import {
+  ScheduleRunOrigin,
+  ScheduleRunOutcome,
+} from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { TRIGGER_DISABLED_MESSAGE } from "../trigger.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+let dir: string;
+let server: ComposedServer;
+let transport: Transport;
+let command: Client<typeof ScheduleCommandController>;
+let query: Client<typeof ScheduleQueryController>;
+let agentCommand: Client<typeof AgentCommandController>;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "schedule-domain-test-"));
+  server = composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      // No engine behind composed tests: 127.0.0.1:1 is deterministically
+      // closed — arming degrades (DD-015 D-A) and the trigger's launch
+      // gates refuse honestly.
+      TEMPORAL_HOST_PORT: "127.0.0.1:1",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      STORAGE_PATH: path.join(dir, "storage"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  transport = createGrpcTransport({ baseUrl: `http://127.0.0.1:${port}` });
+  command = createClient(ScheduleCommandController, transport);
+  query = createClient(ScheduleQueryController, transport);
+  agentCommand = createClient(AgentCommandController, transport);
+
+  for (const [name, slug] of [
+    ["Helper", "helper"],
+    ["Ephemeral", "ephemeral"],
+    ["Ephemeral Two", "ephemeral-2"],
+    ["Ephemeral Three", "ephemeral-3"],
+  ] as const) {
+    await agentCommand.create({
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "Agent",
+      metadata: { name, org: "acme", slug },
+      spec: { instructions: "a composed-test target agent" },
+    });
+  }
+});
+
+/** Deletes a test agent by slug — the dangling-reference setup. */
+async function deleteAgent(slug: string): Promise<void> {
+  const agents = createClient(AgentQueryController, transport);
+  const agent = await agents.getByReference({
+    kind: ApiResourceKind.agent,
+    org: "acme",
+    slug,
+  });
+  await agentCommand.delete({ value: agent.metadata?.id ?? "" });
+}
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function scheduleInput(overrides?: {
+  name?: string;
+  org?: string;
+  slug?: string;
+  cron?: string;
+  timeZone?: string;
+  enabled?: boolean;
+  agentSlug?: string;
+  agentOrg?: string;
+  labels?: Record<string, string>;
+  message?: string;
+}) {
+  return {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "Schedule",
+    metadata: {
+      name: overrides?.name ?? "Daily Rounds",
+      org: overrides?.org ?? "acme",
+      slug: overrides?.slug ?? "",
+      labels: overrides?.labels ?? {},
+    },
+    spec: {
+      cron: overrides?.cron ?? "0 9 * * *",
+      timeZone: overrides?.timeZone ?? "Asia/Kolkata",
+      enabled: overrides?.enabled ?? true,
+      target: {
+        case: "agent" as const,
+        value: {
+          agentRef: {
+            kind: ApiResourceKind.agent,
+            slug: overrides?.agentSlug ?? "helper",
+            org: overrides?.agentOrg ?? "",
+          },
+          message: overrides?.message ?? "Do the rounds",
+        },
+      },
+    },
+  };
+}
+
+async function refusal(run: () => Promise<unknown>): Promise<ConnectError> {
+  try {
+    await run();
+  } catch (error) {
+    if (error instanceof ConnectError) {
+      return error;
+    }
+    throw error;
+  }
+  throw new Error("expected the call to fail");
+}
+
+describe("create — the defaults resolver through the real chain", () => {
+  it("creates with a derived slug and the sch_ id prefix; arming degrades with Temporal away", async () => {
+    const created = await command.create(scheduleInput({ name: "Morning Digest" }));
+    expect(created.metadata?.id).toMatch(/^sch_[0-9a-z]{26}$/);
+    expect(created.metadata?.slug).toBe("morning-digest");
+    // Temporal is a closed port: the arm degraded, next_fire_at absent —
+    // the write still succeeded (DD-015 D-A).
+    expect(created.status?.nextFireAt).toBeUndefined();
+    // The ref org normalized to the schedule's own.
+    expect(
+      created.spec?.target.case === "agent"
+        ? created.spec.target.value.agentRef?.org
+        : "",
+    ).toBe("acme");
+  });
+
+  it("requires metadata.org", async () => {
+    const err = await refusal(() => command.create(scheduleInput({ org: "" })));
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe("metadata.org is required for a schedule");
+  });
+
+  it("refuses a cross-org agent ref BEFORE the agent load (no slug probing)", async () => {
+    const err = await refusal(() =>
+      command.create(scheduleInput({ name: "X", agentOrg: "other-org", agentSlug: "secret" })),
+    );
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(
+      "spec.agent.agent_ref.org must match metadata.org — a schedule must live in the referenced agent's organization (other-org)",
+    );
+  });
+
+  it("refuses a nonexistent agent with the direct-lookup NOT_FOUND", async () => {
+    const err = await refusal(() =>
+      command.create(scheduleInput({ name: "Y", agentSlug: "vanished" })),
+    );
+    expect(err.code).toBe(Code.NotFound);
+  });
+
+  it("validates the cron grammar and time zone through the pipeline", async () => {
+    expect(
+      (await refusal(() => command.create(scheduleInput({ name: "Z", cron: "@every 5m" })))).code,
+    ).toBe(Code.InvalidArgument);
+    expect(
+      (await refusal(() => command.create(scheduleInput({ name: "Z", timeZone: "Local" })))).code,
+    ).toBe(Code.InvalidArgument);
+  });
+});
+
+describe("apply — create-or-update with status preserved verbatim", () => {
+  it("creates, then re-applies as update WITHOUT resetting runtime status", async () => {
+    const applied = await command.apply(scheduleInput({ name: "Weekly Sync", slug: "weekly-sync" }));
+    const id = applied.metadata?.id ?? "";
+
+    // Simulate the clock's runtime writes through the wire-facing store:
+    // pause the schedule as the streak would.
+    const paused = await pauseDirectly(id);
+    expect(paused.status?.pausedReason).not.toBe("");
+
+    // A routine manifest re-apply must never clear the latch or streak.
+    const reApplied = await command.apply(
+      scheduleInput({ name: "Weekly Sync", slug: "weekly-sync", cron: "30 8 * * *" }),
+    );
+    expect(reApplied.metadata?.id).toBe(id);
+    expect(reApplied.spec?.cron).toBe("30 8 * * *");
+    expect(reApplied.status?.pausedReason).toBe(paused.status?.pausedReason);
+    expect(reApplied.status?.consecutiveFailures).toBe(2);
+  });
+});
+
+// Pause a schedule the way the clock does — the same atomic status write
+// recordFailedRun performs, driven through the composed server's exposed
+// store (the boot-test seam). The trigger/resume tests below need a
+// latched row without a live Temporal engine.
+async function pauseDirectly(id: string): Promise<Schedule> {
+  return server.store.updateResource(ApiResourceKind.schedule, id, ScheduleSchema, (live) => {
+    if (live.status === undefined) {
+      live.status = create(ScheduleStatusSchema);
+    }
+    live.status.pausedReason =
+      "Paused after 2 consecutive failed runs. Last failure: run aex_x ended failed";
+    live.status.consecutiveFailures = 2;
+  });
+}
+
+describe("update — immutable identity and the status-honest graft", () => {
+  it("refuses repointing the agent ref with the byte-pinned copy", async () => {
+    await agentCommand.create({
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "Agent",
+      metadata: { name: "Other", org: "acme", slug: "other" },
+      spec: { instructions: "the other assistant agent" },
+    });
+    const created = await command.create(scheduleInput({ name: "Repoint Me", slug: "repoint-me" }));
+    const err = await refusal(() =>
+      command.update({
+        ...scheduleInput({ name: "Repoint Me", slug: "repoint-me", agentSlug: "other" }),
+        metadata: created.metadata,
+      }),
+    );
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(
+      "spec.agent.agent_ref is immutable (schedule runs acme/helper) — create a new schedule to run a different agent",
+    );
+  });
+
+  it("re-validates cron/tz on update (spec replaced wholesale)", async () => {
+    const created = await command.create(scheduleInput({ name: "Revalidate", slug: "revalidate" }));
+    const err = await refusal(() =>
+      command.update({
+        ...scheduleInput({ name: "Revalidate", slug: "revalidate", cron: "bad" }),
+        metadata: created.metadata,
+      }),
+    );
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+
+  it("preserves concurrently-written status through the graft", async () => {
+    const created = await command.create(scheduleInput({ name: "Graft", slug: "graft" }));
+    const id = created.metadata?.id ?? "";
+    await pauseDirectly(id);
+    const updated = await command.update({
+      ...scheduleInput({ name: "Graft", slug: "graft", cron: "15 7 * * *" }),
+      metadata: created.metadata,
+    });
+    // The graft carried the request's spec but answered with the LIVE
+    // status the runtime wrote mid-request.
+    expect(updated.spec?.cron).toBe("15 7 * * *");
+    expect(updated.status?.consecutiveFailures).toBe(2);
+    expect(updated.status?.pausedReason).toContain("Paused after 2");
+  });
+});
+
+describe("resume — the one clearing path (DD-013 D-D)", () => {
+  it("clears the latch AND the streak atomically and re-arms", async () => {
+    const created = await command.create(scheduleInput({ name: "Resume Me", slug: "resume-me" }));
+    const id = created.metadata?.id ?? "";
+    await pauseDirectly(id);
+
+    const resumed = await command.resume({ value: id });
+    expect(resumed.status?.pausedReason).toBe("");
+    expect(resumed.status?.consecutiveFailures).toBe(0);
+  });
+
+  it("is an idempotent no-op on a fresh row — no write, no audit bump", async () => {
+    const created = await command.create(scheduleInput({ name: "Fresh", slug: "fresh" }));
+    const id = created.metadata?.id ?? "";
+    const before = await query.get({ value: id });
+    const resumed = await command.resume({ value: id });
+    expect(resumed.status?.audit?.statusAudit?.updatedAt?.seconds).toBe(
+      before.status?.audit?.statusAudit?.updatedAt?.seconds,
+    );
+    expect(resumed.status?.audit?.statusAudit?.updatedAt?.nanos).toBe(
+      before.status?.audit?.statusAudit?.updatedAt?.nanos,
+    );
+  });
+
+  it("answers NOT_FOUND for a missing schedule", async () => {
+    const err = await refusal(() => command.resume({ value: "sch_missing" }));
+    expect(err.code).toBe(Code.NotFound);
+  });
+});
+
+describe("trigger — the two-level contract (DD-017 D-5)", () => {
+  it("refuses a missing schedule with NOT_FOUND (level one)", async () => {
+    const err = await refusal(() => command.trigger({ value: "sch_missing" }));
+    expect(err.code).toBe(Code.NotFound);
+  });
+
+  it("refuses a disabled schedule with FAILED_PRECONDITION and the byte-pinned copy", async () => {
+    await command.create(scheduleInput({ name: "Disabled", slug: "disabled", enabled: false }));
+    const row = await query.getByReference({
+      kind: ApiResourceKind.schedule,
+      org: "acme",
+      slug: "disabled",
+    });
+    const err = await refusal(() => command.trigger({ value: row.metadata?.id ?? "" }));
+    expect(err.code).toBe(Code.FailedPrecondition);
+    expect(err.rawMessage).toBe(TRIGGER_DISABLED_MESSAGE);
+  });
+
+  it("relays an infrastructure failure as a CLEAN gRPC error (the engine gate's UNAVAILABLE, re-minted — never NGHTTP2 corruption)", async () => {
+    const created = await command.create(scheduleInput({ name: "Fire Me", slug: "fire-me" }));
+    const id = created.metadata?.id ?? "";
+
+    // No engine behind this server: the create pipeline's engine gate
+    // refuses Unavailable — an infrastructure failure, propagated as the
+    // trigger's OWN error (Go: "Manual trigger's run start failed on
+    // infrastructure"). The re-mint matters: echoing the in-process error
+    // corrupts HTTP/2 trailers (the #18 transport finding).
+    const err = await refusal(() => command.trigger({ value: id }));
+    expect(err.code).toBe(Code.Unavailable);
+    // No fire happened: no ledger row, no last_fire_at.
+    const runs = await query.listRuns({ scheduleId: id });
+    expect(runs.totalCount).toBe(0);
+    const after = await query.get({ value: id });
+    expect(after.status?.lastFireAt).toBeUndefined();
+  });
+
+  it("fires and honestly reports TARGET_MISSING (level two: gRPC success, outcome named)", async () => {
+    const created = await command.create(
+      scheduleInput({ name: "Orphan Fire", slug: "orphan-fire", agentSlug: "ephemeral" }),
+    );
+    const id = created.metadata?.id ?? "";
+    await deleteAgent("ephemeral");
+
+    // The fire happened (level two): the deterministic dangling-reference
+    // outcome is a SUCCESSFUL trigger honestly reported, never an
+    // exception (no cascade by contract).
+    const result = await command.trigger({ value: id });
+    expect(result.outcome).toBe(ScheduleRunOutcome.TARGET_MISSING);
+    expect(result.refusalReason).toBe("target agent acme/ephemeral not found");
+    expect(result.executionId).toBe("");
+    // The post-fire row: last_fire_at stamped by the handler.
+    expect(result.schedule?.status?.lastFireAt).toBeDefined();
+
+    // The manual fire left its terminal ledger row.
+    const runs = await query.listRuns({ scheduleId: id });
+    expect(runs.totalCount).toBe(1);
+    expect(runs.items[0]?.origin).toBe(ScheduleRunOrigin.MANUAL);
+    expect(runs.items[0]?.outcome).toBe(ScheduleRunOutcome.TARGET_MISSING);
+    expect(runs.items[0]?.completedAt).toBeDefined();
+  });
+
+  it("a PAUSED schedule is triggerable (test-then-resume) and manual fires never feed the streak", async () => {
+    const created = await command.create(
+      scheduleInput({ name: "Paused Fire", slug: "paused-fire", agentSlug: "ephemeral-2" }),
+    );
+    const id = created.metadata?.id ?? "";
+    await deleteAgent("ephemeral-2");
+    await pauseDirectly(id);
+
+    // Past ValidateTriggerable (paused ≠ disabled), the fire runs and
+    // reports its target-missing outcome.
+    const result = await command.trigger({ value: id });
+    expect(result.outcome).toBe(ScheduleRunOutcome.TARGET_MISSING);
+    const after = await query.get({ value: id });
+    // The streak is untouched by the manual fire's outcome.
+    expect(after.status?.consecutiveFailures).toBe(2);
+    expect(after.status?.pausedReason).toContain("Paused after 2");
+  });
+});
+
+describe("queries — list, getByAgent, listRuns", () => {
+  it("list filters by org and labels (AND), newest first", async () => {
+    await command.create(
+      scheduleInput({ name: "Tagged A", slug: "tagged-a", labels: { team: "ops", tier: "1" } }),
+    );
+    await command.create(
+      scheduleInput({ name: "Tagged B", slug: "tagged-b", labels: { team: "ops" } }),
+    );
+    const both = await query.list({ org: "acme", labels: { team: "ops" } });
+    expect(both.items.map((s) => s.metadata?.slug)).toContain("tagged-a");
+    expect(both.items.map((s) => s.metadata?.slug)).toContain("tagged-b");
+    // Newest first: tagged-b was created after tagged-a.
+    expect(both.items.findIndex((s) => s.metadata?.slug === "tagged-b")).toBeLessThan(
+      both.items.findIndex((s) => s.metadata?.slug === "tagged-a"),
+    );
+
+    const one = await query.list({ org: "acme", labels: { team: "ops", tier: "1" } });
+    expect(one.items.map((s) => s.metadata?.slug)).toEqual(["tagged-a"]);
+
+    const none = await query.list({ org: "other-org", labels: {} });
+    expect(none.totalCount).toBe(0);
+  });
+
+  it("getByAgent answers an empty list for an unknown agent id", async () => {
+    const result = await query.getByAgent({ agentId: "agt_missing", org: "" });
+    expect(result.totalCount).toBe(0);
+    expect(result.items).toEqual([]);
+  });
+
+  it("getByAgent resolves the agent by id and filters by its org+slug identity", async () => {
+    const agents = createClient(AgentQueryController, transport);
+    const helper = await agents.getByReference({
+      kind: ApiResourceKind.agent,
+      org: "acme",
+      slug: "helper",
+    });
+    const result = await query.getByAgent({ agentId: helper.metadata?.id ?? "", org: "acme" });
+    expect(result.totalCount).toBeGreaterThan(0);
+    for (const item of result.items) {
+      expect(
+        item.spec?.target.case === "agent" ? item.spec.target.value.agentRef?.slug : "",
+      ).toBe("helper");
+    }
+  });
+
+  it("listRuns answers NOT_FOUND for a missing schedule (never an empty history)", async () => {
+    const err = await refusal(() => query.listRuns({ scheduleId: "sch_missing" }));
+    expect(err.code).toBe(Code.NotFound);
+  });
+});
+
+describe("delete — teardown posture and the ledger cascade", () => {
+  it("returns the pre-delete resource and cascades the fire ledger", async () => {
+    const created = await command.create(
+      scheduleInput({ name: "Delete Me", slug: "delete-me", agentSlug: "ephemeral-3" }),
+    );
+    const id = created.metadata?.id ?? "";
+    await deleteAgent("ephemeral-3");
+    await command.trigger({ value: id }); // leaves a manual TARGET_MISSING row
+
+    const deleted = await command.delete({ value: id });
+    expect(deleted.metadata?.id).toBe(id);
+
+    const err = await refusal(() => query.get({ value: id }));
+    expect(err.code).toBe(Code.NotFound);
+    // The ledger cascade ran (listRuns on the deleted schedule is NOT_FOUND,
+    // so assert through the store).
+    const { total } = await server.store.listScheduleRuns(id, 0, 10);
+    expect(total).toBe(0);
+  });
+});
+
+// Round-trip guard: the wire schedule marshals/unmarshals through the
+// binary codec the store uses (catches schema drift in the test itself).
+it("schedule wire shape round-trips through the binary codec", async () => {
+  const created = await command.create(scheduleInput({ name: "Round Trip", slug: "round-trip" }));
+  const bytes = toBinary(ScheduleSchema, created);
+  expect(fromBinary(ScheduleSchema, bytes).metadata?.slug).toBe("round-trip");
+});

--- a/backend/services/stigmer-server-ts/src/domain/schedule/clock.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/clock.ts
@@ -1,0 +1,192 @@
+/**
+ * The Clock seam and the write-path arming/teardown steps — ports
+ * pkg/domain/schedule/controller/clock.go.
+ *
+ * Clock is the narrow slice of the scheduling runtime the write paths need
+ * (satisfied by the clock's ScheduleSyncer). Undefined until the server
+ * wires it — and possibly forever, when Temporal was never configured:
+ * every consumer below degrades instead of refusing, because "no Temporal
+ * right now" is a supported OSS state (DD-015 D-A) and a declarative
+ * resource must be writable offline. The reconciliation pass converges
+ * whatever was written while the clock was away.
+ *
+ * Go's Clock also declares Trigger (the DD-014 artifact-trigger lane);
+ * DD-017 D-5 left it with zero production callers, so this seam
+ * deliberately omits it (sub-project decision 2, owner-ratified).
+ */
+import { create } from "@bufbuild/protobuf";
+import type { DescMessage } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ScheduleStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/status_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { RESOURCE_ID_KEY } from "../../pipeline/steps/delete.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import type { Store } from "../../store/interface.js";
+
+/** The write paths' slice of the scheduling runtime (Go Clock). */
+export interface ScheduleClock {
+  /**
+   * Converges the resource's Temporal artifact and stamps
+   * status.next_fire_at; returns the stamp (undefined when paused).
+   */
+  ensureAndRecord(schedule: Schedule): Promise<Date | undefined>;
+  /** Deletes the resource's artifact (not-found is success). */
+  teardown(resourceId: string): Promise<void>;
+}
+
+/** A provider so the compose root can wire the clock after the store stage. */
+export type ClockProvider = () => ScheduleClock | undefined;
+
+/**
+ * Converges the artifact AFTER a successful write (create/update/apply —
+ * pipelines whose request is the Schedule) and mirrors the fresh
+ * next_fire_at into the response state (Go armScheduleStep).
+ *
+ * Non-critical in every outcome: a failed arm logs and succeeds, because
+ * the write already happened and the reconciliation pass is the
+ * correctness path. Refusing here would tear declarative writes away from
+ * offline use for no gain (DD-015 D-A).
+ */
+export function newArmScheduleStep(
+  clock: ClockProvider,
+  logger: Logger,
+): PipelineStep<typeof ScheduleSchema> {
+  return {
+    name: "ArmScheduleArtifact",
+    async execute(ctx: RequestContext<typeof ScheduleSchema>): Promise<void> {
+      await armAndMirror(clock(), ctx.newState, logger);
+    },
+  };
+}
+
+/**
+ * The resume pipeline's arming step (request type ScheduleId; the resumed
+ * schedule lives under EXISTING_RESOURCE_KEY). Re-arming is what makes
+ * resume answer with a fresh next_fire_at — the latch just cleared, so
+ * DesiredPaused flipped and the artifact must unpause NOW, not at the next
+ * sweep (Go armResumedScheduleStep).
+ */
+export function newArmResumedScheduleStep<Desc extends DescMessage>(
+  clock: ClockProvider,
+  logger: Logger,
+): PipelineStep<Desc> {
+  return {
+    name: "ArmResumedScheduleArtifact",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const schedule = ctx.get(EXISTING_RESOURCE_KEY) as Schedule | undefined;
+      if (schedule === undefined) {
+        return;
+      }
+      await armAndMirror(clock(), schedule, logger);
+    },
+  };
+}
+
+/**
+ * Runs the ensure and mirrors the stamp into the in-memory state the
+ * pipeline will answer with, so the response's next_fire_at matches what
+ * was just recorded on the row (Go armAndMirror).
+ */
+async function armAndMirror(
+  clock: ScheduleClock | undefined,
+  schedule: Schedule | undefined,
+  logger: Logger,
+): Promise<void> {
+  if (clock === undefined || schedule === undefined) {
+    return;
+  }
+  let nextFireAt: Date | undefined;
+  try {
+    nextFireAt = await clock.ensureAndRecord(schedule);
+  } catch (error) {
+    logger.warn(
+      "Schedule artifact not armed — next_fire_at stays absent until the reconciliation pass converges it",
+      {
+        schedule_id: schedule.metadata?.id ?? "",
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    return;
+  }
+  if (schedule.status === undefined) {
+    schedule.status = create(ScheduleStatusSchema);
+  }
+  schedule.status.nextFireAt =
+    nextFireAt === undefined ? undefined : timestampFromDate(nextFireAt);
+}
+
+/**
+ * Deletes the artifact AFTER the row delete (DD-008 D9: the row is the
+ * source of truth — a failed row delete must never tear down a live
+ * schedule's clock, so this step only ever runs once the delete
+ * succeeded). Non-critical: an orphaned artifact cannot fire past
+ * revalidation, and the reconciliation pass reaps it (Go
+ * teardownScheduleArtifactStep).
+ */
+export function newTeardownScheduleArtifactStep<Desc extends DescMessage>(
+  clock: ClockProvider,
+  logger: Logger,
+): PipelineStep<Desc> {
+  return {
+    name: "TeardownScheduleArtifact",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const liveClock = clock();
+      if (liveClock === undefined) {
+        return;
+      }
+      const resourceId = ctx.get(RESOURCE_ID_KEY);
+      if (typeof resourceId !== "string" || resourceId === "") {
+        return;
+      }
+      try {
+        await liveClock.teardown(resourceId);
+      } catch (error) {
+        logger.warn(
+          "Schedule artifact teardown failed (non-fatal — the orphan cannot fire past revalidation and the reconciliation pass removes it)",
+          {
+            schedule_id: resourceId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    },
+  };
+}
+
+/**
+ * Removes the schedule's fire-ledger rows AFTER the row delete succeeded —
+ * the teardown step's posture: best-effort, never fails the delete
+ * (orphaned ledger rows answer no query and retention prunes them). Go
+ * deleteScheduleRunsStep.
+ */
+export function newDeleteScheduleRunsStep<Desc extends DescMessage>(
+  store: Store,
+  logger: Logger,
+): PipelineStep<Desc> {
+  return {
+    name: "DeleteScheduleRuns",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const resourceId = ctx.get(RESOURCE_ID_KEY);
+      if (typeof resourceId !== "string" || resourceId === "") {
+        return;
+      }
+      try {
+        await store.deleteScheduleRunsBySchedule(resourceId);
+      } catch (error) {
+        logger.warn(
+          "Fire-ledger cleanup failed (non-fatal — orphaned rows answer no query; retention prunes them)",
+          {
+            schedule_id: resourceId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/schedule/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/controller.ts
@@ -269,7 +269,7 @@ async function deleteSchedule(
   if (deleted === undefined) {
     throw internalError(
       new Error("deleted schedule not found in context"),
-      "delete operation lost its loaded resource",
+      "deleted schedule not found in context",
     );
   }
   return deleted as Schedule;

--- a/backend/services/stigmer-server-ts/src/domain/schedule/controller.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/controller.ts
@@ -1,0 +1,602 @@
+/**
+ * Schedule controller — ports pkg/domain/schedule/controller (command +
+ * query sides): the recurring trigger that runs an agent on a cron
+ * schedule.
+ *
+ * A schedule declares a target (an agent and the prompt each run starts
+ * from), a cron expression with an IANA time zone, and the owner's
+ * enablement switch. Everything the platform observes about firing (next
+ * fire time, failure streak, platform pause) lives in status, written only
+ * by the scheduling runtime and by the explicit resume command — a
+ * declarative apply preserves status verbatim, so a routine manifest apply
+ * can never reset a failure streak or un-pause a platform-paused schedule.
+ *
+ * Vocabulary (DD-013 D-E): "disabled" is the owner's switch (spec.enabled
+ * = false); "paused" is the platform's failure-streak latch
+ * (status.paused_reason). Two words, two levers, two writers.
+ *
+ * The clock (per-resource Temporal Schedules) and the run starter arrive
+ * through PROVIDERS wired by the compose root after the Temporal stage;
+ * both may stay undefined forever when Temporal was never configured —
+ * every consumer degrades instead of refusing (DD-015 D-A), because a
+ * declarative resource must be writable offline.
+ *
+ * Authorization posture (OSS): single-user and local, so handlers perform
+ * no authorization — a documented no-op, not a silent divergence. The
+ * cloud edition enforces the same contracts via FGA.
+ *
+ * Pipeline per RPC mirrors the Go step chains character-for-character.
+ * Proven by schedule.conformance.test.ts (local-ts), the firing suite
+ * (local-ts-execution), and __tests__/schedule.composed.test.ts.
+ */
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import { create, fromBinary } from "@bufbuild/protobuf";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { ScheduleCommandController } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/command_pb";
+import { ScheduleQueryController } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/query_pb";
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ScheduleListSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/io_pb";
+import type {
+  GetSchedulesByAgentRequest,
+  ListScheduleRunsRequest,
+  ListSchedulesRequest,
+  ScheduleId,
+  ScheduleList,
+  ScheduleRunList,
+  ScheduleTriggerResult,
+} from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/io_pb";
+import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
+import { internalError } from "../../pipeline/errors.js";
+import { newPipeline } from "../../pipeline/pipeline.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { RequestContext } from "../../pipeline/request-context.js";
+import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
+import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
+import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
+import {
+  newDeleteResourceStep,
+  newExtractResourceIdStep,
+  newLoadExistingForDeleteStep,
+} from "../../pipeline/steps/delete.js";
+import {
+  compareCreatedAtDesc,
+  matchesAllLabels,
+} from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
+import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
+import { newLoadTargetStep, TARGET_RESOURCE_KEY } from "../../pipeline/steps/load-target.js";
+import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
+import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
+import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
+import type { Store } from "../../store/interface.js";
+import type { ModelRegistryStore } from "../workflow/registry/model-registry-store.js";
+import {
+  newArmResumedScheduleStep,
+  newArmScheduleStep,
+  newDeleteScheduleRunsStep,
+  newTeardownScheduleArtifactStep,
+  type ClockProvider,
+} from "./clock.js";
+import {
+  LIST_RUNS_RESULT_KEY,
+  newListRunsFromLedgerStep,
+  newLoadScheduleForRunsStep,
+} from "./list-runs.js";
+import { newPersistScheduleUpdateStep } from "./persist-update.js";
+import { newClearSchedulePauseStep } from "./resume.js";
+import {
+  newResolveScheduleDefaultsStep,
+  newValidateScheduleUpdateStep,
+} from "./steps.js";
+import {
+  TRIGGER_RESULT_KEY,
+  newFireDirectRunStep,
+  newValidateTriggerableStep,
+  type RunnerProvider,
+} from "./trigger.js";
+
+export interface ScheduleControllerDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly modelRegistry: ModelRegistryStore;
+  /**
+   * The scheduling runtime (clock.ts), resolved at call time so the
+   * compose root can wire it after the Temporal stage — Go's SetClock,
+   * without the mutable-controller seam.
+   */
+  readonly clock: ClockProvider;
+  /**
+   * The run starter (trigger.ts), resolved at call time — Go's SetRunner.
+   * The trigger command is its one consumer: a manual fire needs no
+   * Temporal artifact (DD-017 D-5), so it works even while Temporal is
+   * away.
+   */
+  readonly runner: RunnerProvider;
+}
+
+/** Registers both schedule services on the router (routes stage). */
+export function registerScheduleServices(
+  router: ConnectRouter,
+  deps: ScheduleControllerDeps,
+): void {
+  router.service(ScheduleCommandController, {
+    apply: (schedule, ctx) => apply(deps, schedule, ctx),
+    create: (schedule, ctx) => createSchedule(deps, schedule, ctx),
+    update: (schedule, ctx) => update(deps, schedule, ctx),
+    delete: (scheduleId, ctx) => deleteSchedule(deps, scheduleId, ctx),
+    resume: (scheduleId, ctx) => resume(deps, scheduleId, ctx),
+    trigger: (scheduleId, ctx) => trigger(deps, scheduleId, ctx),
+  });
+  router.service(ScheduleQueryController, {
+    get: (scheduleId, ctx) => get(deps, scheduleId, ctx),
+    getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
+    getByAgent: (req, ctx) => getByAgent(deps, req, ctx),
+    list: (req, ctx) => list(deps, req, ctx),
+    listRuns: (req, ctx) => listRuns(deps, req, ctx),
+  });
+}
+
+function kindOf(ctx: HandlerContext): ApiResourceKind {
+  return ctx.values.get(apiResourceKindKey);
+}
+
+/**
+ * Create — chain per Go buildCreatePipeline (create.go:51-60). No
+ * IndexSearch tail: the schedule kind is deliberately not search-indexed
+ * (no Go extractor exists; the kind registry carries no index flag).
+ */
+async function createSchedule(
+  deps: ScheduleControllerDeps,
+  schedule: Schedule,
+  ctx: HandlerContext,
+): Promise<Schedule> {
+  const reqCtx = new RequestContext(ScheduleSchema, schedule, kindOf(ctx));
+  await newPipeline<typeof ScheduleSchema>("schedule-create", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newValidateVisibilityStep())
+    .addStep(newResolveScheduleDefaultsStep(deps))
+    .addStep(newResolveSlugStep())
+    .addStep(newCheckDuplicateStep(deps.store))
+    .addStep(newBuildNewStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistStep(deps.store))
+    .addStep(newArmScheduleStep(deps.clock, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/** Update — chain per Go buildUpdatePipeline (update.go:59-67). */
+async function update(
+  deps: ScheduleControllerDeps,
+  schedule: Schedule,
+  ctx: HandlerContext,
+): Promise<Schedule> {
+  const reqCtx = new RequestContext(ScheduleSchema, schedule, kindOf(ctx));
+  await newPipeline<typeof ScheduleSchema>("schedule-update", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadExistingStep(deps.store))
+    .addStep(newValidateScheduleUpdateStep(deps))
+    .addStep(newBuildUpdateStateStep())
+    .addStep(newNormalizeReferencesStep())
+    .addStep(newPersistScheduleUpdateStep(deps.store))
+    .addStep(newArmScheduleStep(deps.clock, deps.logger))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.newState;
+}
+
+/**
+ * Apply — declarative create-or-update (apply.go): schedule defaults
+ * resolve FIRST — matching the cloud edition, which runs its defaults
+ * resolver before routing so the existence check sees the normalized
+ * agent_ref and the same-org invariant fails loudly before any routing —
+ * then existence decides create vs update. Delegates with the pipeline's
+ * state, not the original input: the request context clones the input, so
+ * the normalized agent_ref and the populated id (from LoadForApply) live
+ * on the clone. Status is preserved verbatim across apply-as-update
+ * (BuildUpdateState), so a routine manifest apply can never reset the
+ * failure streak or un-pause an auto-paused schedule.
+ */
+async function apply(
+  deps: ScheduleControllerDeps,
+  schedule: Schedule,
+  ctx: HandlerContext,
+): Promise<Schedule> {
+  const reqCtx = new RequestContext(ScheduleSchema, schedule, kindOf(ctx));
+  await newPipeline<typeof ScheduleSchema>("schedule-apply", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newResolveScheduleDefaultsStep(deps))
+    .addStep(newResolveSlugStep())
+    .addStep(newLoadForApplyStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const shouldCreate = reqCtx.get(SHOULD_CREATE_KEY);
+  if (typeof shouldCreate !== "boolean") {
+    throw internalError(
+      new Error("apply pipeline did not set shouldCreate flag"),
+      "apply operation failed to determine create vs update",
+    );
+  }
+  const resolved = reqCtx.newState;
+  if (shouldCreate) {
+    deps.logger.info("Schedule does not exist - delegating to CREATE", {
+      slug: resolved.metadata?.slug ?? "",
+    });
+    return createSchedule(deps, resolved, ctx);
+  }
+  deps.logger.info("Schedule exists - delegating to UPDATE", {
+    slug: resolved.metadata?.slug ?? "",
+    id: resolved.metadata?.id ?? "",
+  });
+  return update(deps, resolved, ctx);
+}
+
+/** Delete — chain per Go buildDeletePipeline (delete.go:57-63). */
+async function deleteSchedule(
+  deps: ScheduleControllerDeps,
+  scheduleId: ScheduleId,
+  ctx: HandlerContext,
+): Promise<Schedule> {
+  type DeleteInput = typeof ScheduleCommandController.method.delete.input;
+  const reqCtx = new RequestContext(
+    ScheduleCommandController.method.delete.input,
+    scheduleId,
+    kindOf(ctx),
+  );
+  await newPipeline<DeleteInput>("schedule-delete", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, ScheduleSchema))
+    .addStep(newDeleteResourceStep(deps.store))
+    .addStep(newTeardownScheduleArtifactStep(deps.clock, deps.logger))
+    .addStep(newDeleteScheduleRunsStep(deps.store, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const deleted = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (deleted === undefined) {
+    throw internalError(
+      new Error("deleted schedule not found in context"),
+      "delete operation lost its loaded resource",
+    );
+  }
+  return deleted as Schedule;
+}
+
+/** Resume — chain per Go buildResumePipeline (resume.go:60-68). */
+async function resume(
+  deps: ScheduleControllerDeps,
+  scheduleId: ScheduleId,
+  ctx: HandlerContext,
+): Promise<Schedule> {
+  type ResumeInput = typeof ScheduleCommandController.method.resume.input;
+  const reqCtx = new RequestContext(
+    ScheduleCommandController.method.resume.input,
+    scheduleId,
+    kindOf(ctx),
+  );
+  await newPipeline<ResumeInput>("schedule-resume", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, ScheduleSchema))
+    .addStep(newClearSchedulePauseStep(deps.store))
+    .addStep(newArmResumedScheduleStep(deps.clock, deps.logger))
+    .build()
+    .execute(reqCtx);
+
+  const resumed = reqCtx.get(EXISTING_RESOURCE_KEY);
+  if (resumed === undefined) {
+    throw internalError(
+      new Error("resumed schedule not found in context"),
+      "resumed schedule not found in context",
+    );
+  }
+  return resumed as Schedule;
+}
+
+/** Trigger — chain per Go Trigger (trigger.go:96-115). */
+async function trigger(
+  deps: ScheduleControllerDeps,
+  scheduleId: ScheduleId,
+  ctx: HandlerContext,
+): Promise<ScheduleTriggerResult> {
+  type TriggerInput = typeof ScheduleCommandController.method.trigger.input;
+  const reqCtx = new RequestContext(
+    ScheduleCommandController.method.trigger.input,
+    scheduleId,
+    kindOf(ctx),
+  );
+  await newPipeline<TriggerInput>("schedule-trigger", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newExtractResourceIdStep())
+    .addStep(newLoadExistingForDeleteStep(deps.store, ScheduleSchema))
+    .addStep(newValidateTriggerableStep())
+    .addStep(newFireDirectRunStep({ store: deps.store, runner: deps.runner, logger: deps.logger }))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(TRIGGER_RESULT_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("trigger result not found in context"),
+      "trigger result not found in context",
+    );
+  }
+  return result as ScheduleTriggerResult;
+}
+
+/** Get — LoadTarget by id; NotFound when absent (get.go). */
+async function get(
+  deps: ScheduleControllerDeps,
+  scheduleId: ScheduleId,
+  ctx: HandlerContext,
+): Promise<Schedule> {
+  type GetInput = typeof ScheduleQueryController.method.get.input;
+  const reqCtx = new RequestContext(
+    ScheduleQueryController.method.get.input,
+    scheduleId,
+    kindOf(ctx),
+  );
+  await newPipeline<GetInput>("schedule-get", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadTargetStep(deps.store, ScheduleSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as Schedule;
+}
+
+/** GetByReference — the shared org+slug reference lookup (get_by_reference.go). */
+async function getByReference(
+  deps: ScheduleControllerDeps,
+  ref: ApiResourceReference,
+  ctx: HandlerContext,
+): Promise<Schedule> {
+  type RefInput = typeof ScheduleQueryController.method.getByReference.input;
+  const reqCtx = new RequestContext(
+    ScheduleQueryController.method.getByReference.input,
+    ref,
+    kindOf(ctx),
+  );
+  await newPipeline<RefInput>("schedule-get-by-reference", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadByReferenceStep(deps.store, ScheduleSchema))
+    .build()
+    .execute(reqCtx);
+  return reqCtx.get(TARGET_RESOURCE_KEY) as Schedule;
+}
+
+const SCHEDULE_LIST_KEY = "scheduleList";
+
+/**
+ * GetByAgent — resolves the agent BY ID to its org+slug identity, then
+ * filters schedules whose agent target matches (get_by_agent.go).
+ * Schedules reference agents by org+slug (the platform's canonical
+ * reference), while this RPC is keyed on the agent ID (the stable handle a
+ * detail view holds) — so the agent resolves first. A nonexistent agent
+ * yields an EMPTY LIST, not an error: "no schedules" is the useful answer
+ * for the operational surface either way. The org filter is contract
+ * parity, not authorization: both editions must answer an org-scoped
+ * request identically.
+ */
+async function getByAgent(
+  deps: ScheduleControllerDeps,
+  req: GetSchedulesByAgentRequest,
+  ctx: HandlerContext,
+): Promise<ScheduleList> {
+  type ByAgentInput = typeof ScheduleQueryController.method.getByAgent.input;
+  const reqCtx = new RequestContext(
+    ScheduleQueryController.method.getByAgent.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<ByAgentInput>("schedule-get-by-agent", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadSchedulesByAgentStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(SCHEDULE_LIST_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("schedule list not found in context"),
+      "schedule list not found in context",
+    );
+  }
+  return result as ScheduleList;
+}
+
+function newLoadSchedulesByAgentStep(
+  store: Store,
+): PipelineStep<typeof ScheduleQueryController.method.getByAgent.input> {
+  return {
+    name: "LoadSchedulesByAgent",
+    async execute(
+      ctx: RequestContext<typeof ScheduleQueryController.method.getByAgent.input>,
+    ): Promise<void> {
+      const req = ctx.input;
+
+      let agentOrg: string;
+      let agentSlug: string;
+      try {
+        const agent = await store.getResource(
+          ApiResourceKind.agent,
+          req.agentId,
+          AgentSchema,
+        );
+        agentOrg = agent.metadata?.org ?? "";
+        agentSlug = agent.metadata?.slug ?? "";
+      } catch {
+        ctx.set(
+          SCHEDULE_LIST_KEY,
+          create(ScheduleListSchema, { totalCount: 0, items: [] }),
+        );
+        return;
+      }
+
+      let resources: Uint8Array[];
+      try {
+        resources = await store.listResources(ApiResourceKind.schedule);
+      } catch (error) {
+        throw internalError(error, "failed to list schedules");
+      }
+
+      const schedules: Schedule[] = [];
+      for (const data of resources) {
+        let schedule: Schedule;
+        try {
+          schedule = fromBinary(ScheduleSchema, data);
+        } catch {
+          continue;
+        }
+        const ref =
+          schedule.spec?.target.case === "agent"
+            ? schedule.spec.target.value.agentRef
+            : undefined;
+        if ((ref?.org ?? "") !== agentOrg || (ref?.slug ?? "") !== agentSlug) {
+          continue;
+        }
+        // Org scope: a multi-org caller asking for one org's schedules
+        // must not see another org's schedules of the same agent.
+        // (Schedules are same-org by invariant, so today this only
+        // excludes rows when the requested org differs from the agent's —
+        // kept anyway for contract parity with the sibling RPCs.)
+        if (req.org !== "" && (schedule.metadata?.org ?? "") !== req.org) {
+          continue;
+        }
+        schedules.push(schedule);
+      }
+
+      ctx.set(
+        SCHEDULE_LIST_KEY,
+        create(ScheduleListSchema, {
+          totalCount: schedules.length,
+          items: schedules,
+        }),
+      );
+    },
+  };
+}
+
+/**
+ * List — schedules filtered by organization and optional labels (AND
+ * semantics), sorted by created_at descending, newest first (list.go).
+ */
+async function list(
+  deps: ScheduleControllerDeps,
+  req: ListSchedulesRequest,
+  ctx: HandlerContext,
+): Promise<ScheduleList> {
+  type ListInput = typeof ScheduleQueryController.method.list.input;
+  const reqCtx = new RequestContext(
+    ScheduleQueryController.method.list.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<ListInput>("schedule-list", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newListByOrgAndLabelsStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(SCHEDULE_LIST_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("schedule list not found in context"),
+      "schedule list not found in context",
+    );
+  }
+  return result as ScheduleList;
+}
+
+function newListByOrgAndLabelsStep(
+  store: Store,
+): PipelineStep<typeof ScheduleQueryController.method.list.input> {
+  return {
+    name: "ListByOrgAndLabels",
+    async execute(
+      ctx: RequestContext<typeof ScheduleQueryController.method.list.input>,
+    ): Promise<void> {
+      const req = ctx.input;
+
+      let resources: Uint8Array[];
+      try {
+        resources = await store.listResources(ApiResourceKind.schedule);
+      } catch (error) {
+        throw internalError(error, "failed to list schedules");
+      }
+
+      const schedules: Schedule[] = [];
+      for (const data of resources) {
+        let schedule: Schedule;
+        try {
+          schedule = fromBinary(ScheduleSchema, data);
+        } catch {
+          continue;
+        }
+        if ((schedule.metadata?.org ?? "") !== req.org) {
+          continue;
+        }
+        if (!matchesAllLabels(schedule.metadata?.labels ?? {}, req.labels)) {
+          continue;
+        }
+        schedules.push(schedule);
+      }
+
+      schedules.sort((a, b) =>
+        compareCreatedAtDesc(
+          a.status?.audit?.specAudit?.createdAt,
+          b.status?.audit?.specAudit?.createdAt,
+        ),
+      );
+
+      ctx.set(
+        SCHEDULE_LIST_KEY,
+        create(ScheduleListSchema, {
+          totalCount: schedules.length,
+          items: schedules,
+        }),
+      );
+    },
+  };
+}
+
+/** ListRuns — the fire-ledger surface (list_runs.go:44-61). */
+async function listRuns(
+  deps: ScheduleControllerDeps,
+  req: ListScheduleRunsRequest,
+  ctx: HandlerContext,
+): Promise<ScheduleRunList> {
+  type ListRunsInput = typeof ScheduleQueryController.method.listRuns.input;
+  const reqCtx = new RequestContext(
+    ScheduleQueryController.method.listRuns.input,
+    req,
+    kindOf(ctx),
+  );
+  await newPipeline<ListRunsInput>("schedule-list-runs", deps.logger)
+    .addStep(newValidateProtoStep())
+    .addStep(newLoadScheduleForRunsStep(deps.store))
+    .addStep(newListRunsFromLedgerStep(deps.store))
+    .build()
+    .execute(reqCtx);
+
+  const result = reqCtx.get(LIST_RUNS_RESULT_KEY);
+  if (result === undefined) {
+    throw internalError(
+      new Error("schedule run list not found in context"),
+      "schedule run list not found in context",
+    );
+  }
+  return result as ScheduleRunList;
+}

--- a/backend/services/stigmer-server-ts/src/domain/schedule/cron.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/cron.ts
@@ -1,0 +1,150 @@
+/**
+ * Lexical cron and time-zone validation — ports
+ * pkg/domain/schedule/controller/cron.go (DD-009 C-4).
+ *
+ * The platform owns NO cron parsing in either edition — calendar and DST
+ * semantics live in the Temporal server (DD-008 D2). This module restricts
+ * the accepted GRAMMAR to the subset that is safe to store: the classic
+ * 5-field form plus the @daily-family shorthands. Everything rejected here
+ * is something Temporal's wider grammar would accept but that must not
+ * reach a stored spec (timezone prefixes carry a second timezone authority
+ * and fail at artifact-create time; @every bypasses the calendar model;
+ * 6/7-field forms defeat the structural one-minute floor; "#" comments are
+ * noise).
+ *
+ * Both server editions and the cloud Java edition mirror these checks with
+ * byte-identical messages; the shared rejection matrix is pinned by unit
+ * tests on every side. Widening this grammar later is additive; narrowing
+ * it would break stored specs — start narrow.
+ */
+import { invalidArgumentError } from "../../pipeline/errors.js";
+
+/**
+ * The accepted @-shorthands — deliberately only the calendar ones Temporal
+ * documents (no @every, and none of the nonstandard aliases like @annually
+ * or @midnight some cron implementations accept).
+ */
+const CRON_SHORTHANDS = new Set([
+  "@hourly",
+  "@daily",
+  "@weekly",
+  "@monthly",
+  "@yearly",
+]);
+
+/**
+ * Bounds each field to the character set of Temporal's CalendarSpec
+ * ranges: digits, month/day names (Jan, MON), '*', ',', '-', '/'.
+ * Quartz-isms ('?', 'L', 'W', '#') and anything else are rejected —
+ * Temporal does not implement them.
+ */
+const CRON_FIELD_PATTERN = /^[0-9A-Za-z*,/-]+$/;
+
+/**
+ * Enforces the DD-009 C-4 grammar; throws InvalidArgument with the
+ * cross-edition byte-pinned copy. Pure and deterministic.
+ */
+export function validateScheduleCron(cron: string): void {
+  if (cron.startsWith("CRON_TZ=") || cron.startsWith("TZ=")) {
+    throw invalidArgumentError(
+      "spec.cron must not carry a timezone prefix (CRON_TZ=/TZ=) — spec.time_zone is the single timezone authority",
+    );
+  }
+
+  if (cron.includes("#")) {
+    throw invalidArgumentError("spec.cron must not contain a comment (#)");
+  }
+
+  if (cron.startsWith("@")) {
+    if (cron.startsWith("@every")) {
+      throw invalidArgumentError(
+        "spec.cron must be a calendar expression — @every intervals are not supported",
+      );
+    }
+    if (!CRON_SHORTHANDS.has(cron)) {
+      throw invalidArgumentError(
+        `spec.cron shorthand "${cron}" is not supported — use @hourly, @daily, @weekly, @monthly, or @yearly, or a 5-field cron expression`,
+      );
+    }
+    return;
+  }
+
+  // Go strings.Fields: split on any run of whitespace, no empty fields.
+  const fields = cron.split(/\s+/).filter((field) => field !== "");
+  if (fields.length !== 5) {
+    throw invalidArgumentError(
+      `spec.cron must have exactly 5 fields (minute hour day-of-month month day-of-week); got ${fields.length}`,
+    );
+  }
+
+  for (const field of fields) {
+    if (!CRON_FIELD_PATTERN.test(field)) {
+      throw invalidArgumentError(
+        `spec.cron field "${field}" contains unsupported characters — allowed: digits, names, '*', ',', '-', '/'`,
+      );
+    }
+  }
+}
+
+/**
+ * Requires a name the platform tz database resolves — Go
+ * validateScheduleTimeZone (the Temporal server loads the same database
+ * when it evaluates the cron, DD-008 D2).
+ *
+ * "Local" is rejected explicitly: Go resolves it to the host's zone
+ * (nondeterministic across replicas) while Java's ZoneId does not resolve
+ * it at all — accepting it would be a cross-edition divergence on top of a
+ * correctness bug. The EMPTY string is valid, as in Go: time.LoadLocation("")
+ * is UTC (and the artifact's empty TimeZoneName means UTC to Temporal).
+ */
+export function validateScheduleTimeZone(timeZone: string): void {
+  if (timeZone === "Local" || !isLoadableTimeZone(timeZone)) {
+    throw invalidArgumentError(
+      `spec.time_zone "${timeZone}" is not a valid IANA time zone (e.g. "Asia/Kolkata")`,
+    );
+  }
+}
+
+// The canonical IANA zone list ICU ships (exact case), plus its lowered
+// twin for the case-guard below. Built once — the list is immutable for
+// the process lifetime.
+let canonicalZones: Set<string> | undefined;
+let canonicalZonesLowered: Set<string> | undefined;
+function zoneSets(): { exact: Set<string>; lowered: Set<string> } {
+  if (canonicalZones === undefined || canonicalZonesLowered === undefined) {
+    const values = Intl.supportedValuesOf("timeZone");
+    canonicalZones = new Set(values);
+    canonicalZonesLowered = new Set(values.map((zone) => zone.toLowerCase()));
+  }
+  return { exact: canonicalZones, lowered: canonicalZonesLowered };
+}
+
+/**
+ * The TS spelling of Go time.LoadLocation's yes/no answer. ICU (behind
+ * Intl) resolves zone names CASE-INSENSITIVELY (and may canonicalize
+ * through historical aliases, e.g. asia/kolkata → Asia/Calcutta) while
+ * Go's tzdata file lookup is case-sensitive. The guard restores Go's
+ * refusal: an input that is a mere case-variant of a canonical zone is
+ * rejected; genuine links ("US/Pacific") pass through ICU acceptance as
+ * they do in Go. Residual divergence — a case-variant of a LINK name —
+ * is a disclosed parity nuance (PR register), not silently absorbed.
+ */
+export function isLoadableTimeZone(timeZone: string): boolean {
+  if (timeZone === "") {
+    return true; // Go LoadLocation("") — UTC.
+  }
+  const { exact, lowered } = zoneSets();
+  if (exact.has(timeZone)) {
+    return true;
+  }
+  // A case-variant of a canonical zone: ICU would accept it, Go refuses.
+  if (lowered.has(timeZone.toLowerCase())) {
+    return false;
+  }
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/backend/services/stigmer-server-ts/src/domain/schedule/list-runs.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/list-runs.ts
@@ -1,0 +1,245 @@
+/**
+ * The listRuns query steps — port pkg/domain/schedule/controller/list_runs.go:
+ * the fire-ledger surface (DD-017 D-7). Every fire leaves a row, INCLUDING
+ * fires that created no execution (a refused launch gate, a missing target
+ * agent), with the refusing gate's copy verbatim: this is the RPC that
+ * explains status.consecutive_failures.
+ *
+ * Rows carrying an execution id but no terminal outcome are enriched with
+ * the execution's LIVE phase at read time — manual fires are untracked by
+ * design (the caller watches the execution), so their outcome is resolved
+ * here rather than by a tracker, and outcome columns never lie while a run
+ * is in flight.
+ */
+import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ScheduleQueryController } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/query_pb";
+import {
+  ScheduleRunListSchema,
+  ScheduleRunOrigin,
+  ScheduleRunOutcome,
+  ScheduleRunSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/io_pb";
+import type { ScheduleRun } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { internalError, notFoundError } from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { ScheduleRunRecord, Store } from "../../store/interface.js";
+
+type ListRunsInput = typeof ScheduleQueryController.method.listRuns.input;
+
+export const LIST_RUNS_RESULT_KEY = "listRunsResult";
+
+/**
+ * Bounds an unpaginated listRuns read — history can hold a quarter's worth
+ * of daily fires, and "the recent runs" is the question the surface
+ * answers (Go defaultRunsPageSize).
+ */
+export const DEFAULT_RUNS_PAGE_SIZE = 50;
+
+/**
+ * Confirms the schedule exists — a missing schedule answers NOT_FOUND,
+ * never an empty history that reads as "exists but never fired" (Go
+ * loadScheduleForRunsStep).
+ */
+export function newLoadScheduleForRunsStep(store: Store): PipelineStep<ListRunsInput> {
+  return {
+    name: "LoadScheduleForRuns",
+    async execute(ctx: RequestContext<ListRunsInput>): Promise<void> {
+      const scheduleId = ctx.input.scheduleId;
+      try {
+        await store.getResource(
+          ApiResourceKind.schedule,
+          scheduleId,
+          ScheduleSchema,
+        );
+      } catch (error) {
+        if (error instanceof ResourceNotFoundError) {
+          throw notFoundError("Schedule", scheduleId);
+        }
+        throw internalError(error, "failed to load schedule");
+      }
+    },
+  };
+}
+
+/**
+ * Pages the fire ledger (newest first) and enriches in-flight rows with
+ * the execution's live phase (Go listRunsFromLedgerStep).
+ */
+export function newListRunsFromLedgerStep(store: Store): PipelineStep<ListRunsInput> {
+  return {
+    name: "ListRunsFromLedger",
+    async execute(ctx: RequestContext<ListRunsInput>): Promise<void> {
+      const req = ctx.input;
+
+      // PageInfo.num is 1-indexed by contract (pagination.proto); a
+      // zero/absent page reads as the first.
+      let size = req.pageInfo?.size ?? 0;
+      if (size <= 0) {
+        size = DEFAULT_RUNS_PAGE_SIZE;
+      }
+      let num = req.pageInfo?.num ?? 0;
+      if (num < 1) {
+        num = 1;
+      }
+      const offset = (num - 1) * size;
+
+      let runs: ScheduleRunRecord[];
+      let total: number;
+      try {
+        ({ runs, total } = await store.listScheduleRuns(
+          req.scheduleId,
+          offset,
+          size,
+        ));
+      } catch (error) {
+        throw internalError(error, "failed to list schedule runs");
+      }
+
+      const items: ScheduleRun[] = [];
+      for (const record of runs) {
+        items.push(await toProtoRun(store, record));
+      }
+
+      ctx.set(
+        LIST_RUNS_RESULT_KEY,
+        create(ScheduleRunListSchema, { totalCount: total, items }),
+      );
+    },
+  };
+}
+
+/**
+ * Maps one ledger row to the wire, enriching a non-terminal row that
+ * carries an execution id with the execution's live phase — the read-time
+ * honesty rule (Go toProtoRun).
+ */
+async function toProtoRun(
+  store: Store,
+  record: ScheduleRunRecord,
+): Promise<ScheduleRun> {
+  const run = create(ScheduleRunSchema, {
+    scheduleId: record.scheduleId,
+    org: record.org,
+    origin: runOriginFromLabel(record.origin),
+    outcome: runOutcomeFromLabel(record.outcome),
+    reason: record.reason,
+    executionId: record.executionId,
+  });
+  const nominal = parseTime(record.nominalFireTime);
+  if (nominal !== undefined) {
+    run.nominalFireTime = timestampFromDate(nominal);
+  }
+  const recordedAt = parseTime(record.recordedAt);
+  if (recordedAt !== undefined) {
+    run.recordedAt = timestampFromDate(recordedAt);
+  }
+  if (record.completedAt !== "") {
+    const completedAt = parseTime(record.completedAt);
+    if (completedAt !== undefined) {
+      run.completedAt = timestampFromDate(completedAt);
+    }
+    return run;
+  }
+
+  // In flight on paper — ask the execution row what actually happened.
+  if (record.executionId === "") {
+    return run;
+  }
+  let phase: ExecutionPhase;
+  try {
+    const execution = await store.getResource(
+      ApiResourceKind.agent_execution,
+      record.executionId,
+      AgentExecutionSchema,
+    );
+    phase = execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+  } catch {
+    // Execution deleted (or unreadable): the ledger row stands as
+    // recorded — deleting a run must not rewrite its history.
+    return run;
+  }
+  switch (phase) {
+    case ExecutionPhase.EXECUTION_COMPLETED:
+      run.outcome = ScheduleRunOutcome.COMPLETED;
+      break;
+    case ExecutionPhase.EXECUTION_FAILED:
+    case ExecutionPhase.EXECUTION_CANCELLED:
+    case ExecutionPhase.EXECUTION_TERMINATED:
+      run.outcome = ScheduleRunOutcome.FAILED;
+      run.reason = `run ${record.executionId} ended ${executionPhaseWord(phase)}`;
+      break;
+    default:
+      // Genuinely still running — "started" is the honest answer.
+      break;
+  }
+  return run;
+}
+
+/**
+ * Lowers an ExecutionPhase to the reason vocabulary the tick's verdict
+ * writer uses ("run X ended failed") — Go executionPhaseWord.
+ */
+function executionPhaseWord(phase: ExecutionPhase): string {
+  switch (phase) {
+    case ExecutionPhase.EXECUTION_FAILED:
+      return "failed";
+    case ExecutionPhase.EXECUTION_CANCELLED:
+      return "cancelled";
+    case ExecutionPhase.EXECUTION_TERMINATED:
+      return "terminated";
+    default:
+      return "unknown";
+  }
+}
+
+/** Maps the ledger's lowercase origin vocabulary back to the wire enum. */
+function runOriginFromLabel(origin: string): ScheduleRunOrigin {
+  switch (origin) {
+    case "cron":
+      return ScheduleRunOrigin.CRON;
+    case "manual":
+      return ScheduleRunOrigin.MANUAL;
+    default:
+      return ScheduleRunOrigin.UNSPECIFIED;
+  }
+}
+
+/** Maps the ledger's lowercase outcome vocabulary back to the wire enum. */
+function runOutcomeFromLabel(outcome: string): ScheduleRunOutcome {
+  switch (outcome) {
+    case "started":
+      return ScheduleRunOutcome.STARTED;
+    case "refused":
+      return ScheduleRunOutcome.REFUSED;
+    case "target_missing":
+      return ScheduleRunOutcome.TARGET_MISSING;
+    case "skipped":
+      return ScheduleRunOutcome.SKIPPED;
+    case "completed":
+      return ScheduleRunOutcome.COMPLETED;
+    case "failed":
+      return ScheduleRunOutcome.FAILED;
+    case "timed_out":
+      return ScheduleRunOutcome.TIMED_OUT;
+    default:
+      return ScheduleRunOutcome.UNSPECIFIED;
+  }
+}
+
+/** Go's time.Parse(time.RFC3339) tolerance: unparseable leaves the field unset. */
+function parseTime(value: string): Date | undefined {
+  if (value === "") {
+    return undefined;
+  }
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}

--- a/backend/services/stigmer-server-ts/src/domain/schedule/persist-update.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/persist-update.ts
@@ -1,0 +1,76 @@
+/**
+ * The update pipeline's persist step — ports persistScheduleUpdateStep of
+ * pkg/domain/schedule/controller/update.go.
+ *
+ * Persists an update as a graft of exactly what the request path owns —
+ * apiVersion/kind/metadata/spec plus the audit bump BuildUpdateState
+ * stamped — onto the LIVE row, inside one store.updateResource closure.
+ * NOT the generic Persist step: schedule status has a concurrent writer
+ * (the tick), and a full-row save of the load-time snapshot could silently
+ * revert a fire record, a streak write, or a PAUSE — breaking the "resume
+ * is the one clearing path" pin. The OSS twin of the cloud's targeted
+ * metadata+spec+status.audit patch, shaped for a store whose unit of write
+ * is the whole protobuf blob (DD-015 D-C).
+ *
+ * Unlike a save, the graft never resurrects a concurrently deleted row:
+ * updateResource answers not-found, relayed as NOT_FOUND — the delete won,
+ * honestly.
+ */
+import { create } from "@bufbuild/protobuf";
+
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ScheduleStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/status_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { internalError, notFoundError } from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+
+export function newPersistScheduleUpdateStep(
+  store: Store,
+): PipelineStep<typeof ScheduleSchema> {
+  return {
+    name: "PersistScheduleUpdate",
+    async execute(ctx: RequestContext<typeof ScheduleSchema>): Promise<void> {
+      const newState = ctx.newState;
+      const scheduleId = newState.metadata?.id ?? "";
+
+      let live: Schedule;
+      try {
+        live = await store.updateResource(
+          ApiResourceKind.schedule,
+          scheduleId,
+          ScheduleSchema,
+          (row) => {
+            row.apiVersion = newState.apiVersion;
+            row.kind = newState.kind;
+            row.metadata = newState.metadata;
+            row.spec = newState.spec;
+            // The one status subtree the request path owns: its own audit
+            // bump. Every other status leaf stays exactly as the
+            // concurrent runtime last wrote it.
+            if (newState.status?.audit !== undefined) {
+              if (row.status === undefined) {
+                row.status = create(ScheduleStatusSchema);
+              }
+              row.status.audit = newState.status.audit;
+            }
+          },
+        );
+      } catch (error) {
+        if (error instanceof ResourceNotFoundError) {
+          throw notFoundError("Schedule", scheduleId);
+        }
+        throw internalError(error, "failed to persist schedule update");
+      }
+
+      // Answer with the persisted post-image: the new spec plus the LIVE
+      // status — fresher than the load-time snapshot, and honest about
+      // anything the runtime wrote mid-request.
+      ctx.setNewState(live);
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/schedule/resume.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/resume.ts
@@ -1,0 +1,117 @@
+/**
+ * The resume command's clearing step — ports
+ * pkg/domain/schedule/controller/resume.go.
+ *
+ * "Paused" is the platform's latch (status.paused_reason, written by the
+ * failure-streak auto-pause), distinct from "disabled", the owner's switch
+ * (spec.enabled) — DD-013 D-E. Resume clears the latch and resets
+ * status.consecutive_failures, and is deliberately the ONLY path that does
+ * either (DD-013 D-D): update and apply preserve status verbatim, so a
+ * routine manifest apply can never silently un-pause a failing schedule.
+ *
+ * Resuming a schedule that is not paused (and has no failure streak)
+ * succeeds and changes nothing — no write, no audit bump. A disabled
+ * schedule stays disabled: the latch and the switch are independent.
+ */
+import type { DescMessage } from "@bufbuild/protobuf";
+
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { internalError, notFoundError } from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+
+/**
+ * Aborts the atomic write on the idempotent no-op path — the fresh row has
+ * no latch and no streak, so nothing is written and no audit bumps (Go
+ * errResumeNothingToClear).
+ */
+class NothingToClearError extends Error {
+  constructor() {
+    super("nothing to clear");
+    this.name = "NothingToClearError";
+  }
+}
+
+/**
+ * Clears status.paused_reason and resets status.consecutive_failures in
+ * ONE store.updateResource closure on the freshly-read row, preserving
+ * every other status leaf as the concurrent runtime last wrote it (Go
+ * clearSchedulePauseStep).
+ *
+ * This is the revisit DD-013 D-D reserved for the clock slice: a previous
+ * load-mutate-save across step boundaries was safe only while nothing else
+ * wrote schedule status. The clock ended that — a fire recorded (or a
+ * streak advanced) between the load and the save would have been silently
+ * reverted. The agent-execution domain adopted this exact primitive after
+ * losing user approvals to the same race class.
+ */
+export function newClearSchedulePauseStep<Desc extends DescMessage>(
+  store: Store,
+): PipelineStep<Desc> {
+  return {
+    name: "ClearSchedulePause",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const loaded = ctx.get(EXISTING_RESOURCE_KEY) as Schedule;
+      const scheduleId = loaded.metadata?.id ?? "";
+
+      let live: Schedule;
+      try {
+        live = await store.updateResource(
+          ApiResourceKind.schedule,
+          scheduleId,
+          ScheduleSchema,
+          (row) => {
+            const status = row.status;
+            if (
+              (status?.pausedReason ?? "") === "" &&
+              (status?.consecutiveFailures ?? 0) === 0
+            ) {
+              throw new NothingToClearError();
+            }
+            // status is defined here: a latch or streak exists only on a
+            // materialized status message.
+            row.status!.pausedReason = "";
+            // Resuming with strikes left would re-pause on the next
+            // failure — a lie; both clear together, always.
+            row.status!.consecutiveFailures = 0;
+            setAuditFieldsForUpdate(ScheduleSchema, row, "status_audit");
+          },
+        );
+      } catch (error) {
+        if (error instanceof NothingToClearError) {
+          // The untouched fresh row is the honest response on the no-op
+          // path; updateResource skipped the write, so re-read the live
+          // row (Go's out-param `live` holds it either way).
+          try {
+            live = await store.getResource(
+              ApiResourceKind.schedule,
+              scheduleId,
+              ScheduleSchema,
+            );
+          } catch (readError) {
+            if (readError instanceof ResourceNotFoundError) {
+              throw notFoundError("Schedule", scheduleId);
+            }
+            throw internalError(readError, "failed to resume schedule");
+          }
+          ctx.set(EXISTING_RESOURCE_KEY, live);
+          return;
+        }
+        if (error instanceof ResourceNotFoundError) {
+          // Deleted between load and clear: the delete won.
+          throw notFoundError("Schedule", scheduleId);
+        }
+        throw internalError(error, "failed to resume schedule");
+      }
+      // live holds the post-image (cleared) — the honest response.
+      ctx.set(EXISTING_RESOURCE_KEY, live);
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/schedule/steps.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/steps.ts
@@ -1,0 +1,281 @@
+/**
+ * Schedule write-path steps — ports the validation half of
+ * pkg/domain/schedule/controller/steps.go: the defaults resolver
+ * (create/apply) and the update validator, plus the workspace and
+ * model-pinning rules both share.
+ *
+ * Proven by schedule.conformance.test.ts (CONFORMANCE_TARGET=local-ts) and
+ * __tests__/schedule.composed.test.ts.
+ */
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { ScheduleSpec } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import {
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { findResourceBySlug } from "../../pipeline/steps/helpers.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import type { Store } from "../../store/interface.js";
+import { scheduleModelPinningRefusal } from "../../temporal/schedule/model-pinning.js";
+import {
+  harnessName,
+  unknownModelPinRefusal,
+} from "../workflow/registry/pin-validation.js";
+import type { ModelRegistryStore } from "../workflow/registry/model-registry-store.js";
+import { validateScheduleCron, validateScheduleTimeZone } from "./cron.js";
+
+export interface ScheduleValidationDeps {
+  readonly store: Store;
+  readonly modelRegistry: ModelRegistryStore;
+}
+
+/**
+ * Prepares a schedule for creation — the ScheduleDefaultsResolver mirror
+ * (cloud edition), whose error contracts this step replicates
+ * byte-identically (Go resolveScheduleDefaultsStep):
+ *
+ *  1. Requires metadata.org — the schedule-owning org is the billing org
+ *     for every fire (DD-008 D4), so it can never be inferred.
+ *  2. Validates the cron grammar and the time zone (cron.ts — the DD-009
+ *     C-4 lexical rules; no cron parsing in either edition).
+ *  3. Requires spec.agent.agent_ref.slug and normalizes its org (empty
+ *     means same-org, the platform-wide relative-reference convention).
+ *  4. Enforces the same-org invariant: agent_ref.org must equal
+ *     metadata.org — the schedule's org pays for every fire, and both must
+ *     be the agent's. Checked BEFORE the agent load so a cross-org request
+ *     cannot probe another org's slugs through this path.
+ *  5. Loads the referenced agent — scheduling a nonexistent agent is
+ *     refused with the same NOT_FOUND a direct agent lookup would produce.
+ *
+ * Deliberately NO slug default from the agent: schedules are N-per-agent
+ * with different prompts, so no single schedule is "the" canonical one. A
+ * schedule without a slug or name falls through to the generic ResolveSlug
+ * derive-from-name behavior.
+ *
+ * Resolution is idempotent: an already-resolved schedule passes through
+ * unchanged, so the apply pipeline running it before delegating to the
+ * create pipeline (which runs it again) is harmless.
+ */
+export function newResolveScheduleDefaultsStep(
+  deps: ScheduleValidationDeps,
+): PipelineStep<typeof ScheduleSchema> {
+  return {
+    name: "ResolveScheduleDefaults",
+    async execute(ctx: RequestContext<typeof ScheduleSchema>): Promise<void> {
+      const schedule = ctx.newState;
+      const metadata = schedule.metadata;
+
+      if ((metadata?.org ?? "") === "") {
+        throw invalidArgumentError("metadata.org is required for a schedule");
+      }
+
+      const spec = schedule.spec;
+      validateScheduleCron(spec?.cron ?? "");
+      validateScheduleTimeZone(spec?.timeZone ?? "");
+
+      const agentRef =
+        spec?.target.case === "agent" ? spec.target.value.agentRef : undefined;
+      if ((agentRef?.slug ?? "") === "") {
+        throw invalidArgumentError("spec.agent.agent_ref.slug is required");
+      }
+
+      validateScheduleWorkspace(spec);
+      validateScheduleModelPinning(deps.modelRegistry, spec);
+
+      // Empty ref org means same-org; make it absolute before the
+      // invariant compares orgs.
+      let refOrg = agentRef?.org ?? "";
+      if (refOrg === "") {
+        refOrg = metadata?.org ?? "";
+      }
+
+      // The same-org invariant (spec.proto): the schedule's org is the
+      // billing org for every fire, and it must be the agent's. Checked
+      // BEFORE the agent load so a cross-org request cannot probe another
+      // org's slugs through this path.
+      if (refOrg !== (metadata?.org ?? "")) {
+        throw failedPreconditionError(
+          `spec.agent.agent_ref.org must match metadata.org — a schedule must live in the referenced agent's organization (${refOrg})`,
+        );
+      }
+
+      let found;
+      try {
+        found = await findResourceBySlug(
+          deps.store,
+          ApiResourceKind.agent,
+          AgentSchema,
+          agentRef?.slug ?? "",
+          refOrg,
+        );
+      } catch (error) {
+        throw internalError(error, "failed to list agent resources");
+      }
+      if (found === undefined) {
+        // Byte-identical with the direct agent lookup's refusal (the T09
+        // indistinguishability contract).
+        throw notFoundError("Agent", agentRef?.slug ?? "");
+      }
+
+      if (agentRef !== undefined) {
+        agentRef.org = refOrg;
+      }
+    },
+  };
+}
+
+/**
+ * Enforces the schedule-specific workspace constraint on the shared
+ * AgentInvocation (DD-018 D-3): every workspace entry must be a git_repo
+ * source. A local_path needs a connected client to serve the directory,
+ * and a schedule fire has none — refusing at write time beats a
+ * deterministic provisioning failure at 3 AM. Copy is cross-edition
+ * contract (Go validateScheduleWorkspace).
+ */
+export function validateScheduleWorkspace(spec: ScheduleSpec | undefined): void {
+  const entries =
+    spec?.target.case === "agent" ? spec.target.value.workspaceEntries : [];
+  for (const [i, entry] of entries.entries()) {
+    if (entry.source?.source.case !== "gitRepo") {
+      throw invalidArgumentError(
+        `spec.agent.workspace_entries[${i}] must use a git_repo source — a scheduled run has no connected client to serve a local_path`,
+      );
+    }
+  }
+}
+
+/**
+ * Enforces the two unattended model-pinning rules at write time (Go
+ * validateScheduleModelPinning):
+ *
+ *   - PRESENCE (stigmer/stigmer#362): a Cursor-harness schedule must pin a
+ *     model. Stated once in the clock's scheduleModelPinningRefusal, which
+ *     the run starter also evaluates as the launch backstop for rows
+ *     written before the rule existed.
+ *   - EXISTENCE (stigmer/stigmer#774): whatever model IS pinned must be in
+ *     the registry for the harness the fires would use — a typo'd pin used
+ *     to pass through verbatim and silently run (and bill) as Auto.
+ *     Write-time only BY DESIGN (no fire-time backstop — registry drift
+ *     must never break an existing schedule at its 3 AM fire).
+ */
+export function validateScheduleModelPinning(
+  modelRegistry: ModelRegistryStore,
+  spec: ScheduleSpec | undefined,
+): void {
+  const presence = scheduleModelPinningRefusal(spec);
+  if (presence !== "") {
+    throw invalidArgumentError(presence);
+  }
+  const invocation = spec?.target.case === "agent" ? spec.target.value : undefined;
+  const existence = unknownModelPinRefusal(
+    modelRegistry,
+    "spec.agent.run_config.model_name",
+    harnessName(invocation?.harness ?? 0),
+    invocation?.runConfig?.modelName ?? "",
+  );
+  if (existence !== "") {
+    throw invalidArgumentError(existence);
+  }
+}
+
+/**
+ * The manifest vocabulary for the schedule's target arm — the populated
+ * target-oneof member's field name, exactly what users declared in YAML
+ * (Go targetFieldName resolves it through proto reflection; connect-es
+ * exposes the case name directly, identical for the single-word fields
+ * this oneof carries — "agent" today, "workflow" reserved).
+ */
+export function targetFieldName(spec: ScheduleSpec | undefined): string {
+  return spec?.target.case ?? "";
+}
+
+/**
+ * Enforces the schedule's immutable identity on update (Go
+ * validateScheduleUpdateStep):
+ *
+ *   - spec.agent.agent_ref must keep referencing the same agent. Create's
+ *     consent bar is can_edit on the REFERENCED agent (cloud edition); if
+ *     an update could repoint the target, a schedule owner could drive an
+ *     agent they may not edit — bypassing that consent. Create a new
+ *     schedule instead (nothing is lost — a schedule carries no install
+ *     state).
+ *   - The target arm (target oneof case) must not change. An agent
+ *     schedule must not morph into a workflow schedule — the two targets
+ *     enter different execution pipelines. Trivially satisfied while one
+ *     arm exists; enforced structurally so the workflow arm lands with the
+ *     rule already in force.
+ *   - The cron grammar and time zone are re-validated: update replaces the
+ *     spec wholesale and does not run the defaults resolver, so the write
+ *     path must hold the same bar as create.
+ *
+ * Runs after LoadExisting. metadata.slug/org immutability needs no step
+ * here: the generic BuildUpdateState preserves both from the existing
+ * resource. Status (firing observations, auto-pause) is likewise preserved
+ * wholesale — the invariant that keeps DD-008 D7's auto-pause immune to
+ * declarative clobber.
+ */
+export function newValidateScheduleUpdateStep(
+  deps: ScheduleValidationDeps,
+): PipelineStep<typeof ScheduleSchema> {
+  return {
+    name: "ValidateScheduleUpdate",
+    execute(ctx: RequestContext<typeof ScheduleSchema>): void {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as Schedule | undefined;
+      if (existing === undefined) {
+        throw internalError(
+          new Error("existing schedule not found in context"),
+          "existing schedule not found in context",
+        );
+      }
+
+      const newState = ctx.newState;
+
+      const inputTarget = targetFieldName(newState.spec);
+      const existingTarget = targetFieldName(existing.spec);
+      if (inputTarget !== existingTarget) {
+        throw failedPreconditionError(
+          `spec target is immutable (schedule target is ${existingTarget}) — create a new schedule for a different target kind`,
+        );
+      }
+
+      const spec = newState.spec;
+      validateScheduleCron(spec?.cron ?? "");
+      validateScheduleTimeZone(spec?.timeZone ?? "");
+      // Update replaces the spec wholesale (no defaults resolver), so the
+      // workspace and model-pinning constraints must hold here too.
+      validateScheduleWorkspace(spec);
+      validateScheduleModelPinning(deps.modelRegistry, spec);
+
+      const inputRef =
+        spec?.target.case === "agent" ? spec.target.value.agentRef : undefined;
+      const existingRef =
+        existing.spec?.target.case === "agent"
+          ? existing.spec.target.value.agentRef
+          : undefined;
+
+      // Normalize the input ref's org the same way create does (empty
+      // means the schedule's own org) before comparing.
+      let inputOrg = inputRef?.org ?? "";
+      if (inputOrg === "") {
+        inputOrg = existing.metadata?.org ?? "";
+      }
+
+      if (
+        (inputRef?.slug ?? "") !== (existingRef?.slug ?? "") ||
+        inputOrg !== (existingRef?.org ?? "")
+      ) {
+        throw failedPreconditionError(
+          `spec.agent.agent_ref is immutable (schedule runs ${existingRef?.org ?? ""}/${existingRef?.slug ?? ""}) — create a new schedule to run a different agent`,
+        );
+      }
+    },
+  };
+}

--- a/backend/services/stigmer-server-ts/src/domain/schedule/trigger.ts
+++ b/backend/services/stigmer-server-ts/src/domain/schedule/trigger.ts
@@ -1,0 +1,273 @@
+/**
+ * The trigger command's steps — ports
+ * pkg/domain/schedule/controller/trigger.go (DD-017 D-5/D-6, amending
+ * DD-014).
+ *
+ * The manual fire runs SYNCHRONOUSLY through the standard execution create
+ * pipeline — every launch gate runs — and the result names what happened:
+ * the created execution's id, or the refusing gate's copy verbatim.
+ * Two-level contract: a gRPC error means the trigger itself was refused
+ * (missing → NOT_FOUND, disabled → FAILED_PRECONDITION); a gRPC success
+ * means the fire happened, whatever the run's outcome — a deterministically
+ * refused run is a successful trigger honestly reported, never an
+ * exception.
+ *
+ * Semantics settled by DD-017 D-5:
+ *   - A PAUSED schedule may be triggered (test-then-resume): a test fire
+ *     is exactly how an owner verifies a fix before resuming, and resume
+ *     stays the one path that clears the latch.
+ *   - Manual fires do NOT feed the failure streak: the sync path is
+ *     untracked (the caller watches the execution), so it has no honest
+ *     completion verdict to contribute — and a test fire of a broken
+ *     schedule must not race its owner to the pause threshold.
+ *   - The handler stamps last_fire_at and writes the fire-ledger row
+ *     (origin=manual) because the tick is not in the path to do it; the
+ *     run starter stamps last_execution_id on success as it does for cron
+ *     fires.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { DescMessage } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import {
+  ScheduleRunOutcome,
+  ScheduleTriggerResultSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/io_pb";
+import { ScheduleStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/status_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { ConnectError } from "@connectrpc/connect";
+
+import type { Logger } from "../../boot/logger.js";
+import {
+  failedPreconditionError,
+  rethrownStatusError,
+} from "../../pipeline/errors.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import {
+  setAuditFieldsForUpdate,
+} from "../../pipeline/steps/defaults.js";
+import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+import { recordManualFire } from "../../temporal/schedule/run-ledger.js";
+import { rfc3339Seconds } from "../../temporal/schedule/run-ledger.js";
+import type { RunOutcomeResult } from "../../temporal/schedule/run-starter.js";
+
+// The trigger refusal copy, byte-identical to the cloud edition's
+// ScheduleTriggerHandler (same error contracts in both editions; the
+// conformance suite asserts these verbatim). A change on either side must
+// change both.
+
+/**
+ * The owner's switch is off. OSS has no blueprint-access layer, so the
+ * refusal here is pure contract parity: cloud MUST refuse (a
+ * disabled-schedule run would die mid-execution after billing side
+ * effects, DD-017 D-5), and the two editions must not diverge on a refusal
+ * a user can observe. Consoles turn the dead end into a one-click
+ * "Enable & run now".
+ */
+export const TRIGGER_DISABLED_MESSAGE =
+  "schedule is disabled (spec.enabled=false) — enable it before triggering";
+
+/**
+ * No run starter is wired into this process (production wiring always
+ * injects it — this is the defensive posture for embedded/test assemblies
+ * that skip server wiring): refuse honestly, never pretend.
+ */
+export const TRIGGER_NO_RUNNER_MESSAGE =
+  "this Stigmer server process has no schedule run starter wired — the schedule cannot fire";
+
+/**
+ * The narrow slice of the scheduling runtime the trigger needs (satisfied
+ * by the clock's RunStarter): start one run through the full execution
+ * create pipeline and answer with the real outcome. Deliberately NOT the
+ * Clock — a manual fire needs no Temporal artifact (DD-017 D-5 amending
+ * DD-014 D-A): the artifact round-trip made the fire asynchronous, so the
+ * RPC answered "started" before the launch gates ran — exactly the false
+ * toast the owner hit (Go Runner).
+ */
+export interface ScheduleRunner {
+  startRun(schedule: Schedule, nominalFireTime: Date): Promise<RunOutcomeResult>;
+}
+
+/** A provider so the compose root can wire the runner after the clock stage. */
+export type RunnerProvider = () => ScheduleRunner | undefined;
+
+/** Carries the shaped ScheduleTriggerResult from the fire step to the handler. */
+export const TRIGGER_RESULT_KEY = "trigger_result";
+
+/**
+ * Refuses a disabled schedule (the owner's switch) — the ONE remaining
+ * trigger refusal (DD-017 D-5 narrowed DD-014 D-B's matrix: paused
+ * schedules are now triggerable, and the tick's revalidation no longer
+ * guards manual fires because manual fires no longer pass through the
+ * tick). Go validateTriggerableStep.
+ */
+export function newValidateTriggerableStep<Desc extends DescMessage>(): PipelineStep<Desc> {
+  return {
+    name: "ValidateTriggerable",
+    execute(ctx: RequestContext<Desc>): void {
+      const schedule = ctx.get(EXISTING_RESOURCE_KEY) as Schedule;
+      if (!(schedule.spec?.enabled ?? false)) {
+        throw failedPreconditionError(TRIGGER_DISABLED_MESSAGE);
+      }
+    },
+  };
+}
+
+export interface FireDirectRunDeps {
+  readonly store: Store;
+  readonly runner: RunnerProvider;
+  readonly logger: Logger;
+}
+
+/**
+ * Starts the run in-process and shapes the result: stamp last_fire_at, run
+ * the full create pipeline via the Runner, write the fire-ledger row,
+ * mirror the outcome into ScheduleTriggerResult. Infrastructure failures
+ * from the create pipeline propagate as the handler's error — the
+ * in-process client already speaks gRPC status (Go fireDirectRunStep).
+ */
+export function newFireDirectRunStep<Desc extends DescMessage>(
+  deps: FireDirectRunDeps,
+): PipelineStep<Desc> {
+  return {
+    name: "FireDirectRun",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const runner = deps.runner();
+      if (runner === undefined) {
+        throw failedPreconditionError(TRIGGER_NO_RUNNER_MESSAGE);
+      }
+
+      const schedule = ctx.get(EXISTING_RESOURCE_KEY) as Schedule;
+      const scheduleId = schedule.metadata?.id ?? "";
+
+      // The manual fire's nominal time is the trigger instant, whole
+      // seconds — the same identity the deterministic execution name uses,
+      // so a manual fire at the exact cron nominal second converges on the
+      // same execution via the ALREADY_EXISTS → re-find path.
+      const nominal = new Date(Math.floor(Date.now() / 1000) * 1000);
+      const nominalRfc3339 = rfc3339Seconds(nominal);
+
+      let outcome: RunOutcomeResult;
+      try {
+        outcome = await runner.startRun(schedule, nominal);
+      } catch (error) {
+        deps.logger.warn("Manual trigger's run start failed on infrastructure", {
+          schedule_id: scheduleId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        // The in-process client's error instance carries the INNER
+        // response's metadata; echoing it corrupts the serving HTTP/2
+        // trailers (NGHTTP2_PROTOCOL_ERROR — the #18 transport finding).
+        // Re-mint code + message, exactly the workflowexecution
+        // forwarding posture.
+        throw error instanceof ConnectError ? rethrownStatusError(error) : error;
+      }
+
+      // The fire happened: record it — last_fire_at on status (the tick is
+      // not in this path to do it) and the ledger row (origin=manual).
+      await stampLastFireAt(deps, scheduleId, nominal);
+      await recordManualFire(
+        deps.store,
+        deps.logger,
+        scheduleId,
+        schedule.metadata?.org ?? "",
+        nominalRfc3339,
+        outcome,
+      );
+
+      const result = create(ScheduleTriggerResultSchema);
+      switch (outcome.kind) {
+        case "started":
+          result.outcome = ScheduleRunOutcome.STARTED;
+          result.executionId = outcome.executionId;
+          deps.logger.info("Schedule triggered manually — run started", {
+            schedule_id: scheduleId,
+            execution_id: outcome.executionId,
+            already_existed: outcome.alreadyExisted,
+          });
+          break;
+        case "targetMissing":
+          result.outcome = ScheduleRunOutcome.TARGET_MISSING;
+          result.refusalReason = outcome.reason;
+          deps.logger.warn("Schedule triggered manually — target missing", {
+            schedule_id: scheduleId,
+            reason: outcome.reason,
+          });
+          break;
+        case "refused":
+          result.outcome = ScheduleRunOutcome.REFUSED;
+          result.refusalReason = outcome.reason;
+          deps.logger.warn(
+            "Schedule triggered manually — run refused by a launch gate",
+            { schedule_id: scheduleId, reason: outcome.reason },
+          );
+          break;
+        default: {
+          const exhaustive: never = outcome;
+          throw new Error(`unknown run outcome ${String(exhaustive)}`);
+        }
+      }
+
+      // Answer with the post-fire row — last_fire_at and (on success)
+      // last_execution_id freshly stamped. A failed re-read degrades to the
+      // loaded schedule rather than failing a fire that already happened.
+      try {
+        result.schedule = await deps.store.getResource(
+          ApiResourceKind.schedule,
+          scheduleId,
+          ScheduleSchema,
+        );
+      } catch {
+        result.schedule = schedule;
+      }
+
+      ctx.set(TRIGGER_RESULT_KEY, result);
+    },
+  };
+}
+
+/**
+ * Records the manual fire on status — best-effort with a loud log: the run
+ * already started, and a bookkeeping failure must not turn a real fire
+ * into a caller-visible error. (The cron path's stamp rides the tick's
+ * recordFire; this is its manual twin. Uses the FULL shared audit helper —
+ * this is a request-path write, unlike the clock's minimal bump.) Go
+ * stampLastFireAt.
+ */
+async function stampLastFireAt(
+  deps: FireDirectRunDeps,
+  scheduleId: string,
+  nominal: Date,
+): Promise<void> {
+  try {
+    await deps.store.updateResource(
+      ApiResourceKind.schedule,
+      scheduleId,
+      ScheduleSchema,
+      (live) => {
+        if (live.status === undefined) {
+          live.status = create(ScheduleStatusSchema);
+        }
+        live.status.lastFireAt = timestampFromDate(nominal);
+        setAuditFieldsForUpdate(ScheduleSchema, live, "status_audit");
+      },
+    );
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      return;
+    }
+    deps.logger.warn(
+      "Manual fire's last_fire_at not stamped (best-effort — the run is unaffected)",
+      {
+        schedule_id: scheduleId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/activities.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/activities.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Pins the tick activities against Go's tick_activities_test.go: the
+ * record-tick revalidation matrix (deleted/disabled/paused decline), the
+ * start-run re-validation collapse to SKIPPED (and its no-ledger-row
+ * deleted arm), phase classification incl. GONE, the idempotent success
+ * reset, and the ONE-closure failure record — increment, threshold latch
+ * (first pause's copy never rewritten), next_fire_at clear, and the
+ * best-effort artifact re-sync exactly at the crossing.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import { createScheduleTickActivities } from "../activities.js";
+import type { ScheduleTickActivityDeps } from "../activities.js";
+import { ScheduleTemporalConfig } from "../config.js";
+import {
+  FAILURE_RUN_FAILED,
+  FAILURE_START_FAILED,
+  PHASE_CANCELLED,
+  PHASE_COMPLETED,
+  PHASE_FAILED,
+  PHASE_GONE,
+  PHASE_RUNNING,
+  PHASE_TERMINATED,
+  RECORD_FAILED_RUN_ACTIVITY_NAME,
+  RECORD_SUCCESSFUL_RUN_ACTIVITY_NAME,
+  RECORD_TICK_ACTIVITY_NAME,
+  POLL_EXECUTION_PHASE_ACTIVITY_NAME,
+  RUN_REFUSED,
+  RUN_SKIPPED,
+  RUN_STARTED,
+  START_SCHEDULED_RUN_ACTIVITY_NAME,
+  TICK_FIRED,
+  TICK_SKIPPED_AUTO_PAUSED,
+  TICK_SKIPPED_DELETED,
+  TICK_SKIPPED_DISABLED,
+} from "../names.js";
+import type { RunOutcomeResult } from "../run-starter.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+const NOMINAL = "2026-08-25T09:30:00Z";
+
+let dir: string;
+let store: SqliteStore;
+
+// Threshold 2 (the conformance execution targets' pin) makes the latch
+// provable in two failures.
+const config = new ScheduleTemporalConfig("schedule_stigmer", 60, 24, 2, 60, true, 5, 20, 1.0, 90);
+
+let peekResult: Date | undefined;
+let peekError: Error | undefined;
+let ensureCalls: string[];
+let startRunOutcome: RunOutcomeResult;
+
+function activities() {
+  const deps: ScheduleTickActivityDeps = {
+    store,
+    config,
+    logger: silentLogger,
+    syncer: {
+      peekNextFireAt: async () => {
+        if (peekError !== undefined) {
+          throw peekError;
+        }
+        return peekResult;
+      },
+      ensureAndRecord: async (schedule) => {
+        ensureCalls.push(schedule.metadata?.id ?? "");
+        return undefined;
+      },
+    },
+    runStarter: { startRun: async () => startRunOutcome },
+  };
+  return createScheduleTickActivities(deps);
+}
+
+function scheduleRow(overrides?: { enabled?: boolean; pausedReason?: string; failures?: number }) {
+  return create(ScheduleSchema, {
+    metadata: { id: "sch_01act", org: "acme", slug: "daily" },
+    spec: {
+      cron: "0 9 * * *",
+      timeZone: "UTC",
+      enabled: overrides?.enabled ?? true,
+      target: { case: "agent", value: { agentRef: { slug: "helper" } } },
+    },
+    status: {
+      pausedReason: overrides?.pausedReason ?? "",
+      consecutiveFailures: overrides?.failures ?? 0,
+    },
+  });
+}
+
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "tick-activities-test-"));
+  store = SqliteStore.open(path.join(dir, "test.db"));
+});
+
+afterAll(async () => {
+  await store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  peekResult = undefined;
+  peekError = undefined;
+  ensureCalls = [];
+  startRunOutcome = { kind: "started", executionId: "aex_01x", alreadyExisted: false };
+  await store.deleteResource(ApiResourceKind.schedule, "sch_01act");
+  await store.deleteScheduleRunsBySchedule("sch_01act");
+});
+
+describe("recordTick — the revalidation matrix", () => {
+  it("declines a deleted row (orphaned artifact fires are harmless by construction)", async () => {
+    const outcome = await activities()[RECORD_TICK_ACTIVITY_NAME]("sch_01act", NOMINAL);
+    expect(outcome).toBe(TICK_SKIPPED_DELETED);
+  });
+
+  it("declines an owner-disabled row", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema, scheduleRow({ enabled: false }));
+    expect(await activities()[RECORD_TICK_ACTIVITY_NAME]("sch_01act", NOMINAL)).toBe(TICK_SKIPPED_DISABLED);
+  });
+
+  it("declines a platform-paused row", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema, scheduleRow({ pausedReason: "Paused after 2..." }));
+    expect(await activities()[RECORD_TICK_ACTIVITY_NAME]("sch_01act", NOMINAL)).toBe(TICK_SKIPPED_AUTO_PAUSED);
+  });
+
+  it("fires a live row: stamps last_fire_at = NOMINAL and refreshes next_fire_at", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema, scheduleRow());
+    peekResult = new Date("2026-08-26T09:30:00Z");
+    expect(await activities()[RECORD_TICK_ACTIVITY_NAME]("sch_01act", NOMINAL)).toBe(TICK_FIRED);
+
+    const row = await store.getResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema);
+    expect(row.status?.lastFireAt?.seconds).toBe(BigInt(Date.parse(NOMINAL) / 1000));
+    expect(row.status?.nextFireAt?.seconds).toBe(BigInt(Date.parse("2026-08-26T09:30:00Z") / 1000));
+    expect(row.status?.audit?.statusAudit?.event).toBe("updated");
+  });
+
+  it("a failed next-fire refresh never blocks recording the fire", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema, scheduleRow());
+    peekError = new Error("temporal is away");
+    expect(await activities()[RECORD_TICK_ACTIVITY_NAME]("sch_01act", NOMINAL)).toBe(TICK_FIRED);
+    const row = await store.getResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema);
+    expect(row.status?.lastFireAt).toBeDefined();
+    expect(row.status?.nextFireAt).toBeUndefined();
+  });
+});
+
+describe("startScheduledRun — re-validation and the ledger", () => {
+  it("collapses a row disabled between record and start into SKIPPED, with a ledger row", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema, scheduleRow({ enabled: false }));
+    const result = await activities()[START_SCHEDULED_RUN_ACTIVITY_NAME]("sch_01act", NOMINAL);
+    expect(result.outcome).toBe(RUN_SKIPPED);
+    // The budget rides the RESULT even on skips (replay-safe timing).
+    expect(result.trackingTimeoutMinutes).toBe(60);
+    const { total } = await store.listScheduleRuns("sch_01act", 0, 10);
+    expect(total).toBe(1); // the skip left its ledger row (row exists)
+  });
+
+  it("the deleted-row skip leaves NO ledger row (the cascade already ran)", async () => {
+    const result = await activities()[START_SCHEDULED_RUN_ACTIVITY_NAME]("sch_01act", NOMINAL);
+    expect(result.outcome).toBe(RUN_SKIPPED);
+    const { total } = await store.listScheduleRuns("sch_01act", 0, 10);
+    expect(total).toBe(0);
+  });
+
+  it("a started run writes the non-terminal cron ledger row", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema, scheduleRow());
+    const result = await activities()[START_SCHEDULED_RUN_ACTIVITY_NAME]("sch_01act", NOMINAL);
+    expect(result.outcome).toBe(RUN_STARTED);
+    expect(result.executionId).toBe("aex_01x");
+    const { runs } = await store.listScheduleRuns("sch_01act", 0, 10);
+    expect(runs).toHaveLength(1);
+    expect(runs[0]?.outcome).toBe("started");
+    expect(runs[0]?.origin).toBe("cron");
+    expect(runs[0]?.completedAt).toBe("");
+  });
+
+  it("a refused run writes a terminal ledger row with the 'run refused: ' prefix", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema, scheduleRow());
+    startRunOutcome = { kind: "refused", reason: "gate said no" };
+    const result = await activities()[START_SCHEDULED_RUN_ACTIVITY_NAME]("sch_01act", NOMINAL);
+    expect(result.outcome).toBe(RUN_REFUSED);
+    expect(result.failureReason).toBe("run refused: gate said no");
+    const { runs } = await store.listScheduleRuns("sch_01act", 0, 10);
+    expect(runs[0]?.outcome).toBe("refused");
+    expect(runs[0]?.reason).toBe("run refused: gate said no");
+    expect(runs[0]?.completedAt).not.toBe("");
+  });
+});
+
+describe("pollExecutionPhase — one row read, GONE distinct from RUNNING", () => {
+  it.each([
+    [ExecutionPhase.EXECUTION_COMPLETED, PHASE_COMPLETED],
+    [ExecutionPhase.EXECUTION_CANCELLED, PHASE_CANCELLED],
+    [ExecutionPhase.EXECUTION_TERMINATED, PHASE_TERMINATED],
+    [ExecutionPhase.EXECUTION_FAILED, PHASE_FAILED],
+    [ExecutionPhase.EXECUTION_IN_PROGRESS, PHASE_RUNNING],
+    [ExecutionPhase.EXECUTION_PENDING, PHASE_RUNNING],
+  ])("classifies phase %d as %s", async (phase, want) => {
+    await store.saveResource(
+      ApiResourceKind.agent_execution,
+      "aex_01poll",
+      AgentExecutionSchema,
+      create(AgentExecutionSchema, {
+        metadata: { id: "aex_01poll", org: "acme" },
+        status: { phase },
+      }),
+    );
+    expect(await activities()[POLL_EXECUTION_PHASE_ACTIVITY_NAME]("aex_01poll")).toBe(want);
+  });
+
+  it("a deleted row answers GONE (a deleted run must not brick its schedule)", async () => {
+    expect(await activities()[POLL_EXECUTION_PHASE_ACTIVITY_NAME]("aex_missing")).toBe(PHASE_GONE);
+  });
+});
+
+describe("recordSuccessfulRun — the absorbing zero", () => {
+  it("resets the streak, marks the cron ledger verdict, and is idempotent", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema, scheduleRow({ failures: 1 }));
+    await activities()[START_SCHEDULED_RUN_ACTIVITY_NAME]("sch_01act", NOMINAL);
+
+    await activities()[RECORD_SUCCESSFUL_RUN_ACTIVITY_NAME]("sch_01act");
+    let row = await store.getResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema);
+    expect(row.status?.consecutiveFailures).toBe(0);
+    const { runs } = await store.listScheduleRuns("sch_01act", 0, 10);
+    expect(runs[0]?.outcome).toBe("completed");
+
+    // Retried freely: a second call is harmless.
+    await activities()[RECORD_SUCCESSFUL_RUN_ACTIVITY_NAME]("sch_01act");
+    row = await store.getResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema);
+    expect(row.status?.consecutiveFailures).toBe(0);
+  });
+
+  it("a deleted row is a silent no-op", async () => {
+    await expect(activities()[RECORD_SUCCESSFUL_RUN_ACTIVITY_NAME]("sch_01act")).resolves.toBeUndefined();
+  });
+});
+
+describe("recordFailedRun — the one-closure verdict", () => {
+  it("increments below the threshold without latching", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema, scheduleRow());
+    const recorded = await activities()[RECORD_FAILED_RUN_ACTIVITY_NAME]("sch_01act", "run aex_01x ended failed", FAILURE_RUN_FAILED);
+    expect(recorded).toEqual({ consecutiveFailures: 1, paused: false });
+    expect(ensureCalls).toEqual([]); // no crossing → no re-sync
+  });
+
+  it("latches the pause with the byte-pinned copy exactly at the crossing and clears next_fire_at", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema, scheduleRow({ failures: 1 }));
+    const recorded = await activities()[RECORD_FAILED_RUN_ACTIVITY_NAME]("sch_01act", "run aex_01x ended failed", FAILURE_RUN_FAILED);
+    expect(recorded).toEqual({ consecutiveFailures: 2, paused: true });
+
+    const row = await store.getResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema);
+    expect(row.status?.pausedReason).toBe(
+      "Paused after 2 consecutive failed runs. Last failure: run aex_01x ended failed",
+    );
+    expect(row.status?.nextFireAt).toBeUndefined();
+    // The crossing triggers the best-effort immediate artifact re-sync.
+    expect(ensureCalls).toEqual(["sch_01act"]);
+  });
+
+  it("never rewrites the first pause's copy past the threshold", async () => {
+    await store.saveResource(
+      ApiResourceKind.schedule,
+      "sch_01act",
+      ScheduleSchema,
+      scheduleRow({ failures: 2, pausedReason: "Paused after 2 consecutive failed runs. Last failure: original" }),
+    );
+    const recorded = await activities()[RECORD_FAILED_RUN_ACTIVITY_NAME]("sch_01act", "a newer failure", FAILURE_RUN_FAILED);
+    expect(recorded).toEqual({ consecutiveFailures: 3, paused: true });
+    const row = await store.getResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema);
+    expect(row.status?.pausedReason).toContain("original");
+    expect(ensureCalls).toEqual([]); // already latched — not a crossing
+  });
+
+  it("a deleted row answers the zero post-image (deleting must never resurrect)", async () => {
+    const recorded = await activities()[RECORD_FAILED_RUN_ACTIVITY_NAME]("sch_01act", "x", FAILURE_START_FAILED);
+    expect(recorded).toEqual({ consecutiveFailures: 0, paused: false });
+  });
+
+  it("marks the cron ledger verdict for tracked failures but not for START_FAILED", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_01act", ScheduleSchema, scheduleRow());
+    await activities()[START_SCHEDULED_RUN_ACTIVITY_NAME]("sch_01act", NOMINAL);
+
+    await activities()[RECORD_FAILED_RUN_ACTIVITY_NAME]("sch_01act", "run aex_01x ended failed", FAILURE_RUN_FAILED);
+    const { runs } = await store.listScheduleRuns("sch_01act", 0, 10);
+    expect(runs[0]?.outcome).toBe("failed");
+    expect(runs[0]?.reason).toBe("run aex_01x ended failed");
+  });
+});

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/artifact.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/artifact.test.ts
@@ -6,6 +6,7 @@
  */
 import { create } from "@bufbuild/protobuf";
 import { ScheduleOverlapPolicy } from "@temporalio/client";
+import type { ScheduleDescription } from "@temporalio/client";
 import { describe, expect, it } from "vitest";
 
 import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
@@ -111,10 +112,12 @@ describe("applyDesiredState — the update half of ensure", () => {
   const artifact = new ScheduleArtifact(config);
 
   it("rewrites spec, action, policy, and state to the complete desired state", () => {
+    // A partial double narrowed through unknown — the target type stays
+    // named, so a ScheduleDescription shape change flags this test.
     const previous = {
       state: { paused: true, note: "cron=old tz=old", remainingActions: 0 },
       info: {},
-    } as never;
+    } as unknown as ScheduleDescription;
     const update = artifact.applyDesiredState(
       previous,
       schedule({ cron: "30 8 * * *", timeZone: "UTC" }),
@@ -134,7 +137,7 @@ describe("applyDesiredState — the update half of ensure", () => {
     const previous = {
       state: { paused: false, note: "x", remainingActions: 7 },
       info: {},
-    } as never;
+    } as unknown as ScheduleDescription;
     const update = artifact.applyDesiredState(previous, schedule());
     expect((update.state as { remainingActions?: number }).remainingActions).toBe(7);
   });

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/artifact.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/artifact.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Pins the artifact mapping against Go's artifact_test.go: the id
+ * contract, the drift-fingerprint note, the two-lever paused derivation,
+ * and the baked policy (SKIP overlap, PauseOnFailure false, one action
+ * arg) — every value here is cross-repo wire contract.
+ */
+import { create } from "@bufbuild/protobuf";
+import { ScheduleOverlapPolicy } from "@temporalio/client";
+import { describe, expect, it } from "vitest";
+
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+
+import { ScheduleArtifact, desiredPaused, note } from "../artifact.js";
+import { ScheduleTemporalConfig } from "../config.js";
+import { artifactId, resourceIdOf } from "../names.js";
+
+const config = new ScheduleTemporalConfig(
+  "schedule_stigmer",
+  60,
+  24,
+  5,
+  60,
+  true,
+  5,
+  20,
+  1.0,
+  90,
+);
+
+function schedule(overrides?: {
+  enabled?: boolean;
+  pausedReason?: string;
+  cron?: string;
+  timeZone?: string;
+}) {
+  return create(ScheduleSchema, {
+    metadata: { id: "sch_01test", org: "acme", slug: "daily" },
+    spec: {
+      cron: overrides?.cron ?? "0 9 * * *",
+      timeZone: overrides?.timeZone ?? "Asia/Kolkata",
+      enabled: overrides?.enabled ?? true,
+      target: { case: "agent", value: { agentRef: { slug: "helper" } } },
+    },
+    status: { pausedReason: overrides?.pausedReason ?? "" },
+  });
+}
+
+describe("artifact identity", () => {
+  it("prefixes the resource id with schedule/tick/", () => {
+    expect(artifactId("sch_01test")).toBe("schedule/tick/sch_01test");
+  });
+
+  it("resourceIdOf inverts artifactId", () => {
+    expect(resourceIdOf("schedule/tick/sch_01test")).toBe("sch_01test");
+  });
+});
+
+describe("note — the drift fingerprint", () => {
+  it("renders cron=<cron> tz=<tz> byte-for-byte", () => {
+    expect(note(schedule())).toBe("cron=0 9 * * * tz=Asia/Kolkata");
+  });
+});
+
+describe("desiredPaused — two levers, one artifact state", () => {
+  it("false when enabled and unlatched", () => {
+    expect(desiredPaused(schedule())).toBe(false);
+  });
+  it("true when owner-disabled", () => {
+    expect(desiredPaused(schedule({ enabled: false }))).toBe(true);
+  });
+  it("true when platform-paused", () => {
+    expect(desiredPaused(schedule({ pausedReason: "Paused after 5..." }))).toBe(true);
+  });
+});
+
+describe("createOptions — the baked policy", () => {
+  const artifact = new ScheduleArtifact(config);
+  const options = artifact.createOptions(schedule());
+
+  it("pins the artifact id and cron spec", () => {
+    expect(options.scheduleId).toBe("schedule/tick/sch_01test");
+    expect(options.spec.cronExpressions).toEqual(["0 9 * * *"]);
+    expect(options.spec.timezone).toBe("Asia/Kolkata");
+  });
+
+  it("pins overlap SKIP, catchup window, and PauseOnFailure=false", () => {
+    expect(options.policies?.overlap).toBe(ScheduleOverlapPolicy.SKIP);
+    expect(options.policies?.catchupWindow).toBe(60 * 60_000);
+    expect(options.policies?.pauseOnFailure).toBe(false);
+  });
+
+  it("bakes the action: workflow id = artifact id, type schedule/tick, ONE arg, own queue, 24h backstop", () => {
+    expect(options.action.type).toBe("startWorkflow");
+    expect(options.action.workflowId).toBe("schedule/tick/sch_01test");
+    expect(options.action.workflowType).toBe("schedule/tick");
+    expect(options.action.args).toEqual(["sch_01test"]);
+    expect(options.action.taskQueue).toBe("schedule_stigmer");
+    expect(options.action.workflowRunTimeout).toBe(24 * 3_600_000);
+    // No retry policy: a failed tick is a missed fire, not a hot loop.
+    expect(options.action.retry).toBeUndefined();
+  });
+
+  it("derives the initial paused state and the note", () => {
+    expect(options.state?.paused).toBe(false);
+    expect(options.state?.note).toBe("cron=0 9 * * * tz=Asia/Kolkata");
+    expect(artifact.createOptions(schedule({ enabled: false })).state?.paused).toBe(true);
+  });
+});
+
+describe("applyDesiredState — the update half of ensure", () => {
+  const artifact = new ScheduleArtifact(config);
+
+  it("rewrites spec, action, policy, and state to the complete desired state", () => {
+    const previous = {
+      state: { paused: true, note: "cron=old tz=old", remainingActions: 0 },
+      info: {},
+    } as never;
+    const update = artifact.applyDesiredState(
+      previous,
+      schedule({ cron: "30 8 * * *", timeZone: "UTC" }),
+    );
+    expect(update.spec?.cronExpressions).toEqual(["30 8 * * *"]);
+    expect(update.spec?.timezone).toBe("UTC");
+    expect(update.action.workflowType).toBe("schedule/tick");
+    expect(update.policies?.overlap).toBe(ScheduleOverlapPolicy.SKIP);
+    // The SDK's ScheduleUpdateOptions types `state` through an Omit over an
+    // optional union; narrow for the assertions.
+    const state = update.state as { paused: boolean; note: string };
+    expect(state.paused).toBe(false);
+    expect(state.note).toBe("cron=30 8 * * * tz=UTC");
+  });
+
+  it("preserves unrelated previous state fields (Go mutates desc.Schedule.State in place)", () => {
+    const previous = {
+      state: { paused: false, note: "x", remainingActions: 7 },
+      info: {},
+    } as never;
+    const update = artifact.applyDesiredState(previous, schedule());
+    expect((update.state as { remainingActions?: number }).remainingActions).toBe(7);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/config.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/config.test.ts
@@ -4,7 +4,7 @@
  * threshold and retention floors, and Go's strict strconv parsing
  * (malformed values keep the default, never NaN).
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { ScheduleTemporalConfig, newScheduleConfigFromEnv } from "../config.js";
 
@@ -21,9 +21,30 @@ const ENV_KEYS = [
   "STIGMER_SCHEDULES_RUN_HISTORY_RETENTION_DAYS",
 ];
 
-afterEach(() => {
+// Snapshot-and-restore rather than delete-and-hope: the invoking shell may
+// legitimately carry STIGMER_SCHEDULES_* values, and a test must neither
+// fail on them nor destroy them for the rest of the worker process.
+const saved = new Map<string, string | undefined>();
+
+beforeAll(() => {
+  for (const key of ENV_KEYS) {
+    saved.set(key, process.env[key]);
+  }
+});
+
+beforeEach(() => {
   for (const key of ENV_KEYS) {
     delete process.env[key];
+  }
+});
+
+afterAll(() => {
+  for (const [key, value] of saved) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
   }
 });
 
@@ -105,5 +126,12 @@ describe("threshold and retention floors", () => {
   it("floors the ledger retention at 1 day (never prune history as it lands)", () => {
     expect(config({ retention: 0 }).resolvedRunHistoryRetentionDays()).toBe(1);
     expect(config({ retention: 90 }).resolvedRunHistoryRetentionDays()).toBe(90);
+  });
+
+  it("floors the reconciliation interval at 1 minute (a zero would hot-loop where Go panics)", () => {
+    const zero = new ScheduleTemporalConfig("q", 60, 24, 5, 60, true, 0, 20, 1.0, 90);
+    expect(zero.resolvedReconciliationIntervalMinutes()).toBe(1);
+    const five = new ScheduleTemporalConfig("q", 60, 24, 5, 60, true, 5, 20, 1.0, 90);
+    expect(five.resolvedReconciliationIntervalMinutes()).toBe(5);
   });
 });

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/config.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/config.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Pins the config clamps and env parsing against Go's config.go: the
+ * tracking-budget ceiling (one hour inside the run timeout), the
+ * threshold and retention floors, and Go's strict strconv parsing
+ * (malformed values keep the default, never NaN).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { ScheduleTemporalConfig, newScheduleConfigFromEnv } from "../config.js";
+
+const ENV_KEYS = [
+  "TEMPORAL_SCHEDULE_STIGMER_TASK_QUEUE",
+  "STIGMER_SCHEDULES_CATCHUP_WINDOW_MINUTES",
+  "STIGMER_SCHEDULES_TICK_RUN_TIMEOUT_HOURS",
+  "STIGMER_SCHEDULES_MAX_CONSECUTIVE_FAILURES",
+  "STIGMER_SCHEDULES_RUN_TRACKING_TIMEOUT_MINUTES",
+  "STIGMER_SCHEDULES_RECONCILIATION_ENABLED",
+  "STIGMER_SCHEDULES_RECONCILIATION_INTERVAL_MINUTES",
+  "STIGMER_SCHEDULES_EXECUTION_PROFILE_MAX_TOOL_ROUNDS",
+  "STIGMER_SCHEDULES_EXECUTION_PROFILE_MAX_COST_USD",
+  "STIGMER_SCHEDULES_RUN_HISTORY_RETENTION_DAYS",
+];
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+});
+
+function config(overrides: Partial<Record<"timeout" | "tracking" | "threshold" | "retention", number>>) {
+  return new ScheduleTemporalConfig(
+    "schedule_stigmer",
+    60,
+    overrides.timeout ?? 24,
+    overrides.threshold ?? 5,
+    overrides.tracking ?? 60,
+    true,
+    5,
+    20,
+    1.0,
+    overrides.retention ?? 90,
+  );
+}
+
+describe("defaults from an empty environment", () => {
+  it("loads the documented defaults", () => {
+    const c = newScheduleConfigFromEnv();
+    expect(c.stigmerQueue).toBe("schedule_stigmer");
+    expect(c.catchupWindowMinutes).toBe(60);
+    expect(c.tickRunTimeoutHours).toBe(24);
+    expect(c.maxConsecutiveFailures).toBe(5);
+    expect(c.runTrackingTimeoutMinutes).toBe(60);
+    expect(c.reconciliationEnabled).toBe(true);
+    expect(c.reconciliationIntervalMinutes).toBe(5);
+    expect(c.executionProfileMaxToolRounds).toBe(20);
+    expect(c.executionProfileMaxCostUsd).toBe(1.0);
+    expect(c.runHistoryRetentionDays).toBe(90);
+  });
+});
+
+describe("env parsing — Go strconv parity", () => {
+  it("reads well-formed overrides", () => {
+    process.env.STIGMER_SCHEDULES_MAX_CONSECUTIVE_FAILURES = "2";
+    process.env.STIGMER_SCHEDULES_RECONCILIATION_ENABLED = "false";
+    process.env.STIGMER_SCHEDULES_EXECUTION_PROFILE_MAX_COST_USD = "0.5";
+    const c = newScheduleConfigFromEnv();
+    expect(c.maxConsecutiveFailures).toBe(2);
+    expect(c.reconciliationEnabled).toBe(false);
+    expect(c.executionProfileMaxCostUsd).toBe(0.5);
+  });
+
+  it("keeps the default on a malformed int (Go Atoi failure)", () => {
+    process.env.STIGMER_SCHEDULES_MAX_CONSECUTIVE_FAILURES = "two";
+    expect(newScheduleConfigFromEnv().maxConsecutiveFailures).toBe(5);
+  });
+
+  it("keeps the default on a non-ParseBool token (Go ParseBool failure)", () => {
+    process.env.STIGMER_SCHEDULES_RECONCILIATION_ENABLED = "no";
+    expect(newScheduleConfigFromEnv().reconciliationEnabled).toBe(true);
+  });
+});
+
+describe("resolvedRunTrackingTimeoutMinutes — the cloud edition's exact clamp", () => {
+  it("passes an in-range budget through", () => {
+    expect(config({}).resolvedRunTrackingTimeoutMinutes()).toBe(60);
+  });
+  it("caps at one hour inside the baked run timeout", () => {
+    expect(config({ timeout: 2, tracking: 600 }).resolvedRunTrackingTimeoutMinutes()).toBe(60);
+  });
+  it("floors at 1 minute", () => {
+    expect(config({ tracking: 0 }).resolvedRunTrackingTimeoutMinutes()).toBe(1);
+    expect(config({ tracking: -5 }).resolvedRunTrackingTimeoutMinutes()).toBe(1);
+  });
+  it("a degenerate run timeout still yields a 1-minute ceiling", () => {
+    expect(config({ timeout: 1, tracking: 60 }).resolvedRunTrackingTimeoutMinutes()).toBe(1);
+  });
+});
+
+describe("threshold and retention floors", () => {
+  it("floors the pause threshold at 1 (never pause on configuration)", () => {
+    expect(config({ threshold: 0 }).resolvedMaxConsecutiveFailures()).toBe(1);
+    expect(config({ threshold: -3 }).resolvedMaxConsecutiveFailures()).toBe(1);
+    expect(config({ threshold: 5 }).resolvedMaxConsecutiveFailures()).toBe(5);
+  });
+  it("floors the ledger retention at 1 day (never prune history as it lands)", () => {
+    expect(config({ retention: 0 }).resolvedRunHistoryRetentionDays()).toBe(1);
+    expect(config({ retention: 90 }).resolvedRunHistoryRetentionDays()).toBe(90);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/reconciler.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/reconciler.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Pins the reconciler against Go's reconcile.go — the OSS-load-bearing
+ * convergence pass (panel finding 1 — this machinery previously shipped
+ * untested, with a comment claiming otherwise):
+ *
+ *   - phase 2 arms rows without artifacts and repairs note/paused drift;
+ *   - phase 3 reaps orphans ONLY after the point read confirms the row is
+ *     genuinely gone — a row created after phase 2's listing must never
+ *     lose its just-armed clock (THE guard);
+ *   - probe-prefixed and foreign artifacts are never touched;
+ *   - per-row failures count and the pass continues;
+ *   - the kick queue coalesces, stop() drains, and a rejected pass can
+ *     neither brick the queue nor escape into shutdown (finding 2).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import type { Client } from "@temporalio/client";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import { ScheduleTemporalConfig } from "../config.js";
+import { ScheduleReconciler } from "../reconciler.js";
+import type { ScheduleSyncer } from "../syncer.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const config = new ScheduleTemporalConfig(
+  "schedule_stigmer",
+  60,
+  24,
+  5,
+  60,
+  // Periodic pass DISABLED: these tests drive passes explicitly; the
+  // kill-switch arm below asserts kicked passes still run.
+  false,
+  5,
+  20,
+  1.0,
+  90,
+);
+
+let dir: string;
+let store: SqliteStore;
+
+interface ListedArtifact {
+  scheduleId: string;
+  state: { note?: string; paused: boolean };
+}
+
+/** The one client seam the reconciler reads: schedule.list. */
+let listedArtifacts: ListedArtifact[];
+let listError: Error | undefined;
+
+function fakeClient(): Client {
+  const schedule = {
+    list: () => ({
+      async *[Symbol.asyncIterator]() {
+        if (listError) throw listError;
+        yield* listedArtifacts;
+      },
+    }),
+  };
+  return { schedule } as unknown as Client;
+}
+
+/** A scriptable syncer double recording ensure/teardown calls. */
+interface SyncerScript {
+  ensured: string[];
+  toreDown: string[];
+  ensureError?: Error;
+  teardownError?: Error;
+}
+let syncerScript: SyncerScript;
+
+function fakeSyncer(): Pick<ScheduleSyncer, "ensureAndRecord" | "teardown"> {
+  return {
+    ensureAndRecord: async (schedule: Schedule) => {
+      if (syncerScript.ensureError) throw syncerScript.ensureError;
+      syncerScript.ensured.push(schedule.metadata?.id ?? "");
+      return undefined;
+    },
+    teardown: async (resourceId: string) => {
+      if (syncerScript.teardownError) throw syncerScript.teardownError;
+      syncerScript.toreDown.push(resourceId);
+    },
+  };
+}
+
+function reconciler(client: Client | undefined = fakeClient()): ScheduleReconciler {
+  return new ScheduleReconciler(
+    () => client,
+    store,
+    fakeSyncer(),
+    config,
+    silentLogger,
+  );
+}
+
+function scheduleRow(id: string, overrides?: { enabled?: boolean; pausedReason?: string }) {
+  return create(ScheduleSchema, {
+    metadata: { id, org: "acme", slug: id },
+    spec: {
+      cron: "0 9 * * *",
+      timeZone: "UTC",
+      enabled: overrides?.enabled ?? true,
+      target: { case: "agent", value: { agentRef: { slug: "helper" } } },
+    },
+    status: { pausedReason: overrides?.pausedReason ?? "" },
+  });
+}
+
+/** Polls a condition to true — no fixed sleeps (determinism rule). */
+async function waitFor(condition: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!condition()) {
+    if (Date.now() > deadline) {
+      throw new Error("waitFor: condition not met within the timeout");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+/** The live artifact state that MATCHES a row (no drift). */
+function converged(id: string): ListedArtifact {
+  return {
+    scheduleId: `schedule/tick/${id}`,
+    state: { note: "cron=0 9 * * * tz=UTC", paused: false },
+  };
+}
+
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "schedule-reconciler-test-"));
+  store = SqliteStore.open(path.join(dir, "test.db"));
+});
+
+afterAll(async () => {
+  await store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  listedArtifacts = [];
+  listError = undefined;
+  syncerScript = { ensured: [], toreDown: [] };
+  for (const bytes of await store.listResources(ApiResourceKind.schedule)) {
+    const { fromBinary } = await import("@bufbuild/protobuf");
+    const row = fromBinary(ScheduleSchema, bytes);
+    await store.deleteResource(ApiResourceKind.schedule, row.metadata?.id ?? "");
+  }
+});
+
+describe("runPass — the four phases", () => {
+  it("arms a row without an artifact", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_unarmed", ScheduleSchema, scheduleRow("sch_unarmed"));
+
+    const counts = await reconciler().runPass();
+    expect(counts).toMatchObject({ rowsExamined: 1, armed: 1, repaired: 0, orphansDeleted: 0, failures: 0 });
+    expect(syncerScript.ensured).toEqual(["sch_unarmed"]);
+  });
+
+  it("leaves a converged artifact untouched", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_ok", ScheduleSchema, scheduleRow("sch_ok"));
+    listedArtifacts = [converged("sch_ok")];
+
+    const counts = await reconciler().runPass();
+    expect(counts).toMatchObject({ armed: 0, repaired: 0, orphansDeleted: 0, failures: 0 });
+    expect(syncerScript.ensured).toEqual([]);
+  });
+
+  it("repairs note drift (the fingerprint is the only spec-change witness)", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_drift", ScheduleSchema, scheduleRow("sch_drift"));
+    listedArtifacts = [
+      { scheduleId: "schedule/tick/sch_drift", state: { note: "cron=old tz=old", paused: false } },
+    ];
+
+    const counts = await reconciler().runPass();
+    expect(counts.repaired).toBe(1);
+    expect(syncerScript.ensured).toEqual(["sch_drift"]);
+  });
+
+  it("repairs paused drift (the two-lever DesiredPaused diff)", async () => {
+    await store.saveResource(
+      ApiResourceKind.schedule,
+      "sch_pausedrift",
+      ScheduleSchema,
+      scheduleRow("sch_pausedrift", { pausedReason: "Paused after 5..." }),
+    );
+    listedArtifacts = [converged("sch_pausedrift")]; // live artifact NOT paused
+
+    const counts = await reconciler().runPass();
+    expect(counts.repaired).toBe(1);
+  });
+
+  it("reaps a genuine orphan only after the point read confirms the row is gone", async () => {
+    listedArtifacts = [converged("sch_ghost")];
+
+    const counts = await reconciler().runPass();
+    expect(counts.orphansDeleted).toBe(1);
+    expect(syncerScript.toreDown).toEqual(["sch_ghost"]);
+  });
+
+  it("NEVER reaps an artifact whose row exists at the point read (THE phase-3 guard)", async () => {
+    // The race the guard exists for: the artifact is listed but the row
+    // was missing from phase 2's snapshot (created between the listing
+    // and the walk). The fresh point read finds it — no teardown.
+    listedArtifacts = [converged("sch_latecomer")];
+    const passPromise = (async () => {
+      // The row lands before phase 3's point read (deterministically:
+      // before the pass even starts — the guard must hold a fortiori).
+      await store.saveResource(
+        ApiResourceKind.schedule,
+        "sch_latecomer",
+        ScheduleSchema,
+        scheduleRow("sch_latecomer"),
+      );
+      return reconciler().runPass();
+    })();
+
+    const counts = await passPromise;
+    expect(counts.orphansDeleted).toBe(0);
+    expect(syncerScript.toreDown).toEqual([]);
+  });
+
+  it("skips probe-prefixed and foreign artifacts entirely", async () => {
+    listedArtifacts = [
+      { scheduleId: "schedule/probe/sch_x", state: { paused: false } },
+      { scheduleId: "someone-elses-workflow-schedule", state: { paused: false } },
+    ];
+
+    const counts = await reconciler().runPass();
+    expect(counts.orphansDeleted).toBe(0);
+    expect(syncerScript.toreDown).toEqual([]);
+  });
+
+  it("counts a per-row arm failure and continues the pass", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_a", ScheduleSchema, scheduleRow("sch_a"));
+    await store.saveResource(ApiResourceKind.schedule, "sch_b", ScheduleSchema, scheduleRow("sch_b"));
+    syncerScript.ensureError = new Error("temporal away");
+
+    const counts = await reconciler().runPass();
+    expect(counts.rowsExamined).toBe(2);
+    expect(counts.failures).toBe(2); // both arms failed, pass finished
+  });
+
+  it("a failed artifact listing aborts the pass with one counted failure", async () => {
+    listError = new Error("list exploded");
+    const counts = await reconciler().runPass();
+    expect(counts.failures).toBe(1);
+    expect(counts.rowsExamined).toBe(0);
+  });
+
+  it("skips silently when Temporal is not connected", async () => {
+    const counts = await reconciler(undefined).runPass();
+    expect(counts).toMatchObject({ rowsExamined: 0, failures: 0 });
+  });
+
+  it("phase 4 prunes ledger rows past retention and keeps fresh ones (DD-017 D-7)", async () => {
+    const base = {
+      scheduleId: "sch_prune",
+      org: "acme",
+      origin: "cron",
+      outcome: "completed",
+      reason: "",
+      executionId: "aex_x",
+      completedAt: "2020-01-01T00:00:00Z",
+    };
+    await store.upsertScheduleRun({
+      ...base,
+      nominalFireTime: "2020-01-01T00:00:00Z",
+      recordedAt: "2020-01-01T00:00:00Z", // ancient — beyond any retention
+    });
+    await store.upsertScheduleRun({
+      ...base,
+      nominalFireTime: "2099-01-01T00:00:00Z",
+      recordedAt: "2099-01-01T00:00:00Z", // future-fresh — must survive
+    });
+
+    await reconciler().runPass();
+
+    const { runs, total } = await store.listScheduleRuns("sch_prune", 0, 10);
+    expect(total).toBe(1);
+    expect(runs[0]?.nominalFireTime).toBe("2099-01-01T00:00:00Z");
+  });
+});
+
+describe("the loop — kicks, coalescing, stop, containment", () => {
+  it("kill-switch off: the kick still runs a pass (reconnect convergence is correctness)", async () => {
+    await store.saveResource(ApiResourceKind.schedule, "sch_kick", ScheduleSchema, scheduleRow("sch_kick"));
+    const r = reconciler();
+    const kick = r.startReconciliation(); // boot pass queues immediately
+    kick(); // coalesces with the boot pass or queues one more
+    // Observe the pass land BEFORE stopping: stop() deliberately skips
+    // queued-but-unstarted passes (Go's context-cancel shutdown).
+    await waitFor(() => syncerScript.ensured.includes("sch_kick"));
+    await r.stop();
+    expect(syncerScript.ensured).toContain("sch_kick");
+  });
+
+  it("a pass that throws unexpectedly neither bricks the queue nor escapes stop()", async () => {
+    // Force runPass itself to reject by making the STORE listing throw a
+    // non-Error the internal catches don't expect... every internal await
+    // is caught today, so drive the containment seam directly: a client
+    // provider that THROWS (never legal, but the backstop must hold).
+    const r = new ScheduleReconciler(
+      () => {
+        throw new Error("provider exploded");
+      },
+      store,
+      fakeSyncer(),
+      config,
+      silentLogger,
+    );
+    const kick = r.startReconciliation();
+    kick();
+    // stop() must resolve (never rethrow the pass failure into shutdown).
+    await expect(r.stop()).resolves.toBeUndefined();
+
+    // And a NEW reconciler after a failure keeps working (the queue was
+    // never poisoned for subsequent enqueues).
+    await store.saveResource(ApiResourceKind.schedule, "sch_after", ScheduleSchema, scheduleRow("sch_after"));
+    const healthy = reconciler();
+    const kick2 = healthy.startReconciliation();
+    kick2();
+    await waitFor(() => syncerScript.ensured.includes("sch_after"));
+    await healthy.stop();
+    expect(syncerScript.ensured).toContain("sch_after");
+  });
+
+  it("no pass starts after stop()", async () => {
+    const r = reconciler();
+    const kick = r.startReconciliation();
+    await r.stop();
+    kick(); // post-stop kicks are refused
+    await r.stop();
+    expect(syncerScript.toreDown).toEqual([]);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-completed-run.json
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-completed-run.json
@@ -1,0 +1,726 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 818774000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048587",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "schedule/tick"
+        },
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InNjaC1yZXBsYXki"
+            }
+          ]
+        },
+        "workflowTaskTimeout": {
+          "seconds": "10"
+        },
+        "originalExecutionRunId": "01a0386d-46f2-7bcb-9fef-8b7472bb108a",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "firstExecutionRunId": "01a0386d-46f2-7bcb-9fef-8b7472bb108a",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": {},
+        "header": {},
+        "workflowId": "schedule/tick/sch-replay-2026-08-25T09:30:00Z-tick-completed-run"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 818834000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048588",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 821462000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048593",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "74ec1e9f-e2aa-4a66-81e9-2a76637d9e4b",
+        "historySizeBytes": "366",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 852283000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048597",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        },
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            3,
+            2,
+            1
+          ],
+          "sdkName": "temporal-typescript",
+          "sdkVersion": "1.16.2"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 852388000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048598",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "1",
+        "activityType": {
+          "name": "stigmer/schedule/record-tick"
+        },
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InNjaC1yZXBsYXki"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IjIwMjYtMDgtMjVUMTA6MTg6MDBaIg=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {},
+        "startToCloseTimeout": {
+          "seconds": "30"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "5"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "500"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 854135000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048604",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "2eede19f-d414-4e24-bd9d-2d6a17a357be",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 860645000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048605",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IkZJUkVEIg=="
+            }
+          ]
+        },
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "82393@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 860654000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048606",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "schedule-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 861925000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048610",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "b2d6fb03-0e14-4939-93d1-ea59d03a6dda",
+        "historySizeBytes": "1404",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 867208000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048614",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 867243000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048615",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "2",
+        "activityType": {
+          "name": "stigmer/schedule/start-run"
+        },
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InNjaC1yZXBsYXki"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IjIwMjYtMDgtMjVUMTA6MTg6MDBaIg=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {},
+        "startToCloseTimeout": {
+          "seconds": "180"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "5"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "500"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 868325000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048620",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "94759ef7-e1f0-4a8e-bdd5-13375e11ab88",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 870803000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048621",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJvdXRjb21lIjoiU1RBUlRFRCIsImV4ZWN1dGlvbklkIjoiYWV4LXJlcGxheSIsInRyYWNraW5nVGltZW91dE1pbnV0ZXMiOjYwLCJmYWlsdXJlUmVhc29uIjoiIn0="
+            }
+          ]
+        },
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "82393@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 870810000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048622",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "schedule-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 871882000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048626",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "658bc291-90fe-4ea1-b990-25dbcc1719b2",
+        "historySizeBytes": "2497",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 875810000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048630",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 875848000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048631",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "3",
+        "activityType": {
+          "name": "stigmer/schedule/poll-phase"
+        },
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "ImFleC1yZXBsYXki"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {},
+        "startToCloseTimeout": {
+          "seconds": "30"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "16",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "5"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "500"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 876830000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048636",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "17",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "a350d10e-51f3-41cc-9dcd-59cb182643bc",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 878901000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048637",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IkNPTVBMRVRFRCI="
+            }
+          ]
+        },
+        "scheduledEventId": "17",
+        "startedEventId": "18",
+        "identity": "82393@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 878907000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048638",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "schedule-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 879847000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048642",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "20",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "844e0146-2078-4527-95ae-eb677a5a6a3f",
+        "historySizeBytes": "3454",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 883114000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048646",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "20",
+        "startedEventId": "21",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 883143000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048647",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "4",
+        "activityType": {
+          "name": "stigmer/schedule/record-success"
+        },
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InNjaC1yZXBsYXki"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {},
+        "startToCloseTimeout": {
+          "seconds": "30"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "22",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "5"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "500"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 884020000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048652",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "23",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "d240d7f7-0b22-4ad5-9512-0a5d78c26f70",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "25",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 886256000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048653",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "scheduledEventId": "23",
+        "startedEventId": "24",
+        "identity": "82393@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "26",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 886261000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048654",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "schedule-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "27",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 887200000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048658",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "26",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "03170c6f-8830-4c72-82b4-f36f85cce9be",
+        "historySizeBytes": "4403",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "28",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 891105000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048662",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "26",
+        "startedEventId": "27",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "29",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 891151000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1048663",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "28"
+      }
+    }
+  ]
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-completed-run.json
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-completed-run.json
@@ -3,8 +3,8 @@
     {
       "eventId": "1",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 818774000
+        "seconds": "1787654816",
+        "nanos": 414379000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
       "taskId": "1048587",
@@ -22,27 +22,27 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "InNjaC1yZXBsYXki"
+              "data": "InNjaC1yZXBsYXktdGljay1jb21wbGV0ZWQtcnVuIg=="
             }
           ]
         },
         "workflowTaskTimeout": {
           "seconds": "10"
         },
-        "originalExecutionRunId": "01a0386d-46f2-7bcb-9fef-8b7472bb108a",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "firstExecutionRunId": "01a0386d-46f2-7bcb-9fef-8b7472bb108a",
+        "originalExecutionRunId": "01a03887-c29e-75c4-98b0-230158b94f0d",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "firstExecutionRunId": "01a03887-c29e-75c4-98b0-230158b94f0d",
         "attempt": 1,
         "firstWorkflowTaskBackoff": {},
         "header": {},
-        "workflowId": "schedule/tick/sch-replay-2026-08-25T09:30:00Z-tick-completed-run"
+        "workflowId": "schedule/tick/sch-replay-tick-completed-run-2026-08-25T09:30:00Z"
       }
     },
     {
       "eventId": "2",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 818834000
+        "seconds": "1787654816",
+        "nanos": 414437000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "taskId": "1048588",
@@ -60,41 +60,41 @@
     {
       "eventId": "3",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 821462000
+        "seconds": "1787654816",
+        "nanos": 417023000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "taskId": "1048593",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "2",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "74ec1e9f-e2aa-4a66-81e9-2a76637d9e4b",
-        "historySizeBytes": "366",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "72bbf231-9cab-414a-a393-9d115c53e151",
+        "historySizeBytes": "385",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "4",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 852283000
+        "seconds": "1787654816",
+        "nanos": 445416000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "taskId": "1048597",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "2",
         "startedEventId": "3",
-        "identity": "82393@Sureshs-Mac-Studio.local",
+        "identity": "11185@Sureshs-Mac-Studio.local",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         },
         "sdkMetadata": {
           "coreUsedFlags": [
-            3,
+            1,
             2,
-            1
+            3
           ],
           "sdkName": "temporal-typescript",
           "sdkVersion": "1.16.2"
@@ -105,8 +105,8 @@
     {
       "eventId": "5",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 852388000
+        "seconds": "1787654816",
+        "nanos": 445504000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "taskId": "1048598",
@@ -126,13 +126,13 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "InNjaC1yZXBsYXki"
+              "data": "InNjaC1yZXBsYXktdGljay1jb21wbGV0ZWQtcnVuIg=="
             },
             {
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "IjIwMjYtMDgtMjVUMTA6MTg6MDBaIg=="
+              "data": "IjIwMjYtMDgtMjVUMDk6MzA6MDBaIg=="
             }
           ]
         },
@@ -159,26 +159,26 @@
     {
       "eventId": "6",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 854135000
+        "seconds": "1787654816",
+        "nanos": 446982000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "taskId": "1048604",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "5",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "2eede19f-d414-4e24-bd9d-2d6a17a357be",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "a5f59af3-4b8b-42d3-b32f-ea4ee4eb6139",
         "attempt": 1,
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "7",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 860645000
+        "seconds": "1787654816",
+        "nanos": 452683000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "taskId": "1048605",
@@ -195,20 +195,20 @@
         },
         "scheduledEventId": "5",
         "startedEventId": "6",
-        "identity": "82393@Sureshs-Mac-Studio.local"
+        "identity": "11185@Sureshs-Mac-Studio.local"
       }
     },
     {
       "eventId": "8",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 860654000
+        "seconds": "1787654816",
+        "nanos": 452690000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "taskId": "1048606",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "name": "11185@Sureshs-Mac-Studio.local-27cd7f003fae4b39ad6ff89ec0783b92",
           "kind": "TASK_QUEUE_KIND_STICKY",
           "normalName": "schedule-replay-capture"
         },
@@ -221,35 +221,35 @@
     {
       "eventId": "9",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 861925000
+        "seconds": "1787654816",
+        "nanos": 453628000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "taskId": "1048610",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "8",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "b2d6fb03-0e14-4939-93d1-ea59d03a6dda",
-        "historySizeBytes": "1404",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "91c55e19-f15d-4952-a350-5dd4f4f49a22",
+        "historySizeBytes": "1442",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "10",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 867208000
+        "seconds": "1787654816",
+        "nanos": 458167000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "taskId": "1048614",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "8",
         "startedEventId": "9",
-        "identity": "82393@Sureshs-Mac-Studio.local",
+        "identity": "11185@Sureshs-Mac-Studio.local",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         },
         "sdkMetadata": {},
         "meteringMetadata": {}
@@ -258,8 +258,8 @@
     {
       "eventId": "11",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 867243000
+        "seconds": "1787654816",
+        "nanos": 458197000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "taskId": "1048615",
@@ -279,13 +279,13 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "InNjaC1yZXBsYXki"
+              "data": "InNjaC1yZXBsYXktdGljay1jb21wbGV0ZWQtcnVuIg=="
             },
             {
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "IjIwMjYtMDgtMjVUMTA6MTg6MDBaIg=="
+              "data": "IjIwMjYtMDgtMjVUMDk6MzA6MDBaIg=="
             }
           ]
         },
@@ -312,26 +312,26 @@
     {
       "eventId": "12",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 868325000
+        "seconds": "1787654816",
+        "nanos": 459095000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "taskId": "1048620",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "11",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "94759ef7-e1f0-4a8e-bdd5-13375e11ab88",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "3fff64e4-2229-4df9-93de-1c53dad4db92",
         "attempt": 1,
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "13",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 870803000
+        "seconds": "1787654816",
+        "nanos": 460788000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "taskId": "1048621",
@@ -348,20 +348,20 @@
         },
         "scheduledEventId": "11",
         "startedEventId": "12",
-        "identity": "82393@Sureshs-Mac-Studio.local"
+        "identity": "11185@Sureshs-Mac-Studio.local"
       }
     },
     {
       "eventId": "14",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 870810000
+        "seconds": "1787654816",
+        "nanos": 460794000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "taskId": "1048622",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "name": "11185@Sureshs-Mac-Studio.local-27cd7f003fae4b39ad6ff89ec0783b92",
           "kind": "TASK_QUEUE_KIND_STICKY",
           "normalName": "schedule-replay-capture"
         },
@@ -374,35 +374,35 @@
     {
       "eventId": "15",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 871882000
+        "seconds": "1787654816",
+        "nanos": 461714000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "taskId": "1048626",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "14",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "658bc291-90fe-4ea1-b990-25dbcc1719b2",
-        "historySizeBytes": "2497",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "f52a54fa-b505-4a85-8485-c5cf5e5575cf",
+        "historySizeBytes": "2554",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "16",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 875810000
+        "seconds": "1787654816",
+        "nanos": 464653000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "taskId": "1048630",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "14",
         "startedEventId": "15",
-        "identity": "82393@Sureshs-Mac-Studio.local",
+        "identity": "11185@Sureshs-Mac-Studio.local",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         },
         "sdkMetadata": {},
         "meteringMetadata": {}
@@ -411,8 +411,8 @@
     {
       "eventId": "17",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 875848000
+        "seconds": "1787654816",
+        "nanos": 464674000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "taskId": "1048631",
@@ -459,26 +459,26 @@
     {
       "eventId": "18",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 876830000
+        "seconds": "1787654816",
+        "nanos": 465638000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "taskId": "1048636",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "17",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "a350d10e-51f3-41cc-9dcd-59cb182643bc",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "8e9ac29f-4760-4dc3-8a84-e134d927b559",
         "attempt": 1,
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "19",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 878901000
+        "seconds": "1787654816",
+        "nanos": 467200000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "taskId": "1048637",
@@ -495,20 +495,20 @@
         },
         "scheduledEventId": "17",
         "startedEventId": "18",
-        "identity": "82393@Sureshs-Mac-Studio.local"
+        "identity": "11185@Sureshs-Mac-Studio.local"
       }
     },
     {
       "eventId": "20",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 878907000
+        "seconds": "1787654816",
+        "nanos": 467203000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "taskId": "1048638",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "name": "11185@Sureshs-Mac-Studio.local-27cd7f003fae4b39ad6ff89ec0783b92",
           "kind": "TASK_QUEUE_KIND_STICKY",
           "normalName": "schedule-replay-capture"
         },
@@ -521,35 +521,35 @@
     {
       "eventId": "21",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 879847000
+        "seconds": "1787654816",
+        "nanos": 467935000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "taskId": "1048642",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "20",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "844e0146-2078-4527-95ae-eb677a5a6a3f",
-        "historySizeBytes": "3454",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "6ebb8215-ce32-4056-a9ef-7d125f035fc6",
+        "historySizeBytes": "3511",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "22",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 883114000
+        "seconds": "1787654816",
+        "nanos": 470758000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "taskId": "1048646",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "20",
         "startedEventId": "21",
-        "identity": "82393@Sureshs-Mac-Studio.local",
+        "identity": "11185@Sureshs-Mac-Studio.local",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         },
         "sdkMetadata": {},
         "meteringMetadata": {}
@@ -558,8 +558,8 @@
     {
       "eventId": "23",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 883143000
+        "seconds": "1787654816",
+        "nanos": 470788000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "taskId": "1048647",
@@ -579,7 +579,7 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "InNjaC1yZXBsYXki"
+              "data": "InNjaC1yZXBsYXktdGljay1jb21wbGV0ZWQtcnVuIg=="
             }
           ]
         },
@@ -606,26 +606,26 @@
     {
       "eventId": "24",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 884020000
+        "seconds": "1787654816",
+        "nanos": 471594000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "taskId": "1048652",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "23",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "d240d7f7-0b22-4ad5-9512-0a5d78c26f70",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "b08fea38-1a1e-4e48-8f7b-a2438ed1e93b",
         "attempt": 1,
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "25",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 886256000
+        "seconds": "1787654816",
+        "nanos": 473112000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "taskId": "1048653",
@@ -641,20 +641,20 @@
         },
         "scheduledEventId": "23",
         "startedEventId": "24",
-        "identity": "82393@Sureshs-Mac-Studio.local"
+        "identity": "11185@Sureshs-Mac-Studio.local"
       }
     },
     {
       "eventId": "26",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 886261000
+        "seconds": "1787654816",
+        "nanos": 473116000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "taskId": "1048654",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "name": "11185@Sureshs-Mac-Studio.local-27cd7f003fae4b39ad6ff89ec0783b92",
           "kind": "TASK_QUEUE_KIND_STICKY",
           "normalName": "schedule-replay-capture"
         },
@@ -667,35 +667,35 @@
     {
       "eventId": "27",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 887200000
+        "seconds": "1787654816",
+        "nanos": 473875000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "taskId": "1048658",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "26",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "03170c6f-8830-4c72-82b4-f36f85cce9be",
-        "historySizeBytes": "4403",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "4be86fb6-59c6-4953-b012-96f9f8311c06",
+        "historySizeBytes": "4479",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "28",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 891105000
+        "seconds": "1787654816",
+        "nanos": 477082000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "taskId": "1048662",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "26",
         "startedEventId": "27",
-        "identity": "82393@Sureshs-Mac-Studio.local",
+        "identity": "11185@Sureshs-Mac-Studio.local",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         },
         "sdkMetadata": {},
         "meteringMetadata": {}
@@ -704,8 +704,8 @@
     {
       "eventId": "29",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 891151000
+        "seconds": "1787654816",
+        "nanos": 477144000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
       "taskId": "1048663",

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-skipped-disabled.json
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-skipped-disabled.json
@@ -1,0 +1,280 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 908233000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048668",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "schedule/tick"
+        },
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InNjaC1yZXBsYXki"
+            }
+          ]
+        },
+        "workflowTaskTimeout": {
+          "seconds": "10"
+        },
+        "originalExecutionRunId": "01a0386d-474c-738e-ab52-3d47d083d2f4",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "firstExecutionRunId": "01a0386d-474c-738e-ab52-3d47d083d2f4",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": {},
+        "header": {},
+        "workflowId": "schedule/tick/sch-replay-2026-08-25T09:30:00Z-tick-skipped-disabled"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 908283000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048669",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 910631000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048674",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "f07bf8de-246c-4e52-b0b1-324096773606",
+        "historySizeBytes": "369",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 917156000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048678",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        },
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            2,
+            1,
+            3
+          ],
+          "sdkName": "temporal-typescript",
+          "sdkVersion": "1.16.2"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 917200000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048679",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "1",
+        "activityType": {
+          "name": "stigmer/schedule/record-tick"
+        },
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InNjaC1yZXBsYXki"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IjIwMjYtMDgtMjVUMTA6MTg6MDBaIg=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {},
+        "startToCloseTimeout": {
+          "seconds": "30"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "5"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "500"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 918661000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048685",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "dff3ec6e-38b9-49b3-b115-4bef81653b01",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 921126000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048686",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IlNLSVBQRURfRElTQUJMRUQi"
+            }
+          ]
+        },
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "82393@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 921133000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048687",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "schedule-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 922166000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048691",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "ba14385d-b674-4ae1-9b7d-dc1e303beea2",
+        "historySizeBytes": "1418",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 926392000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048695",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 926418000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1048696",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "10"
+      }
+    }
+  ]
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-skipped-disabled.json
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-skipped-disabled.json
@@ -3,8 +3,8 @@
     {
       "eventId": "1",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 908233000
+        "seconds": "1787654816",
+        "nanos": 494237000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
       "taskId": "1048668",
@@ -22,27 +22,27 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "InNjaC1yZXBsYXki"
+              "data": "InNjaC1yZXBsYXktdGljay1za2lwcGVkLWRpc2FibGVkIg=="
             }
           ]
         },
         "workflowTaskTimeout": {
           "seconds": "10"
         },
-        "originalExecutionRunId": "01a0386d-474c-738e-ab52-3d47d083d2f4",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "firstExecutionRunId": "01a0386d-474c-738e-ab52-3d47d083d2f4",
+        "originalExecutionRunId": "01a03887-c2ee-739d-849b-5f74a9a5906d",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "firstExecutionRunId": "01a03887-c2ee-739d-849b-5f74a9a5906d",
         "attempt": 1,
         "firstWorkflowTaskBackoff": {},
         "header": {},
-        "workflowId": "schedule/tick/sch-replay-2026-08-25T09:30:00Z-tick-skipped-disabled"
+        "workflowId": "schedule/tick/sch-replay-tick-skipped-disabled-2026-08-25T09:30:00Z"
       }
     },
     {
       "eventId": "2",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 908283000
+        "seconds": "1787654816",
+        "nanos": 494278000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "taskId": "1048669",
@@ -60,41 +60,41 @@
     {
       "eventId": "3",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 910631000
+        "seconds": "1787654816",
+        "nanos": 495656000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "taskId": "1048674",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "2",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "f07bf8de-246c-4e52-b0b1-324096773606",
-        "historySizeBytes": "369",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "a9a16625-663c-4f0c-8f95-33dfa311d750",
+        "historySizeBytes": "391",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "4",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 917156000
+        "seconds": "1787654816",
+        "nanos": 499624000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "taskId": "1048678",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "2",
         "startedEventId": "3",
-        "identity": "82393@Sureshs-Mac-Studio.local",
+        "identity": "11185@Sureshs-Mac-Studio.local",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         },
         "sdkMetadata": {
           "coreUsedFlags": [
-            2,
             1,
-            3
+            3,
+            2
           ],
           "sdkName": "temporal-typescript",
           "sdkVersion": "1.16.2"
@@ -105,8 +105,8 @@
     {
       "eventId": "5",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 917200000
+        "seconds": "1787654816",
+        "nanos": 499656000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "taskId": "1048679",
@@ -126,13 +126,13 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "InNjaC1yZXBsYXki"
+              "data": "InNjaC1yZXBsYXktdGljay1za2lwcGVkLWRpc2FibGVkIg=="
             },
             {
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "IjIwMjYtMDgtMjVUMTA6MTg6MDBaIg=="
+              "data": "IjIwMjYtMDgtMjVUMDk6MzA6MDBaIg=="
             }
           ]
         },
@@ -159,26 +159,26 @@
     {
       "eventId": "6",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 918661000
+        "seconds": "1787654816",
+        "nanos": 500707000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "taskId": "1048685",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "5",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "dff3ec6e-38b9-49b3-b115-4bef81653b01",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "e59523f2-a005-44e7-a9b6-bbea3704584c",
         "attempt": 1,
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "7",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 921126000
+        "seconds": "1787654816",
+        "nanos": 502649000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "taskId": "1048686",
@@ -195,20 +195,20 @@
         },
         "scheduledEventId": "5",
         "startedEventId": "6",
-        "identity": "82393@Sureshs-Mac-Studio.local"
+        "identity": "11185@Sureshs-Mac-Studio.local"
       }
     },
     {
       "eventId": "8",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 921133000
+        "seconds": "1787654816",
+        "nanos": 502653000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "taskId": "1048687",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "name": "11185@Sureshs-Mac-Studio.local-27cd7f003fae4b39ad6ff89ec0783b92",
           "kind": "TASK_QUEUE_KIND_STICKY",
           "normalName": "schedule-replay-capture"
         },
@@ -221,35 +221,35 @@
     {
       "eventId": "9",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 922166000
+        "seconds": "1787654816",
+        "nanos": 503360000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "taskId": "1048691",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "8",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "ba14385d-b674-4ae1-9b7d-dc1e303beea2",
-        "historySizeBytes": "1418",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "9d198f17-440f-4267-a76b-7444f7a60ec4",
+        "historySizeBytes": "1462",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "10",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 926392000
+        "seconds": "1787654816",
+        "nanos": 506051000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "taskId": "1048695",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "8",
         "startedEventId": "9",
-        "identity": "82393@Sureshs-Mac-Studio.local",
+        "identity": "11185@Sureshs-Mac-Studio.local",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         },
         "sdkMetadata": {},
         "meteringMetadata": {}
@@ -258,8 +258,8 @@
     {
       "eventId": "11",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 926418000
+        "seconds": "1787654816",
+        "nanos": 506068000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
       "taskId": "1048696",

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-start-failed.json
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-start-failed.json
@@ -1,0 +1,592 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 934151000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048701",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "schedule/tick"
+        },
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InNjaC1yZXBsYXki"
+            }
+          ]
+        },
+        "workflowTaskTimeout": {
+          "seconds": "10"
+        },
+        "originalExecutionRunId": "01a0386d-4766-724d-8804-ba2fdfe7ae73",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "firstExecutionRunId": "01a0386d-4766-724d-8804-ba2fdfe7ae73",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": {},
+        "header": {},
+        "workflowId": "schedule/tick/sch-replay-2026-08-25T09:30:00Z-tick-start-failed"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 934199000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048702",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 935866000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048707",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "593d2c6a-23d4-4867-a897-967631d091e3",
+        "historySizeBytes": "365",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 940831000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048711",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        },
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            3,
+            1,
+            2
+          ],
+          "sdkName": "temporal-typescript",
+          "sdkVersion": "1.16.2"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 940868000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048712",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "1",
+        "activityType": {
+          "name": "stigmer/schedule/record-tick"
+        },
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InNjaC1yZXBsYXki"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IjIwMjYtMDgtMjVUMTA6MTg6MDBaIg=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {},
+        "startToCloseTimeout": {
+          "seconds": "30"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "5"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "500"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 942131000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048718",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "5",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "9e6cd3d4-91ea-4bb4-9bab-8631266a44f6",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 944866000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048719",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IkZJUkVEIg=="
+            }
+          ]
+        },
+        "scheduledEventId": "5",
+        "startedEventId": "6",
+        "identity": "82393@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 944873000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048720",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "schedule-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 945987000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048724",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "1aebc016-57fe-41ef-8592-023020d365ad",
+        "historySizeBytes": "1403",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 951160000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048728",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 951198000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048729",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "2",
+        "activityType": {
+          "name": "stigmer/schedule/start-run"
+        },
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InNjaC1yZXBsYXki"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IjIwMjYtMDgtMjVUMTA6MTg6MDBaIg=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {},
+        "startToCloseTimeout": {
+          "seconds": "180"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "10",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "5"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "500"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 952433000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048734",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "11",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "318471b9-28e3-4238-94db-c08cab94a102",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 954435000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048735",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJvdXRjb21lIjoiVEFSR0VUX01JU1NJTkciLCJleGVjdXRpb25JZCI6IiIsInRyYWNraW5nVGltZW91dE1pbnV0ZXMiOjYwLCJmYWlsdXJlUmVhc29uIjoidGFyZ2V0IGFnZW50IGFjbWUvZ29uZSBub3QgZm91bmQifQ=="
+            }
+          ]
+        },
+        "scheduledEventId": "11",
+        "startedEventId": "12",
+        "identity": "82393@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 954455000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048736",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "schedule-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 955522000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048740",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "14",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "7e75af60-e6f6-4426-bb27-84261dba3a1e",
+        "historySizeBytes": "2527",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 959040000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048744",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "14",
+        "startedEventId": "15",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 959081000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048745",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "3",
+        "activityType": {
+          "name": "stigmer/schedule/record-failure"
+        },
+        "taskQueue": {
+          "name": "schedule-replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InNjaC1yZXBsYXki"
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InRhcmdldCBhZ2VudCBhY21lL2dvbmUgbm90IGZvdW5kIg=="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "IlNUQVJUX0ZBSUxFRCI="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {},
+        "startToCloseTimeout": {
+          "seconds": "30"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "16",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "1"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "100"
+          },
+          "maximumAttempts": 1
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 960227000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048750",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "17",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "03f18a21-bb2f-4e41-9064-447fd6f0629a",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 962309000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048751",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJjb25zZWN1dGl2ZUZhaWx1cmVzIjoxLCJwYXVzZWQiOmZhbHNlfQ=="
+            }
+          ]
+        },
+        "scheduledEventId": "17",
+        "startedEventId": "18",
+        "identity": "82393@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 962316000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048752",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "schedule-replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 963309000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048756",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "20",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "requestId": "711de5ba-1c8c-4cd8-9c89-c82dbd5fb9d8",
+        "historySizeBytes": "3622",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        }
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 966797000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048760",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "20",
+        "startedEventId": "21",
+        "identity": "82393@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": {
+        "seconds": "1787653080",
+        "nanos": 966835000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1048761",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "22"
+      }
+    }
+  ]
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-start-failed.json
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay-histories/tick-start-failed.json
@@ -3,8 +3,8 @@
     {
       "eventId": "1",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 934151000
+        "seconds": "1787654816",
+        "nanos": 510997000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
       "taskId": "1048701",
@@ -22,27 +22,27 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "InNjaC1yZXBsYXki"
+              "data": "InNjaC1yZXBsYXktdGljay1zdGFydC1mYWlsZWQi"
             }
           ]
         },
         "workflowTaskTimeout": {
           "seconds": "10"
         },
-        "originalExecutionRunId": "01a0386d-4766-724d-8804-ba2fdfe7ae73",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "firstExecutionRunId": "01a0386d-4766-724d-8804-ba2fdfe7ae73",
+        "originalExecutionRunId": "01a03887-c2fe-7f32-b4cd-0d52f2193bb5",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "firstExecutionRunId": "01a03887-c2fe-7f32-b4cd-0d52f2193bb5",
         "attempt": 1,
         "firstWorkflowTaskBackoff": {},
         "header": {},
-        "workflowId": "schedule/tick/sch-replay-2026-08-25T09:30:00Z-tick-start-failed"
+        "workflowId": "schedule/tick/sch-replay-tick-start-failed-2026-08-25T09:30:00Z"
       }
     },
     {
       "eventId": "2",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 934199000
+        "seconds": "1787654816",
+        "nanos": 511035000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "taskId": "1048702",
@@ -60,41 +60,41 @@
     {
       "eventId": "3",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 935866000
+        "seconds": "1787654816",
+        "nanos": 512322000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "taskId": "1048707",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "2",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "593d2c6a-23d4-4867-a897-967631d091e3",
-        "historySizeBytes": "365",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "7e98ff09-308f-40f6-a77f-dcd0d518da07",
+        "historySizeBytes": "383",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "4",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 940831000
+        "seconds": "1787654816",
+        "nanos": 516638000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "taskId": "1048711",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "2",
         "startedEventId": "3",
-        "identity": "82393@Sureshs-Mac-Studio.local",
+        "identity": "11185@Sureshs-Mac-Studio.local",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         },
         "sdkMetadata": {
           "coreUsedFlags": [
+            2,
             3,
-            1,
-            2
+            1
           ],
           "sdkName": "temporal-typescript",
           "sdkVersion": "1.16.2"
@@ -105,8 +105,8 @@
     {
       "eventId": "5",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 940868000
+        "seconds": "1787654816",
+        "nanos": 516666000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "taskId": "1048712",
@@ -126,13 +126,13 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "InNjaC1yZXBsYXki"
+              "data": "InNjaC1yZXBsYXktdGljay1zdGFydC1mYWlsZWQi"
             },
             {
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "IjIwMjYtMDgtMjVUMTA6MTg6MDBaIg=="
+              "data": "IjIwMjYtMDgtMjVUMDk6MzA6MDBaIg=="
             }
           ]
         },
@@ -159,26 +159,26 @@
     {
       "eventId": "6",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 942131000
+        "seconds": "1787654816",
+        "nanos": 517541000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "taskId": "1048718",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "5",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "9e6cd3d4-91ea-4bb4-9bab-8631266a44f6",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "b3999f2c-9294-4db6-945e-b6d05a726e97",
         "attempt": 1,
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "7",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 944866000
+        "seconds": "1787654816",
+        "nanos": 519329000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "taskId": "1048719",
@@ -195,20 +195,20 @@
         },
         "scheduledEventId": "5",
         "startedEventId": "6",
-        "identity": "82393@Sureshs-Mac-Studio.local"
+        "identity": "11185@Sureshs-Mac-Studio.local"
       }
     },
     {
       "eventId": "8",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 944873000
+        "seconds": "1787654816",
+        "nanos": 519334000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "taskId": "1048720",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "name": "11185@Sureshs-Mac-Studio.local-27cd7f003fae4b39ad6ff89ec0783b92",
           "kind": "TASK_QUEUE_KIND_STICKY",
           "normalName": "schedule-replay-capture"
         },
@@ -221,35 +221,35 @@
     {
       "eventId": "9",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 945987000
+        "seconds": "1787654816",
+        "nanos": 520008000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "taskId": "1048724",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "8",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "1aebc016-57fe-41ef-8592-023020d365ad",
-        "historySizeBytes": "1403",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "618de130-046e-45f3-a5a5-ff9fb266cad2",
+        "historySizeBytes": "1439",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "10",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 951160000
+        "seconds": "1787654816",
+        "nanos": 524351000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "taskId": "1048728",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "8",
         "startedEventId": "9",
-        "identity": "82393@Sureshs-Mac-Studio.local",
+        "identity": "11185@Sureshs-Mac-Studio.local",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         },
         "sdkMetadata": {},
         "meteringMetadata": {}
@@ -258,8 +258,8 @@
     {
       "eventId": "11",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 951198000
+        "seconds": "1787654816",
+        "nanos": 524384000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "taskId": "1048729",
@@ -279,13 +279,13 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "InNjaC1yZXBsYXki"
+              "data": "InNjaC1yZXBsYXktdGljay1zdGFydC1mYWlsZWQi"
             },
             {
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "IjIwMjYtMDgtMjVUMTA6MTg6MDBaIg=="
+              "data": "IjIwMjYtMDgtMjVUMDk6MzA6MDBaIg=="
             }
           ]
         },
@@ -312,26 +312,26 @@
     {
       "eventId": "12",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 952433000
+        "seconds": "1787654816",
+        "nanos": 525627000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "taskId": "1048734",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "11",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "318471b9-28e3-4238-94db-c08cab94a102",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "5c6afa2d-9480-4cd6-b50b-3d4b34267e73",
         "attempt": 1,
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "13",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 954435000
+        "seconds": "1787654816",
+        "nanos": 528447000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "taskId": "1048735",
@@ -348,20 +348,20 @@
         },
         "scheduledEventId": "11",
         "startedEventId": "12",
-        "identity": "82393@Sureshs-Mac-Studio.local"
+        "identity": "11185@Sureshs-Mac-Studio.local"
       }
     },
     {
       "eventId": "14",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 954455000
+        "seconds": "1787654816",
+        "nanos": 528452000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "taskId": "1048736",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "name": "11185@Sureshs-Mac-Studio.local-27cd7f003fae4b39ad6ff89ec0783b92",
           "kind": "TASK_QUEUE_KIND_STICKY",
           "normalName": "schedule-replay-capture"
         },
@@ -374,35 +374,35 @@
     {
       "eventId": "15",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 955522000
+        "seconds": "1787654816",
+        "nanos": 529327000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "taskId": "1048740",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "14",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "7e75af60-e6f6-4426-bb27-84261dba3a1e",
-        "historySizeBytes": "2527",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "c51a78a6-bfba-489f-a91a-99fd7f47a866",
+        "historySizeBytes": "2581",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "16",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 959040000
+        "seconds": "1787654816",
+        "nanos": 532392000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "taskId": "1048744",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "14",
         "startedEventId": "15",
-        "identity": "82393@Sureshs-Mac-Studio.local",
+        "identity": "11185@Sureshs-Mac-Studio.local",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         },
         "sdkMetadata": {},
         "meteringMetadata": {}
@@ -411,8 +411,8 @@
     {
       "eventId": "17",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 959081000
+        "seconds": "1787654816",
+        "nanos": 532416000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
       "taskId": "1048745",
@@ -432,7 +432,7 @@
               "metadata": {
                 "encoding": "anNvbi9wbGFpbg=="
               },
-              "data": "InNjaC1yZXBsYXki"
+              "data": "InNjaC1yZXBsYXktdGljay1zdGFydC1mYWlsZWQi"
             },
             {
               "metadata": {
@@ -471,26 +471,26 @@
     {
       "eventId": "18",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 960227000
+        "seconds": "1787654816",
+        "nanos": 533197000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
       "taskId": "1048750",
       "activityTaskStartedEventAttributes": {
         "scheduledEventId": "17",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "03f18a21-bb2f-4e41-9064-447fd6f0629a",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "a669c536-3131-49c1-a166-c59e7c5e2bc7",
         "attempt": 1,
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "19",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 962309000
+        "seconds": "1787654816",
+        "nanos": 534811000
       },
       "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
       "taskId": "1048751",
@@ -507,20 +507,20 @@
         },
         "scheduledEventId": "17",
         "startedEventId": "18",
-        "identity": "82393@Sureshs-Mac-Studio.local"
+        "identity": "11185@Sureshs-Mac-Studio.local"
       }
     },
     {
       "eventId": "20",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 962316000
+        "seconds": "1787654816",
+        "nanos": 534816000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
       "taskId": "1048752",
       "workflowTaskScheduledEventAttributes": {
         "taskQueue": {
-          "name": "82393@Sureshs-Mac-Studio.local-f5bc8d8de704468f83fbb0ddc65be407",
+          "name": "11185@Sureshs-Mac-Studio.local-27cd7f003fae4b39ad6ff89ec0783b92",
           "kind": "TASK_QUEUE_KIND_STICKY",
           "normalName": "schedule-replay-capture"
         },
@@ -533,35 +533,35 @@
     {
       "eventId": "21",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 963309000
+        "seconds": "1787654816",
+        "nanos": 535700000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
       "taskId": "1048756",
       "workflowTaskStartedEventAttributes": {
         "scheduledEventId": "20",
-        "identity": "82393@Sureshs-Mac-Studio.local",
-        "requestId": "711de5ba-1c8c-4cd8-9c89-c82dbd5fb9d8",
-        "historySizeBytes": "3622",
+        "identity": "11185@Sureshs-Mac-Studio.local",
+        "requestId": "7781108b-b5ee-47f7-874a-0b60b986e0af",
+        "historySizeBytes": "3694",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         }
       }
     },
     {
       "eventId": "22",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 966797000
+        "seconds": "1787654816",
+        "nanos": 538193000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
       "taskId": "1048760",
       "workflowTaskCompletedEventAttributes": {
         "scheduledEventId": "20",
         "startedEventId": "21",
-        "identity": "82393@Sureshs-Mac-Studio.local",
+        "identity": "11185@Sureshs-Mac-Studio.local",
         "workerVersion": {
-          "buildId": "@temporalio/worker@1.16.2+7cf77d77c18a34225e57ea36a544f8a59c720a59594f05666b67846065129890"
+          "buildId": "@temporalio/worker@1.16.2+665dc1c091250fcb3f7828693b2e5b3862411e81c287f102332cfba42403b1f9"
         },
         "sdkMetadata": {},
         "meteringMetadata": {}
@@ -570,8 +570,8 @@
     {
       "eventId": "23",
       "eventTime": {
-        "seconds": "1787653080",
-        "nanos": 966835000
+        "seconds": "1787654816",
+        "nanos": 538215000
       },
       "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
       "taskId": "1048761",

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/replay.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Replay determinism gate for the schedule/tick workflow — the OD-6
+ * discipline this domain ORIGINATED (Go tick_replay_test.go, whose rule
+ * the agent-execution gate adopted at #18; this port brings it home):
+ * committed histories from released workflow code must replay green on
+ * the CURRENT code. A red run here means a change to the tick's logic is
+ * NOT replay-safe for in-flight ticks — ticks live for minutes-to-an-hour
+ * and OSS releases cut every 1-3 days, so an in-flight tick WILL straddle
+ * a binary upgrade. Gate changes with patched()/deprecatePatch(); never
+ * regenerate the histories while a producing release is supported.
+ *
+ * Fully local: replay needs no Temporal server, so this gate runs in the
+ * plain vitest suite (and the ci.stigmer-server-ts workflow) on every
+ * change. Histories are captured by
+ * scripts/capture-schedule-replay-histories.ts (mock payloads only).
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import proto from "@temporalio/proto";
+import { Worker } from "@temporalio/worker";
+import { describe, expect, it } from "vitest";
+
+const HISTORY_DIR = fileURLToPath(new URL("./replay-histories", import.meta.url));
+const WORKFLOWS_PATH = fileURLToPath(new URL("../workflows/index.ts", import.meta.url));
+
+const historyFiles = readdirSync(HISTORY_DIR).filter((name) =>
+  name.endsWith(".json"),
+);
+
+describe("schedule/tick replay determinism", () => {
+  it("has committed histories to replay (the gate cannot be empty)", () => {
+    expect(historyFiles.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("replays every committed history deterministically", async () => {
+    // ONE runReplayHistories call for all files (the agent-execution
+    // gate's native-bridge constraint applies here identically).
+    const histories = historyFiles.map((file) => ({
+      workflowId: file,
+      history: proto.temporal.api.history.v1.History.fromObject(
+        JSON.parse(readFileSync(`${HISTORY_DIR}/${file}`, "utf8")),
+      ),
+    }));
+    const results = Worker.runReplayHistories(
+      { workflowsPath: WORKFLOWS_PATH },
+      histories,
+    );
+    for await (const result of results) {
+      expect(
+        result.error,
+        `history ${result.workflowId} must replay deterministically`,
+      ).toBeUndefined();
+    }
+  }, 120_000);
+});

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/run-starter.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/run-starter.test.ts
@@ -1,0 +1,357 @@
+/**
+ * Pins the RunStarter against Go's runstarter_test.go: the deterministic
+ * execution name (THE idempotency key, byte-pinned on both editions), the
+ * fire-context message rendering (the model's only "today"), the
+ * owner-vs-platform clamps, the find-before-create idempotency, the
+ * refusal-code partition, and the execution-request shape.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { Code, ConnectError } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  ApprovalMode,
+  ServiceTier,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { Harness } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import { ScheduleTemporalConfig } from "../config.js";
+import {
+  RunStarter,
+  SCHEDULE_ID_LABEL_KEY,
+  SESSION_SUBJECT_PREFIX,
+  clampedRunBound,
+  composeMessage,
+  scheduledExecutionName,
+} from "../run-starter.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const NOMINAL = new Date("2026-08-25T09:30:00Z");
+
+describe("scheduledExecutionName — THE idempotency key (byte-pinned)", () => {
+  it("lowercases the id, maps underscores to hyphens, appends the 20060102t150405z time", () => {
+    expect(scheduledExecutionName("SCH_01ABC", NOMINAL)).toBe(
+      "sch-01abc-20260825t093000z",
+    );
+  });
+
+  it("truncates the nominal time to whole seconds", () => {
+    expect(scheduledExecutionName("sch_x", new Date("2026-08-25T09:30:00.999Z"))).toBe(
+      "sch-x-20260825t093000z",
+    );
+  });
+
+  it("every character is slug-shaped (the name IS the execution's slug)", () => {
+    expect(scheduledExecutionName("sch_01ABC", NOMINAL)).toMatch(/^[a-z0-9-]+$/);
+  });
+});
+
+function scheduleWith(overrides?: {
+  message?: string;
+  timeZone?: string;
+  harness?: Harness;
+  modelName?: string;
+  maxToolRounds?: number;
+  maxCostUsd?: number;
+  serviceTier?: ServiceTier;
+  agentSlug?: string;
+  slug?: string;
+}): Schedule {
+  return create(ScheduleSchema, {
+    metadata: { id: "sch_01test", org: "acme", slug: overrides?.slug ?? "daily" },
+    spec: {
+      cron: "0 9 * * *",
+      timeZone: overrides?.timeZone ?? "Asia/Kolkata",
+      enabled: true,
+      target: {
+        case: "agent",
+        value: {
+          agentRef: { slug: overrides?.agentSlug ?? "helper" },
+          message: overrides?.message ?? "Do the morning rounds",
+          harness: overrides?.harness ?? Harness.UNSPECIFIED,
+          runConfig: {
+            modelName: overrides?.modelName ?? "",
+            maxToolRounds: overrides?.maxToolRounds ?? 0,
+            maxCostUsd: overrides?.maxCostUsd ?? 0,
+            serviceTier: overrides?.serviceTier ?? ServiceTier.UNSPECIFIED,
+          },
+        },
+      },
+    },
+  });
+}
+
+describe("composeMessage — the fire-context line (byte contract)", () => {
+  it("renders 'Monday, 2006-01-02 15:04' in the schedule's zone with the zone-name echo", () => {
+    // 2026-08-25T09:30:00Z is 15:00 IST on Tuesday 2026-08-25.
+    expect(composeMessage(scheduleWith(), NOMINAL)).toBe(
+      "Do the morning rounds\n\n(Scheduled fire time: Tuesday, 2026-08-25 15:00 (Asia/Kolkata))",
+    );
+  });
+
+  it("an empty zone renders in UTC and echoes 'UTC' (Go LoadLocation(''))", () => {
+    expect(composeMessage(scheduleWith({ timeZone: "" }), NOMINAL)).toBe(
+      "Do the morning rounds\n\n(Scheduled fire time: Tuesday, 2026-08-25 09:30 (UTC))",
+    );
+  });
+
+  it("an unloadable zone degrades to UTC (a slightly wrong-timezone reminder beats a dead fire)", () => {
+    expect(composeMessage(scheduleWith({ timeZone: "Mars/Olympus" }), NOMINAL)).toBe(
+      "Do the morning rounds\n\n(Scheduled fire time: Tuesday, 2026-08-25 09:30 (UTC))",
+    );
+  });
+
+  it("uses h23 hours (Go's 15 layout: 00-23, never 24)", () => {
+    const midnight = new Date("2026-08-25T00:05:00Z");
+    expect(composeMessage(scheduleWith({ timeZone: "UTC" }), midnight)).toContain(
+      "Tuesday, 2026-08-25 00:05 (UTC)",
+    );
+  });
+});
+
+describe("clampedRunBound — min(owner, platform), zero = unset", () => {
+  it.each([
+    [0, 20, 20], // owner unset → platform
+    [5, 20, 5], // both set → lower wins
+    [50, 20, 20], // owner cannot raise past the platform
+    [5, 0, 5], // platform unset → owner stands
+    [0, 0, 0], // both unset
+    [-1, 20, 20], // negative reads as unset
+  ])("owner=%d platform=%d → %d", (owner, platform, want) => {
+    expect(clampedRunBound(owner, platform)).toBe(want);
+  });
+});
+
+describe("RunStarter.startRun — against a real store", () => {
+  let dir: string;
+  let store: SqliteStore;
+
+  const config = new ScheduleTemporalConfig(
+    "schedule_stigmer",
+    60,
+    24,
+    5,
+    60,
+    true,
+    5,
+    20,
+    1.0,
+    90,
+  );
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "run-starter-test-"));
+    store = SqliteStore.open(path.join(dir, "test.db"));
+    await store.saveResource(
+      ApiResourceKind.agent,
+      "agt_01helper",
+      AgentSchema,
+      create(AgentSchema, {
+        metadata: { id: "agt_01helper", org: "acme", slug: "helper" },
+      }),
+    );
+    await store.saveResource(
+      ApiResourceKind.schedule,
+      "sch_01test",
+      ScheduleSchema,
+      scheduleWith(),
+    );
+  });
+
+  afterAll(async () => {
+    await store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function starter(create_: (execution: AgentExecution) => Promise<AgentExecution>) {
+    return new RunStarter({
+      store,
+      config,
+      executions: { create: create_ },
+      logger: silentLogger,
+    });
+  }
+
+  it("shapes the execution request: name, org, label, UNATTENDED, subject prefix, fire-context message", async () => {
+    let seen: AgentExecution | undefined;
+    const runStarter = starter(async (execution) => {
+      seen = execution;
+      return create(AgentExecutionSchema, {
+        metadata: { id: "aex_01new", org: "acme" },
+      });
+    });
+
+    const outcome = await runStarter.startRun(scheduleWith(), NOMINAL);
+    expect(outcome).toEqual({
+      kind: "started",
+      executionId: "aex_01new",
+      alreadyExisted: false,
+    });
+
+    expect(seen?.apiVersion).toBe("agentic.stigmer.ai/v1");
+    expect(seen?.kind).toBe("AgentExecution");
+    expect(seen?.metadata?.name).toBe("sch-01test-20260825t093000z");
+    expect(seen?.metadata?.org).toBe("acme");
+    expect(seen?.metadata?.labels[SCHEDULE_ID_LABEL_KEY]).toBe("sch_01test");
+    expect(seen?.spec?.agentId).toBe("agt_01helper");
+    expect(seen?.spec?.message).toContain("(Scheduled fire time: ");
+    expect(seen?.spec?.sessionSpec?.subject).toBe(`${SESSION_SUBJECT_PREFIX}daily`);
+    expect(seen?.spec?.executionConfig?.approvalMode).toBe(ApprovalMode.UNATTENDED);
+    // Platform profile applies when the owner set nothing.
+    expect(seen?.spec?.executionConfig?.maxToolRounds).toBe(20);
+    expect(seen?.spec?.executionConfig?.maxCostUsd).toBe(1.0);
+    // Unset tier/model stay unset (never stamped).
+    expect(seen?.spec?.executionConfig?.modelName).toBe("");
+    expect(seen?.spec?.executionConfig?.serviceTier).toBe(ServiceTier.UNSPECIFIED);
+
+    // Success stamped last_execution_id on the row.
+    const row = await store.getResource(
+      ApiResourceKind.schedule,
+      "sch_01test",
+      ScheduleSchema,
+    );
+    expect(row.status?.lastExecutionId).toBe("aex_01new");
+  });
+
+  it("finds an existing execution by the deterministic name instead of creating (idempotent retry)", async () => {
+    await store.saveResource(
+      ApiResourceKind.agent_execution,
+      "aex_01prior",
+      AgentExecutionSchema,
+      create(AgentExecutionSchema, {
+        metadata: {
+          id: "aex_01prior",
+          org: "acme",
+          slug: scheduledExecutionName("sch_01test", NOMINAL),
+        },
+      }),
+    );
+    const runStarter = starter(async () => {
+      throw new Error("create must not be called on the idempotent path");
+    });
+    const outcome = await runStarter.startRun(scheduleWith(), NOMINAL);
+    expect(outcome).toEqual({
+      kind: "started",
+      executionId: "aex_01prior",
+      alreadyExisted: true,
+    });
+    await store.deleteResource(ApiResourceKind.agent_execution, "aex_01prior");
+  });
+
+  it("answers targetMissing with the byte-pinned copy when the agent is gone", async () => {
+    const runStarter = starter(async () => {
+      throw new Error("unreachable");
+    });
+    const outcome = await runStarter.startRun(
+      scheduleWith({ agentSlug: "vanished" }),
+      NOMINAL,
+    );
+    expect(outcome).toEqual({
+      kind: "targetMissing",
+      reason: "target agent acme/vanished not found",
+    });
+  });
+
+  it("refuses via the model-pinning launch backstop for a pre-rule cursor row", async () => {
+    const runStarter = starter(async () => {
+      throw new Error("unreachable");
+    });
+    const outcome = await runStarter.startRun(
+      scheduleWith({ harness: Harness.CURSOR, modelName: "" }),
+      NOMINAL,
+    );
+    expect(outcome.kind).toBe("refused");
+    if (outcome.kind === "refused") {
+      expect(outcome.reason).toContain("stigmer/stigmer#362");
+    }
+  });
+
+  it.each([
+    Code.FailedPrecondition,
+    Code.PermissionDenied,
+    Code.NotFound,
+    Code.InvalidArgument,
+    Code.ResourceExhausted,
+  ])("maps the launch-gate code %s to a refused outcome (the streak counts it)", async (code) => {
+    const runStarter = starter(async () => {
+      throw new ConnectError("gate refused this run", code);
+    });
+    const outcome = await runStarter.startRun(scheduleWith(), NOMINAL);
+    expect(outcome).toEqual({ kind: "refused", reason: "gate refused this run" });
+  });
+
+  it("rethrows infrastructure codes so the activity retries", async () => {
+    const runStarter = starter(async () => {
+      throw new ConnectError("store exploded", Code.Internal);
+    });
+    await expect(runStarter.startRun(scheduleWith(), NOMINAL)).rejects.toThrow(
+      "store exploded",
+    );
+  });
+
+  it("re-finds the winner on AlreadyExists from the session duplicate check", async () => {
+    // The pre-check misses (no row yet); create refuses AlreadyExists and
+    // the winner row lands concurrently (the session auto-create race the
+    // Go comment describes) — the starter must re-read the winner.
+    const raceNominal = new Date("2026-08-26T09:30:00Z");
+    let calls = 0;
+    const runStarter = starter(async () => {
+      calls++;
+      await store.saveResource(
+        ApiResourceKind.agent_execution,
+        "aex_01winner",
+        AgentExecutionSchema,
+        create(AgentExecutionSchema, {
+          metadata: {
+            id: "aex_01winner",
+            org: "acme",
+            slug: scheduledExecutionName("sch_01test", raceNominal),
+          },
+        }),
+      );
+      throw new ConnectError("duplicate", Code.AlreadyExists);
+    });
+    const outcome = await runStarter.startRun(scheduleWith(), raceNominal);
+    expect(calls).toBe(1);
+    expect(outcome).toEqual({
+      kind: "started",
+      executionId: "aex_01winner",
+      alreadyExisted: true,
+    });
+    await store.deleteResource(ApiResourceKind.agent_execution, "aex_01winner");
+  });
+
+  it("clamps owner run bounds by the platform profile and stamps owner-set tier/model", async () => {
+    let seen: AgentExecution | undefined;
+    const runStarter = starter(async (execution) => {
+      seen = execution;
+      return create(AgentExecutionSchema, { metadata: { id: "aex_01x", org: "acme" } });
+    });
+    await runStarter.startRun(
+      scheduleWith({
+        maxToolRounds: 50, // above the platform 20 → clamped
+        maxCostUsd: 0.25, // below the platform 1.00 → stands
+        modelName: " gpt-x ",
+        serviceTier: ServiceTier.FAST,
+      }),
+      new Date("2026-08-27T09:30:00Z"),
+    );
+    expect(seen?.spec?.executionConfig?.maxToolRounds).toBe(20);
+    expect(seen?.spec?.executionConfig?.maxCostUsd).toBe(0.25);
+    expect(seen?.spec?.executionConfig?.modelName).toBe("gpt-x");
+    expect(seen?.spec?.executionConfig?.serviceTier).toBe(ServiceTier.FAST);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/syncer.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/syncer.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Pins the syncer against Go's syncer.go: the create-or-update convergence
+ * on ScheduleAlreadyRunning, next_fire_at stamped from Temporal's OWN
+ * answer through the atomic row write (undefined while paused), teardown's
+ * not-found-is-success idempotence, and the unavailable posture when no
+ * client exists (panel finding 1 — this machinery previously shipped
+ * untested).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import type { Client } from "@temporalio/client";
+import { ScheduleAlreadyRunning, ScheduleNotFoundError } from "@temporalio/client";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+import { ScheduleArtifact } from "../artifact.js";
+import { ScheduleTemporalConfig } from "../config.js";
+import { ScheduleSyncer, TemporalUnavailableError } from "../syncer.js";
+
+const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const config = new ScheduleTemporalConfig("schedule_stigmer", 60, 24, 5, 60, true, 5, 20, 1.0, 90);
+
+let dir: string;
+let store: SqliteStore;
+
+/**
+ * A scriptable ScheduleClient double. Narrowed through unknown at the ONE
+ * seam the syncer touches (client.schedule) — a full Client fake would be
+ * machinery without a beneficiary; the script object keeps the calls
+ * observable.
+ */
+interface FakeScheduleApi {
+  createError?: Error;
+  updateError?: Error;
+  deleteError?: Error;
+  describeNextActionTimes: Date[];
+  createCalls: number;
+  updateCalls: number;
+  deleteCalls: string[];
+}
+
+let fake: FakeScheduleApi;
+
+function fakeClient(): Client {
+  const schedule = {
+    create: async () => {
+      fake.createCalls++;
+      if (fake.createError) throw fake.createError;
+    },
+    getHandle: (scheduleId: string) => ({
+      describe: async () => ({ info: { nextActionTimes: fake.describeNextActionTimes } }),
+      update: async () => {
+        fake.updateCalls++;
+        if (fake.updateError) throw fake.updateError;
+      },
+      delete: async () => {
+        fake.deleteCalls.push(scheduleId);
+        if (fake.deleteError) throw fake.deleteError;
+      },
+    }),
+  };
+  return { schedule } as unknown as Client;
+}
+
+function scheduleRow(overrides?: { enabled?: boolean; pausedReason?: string }) {
+  return create(ScheduleSchema, {
+    metadata: { id: "sch_01sync", org: "acme", slug: "daily" },
+    spec: {
+      cron: "0 9 * * *",
+      timeZone: "UTC",
+      enabled: overrides?.enabled ?? true,
+      target: { case: "agent", value: { agentRef: { slug: "helper" } } },
+    },
+    status: { pausedReason: overrides?.pausedReason ?? "" },
+  });
+}
+
+function syncer(client: Client | undefined): ScheduleSyncer {
+  return new ScheduleSyncer(
+    () => client,
+    store,
+    new ScheduleArtifact(config),
+    silentLogger,
+  );
+}
+
+beforeAll(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "schedule-syncer-test-"));
+  store = SqliteStore.open(path.join(dir, "test.db"));
+});
+
+afterAll(async () => {
+  await store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  fake = {
+    describeNextActionTimes: [new Date("2026-08-26T09:00:00Z")],
+    createCalls: 0,
+    updateCalls: 0,
+    deleteCalls: [],
+  };
+  await store.saveResource(ApiResourceKind.schedule, "sch_01sync", ScheduleSchema, scheduleRow());
+});
+
+describe("ensureAndRecord — create-or-update convergence", () => {
+  it("creates a missing artifact and stamps next_fire_at from Temporal's answer", async () => {
+    const next = await syncer(fakeClient()).ensureAndRecord(scheduleRow());
+    expect(fake.createCalls).toBe(1);
+    expect(fake.updateCalls).toBe(0);
+    expect(next).toEqual(new Date("2026-08-26T09:00:00Z"));
+
+    const row = await store.getResource(ApiResourceKind.schedule, "sch_01sync", ScheduleSchema);
+    expect(row.status?.nextFireAt?.seconds).toBe(
+      BigInt(Date.parse("2026-08-26T09:00:00Z") / 1000),
+    );
+    expect(row.status?.audit?.statusAudit?.event).toBe("updated");
+  });
+
+  it("falls to the update path on ScheduleAlreadyRunning (benign lost race)", async () => {
+    fake.createError = new ScheduleAlreadyRunning("exists", "schedule/tick/sch_01sync");
+    const next = await syncer(fakeClient()).ensureAndRecord(scheduleRow());
+    expect(fake.updateCalls).toBe(1);
+    expect(next).toEqual(new Date("2026-08-26T09:00:00Z"));
+  });
+
+  it("wraps a non-AlreadyRunning create failure with the artifact id", async () => {
+    fake.createError = new Error("frontend hiccup");
+    await expect(syncer(fakeClient()).ensureAndRecord(scheduleRow())).rejects.toThrow(
+      "create schedule artifact schedule/tick/sch_01sync: frontend hiccup",
+    );
+  });
+
+  it("a paused schedule stamps next_fire_at ABSENT (never describes)", async () => {
+    const paused = scheduleRow({ enabled: false });
+    await store.saveResource(ApiResourceKind.schedule, "sch_01sync", ScheduleSchema, paused);
+    const next = await syncer(fakeClient()).ensureAndRecord(paused);
+    expect(next).toBeUndefined();
+    const row = await store.getResource(ApiResourceKind.schedule, "sch_01sync", ScheduleSchema);
+    expect(row.status?.nextFireAt).toBeUndefined();
+  });
+
+  it("a row deleted between arm and stamp is a logged no-op, not an error", async () => {
+    await store.deleteResource(ApiResourceKind.schedule, "sch_01sync");
+    const next = await syncer(fakeClient()).ensureAndRecord(scheduleRow());
+    expect(next).toEqual(new Date("2026-08-26T09:00:00Z"));
+  });
+
+  it("throws TemporalUnavailableError when no client exists (arming degrades upstream)", async () => {
+    await expect(syncer(undefined).ensureAndRecord(scheduleRow())).rejects.toBeInstanceOf(
+      TemporalUnavailableError,
+    );
+  });
+});
+
+describe("teardown — idempotent from the platform's view", () => {
+  it("deletes the artifact", async () => {
+    await syncer(fakeClient()).teardown("sch_01sync");
+    expect(fake.deleteCalls).toEqual(["schedule/tick/sch_01sync"]);
+  });
+
+  it("not-found is success (Temporal's delete is not idempotent; ours is)", async () => {
+    fake.deleteError = new ScheduleNotFoundError("gone", "schedule/tick/sch_01sync");
+    await expect(syncer(fakeClient()).teardown("sch_01sync")).resolves.toBeUndefined();
+  });
+
+  it("other delete failures propagate with the artifact id", async () => {
+    fake.deleteError = new Error("boom");
+    await expect(syncer(fakeClient()).teardown("sch_01sync")).rejects.toThrow(
+      "delete schedule artifact schedule/tick/sch_01sync: boom",
+    );
+  });
+});
+
+describe("peekNextFireAt", () => {
+  it("answers undefined while paused without touching Temporal", async () => {
+    const result = await syncer(undefined).peekNextFireAt(scheduleRow({ pausedReason: "Paused" }));
+    expect(result).toBeUndefined();
+  });
+
+  it("answers undefined when Temporal reports no upcoming action", async () => {
+    fake.describeNextActionTimes = [];
+    const result = await syncer(fakeClient()).peekNextFireAt(scheduleRow());
+    expect(result).toBeUndefined();
+  });
+});

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/tick-workflow.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/tick-workflow.test.ts
@@ -43,9 +43,10 @@ import {
   type FailureKind,
   type RunPhase,
   type RunStart,
+  type ScheduleTickActivities,
   type TickOutcome,
 } from "../names.js";
-import { MAX_TRACKING_CYCLES } from "../workflows/tick.js";
+import { MAX_TRACKING_CYCLES, trackingBackoffMs } from "../workflows/tick.js";
 
 const TASK_QUEUE = "tick-workflow-test";
 const WORKFLOWS_PATH = new URL("../workflows/index.ts", import.meta.url).pathname;
@@ -106,44 +107,35 @@ async function nonRetryable(message: string): Promise<never> {
   throw ApplicationFailure.nonRetryable(message);
 }
 
-function scriptedActivities(): Record<string, (...args: never[]) => Promise<unknown>> {
+// Typed as the REAL activity surface: a signature change in
+// ScheduleTickActivities flags these doubles at compile time instead of
+// silently decoupling the tests from the contract they pin.
+function scriptedActivities(): ScheduleTickActivities {
   return {
-    "stigmer/schedule/record-tick": (async (
-      scheduleId: string,
-      nominal: string,
-    ): Promise<TickOutcome> => {
+    "stigmer/schedule/record-tick": async (scheduleId, nominal) => {
       script.recordTickArgs.push({ scheduleId, nominal });
       if (script.tickError !== undefined) {
         await nonRetryable(script.tickError);
       }
       return script.tickOutcome;
-    }) as never,
-    "stigmer/schedule/start-run": (async (): Promise<RunStart> =>
-      script.runStart) as never,
-    "stigmer/schedule/poll-phase": (async (): Promise<RunPhase> => {
+    },
+    "stigmer/schedule/start-run": async () => script.runStart,
+    "stigmer/schedule/poll-phase": async () => {
       if (script.pollError !== undefined) {
         await nonRetryable(script.pollError);
       }
       script.pollCount++;
-      const result =
-        script.pollResults.length > 1
-          ? script.pollResults.shift()!
-          : script.pollResults[0]!;
-      return result;
-    }) as never,
-    "stigmer/schedule/record-success": (async (
-      scheduleId: string,
-    ): Promise<void> => {
+      return script.pollResults.length > 1
+        ? script.pollResults.shift()!
+        : script.pollResults[0]!;
+    },
+    "stigmer/schedule/record-success": async (scheduleId) => {
       script.successCalls.push(scheduleId);
-    }) as never,
-    "stigmer/schedule/record-failure": (async (
-      scheduleId: string,
-      reason: string,
-      kind: FailureKind,
-    ): Promise<{ consecutiveFailures: number; paused: boolean }> => {
+    },
+    "stigmer/schedule/record-failure": async (scheduleId, reason, kind) => {
       script.failureCalls.push({ scheduleId, reason, kind });
       return { consecutiveFailures: script.failureCalls.length, paused: false };
-    }) as never,
+    },
   };
 }
 
@@ -252,6 +244,18 @@ describe("schedule/tick workflow (TestWorkflowEnvironment)", () => {
     expect(script.failureCalls).toEqual([]);
   }, 30_000);
 
+  it("re-polls a still-RUNNING run through the backoff sleep to its verdict", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    // Two polls with one real cycle-1 backoff (5s) between them — the
+    // sleep→re-poll path the single-poll scenarios never execute.
+    script.pollResults = [PHASE_RUNNING, PHASE_COMPLETED];
+
+    await runTick();
+    expect(script.pollCount).toBe(2);
+    expect(script.successCalls).toEqual(["sch_tick"]);
+    expect(script.failureCalls).toEqual([]);
+  }, 30_000);
+
   it("an ALREADY_STARTED retry tracks exactly like STARTED", async (testCtx) => {
     if (!envReady) return testCtx.skip();
     script.runStart = {
@@ -351,5 +355,14 @@ describe("schedule/tick workflow (TestWorkflowEnvironment)", () => {
 describe("tick loop bounds (plain unit)", () => {
   it("pins MAX_TRACKING_CYCLES at 240 (the recorded-history backstop)", () => {
     expect(MAX_TRACKING_CYCLES).toBe(240);
+  });
+
+  it("pins the tracking backoff curve: linear cycle×5s, capped at 60s by cycle twelve", () => {
+    expect(trackingBackoffMs(1)).toBe(5_000);
+    expect(trackingBackoffMs(2)).toBe(10_000);
+    expect(trackingBackoffMs(11)).toBe(55_000);
+    expect(trackingBackoffMs(12)).toBe(60_000);
+    expect(trackingBackoffMs(13)).toBe(60_000);
+    expect(trackingBackoffMs(240)).toBe(60_000);
   });
 });

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/tick-workflow.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/__tests__/tick-workflow.test.ts
@@ -1,0 +1,355 @@
+/**
+ * Tick-workflow orchestration tests — port the scenario matrix of
+ * pkg/domain/schedule/temporal/tick_workflow_test.go through a
+ * TestWorkflowEnvironment with scripted activities.
+ *
+ * What these pin (the clock's orchestration contract):
+ *   - skip outcomes end the tick without a run start;
+ *   - start failures (TARGET_MISSING/REFUSED) record ONE failure with the
+ *     START_FAILED kind and the deterministic reason;
+ *   - a tracked run polls to COMPLETED → the success reset (never the
+ *     failure recorder);
+ *   - FAILED/CANCELLED/TERMINATED record the "run X ended <phase>" verdict;
+ *   - GONE yields NO verdict (a deleted run must not brick its schedule);
+ *   - budget exhaustion records RUN_TIMED_OUT with the byte-pinned reason
+ *     and does NOT cancel the run;
+ *   - a poll failure past retries fails the tick with NO verdict;
+ *   - the 3-tier nominal-time derivation (workflow-id suffix, then
+ *     workflow time truncated to whole seconds).
+ *
+ * Follows the invoke-workflow precedent: TestWorkflowEnvironment
+ * .createLocal (needs the `temporal` CLI on PATH); every test skips
+ * VISIBLY when the local test server cannot start — never a vacuous green
+ * (the #18 panel lesson).
+ */
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  FAILURE_RUN_FAILED,
+  FAILURE_RUN_TIMED_OUT,
+  FAILURE_START_FAILED,
+  PHASE_COMPLETED,
+  PHASE_FAILED,
+  PHASE_GONE,
+  PHASE_RUNNING,
+  RUN_ALREADY_STARTED,
+  RUN_REFUSED,
+  RUN_SKIPPED,
+  RUN_STARTED,
+  RUN_TARGET_MISSING,
+  TICK_FIRED,
+  TICK_SKIPPED_DISABLED,
+  TICK_WORKFLOW_TYPE,
+  type FailureKind,
+  type RunPhase,
+  type RunStart,
+  type TickOutcome,
+} from "../names.js";
+import { MAX_TRACKING_CYCLES } from "../workflows/tick.js";
+
+const TASK_QUEUE = "tick-workflow-test";
+const WORKFLOWS_PATH = new URL("../workflows/index.ts", import.meta.url).pathname;
+
+type TestWorkflowEnvironment = import("@temporalio/testing").TestWorkflowEnvironment;
+type Worker = import("@temporalio/worker").Worker;
+
+let env: TestWorkflowEnvironment | null = null;
+let worker: Worker | null = null;
+let workerRunPromise: Promise<void> | null = null;
+let envReady = false;
+
+// ─── Scriptable activity doubles ────────────────────────────────────────
+
+interface FailureCall {
+  scheduleId: string;
+  reason: string;
+  kind: FailureKind;
+}
+
+interface TickScript {
+  tickOutcome: TickOutcome;
+  /** Thrown from record-tick when set (nonRetryable — fails the tick fast). */
+  tickError?: string;
+  recordTickArgs: Array<{ scheduleId: string; nominal: string }>;
+  runStart: RunStart;
+  /** Consumed per poll, in order; the last one sticks. */
+  pollResults: RunPhase[];
+  /** Thrown from poll when set. */
+  pollError?: string;
+  pollCount: number;
+  successCalls: string[];
+  failureCalls: FailureCall[];
+}
+
+let script: TickScript;
+
+function resetScript(): void {
+  script = {
+    tickOutcome: TICK_FIRED,
+    recordTickArgs: [],
+    runStart: {
+      outcome: RUN_STARTED,
+      executionId: "aex_tick",
+      trackingTimeoutMinutes: 60,
+      failureReason: "",
+    },
+    pollResults: [PHASE_COMPLETED],
+    pollCount: 0,
+    successCalls: [],
+    failureCalls: [],
+  };
+}
+resetScript();
+
+async function nonRetryable(message: string): Promise<never> {
+  const { ApplicationFailure } = await import("@temporalio/common");
+  throw ApplicationFailure.nonRetryable(message);
+}
+
+function scriptedActivities(): Record<string, (...args: never[]) => Promise<unknown>> {
+  return {
+    "stigmer/schedule/record-tick": (async (
+      scheduleId: string,
+      nominal: string,
+    ): Promise<TickOutcome> => {
+      script.recordTickArgs.push({ scheduleId, nominal });
+      if (script.tickError !== undefined) {
+        await nonRetryable(script.tickError);
+      }
+      return script.tickOutcome;
+    }) as never,
+    "stigmer/schedule/start-run": (async (): Promise<RunStart> =>
+      script.runStart) as never,
+    "stigmer/schedule/poll-phase": (async (): Promise<RunPhase> => {
+      if (script.pollError !== undefined) {
+        await nonRetryable(script.pollError);
+      }
+      script.pollCount++;
+      const result =
+        script.pollResults.length > 1
+          ? script.pollResults.shift()!
+          : script.pollResults[0]!;
+      return result;
+    }) as never,
+    "stigmer/schedule/record-success": (async (
+      scheduleId: string,
+    ): Promise<void> => {
+      script.successCalls.push(scheduleId);
+    }) as never,
+    "stigmer/schedule/record-failure": (async (
+      scheduleId: string,
+      reason: string,
+      kind: FailureKind,
+    ): Promise<{ consecutiveFailures: number; paused: boolean }> => {
+      script.failureCalls.push({ scheduleId, reason, kind });
+      return { consecutiveFailures: script.failureCalls.length, paused: false };
+    }) as never,
+  };
+}
+
+let workflowSeq = 0;
+
+async function runTick(options?: { workflowId?: string }): Promise<void> {
+  if (!env) throw new Error("TestWorkflowEnvironment not initialized");
+  workflowSeq++;
+  const handle = await env.client.workflow.start(TICK_WORKFLOW_TYPE, {
+    taskQueue: TASK_QUEUE,
+    workflowId: options?.workflowId ?? `tick-test-${workflowSeq}-${Date.now()}`,
+    args: ["sch_tick"],
+  });
+  await handle.result();
+}
+
+describe("schedule/tick workflow (TestWorkflowEnvironment)", () => {
+  beforeAll(async () => {
+    try {
+      const { TestWorkflowEnvironment: TWE } = await import("@temporalio/testing");
+      const { Worker: W } = await import("@temporalio/worker");
+      env = await TWE.createLocal();
+      worker = await W.create({
+        connection: env.nativeConnection,
+        taskQueue: TASK_QUEUE,
+        workflowsPath: WORKFLOWS_PATH,
+        activities: scriptedActivities(),
+      });
+      workerRunPromise = worker.run();
+      envReady = true;
+    } catch (error) {
+      console.warn(
+        `Temporal test server unavailable (tests will be skipped): ${error instanceof Error ? error.message : String(error)}`,
+      );
+      envReady = false;
+    }
+  }, 120_000);
+
+  afterAll(async () => {
+    if (worker) {
+      worker.shutdown();
+      await workerRunPromise?.catch(() => {});
+    }
+    if (env) await env.teardown();
+  }, 30_000);
+
+  afterEach(() => {
+    resetScript();
+  });
+
+  it("a skipped tick ends without a run start or verdict", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    script.tickOutcome = TICK_SKIPPED_DISABLED;
+
+    await runTick();
+    expect(script.recordTickArgs).toHaveLength(1);
+    expect(script.pollCount).toBe(0);
+    expect(script.successCalls).toEqual([]);
+    expect(script.failureCalls).toEqual([]);
+  }, 30_000);
+
+  it.for([
+    [RUN_TARGET_MISSING, "target agent acme/gone not found"],
+    [RUN_REFUSED, "run refused: gate said no"],
+  ] as const)(
+    "a %s start records ONE START_FAILED verdict with the deterministic reason",
+    { timeout: 30_000 },
+    async ([outcome, reason], testCtx) => {
+      if (!envReady) return testCtx.skip();
+      script.runStart = {
+        outcome,
+        executionId: "",
+        trackingTimeoutMinutes: 60,
+        failureReason: reason,
+      };
+
+      await runTick();
+      expect(script.failureCalls).toEqual([
+        { scheduleId: "sch_tick", reason, kind: FAILURE_START_FAILED },
+      ]);
+      expect(script.successCalls).toEqual([]);
+      expect(script.pollCount).toBe(0);
+    },
+  );
+
+  it("a SKIPPED run start ends the tick quietly", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    script.runStart = {
+      outcome: RUN_SKIPPED,
+      executionId: "",
+      trackingTimeoutMinutes: 60,
+      failureReason: "",
+    };
+    await runTick();
+    expect(script.failureCalls).toEqual([]);
+    expect(script.pollCount).toBe(0);
+  }, 30_000);
+
+  it("tracks a started run to COMPLETED and resets the streak", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    script.pollResults = [PHASE_COMPLETED];
+
+    await runTick();
+    expect(script.pollCount).toBe(1);
+    expect(script.successCalls).toEqual(["sch_tick"]);
+    expect(script.failureCalls).toEqual([]);
+  }, 30_000);
+
+  it("an ALREADY_STARTED retry tracks exactly like STARTED", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    script.runStart = {
+      outcome: RUN_ALREADY_STARTED,
+      executionId: "aex_tick",
+      trackingTimeoutMinutes: 60,
+      failureReason: "",
+    };
+    await runTick();
+    expect(script.successCalls).toEqual(["sch_tick"]);
+  }, 30_000);
+
+  it("records the 'run X ended failed' verdict on a FAILED phase", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    script.pollResults = [PHASE_FAILED];
+
+    await runTick();
+    expect(script.failureCalls).toEqual([
+      {
+        scheduleId: "sch_tick",
+        reason: "run aex_tick ended failed",
+        kind: FAILURE_RUN_FAILED,
+      },
+    ]);
+    expect(script.successCalls).toEqual([]);
+  }, 30_000);
+
+  it("GONE yields no verdict (a deleted run must not brick its schedule)", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    script.pollResults = [PHASE_GONE];
+
+    await runTick();
+    expect(script.successCalls).toEqual([]);
+    expect(script.failureCalls).toEqual([]);
+  }, 30_000);
+
+  it("budget exhaustion records RUN_TIMED_OUT with the byte-pinned reason (run NOT cancelled)", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    // A zero-minute budget: the deadline passes after the first RUNNING
+    // poll (the poll-first loop never sleeps past its own deadline).
+    script.runStart = {
+      outcome: RUN_STARTED,
+      executionId: "aex_tick",
+      trackingTimeoutMinutes: 0,
+      failureReason: "",
+    };
+    script.pollResults = [PHASE_RUNNING];
+
+    await runTick();
+    expect(script.pollCount).toBe(1);
+    expect(script.failureCalls).toEqual([
+      {
+        scheduleId: "sch_tick",
+        reason: "run aex_tick did not finish within 0 minutes",
+        kind: FAILURE_RUN_TIMED_OUT,
+      },
+    ]);
+  }, 30_000);
+
+  it("a poll failure past retries fails the tick with NO verdict", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    script.pollError = "db unreachable";
+
+    await expect(runTick()).rejects.toThrow();
+    expect(script.successCalls).toEqual([]);
+    expect(script.failureCalls).toEqual([]);
+  }, 30_000);
+
+  it("a record-tick failure fails the tick before any run start", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    script.tickError = "row unreadable";
+
+    await expect(runTick()).rejects.toThrow();
+    expect(script.pollCount).toBe(0);
+    expect(script.failureCalls).toEqual([]);
+  }, 30_000);
+
+  it("derives the nominal fire time from the workflow-id suffix (tier 2)", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    script.tickOutcome = TICK_SKIPPED_DISABLED;
+
+    await runTick({ workflowId: "schedule/tick/sch_tick-2026-08-25T09:30:00Z" });
+    expect(script.recordTickArgs[0]?.nominal).toBe("2026-08-25T09:30:00Z");
+  }, 30_000);
+
+  it("falls back to workflow time truncated to whole seconds (tier 3)", async (testCtx) => {
+    if (!envReady) return testCtx.skip();
+    script.tickOutcome = TICK_SKIPPED_DISABLED;
+
+    await runTick();
+    const nominal = script.recordTickArgs[0]?.nominal ?? "";
+    // RFC-3339, whole seconds, UTC — the fire-identity format.
+    expect(nominal).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+  }, 30_000);
+});
+
+describe("tick loop bounds (plain unit)", () => {
+  it("pins MAX_TRACKING_CYCLES at 240 (the recorded-history backstop)", () => {
+    expect(MAX_TRACKING_CYCLES).toBe(240);
+  });
+});

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/activities.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/activities.ts
@@ -1,0 +1,544 @@
+/**
+ * The tick workflow's activity surface — ports
+ * pkg/domain/schedule/temporal/tick_activities.go. Nominal fire times
+ * cross the boundary as RFC-3339 UTC strings so the payload never depends
+ * on the data converter's time handling — the same wire shape the cloud
+ * tick uses.
+ *
+ * Registered by the schedule worker under the pinned slash names
+ * (names.ts); the retry postures live with the CALLER (workflows/tick.ts's
+ * three activity-option contexts), most critically record-failure's
+ * single attempt — the streak increment is the clock's one non-idempotent
+ * write.
+ */
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+import type { ScheduleTemporalConfig } from "./config.js";
+import {
+  FAILURE_RUN_FAILED,
+  FAILURE_RUN_TIMED_OUT,
+  FAILURE_START_FAILED,
+  PHASE_CANCELLED,
+  PHASE_COMPLETED,
+  PHASE_FAILED,
+  PHASE_GONE,
+  PHASE_RUNNING,
+  PHASE_TERMINATED,
+  RECORD_FAILED_RUN_ACTIVITY_NAME,
+  RECORD_SUCCESSFUL_RUN_ACTIVITY_NAME,
+  RECORD_TICK_ACTIVITY_NAME,
+  POLL_EXECUTION_PHASE_ACTIVITY_NAME,
+  RUN_ALREADY_STARTED,
+  RUN_REFUSED,
+  RUN_SKIPPED,
+  RUN_STARTED,
+  RUN_TARGET_MISSING,
+  START_SCHEDULED_RUN_ACTIVITY_NAME,
+  TICK_FIRED,
+  TICK_SKIPPED_AUTO_PAUSED,
+  TICK_SKIPPED_DELETED,
+  TICK_SKIPPED_DISABLED,
+  type FailureKind,
+  type FailureRecorded,
+  type RunPhase,
+  type RunStart,
+  type ScheduleTickActivities,
+  type TickOutcome,
+} from "./names.js";
+import {
+  RUN_LEDGER_ORIGIN_CRON,
+  RUN_LEDGER_OUTCOME_COMPLETED,
+  RUN_LEDGER_OUTCOME_FAILED,
+  RUN_LEDGER_OUTCOME_TIMED_OUT,
+  recordRunLedgerStart,
+  recordRunLedgerVerdict,
+} from "./run-ledger.js";
+import type { RunStarter } from "./run-starter.js";
+import type { ScheduleSyncer } from "./syncer.js";
+import { bumpStatusAudit, ensureStatus } from "./status-writes.js";
+
+export interface ScheduleTickActivityDeps {
+  readonly store: Store;
+  readonly config: ScheduleTemporalConfig;
+  /**
+   * The narrow syncer slice the activities call (satisfied by
+   * ScheduleSyncer): the next-fire refresh on record-tick and the
+   * best-effort artifact re-sync at the pause-threshold crossing.
+   */
+  readonly syncer: Pick<ScheduleSyncer, "peekNextFireAt" | "ensureAndRecord">;
+  /** The fire edge (satisfied by RunStarter). */
+  readonly runStarter: Pick<RunStarter, "startRun">;
+  readonly logger: Logger;
+}
+
+/** Wires the activity implementations (Go NewTickActivities). */
+export function createScheduleTickActivities(
+  deps: ScheduleTickActivityDeps,
+): ScheduleTickActivities {
+  return {
+    [RECORD_TICK_ACTIVITY_NAME]: (scheduleResourceId, nominalFireTimeRfc3339) =>
+      recordTick(deps, scheduleResourceId, nominalFireTimeRfc3339),
+    [START_SCHEDULED_RUN_ACTIVITY_NAME]: (
+      scheduleResourceId,
+      nominalFireTimeRfc3339,
+    ) => startScheduledRun(deps, scheduleResourceId, nominalFireTimeRfc3339),
+    [POLL_EXECUTION_PHASE_ACTIVITY_NAME]: (executionId) =>
+      pollExecutionPhase(deps, executionId),
+    [RECORD_SUCCESSFUL_RUN_ACTIVITY_NAME]: (scheduleResourceId) =>
+      recordSuccessfulRun(deps, scheduleResourceId),
+    [RECORD_FAILED_RUN_ACTIVITY_NAME]: (scheduleResourceId, reason, kind) =>
+      recordFailedRun(deps, scheduleResourceId, reason, kind),
+  };
+}
+
+/**
+ * Re-reads the schedule row and either records the fire or explains why
+ * this tick is a no-op — the revalidation that makes every orphaned
+ * artifact harmless by construction (DD-008 D2): deleted, owner-disabled,
+ * and platform-paused rows all decline the fire (Go RecordTick).
+ */
+async function recordTick(
+  deps: ScheduleTickActivityDeps,
+  scheduleResourceId: string,
+  nominalFireTimeRfc3339: string,
+): Promise<TickOutcome> {
+  let schedule: Schedule;
+  try {
+    schedule = await deps.store.getResource(
+      ApiResourceKind.schedule,
+      scheduleResourceId,
+      ScheduleSchema,
+    );
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      deps.logger.info(
+        "Schedule tick no-op — row deleted (orphaned artifact; the reconciliation pass removes it)",
+        { schedule_id: scheduleResourceId },
+      );
+      return TICK_SKIPPED_DELETED;
+    }
+    throw new Error(`load schedule ${scheduleResourceId}: ${message(error)}`, {
+      cause: error,
+    });
+  }
+  if (!(schedule.spec?.enabled ?? false)) {
+    deps.logger.info("Schedule tick no-op — owner-disabled", {
+      schedule_id: scheduleResourceId,
+    });
+    return TICK_SKIPPED_DISABLED;
+  }
+  const pausedReason = schedule.status?.pausedReason ?? "";
+  if (pausedReason !== "") {
+    deps.logger.info("Schedule tick no-op — platform-paused", {
+      schedule_id: scheduleResourceId,
+      reason: pausedReason,
+    });
+    return TICK_SKIPPED_AUTO_PAUSED;
+  }
+
+  await recordFire(deps, schedule, nominalFireTimeRfc3339);
+  return TICK_FIRED;
+}
+
+/**
+ * Stamps the fire on status: last_fire_at = the NOMINAL time (identical on
+ * activity retry — idempotent by construction), plus a best-effort
+ * next_fire_at refresh from the live artifact. The refresh failing must
+ * never block recording the fire that already happened (Go recordFire).
+ */
+async function recordFire(
+  deps: ScheduleTickActivityDeps,
+  schedule: Schedule,
+  nominalFireTimeRfc3339: string,
+): Promise<void> {
+  const nominal = parseRfc3339(nominalFireTimeRfc3339);
+
+  let nextFireAt: Date | undefined;
+  let peekFailed = false;
+  try {
+    nextFireAt = await deps.syncer.peekNextFireAt(schedule);
+  } catch (error) {
+    peekFailed = true;
+    deps.logger.warn(
+      "Could not refresh next_fire_at during tick (recording the fire without it)",
+      {
+        schedule_id: schedule.metadata?.id ?? "",
+        error: message(error),
+      },
+    );
+  }
+
+  try {
+    await deps.store.updateResource(
+      ApiResourceKind.schedule,
+      schedule.metadata?.id ?? "",
+      ScheduleSchema,
+      (live) => {
+        const status = ensureStatus(live);
+        status.lastFireAt = timestampFromDate(nominal);
+        if (!peekFailed) {
+          status.nextFireAt =
+            nextFireAt === undefined ? undefined : timestampFromDate(nextFireAt);
+        }
+        bumpStatusAudit(status);
+      },
+    );
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      // Deleted between revalidation and the write: nothing to record.
+      return;
+    }
+    throw new Error(`record schedule fire on status: ${message(error)}`, {
+      cause: error,
+    });
+  }
+  deps.logger.info("Schedule fire recorded", {
+    schedule_id: schedule.metadata?.id ?? "",
+    nominal_fire_time: nominalFireTimeRfc3339,
+  });
+}
+
+/**
+ * Re-validates and starts this fire's run. The revalidation repeats
+ * recordTick's checks collapsed into one SKIPPED outcome — the row may
+ * have changed between the two activities, and a fire that recorded must
+ * still decline to run against a row that no longer wants it (Go
+ * StartScheduledRun).
+ */
+async function startScheduledRun(
+  deps: ScheduleTickActivityDeps,
+  scheduleResourceId: string,
+  nominalFireTimeRfc3339: string,
+): Promise<RunStart> {
+  const trackingBudget = deps.config.resolvedRunTrackingTimeoutMinutes();
+
+  let schedule: Schedule | undefined;
+  try {
+    schedule = await deps.store.getResource(
+      ApiResourceKind.schedule,
+      scheduleResourceId,
+      ScheduleSchema,
+    );
+  } catch (error) {
+    if (!(error instanceof ResourceNotFoundError)) {
+      throw new Error(
+        `load schedule ${scheduleResourceId}: ${message(error)}`,
+        { cause: error },
+      );
+    }
+    schedule = undefined;
+  }
+  if (
+    schedule === undefined ||
+    !(schedule.spec?.enabled ?? false) ||
+    (schedule.status?.pausedReason ?? "") !== ""
+  ) {
+    deps.logger.info(
+      "Schedule run start no-op — row deleted/disabled/paused between record and start",
+      { schedule_id: scheduleResourceId },
+    );
+    const skipped: RunStart = {
+      outcome: RUN_SKIPPED,
+      executionId: "",
+      trackingTimeoutMinutes: trackingBudget,
+      failureReason: "",
+    };
+    // The deleted-row skip deliberately leaves NO ledger row: the delete
+    // already cascaded the schedule's history, and a bookkeeping write here
+    // would resurrect it.
+    if (schedule !== undefined) {
+      await recordRunLedgerStart(
+        deps.store,
+        deps.logger,
+        scheduleResourceId,
+        schedule.metadata?.org ?? "",
+        nominalFireTimeRfc3339,
+        RUN_LEDGER_ORIGIN_CRON,
+        skipped,
+      );
+    }
+    return skipped;
+  }
+
+  const nominal = parseRfc3339(nominalFireTimeRfc3339);
+
+  // Infrastructure failures throw: the activity retries, and the
+  // deterministic execution name absorbs the retry.
+  const outcome = await deps.runStarter.startRun(schedule, nominal);
+
+  const result: RunStart = {
+    outcome: RUN_STARTED,
+    executionId: "",
+    trackingTimeoutMinutes: trackingBudget,
+    failureReason: "",
+  };
+  switch (outcome.kind) {
+    case "started":
+      result.outcome = outcome.alreadyExisted ? RUN_ALREADY_STARTED : RUN_STARTED;
+      result.executionId = outcome.executionId;
+      deps.logger.info("Schedule fire started its run", {
+        schedule_id: scheduleResourceId,
+        execution_id: outcome.executionId,
+        already_existed: outcome.alreadyExisted,
+      });
+      break;
+    case "targetMissing":
+      result.outcome = RUN_TARGET_MISSING;
+      result.failureReason = outcome.reason;
+      break;
+    case "refused":
+      result.outcome = RUN_REFUSED;
+      result.failureReason = `run refused: ${outcome.reason}`;
+      break;
+    default: {
+      const exhaustive: never = outcome;
+      throw new Error(`unknown run outcome ${String(exhaustive)}`);
+    }
+  }
+  // The fire ledger (DD-017 D-7): start failures are terminal at insert —
+  // the refusal reason must survive NOW, not at the pause threshold.
+  await recordRunLedgerStart(
+    deps.store,
+    deps.logger,
+    scheduleResourceId,
+    schedule.metadata?.org ?? "",
+    nominalFireTimeRfc3339,
+    RUN_LEDGER_ORIGIN_CRON,
+    result,
+  );
+  return result;
+}
+
+/**
+ * Classifies the tracked run's current phase from one row read. GONE (row
+ * deleted mid-track) is distinct from RUNNING: a deleted run must not
+ * brick its schedule, so it yields no verdict.
+ *
+ * The read unmarshals the whole execution row — SQLite stores one protobuf
+ * blob with no projection (DD-015 D-E). At one poll per 5-60s per active
+ * run on a single-user daemon that is noise; a projected phase column is
+ * the named follow-up if it ever isn't (Go PollExecutionPhase).
+ */
+async function pollExecutionPhase(
+  deps: ScheduleTickActivityDeps,
+  executionId: string,
+): Promise<RunPhase> {
+  let phase: ExecutionPhase;
+  try {
+    const execution = await deps.store.getResource(
+      ApiResourceKind.agent_execution,
+      executionId,
+      AgentExecutionSchema,
+    );
+    phase = execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      return PHASE_GONE;
+    }
+    throw new Error(`load execution ${executionId}: ${message(error)}`, {
+      cause: error,
+    });
+  }
+
+  switch (phase) {
+    case ExecutionPhase.EXECUTION_COMPLETED:
+      return PHASE_COMPLETED;
+    case ExecutionPhase.EXECUTION_CANCELLED:
+      return PHASE_CANCELLED;
+    case ExecutionPhase.EXECUTION_TERMINATED:
+      return PHASE_TERMINATED;
+    case ExecutionPhase.EXECUTION_FAILED:
+      return PHASE_FAILED;
+    default:
+      // PENDING, IN_PROGRESS, WAITING_FOR_APPROVAL, PAUSED, and any future
+      // non-terminal phase: still running.
+      return PHASE_RUNNING;
+  }
+}
+
+/**
+ * Resets the failure streak to its absorbing zero. Idempotent — the caller
+ * retries freely: a LOST reset strands a stale streak that pauses a
+ * healthy schedule later, so this write must land (Go RecordSuccessfulRun).
+ */
+async function recordSuccessfulRun(
+  deps: ScheduleTickActivityDeps,
+  scheduleResourceId: string,
+): Promise<void> {
+  try {
+    await deps.store.updateResource(
+      ApiResourceKind.schedule,
+      scheduleResourceId,
+      ScheduleSchema,
+      (live) => {
+        const status = ensureStatus(live);
+        status.consecutiveFailures = 0;
+        bumpStatusAudit(status);
+      },
+    );
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      return; // deleted mid-track: nothing to reset
+    }
+    throw new Error(
+      `reset failure streak on schedule ${scheduleResourceId}: ${message(error)}`,
+      { cause: error },
+    );
+  }
+  await recordRunLedgerVerdict(
+    deps.store,
+    deps.logger,
+    scheduleResourceId,
+    RUN_LEDGER_OUTCOME_COMPLETED,
+    "",
+  );
+  deps.logger.info("Schedule run completed — failure streak reset", {
+    schedule_id: scheduleResourceId,
+  });
+}
+
+/**
+ * Increments the failure streak and, exactly at the threshold crossing,
+ * latches the platform pause. The whole verdict is ONE updateResource
+ * closure on the freshly-read row — the OSS shape of the cloud's single
+ * guarded SQL statement (DD-015 D-C): the increment reads the live value
+ * inside the lock, the pause is written only at the crossing and only when
+ * no reason is already latched (the first pause's copy is never
+ * rewritten), and next_fire_at clears so the schedule advertises no fire
+ * it will decline.
+ *
+ * The caller gives this activity EXACTLY ONE attempt: an increment is not
+ * idempotent — a retry after a successful write over-counts and pauses a
+ * healthy schedule early, while a lost write under-counts and fails safe
+ * (Go RecordFailedRun).
+ */
+async function recordFailedRun(
+  deps: ScheduleTickActivityDeps,
+  scheduleResourceId: string,
+  reason: string,
+  kind: FailureKind,
+): Promise<FailureRecorded> {
+  const threshold = deps.config.resolvedMaxConsecutiveFailures();
+  const pausedReason = `Paused after ${threshold} consecutive failed runs. Last failure: ${reason}`;
+
+  let recorded: FailureRecorded = { consecutiveFailures: 0, paused: false };
+  let crossedThreshold = false;
+  try {
+    await deps.store.updateResource(
+      ApiResourceKind.schedule,
+      scheduleResourceId,
+      ScheduleSchema,
+      (live) => {
+        const status = ensureStatus(live);
+        status.consecutiveFailures++;
+        if (status.consecutiveFailures >= threshold && status.pausedReason === "") {
+          status.pausedReason = pausedReason;
+          crossedThreshold = true;
+        }
+        if (status.consecutiveFailures >= threshold) {
+          status.nextFireAt = undefined;
+        }
+        bumpStatusAudit(status);
+        recorded = {
+          consecutiveFailures: status.consecutiveFailures,
+          paused: status.pausedReason !== "",
+        };
+      },
+    );
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      // Deleted mid-track: a no-op by construction — deleting a run or its
+      // schedule must never resurrect either.
+      deps.logger.info(
+        "Schedule run failure not recorded — row deleted mid-track",
+        { schedule_id: scheduleResourceId, reason },
+      );
+      return { consecutiveFailures: 0, paused: false };
+    }
+    throw new Error(
+      `record failed run on schedule ${scheduleResourceId}: ${message(error)}`,
+      { cause: error },
+    );
+  }
+
+  deps.logger.warn("Schedule run failed", {
+    failure_kind: kind,
+    schedule_id: scheduleResourceId,
+    consecutive_failures: recorded.consecutiveFailures,
+    threshold,
+    paused: recorded.paused,
+    reason,
+  });
+
+  // The fire ledger's terminal verdict. START_FAILED rows were already
+  // written terminal by the start activity — only tracked-run verdicts
+  // mark here.
+  switch (kind) {
+    case FAILURE_RUN_FAILED:
+      await recordRunLedgerVerdict(
+        deps.store,
+        deps.logger,
+        scheduleResourceId,
+        RUN_LEDGER_OUTCOME_FAILED,
+        reason,
+      );
+      break;
+    case FAILURE_RUN_TIMED_OUT:
+      await recordRunLedgerVerdict(
+        deps.store,
+        deps.logger,
+        scheduleResourceId,
+        RUN_LEDGER_OUTCOME_TIMED_OUT,
+        reason,
+      );
+      break;
+    case FAILURE_START_FAILED:
+      // Terminal at insert (recordRunLedgerStart) — nothing to mark.
+      break;
+    default: {
+      const exhaustive: never = kind;
+      throw new Error(`unknown failure kind ${String(exhaustive)}`);
+    }
+  }
+
+  if (crossedThreshold) {
+    // Best-effort immediate artifact re-sync so the pause reaches Temporal
+    // now; the reconciliation pass is the correctness path.
+    try {
+      const schedule = await deps.store.getResource(
+        ApiResourceKind.schedule,
+        scheduleResourceId,
+        ScheduleSchema,
+      );
+      await deps.syncer.ensureAndRecord(schedule);
+    } catch (error) {
+      deps.logger.error(
+        "Paused schedule's artifact not yet converged (the reconciliation pass will pause it)",
+        { schedule_id: scheduleResourceId, error: message(error) },
+      );
+    }
+  }
+  return recorded;
+}
+
+/** Go time.Parse(time.RFC3339) — an unparseable nominal time fails the activity. */
+function parseRfc3339(value: string): Date {
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`parse nominal fire time "${value}": invalid RFC-3339`);
+  }
+  return parsed;
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/artifact.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/artifact.ts
@@ -1,0 +1,137 @@
+/**
+ * The ONE resource-to-Temporal mapping — ports
+ * pkg/domain/schedule/temporal/artifact.go (the cloud ScheduleArtifact's
+ * twin). Whatever this writes is final for every artifact it creates,
+ * because the baked action is invisible to Temporal's schedule listing and
+ * cannot be repaired by the reconciliation sweep.
+ *
+ * Pinned policy, identical to cloud (Go CreateOptions):
+ *   - Overlap SKIP is explicit: since a tick SPANS its run (tracking),
+ *     SKIP genuinely means "never start a run while the last is active".
+ *   - PauseOnFailure stays false: Temporal must never pause behind the
+ *     platform's back, or the artifact would oscillate against the
+ *     reconciliation pass (which converges paused-state from the row).
+ *   - The action carries exactly ONE argument — the schedule resource id.
+ *     The nominal fire time cannot ride here (Temporal bakes action args
+ *     once and replays them verbatim per fire); the tick derives it from
+ *     the fire itself.
+ */
+import {
+  ScheduleOverlapPolicy,
+  type ScheduleDescription,
+  type ScheduleOptions,
+  type ScheduleOptionsAction,
+  type ScheduleUpdateOptions,
+  type ScheduleOptionsStartWorkflowAction,
+} from "@temporalio/client";
+import type { Workflow } from "@temporalio/common";
+
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+
+import type { ScheduleTemporalConfig } from "./config.js";
+import { TICK_WORKFLOW_TYPE, artifactId } from "./names.js";
+
+/**
+ * The drift fingerprint written into the artifact's state note. Cron
+ * itself does NOT round-trip (the Temporal server compiles it into
+ * calendar specs and describes cronExpressions as empty), so the note is
+ * the only way the reconciliation pass can detect a spec change (Go Note).
+ */
+export function note(schedule: Schedule): string {
+  return `cron=${specOf(schedule).cron} tz=${specOf(schedule).timeZone}`;
+}
+
+/**
+ * The artifact must be paused when the owner disabled the schedule
+ * (spec.enabled=false) OR the platform latched it (status.paused_reason) —
+ * two levers, one artifact state (Go DesiredPaused).
+ */
+export function desiredPaused(schedule: Schedule): boolean {
+  return !specOf(schedule).enabled || (schedule.status?.pausedReason ?? "") !== "";
+}
+
+function specOf(schedule: Schedule): { cron: string; timeZone: string; enabled: boolean } {
+  return {
+    cron: schedule.spec?.cron ?? "",
+    timeZone: schedule.spec?.timeZone ?? "",
+    enabled: schedule.spec?.enabled ?? false,
+  };
+}
+
+export class ScheduleArtifact {
+  constructor(private readonly config: ScheduleTemporalConfig) {}
+
+  /** Builds the complete desired artifact for create (Go CreateOptions). */
+  createOptions(schedule: Schedule): ScheduleOptions {
+    const resourceId = schedule.metadata?.id ?? "";
+    return {
+      scheduleId: artifactId(resourceId),
+      spec: {
+        cronExpressions: [specOf(schedule).cron],
+        timezone: specOf(schedule).timeZone,
+      },
+      action: this.tickAction(resourceId),
+      policies: {
+        overlap: ScheduleOverlapPolicy.SKIP,
+        catchupWindow: this.config.catchupWindowMinutes * 60_000,
+        pauseOnFailure: false,
+      },
+      state: {
+        paused: desiredPaused(schedule),
+        note: note(schedule),
+      },
+    };
+  }
+
+  /**
+   * Rewrites a described artifact to the resource's complete desired
+   * state — the update half of ensure's create-or-update (Go
+   * ApplyDesiredState). A lost race between two writers is benign: both
+   * write the same desired state.
+   *
+   * The ACTION is deliberately rewritten too, even though drift detection
+   * cannot see it (invisible to describe-level diffing): on the update
+   * path rewriting it is free and self-heals a hand-edited artifact.
+   */
+  applyDesiredState(
+    previous: ScheduleDescription,
+    schedule: Schedule,
+  ): ScheduleUpdateOptions<ScheduleOptionsStartWorkflowAction<Workflow>> {
+    const resourceId = schedule.metadata?.id ?? "";
+    return {
+      spec: {
+        cronExpressions: [specOf(schedule).cron],
+        timezone: specOf(schedule).timeZone,
+      },
+      action: this.tickAction(resourceId),
+      policies: {
+        overlap: ScheduleOverlapPolicy.SKIP,
+        catchupWindow: this.config.catchupWindowMinutes * 60_000,
+        pauseOnFailure: false,
+      },
+      state: {
+        ...previous.state,
+        paused: desiredPaused(schedule),
+        note: note(schedule),
+      },
+    };
+  }
+
+  /**
+   * Bakes the tick workflow start: workflow id = artifact id (Temporal
+   * appends the nominal fire time per fire — the tick's second-tier
+   * nominal-time derivation), the schedule's own queue, and the 24h
+   * run-timeout backstop. Retry deliberately stays at the workflow default
+   * (none): a failed tick is a missed fire, not a hot loop (Go tickAction).
+   */
+  private tickAction(resourceId: string): ScheduleOptionsAction {
+    return {
+      type: "startWorkflow",
+      workflowId: artifactId(resourceId),
+      workflowType: TICK_WORKFLOW_TYPE,
+      args: [resourceId],
+      taskQueue: this.config.stigmerQueue,
+      workflowRunTimeout: this.config.tickRunTimeoutHours * 3_600_000,
+    };
+  }
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/config.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/config.ts
@@ -108,6 +108,20 @@ export class ScheduleTemporalConfig {
   resolvedRunHistoryRetentionDays(): number {
     return this.runHistoryRetentionDays < 1 ? 1 : this.runHistoryRetentionDays;
   }
+
+  /**
+   * Floors the periodic-pass cadence at 1 minute. Go has no clamp here and
+   * time.NewTicker(0) PANICS the process; a zero interval through
+   * setInterval would instead hot-loop full-table reconciliation passes
+   * silently — the worse failure mode. The floor follows this file's
+   * sibling clamps and is a disclosed divergence (crash → clamp) on a
+   * misconfiguration no healthy deployment carries.
+   */
+  resolvedReconciliationIntervalMinutes(): number {
+    return this.reconciliationIntervalMinutes < 1
+      ? 1
+      : this.reconciliationIntervalMinutes;
+  }
 }
 
 /** Loads configuration from environment variables (Go LoadConfig). */

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/config.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/config.ts
@@ -1,0 +1,172 @@
+/**
+ * Schedule-clock configuration — ports
+ * pkg/domain/schedule/temporal/config.go.
+ *
+ * Environment variables deliberately share the STIGMER_SCHEDULES_* names
+ * with the cloud edition, so test harnesses and runbooks use one
+ * vocabulary. There is deliberately NO interval-floor knob: the floor is a
+ * platform guardrail for a shared metered system, enforced by cloud's
+ * pre-persist probe; OSS is one user on their own machine and has no probe
+ * (DD-015 D-A) — a present-but-ignored knob would be a lie.
+ *
+ * Config lives with the clock, not the domain (sub-project decision 1,
+ * owner-ratified): every reader is clock-side — the agentexecution
+ * precedent of a domain-local config was driven by a domain-step consumer
+ * (oss#397) that schedule does not have.
+ */
+
+export class ScheduleTemporalConfig {
+  constructor(
+    /**
+     * Task queue for the tick workflow and its activities. Dedicated (not
+     * the agent-execution queue) so a spanning tick can never starve agent
+     * executions. Default: schedule_stigmer.
+     */
+    readonly stigmerQueue: string,
+    /**
+     * Baked into every artifact's policy: how far back Temporal fires
+     * missed ticks after downtime (the laptop that slept through 9am).
+     * Default: 60.
+     */
+    readonly catchupWindowMinutes: number,
+    /**
+     * The artifact's baked workflow run timeout — a backstop, not policy
+     * (the tracking budget is the policy). Default: 24.
+     */
+    readonly tickRunTimeoutHours: number,
+    /** The auto-pause threshold (DD-008 D7). Default: 5. */
+    readonly maxConsecutiveFailures: number,
+    /**
+     * One fire's tracking budget — under overlap SKIP, literally the
+     * maximum time one hung run may silence a schedule. Clamped at fire
+     * time (resolvedRunTrackingTimeoutMinutes). Default: 60.
+     */
+    readonly runTrackingTimeoutMinutes: number,
+    /**
+     * Gates the periodic convergence pass (the reconnect-triggered pass
+     * always runs — it is correctness, not hygiene, on an ephemeral dev
+     * server). Default: true.
+     */
+    readonly reconciliationEnabled: boolean,
+    /** The periodic pass cadence. Default: 5. */
+    readonly reconciliationIntervalMinutes: number,
+    /**
+     * Bounds each scheduled run's tool rounds (0 disables the bound). An
+     * unattended runaway burns the user's own API budget with nobody
+     * watching — worse than an interactive one. Default: 20 (the cloud
+     * profile's value).
+     */
+    readonly executionProfileMaxToolRounds: number,
+    /**
+     * Bounds each scheduled run's spend, enforced by the shared runner
+     * (0 disables). Default: 1.00.
+     */
+    readonly executionProfileMaxCostUsd: number,
+    /**
+     * Bounds the fire ledger (DD-017 D-7): rows recorded earlier than this
+     * are pruned by the reconciliation pass. Default: 90 (a quarter of
+     * monthly reminder cycles — run history is a product surface, not
+     * delivery plumbing).
+     */
+    readonly runHistoryRetentionDays: number,
+  ) {}
+
+  /**
+   * Clamps the tracking budget to at least 1 minute and at least one hour
+   * inside the baked artifact run timeout — the cloud edition's exact
+   * clamp, so a misconfigured budget cannot outlive the tick that carries
+   * it (Go ResolvedRunTrackingTimeoutMinutes).
+   */
+  resolvedRunTrackingTimeoutMinutes(): number {
+    let ceiling = (this.tickRunTimeoutHours - 1) * 60;
+    if (ceiling < 1) {
+      ceiling = 1;
+    }
+    let resolved = this.runTrackingTimeoutMinutes;
+    if (resolved > ceiling) {
+      resolved = ceiling;
+    }
+    if (resolved < 1) {
+      resolved = 1;
+    }
+    return resolved;
+  }
+
+  /**
+   * Floors the pause threshold at 1 — a zero/negative threshold would
+   * pause on configuration, not on failure (Go
+   * ResolvedMaxConsecutiveFailures).
+   */
+  resolvedMaxConsecutiveFailures(): number {
+    return this.maxConsecutiveFailures < 1 ? 1 : this.maxConsecutiveFailures;
+  }
+
+  /**
+   * Floors the fire-ledger retention at 1 day — zero/negative would prune
+   * history as it lands (Go ResolvedRunHistoryRetentionDays).
+   */
+  resolvedRunHistoryRetentionDays(): number {
+    return this.runHistoryRetentionDays < 1 ? 1 : this.runHistoryRetentionDays;
+  }
+}
+
+/** Loads configuration from environment variables (Go LoadConfig). */
+export function newScheduleConfigFromEnv(): ScheduleTemporalConfig {
+  return new ScheduleTemporalConfig(
+    getEnv("TEMPORAL_SCHEDULE_STIGMER_TASK_QUEUE", "schedule_stigmer"),
+    getEnvInt("STIGMER_SCHEDULES_CATCHUP_WINDOW_MINUTES", 60),
+    getEnvInt("STIGMER_SCHEDULES_TICK_RUN_TIMEOUT_HOURS", 24),
+    getEnvInt("STIGMER_SCHEDULES_MAX_CONSECUTIVE_FAILURES", 5),
+    getEnvInt("STIGMER_SCHEDULES_RUN_TRACKING_TIMEOUT_MINUTES", 60),
+    getEnvBool("STIGMER_SCHEDULES_RECONCILIATION_ENABLED", true),
+    getEnvInt("STIGMER_SCHEDULES_RECONCILIATION_INTERVAL_MINUTES", 5),
+    getEnvInt("STIGMER_SCHEDULES_EXECUTION_PROFILE_MAX_TOOL_ROUNDS", 20),
+    getEnvFloat("STIGMER_SCHEDULES_EXECUTION_PROFILE_MAX_COST_USD", 1.0),
+    getEnvInt("STIGMER_SCHEDULES_RUN_HISTORY_RETENTION_DAYS", 90),
+  );
+}
+
+function getEnv(key: string, defaultValue: string): string {
+  const value = process.env[key];
+  return value !== undefined && value !== "" ? value : defaultValue;
+}
+
+/**
+ * Go strconv.Atoi parity: only a plain (optionally signed) integer parses;
+ * anything else silently keeps the default, exactly Go's getEnvInt.
+ */
+function getEnvInt(key: string, defaultValue: number): number {
+  const value = process.env[key];
+  if (value === undefined || value === "" || !/^[+-]?\d+$/.test(value)) {
+    return defaultValue;
+  }
+  return Number.parseInt(value, 10);
+}
+
+/**
+ * Go strconv.ParseBool parity: exactly 1/t/T/TRUE/true/True and the 0/f
+ * family parse; anything else keeps the default.
+ */
+function getEnvBool(key: string, defaultValue: boolean): boolean {
+  const value = process.env[key];
+  if (value === undefined || value === "") {
+    return defaultValue;
+  }
+  if (["1", "t", "T", "TRUE", "true", "True"].includes(value)) {
+    return true;
+  }
+  if (["0", "f", "F", "FALSE", "false", "False"].includes(value)) {
+    return false;
+  }
+  return defaultValue;
+}
+
+/** Go strconv.ParseFloat parity: a finite float parses, else the default. */
+function getEnvFloat(key: string, defaultValue: number): number {
+  const value = process.env[key];
+  if (value === undefined || value === "") {
+    return defaultValue;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : defaultValue;
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/model-pinning.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/model-pinning.ts
@@ -1,0 +1,47 @@
+/**
+ * The unattended model-pinning rule — ports
+ * pkg/domain/schedule/temporal/modelpinning.go (stigmer/stigmer#362).
+ *
+ * A schedule whose fires would run the CURSOR harness must pin a model: an
+ * empty model there selects Auto, whose price variant follows the provider
+ * ACCOUNT's out-of-band default speed setting — nobody at a 3 AM fire is
+ * watching a rate change. The native harness is exempt on purpose: an
+ * empty model resolves to the platform's own registry-priced default at an
+ * explicitly requested tier — deterministic, nothing to pin.
+ *
+ * Only an EXPLICIT cursor harness trips the rule in this edition: an unset
+ * harness resolves to the OSS platform default (native), so there is no
+ * cursor path to guard. The cloud edition additionally judges its
+ * configured default harness (cursor there) — same contract, each
+ * edition's own default-harness truth (the DD-015 divergence posture).
+ *
+ * Evaluated at write time (the controller's model-pinning validator
+ * delegates here) AND as the run starter's launch backstop, so rows
+ * written before the rule existed refuse at fire time instead of running
+ * mispriced. Pure module (no node built-ins): the domain validator imports
+ * it across the domain→clock boundary, exactly Go's controller →
+ * scheduletemporal edge.
+ */
+import type { ScheduleSpec } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/spec_pb";
+import { Harness } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+
+/**
+ * Returns the refusal copy, or "" when the fire is allowed (Go
+ * ScheduleModelPinningRefusal — the copy is cross-edition byte contract).
+ */
+export function scheduleModelPinningRefusal(
+  spec: ScheduleSpec | undefined,
+): string {
+  const agent = spec?.target.case === "agent" ? spec.target.value : undefined;
+  if (agent?.harness !== Harness.CURSOR) {
+    return "";
+  }
+  if ((agent.runConfig?.modelName ?? "").trim() !== "") {
+    return "";
+  }
+  return (
+    "spec.agent.run_config.model_name must name a pinned model when the run would use " +
+    "the Cursor harness — with no pinned model Cursor runs Auto, whose price variant " +
+    "follows the provider account's out-of-band default speed setting (stigmer/stigmer#362)"
+  );
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/names.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/names.ts
@@ -1,0 +1,168 @@
+/**
+ * Schedule-clock Temporal wire identifiers and the tick's outcome
+ * vocabulary — ports the constants of pkg/domain/schedule/temporal
+ * (artifact.go, tick_activities.go).
+ *
+ * Every value here is a byte-pinned cross-repo wire constant: the cloud
+ * Java ScheduleArtifact, the integration harness's ScheduleInspector, and
+ * both server editions address artifacts, workflows, and activities by
+ * these exact strings — changing one on any side strands every existing
+ * artifact. The outcome vocabulary rides Temporal's JSON data converter
+ * into recorded histories, so the STRING VALUES and the RunStart /
+ * FailureRecorded FIELD NAMES are replay contract too.
+ *
+ * Imported by BOTH the workflow bundle and host code — no node built-ins,
+ * no framework imports (the workflow-bundle import discipline).
+ */
+
+/**
+ * The tick workflow's registered type and the artifact-id prefix's stem
+ * (Go TickWorkflowType). The artifact's baked action starts this exact
+ * type name — a rename would fail every fire with "workflow type not
+ * found".
+ */
+export const TICK_WORKFLOW_TYPE = "schedule/tick";
+
+/**
+ * Prefixes each Schedule resource's Temporal Schedule artifact id:
+ * schedule/tick/{scheduleResourceId} (Go TickIDPrefix).
+ */
+export const TICK_ID_PREFIX = `${TICK_WORKFLOW_TYPE}/`;
+
+/**
+ * The cloud write-path's throwaway fire-time probes (Go probeIDPrefix).
+ * OSS never creates probes (no pre-persist probe — DD-015 D-A), but the
+ * reconciler skips the prefix defensively so a shared/dev namespace never
+ * gets its probes treated as tick orphans.
+ */
+export const PROBE_ID_PREFIX = "schedule/probe/";
+
+/** The Temporal Schedule artifact id for a Schedule resource id. */
+export function artifactId(scheduleResourceId: string): string {
+  return TICK_ID_PREFIX + scheduleResourceId;
+}
+
+/** Inverts artifactId. */
+export function resourceIdOf(artifactIdValue: string): string {
+  return artifactIdValue.startsWith(TICK_ID_PREFIX)
+    ? artifactIdValue.slice(TICK_ID_PREFIX.length)
+    : artifactIdValue;
+}
+
+// ─── Activity names ─────────────────────────────────────────────────────
+// Slash-namespaced like the platform's other Go-owned system activities,
+// registered by the schedule worker under these exact names.
+
+export const RECORD_TICK_ACTIVITY_NAME = "stigmer/schedule/record-tick";
+export const START_SCHEDULED_RUN_ACTIVITY_NAME = "stigmer/schedule/start-run";
+export const POLL_EXECUTION_PHASE_ACTIVITY_NAME =
+  "stigmer/schedule/poll-phase";
+export const RECORD_SUCCESSFUL_RUN_ACTIVITY_NAME =
+  "stigmer/schedule/record-success";
+export const RECORD_FAILED_RUN_ACTIVITY_NAME =
+  "stigmer/schedule/record-failure";
+
+// ─── The tick's outcome vocabulary ──────────────────────────────────────
+// String-typed so the JSON data converter serializes them stably across
+// releases; the VALUES mirror the cloud edition's enums name-for-name
+// (one runbook, two editions) — Go tick_activities.go.
+
+/** recordTick's verdict on whether this fire proceeds (Go TickOutcome). */
+export type TickOutcome =
+  | "FIRED"
+  | "SKIPPED_DELETED"
+  | "SKIPPED_DISABLED"
+  | "SKIPPED_AUTO_PAUSED";
+
+export const TICK_FIRED = "FIRED" satisfies TickOutcome;
+export const TICK_SKIPPED_DELETED = "SKIPPED_DELETED" satisfies TickOutcome;
+export const TICK_SKIPPED_DISABLED = "SKIPPED_DISABLED" satisfies TickOutcome;
+export const TICK_SKIPPED_AUTO_PAUSED = "SKIPPED_AUTO_PAUSED" satisfies TickOutcome;
+
+/** startScheduledRun's verdict on the run start (Go RunOutcome). */
+export type RunOutcome =
+  | "STARTED"
+  | "ALREADY_STARTED"
+  | "SKIPPED"
+  | "TARGET_MISSING"
+  | "REFUSED";
+
+export const RUN_STARTED = "STARTED" satisfies RunOutcome;
+export const RUN_ALREADY_STARTED = "ALREADY_STARTED" satisfies RunOutcome;
+export const RUN_SKIPPED = "SKIPPED" satisfies RunOutcome;
+export const RUN_TARGET_MISSING = "TARGET_MISSING" satisfies RunOutcome;
+export const RUN_REFUSED = "REFUSED" satisfies RunOutcome;
+
+/** The tracked execution's observed phase class (Go RunPhase). */
+export type RunPhase =
+  | "RUNNING"
+  | "COMPLETED"
+  | "FAILED"
+  | "CANCELLED"
+  | "TERMINATED"
+  | "GONE";
+
+export const PHASE_RUNNING = "RUNNING" satisfies RunPhase;
+export const PHASE_COMPLETED = "COMPLETED" satisfies RunPhase;
+export const PHASE_FAILED = "FAILED" satisfies RunPhase;
+export const PHASE_CANCELLED = "CANCELLED" satisfies RunPhase;
+export const PHASE_TERMINATED = "TERMINATED" satisfies RunPhase;
+export const PHASE_GONE = "GONE" satisfies RunPhase;
+
+/** Which path fed the streak, for the log line (Go FailureKind). */
+export type FailureKind = "START_FAILED" | "RUN_FAILED" | "RUN_TIMED_OUT";
+
+export const FAILURE_START_FAILED = "START_FAILED" satisfies FailureKind;
+export const FAILURE_RUN_FAILED = "RUN_FAILED" satisfies FailureKind;
+export const FAILURE_RUN_TIMED_OUT = "RUN_TIMED_OUT" satisfies FailureKind;
+
+/**
+ * startScheduledRun's full answer (Go RunStart). The tracking budget rides
+ * the activity RESULT so workflow timing derives from recorded history — a
+ * config flip can never confuse an in-flight replay. Field names are the
+ * recorded-history JSON contract (Go's json tags), never rename.
+ */
+export interface RunStart {
+  outcome: RunOutcome;
+  /** Set exactly when outcome ∈ {STARTED, ALREADY_STARTED}. */
+  executionId: string;
+  /** This fire's tracking budget, already clamped. */
+  trackingTimeoutMinutes: number;
+  /**
+   * The deterministic start-failure copy when outcome ∈ {TARGET_MISSING,
+   * REFUSED}.
+   */
+  failureReason: string;
+}
+
+/** recordFailedRun's post-image summary (Go FailureRecorded). */
+export interface FailureRecorded {
+  consecutiveFailures: number;
+  paused: boolean;
+}
+
+/**
+ * The activity surface the tick workflow proxies, keyed by the pinned
+ * slash names (the TS SDK registers and invokes activities by object key).
+ */
+export interface ScheduleTickActivities {
+  [RECORD_TICK_ACTIVITY_NAME]: (
+    scheduleResourceId: string,
+    nominalFireTimeRfc3339: string,
+  ) => Promise<TickOutcome>;
+  [START_SCHEDULED_RUN_ACTIVITY_NAME]: (
+    scheduleResourceId: string,
+    nominalFireTimeRfc3339: string,
+  ) => Promise<RunStart>;
+  [POLL_EXECUTION_PHASE_ACTIVITY_NAME]: (
+    executionId: string,
+  ) => Promise<RunPhase>;
+  [RECORD_SUCCESSFUL_RUN_ACTIVITY_NAME]: (
+    scheduleResourceId: string,
+  ) => Promise<void>;
+  [RECORD_FAILED_RUN_ACTIVITY_NAME]: (
+    scheduleResourceId: string,
+    reason: string,
+    kind: FailureKind,
+  ) => Promise<FailureRecorded>;
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/reconciler.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/reconciler.ts
@@ -70,7 +70,8 @@ export class ScheduleReconciler {
   constructor(
     private readonly clientProvider: () => Client | undefined,
     private readonly store: Store,
-    private readonly syncer: ScheduleSyncer,
+    /** The narrow syncer slice the pass calls (satisfied by ScheduleSyncer). */
+    private readonly syncer: Pick<ScheduleSyncer, "ensureAndRecord" | "teardown">,
     private readonly config: ScheduleTemporalConfig,
     private readonly logger: Logger,
   ) {}
@@ -237,7 +238,7 @@ export class ScheduleReconciler {
     if (this.config.reconciliationEnabled) {
       this.interval = setInterval(
         () => void this.enqueuePass(),
-        this.config.reconciliationIntervalMinutes * 60_000,
+        this.config.resolvedReconciliationIntervalMinutes() * 60_000,
       );
       // Unref'd like the manager's monitor: an unclosed reconciler must
       // not keep the process alive past main's intent.
@@ -270,6 +271,14 @@ export class ScheduleReconciler {
    * Serializes passes (Go's single goroutine consuming ticker + kicks): at
    * most one pass runs at a time, and at most one further pass queues —
    * exactly the 1-buffered kick channel's coalescing.
+   *
+   * The chained callback CONTAINS every rejection: `running` must never
+   * become a rejected promise, because the next enqueue would chain onto a
+   * callback that never runs (kickQueued stuck true — the reconciler
+   * bricked), stop() would rethrow into the compose shutdown, and an
+   * unawaited rejection kills the process under Node's default policy.
+   * runPass already catches per-phase errors; this is the backstop for
+   * the invariant no type can enforce (panel finding).
    */
   private enqueuePass(): Promise<void> {
     if (this.stopped) {
@@ -284,7 +293,14 @@ export class ScheduleReconciler {
       if (this.stopped) {
         return;
       }
-      await this.runPass();
+      try {
+        await this.runPass();
+      } catch (error) {
+        this.logger.error(
+          "Schedule reconciliation pass failed unexpectedly (the loop continues; the next tick or kick retries)",
+          { error: message(error) },
+        );
+      }
     });
     return this.running;
   }

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/reconciler.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/reconciler.ts
@@ -1,0 +1,316 @@
+/**
+ * The reconciler — ports pkg/domain/schedule/temporal/reconcile.go:
+ * converges Schedule rows and Temporal artifacts in both directions — rows
+ * without artifacts get armed, drifted artifacts get rewritten, artifacts
+ * without rows get deleted.
+ *
+ * In cloud this pass is belt-and-braces behind a non-critical arming step.
+ * In OSS it is LOAD-BEARING (DD-015 D-B): `stigmer up` runs a managed
+ * Temporal DEV SERVER whose state is a local SQLite file — a restart,
+ * crash, or reset destroys every artifact, and without this pass every
+ * schedule would silently never fire again. That is also why
+ * startReconciliation hooks the Temporal RECONNECT path, not just a timer:
+ * a reconnect is precisely the moment the artifacts are most likely to be
+ * gone.
+ *
+ * Lifecycle in TS idiom (sub-project decision 4, owner-ratified): Go's
+ * goroutine+channel loop becomes an unref'd interval plus a kick queue
+ * with an explicit stop() called from the compose shutdown — nothing may
+ * fire after shutdown (the #18 manager-close panel lesson). Semantics are
+ * preserved exactly: an immediate boot pass, periodic passes gated by the
+ * env kill-switch, and kicked passes that ALWAYS run (reconnect
+ * convergence is correctness, not hygiene).
+ */
+import type { Client } from "@temporalio/client";
+import { fromBinary } from "@bufbuild/protobuf";
+
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+import { desiredPaused, note } from "./artifact.js";
+import type { ScheduleTemporalConfig } from "./config.js";
+import { PROBE_ID_PREFIX, TICK_ID_PREFIX, resourceIdOf } from "./names.js";
+import { pruneRunLedger } from "./run-ledger.js";
+import type { ScheduleSyncer } from "./syncer.js";
+
+/** Summarizes one convergence pass, for the log line (Go ReconcileCounts). */
+export interface ReconcileCounts {
+  rowsExamined: number;
+  armed: number;
+  repaired: number;
+  orphansDeleted: number;
+  failures: number;
+}
+
+function formatCounts(counts: ReconcileCounts): string {
+  return `rows=${counts.rowsExamined} armed=${counts.armed} repaired=${counts.repaired} orphans_deleted=${counts.orphansDeleted} failures=${counts.failures}`;
+}
+
+/**
+ * The describable slice the drift diff runs on. The baked ACTION is
+ * invisible to the listing — which is why the state note carries the
+ * cron+tz fingerprint (cron does not round-trip).
+ */
+interface ArtifactState {
+  readonly note: string;
+  readonly paused: boolean;
+}
+
+export class ScheduleReconciler {
+  private interval: NodeJS.Timeout | undefined;
+  private stopped = false;
+  /** One queued kick is enough (Go's 1-buffered channel). */
+  private kickQueued = false;
+  private running: Promise<void> = Promise.resolve();
+
+  constructor(
+    private readonly clientProvider: () => Client | undefined,
+    private readonly store: Store,
+    private readonly syncer: ScheduleSyncer,
+    private readonly config: ScheduleTemporalConfig,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Executes one convergence pass. Per-row failures are counted and the
+   * pass continues — one broken schedule must never stop the rest from
+   * converging (Go RunPass).
+   */
+  async runPass(): Promise<ReconcileCounts> {
+    const counts: ReconcileCounts = {
+      rowsExamined: 0,
+      armed: 0,
+      repaired: 0,
+      orphansDeleted: 0,
+      failures: 0,
+    };
+
+    const client = this.clientProvider();
+    if (client === undefined) {
+      this.logger.debug("Schedule reconciliation skipped — Temporal not connected");
+      return counts;
+    }
+
+    // Phase 1: snapshot every tick artifact in one listing.
+    const artifacts = new Map<string, ArtifactState>();
+    try {
+      for await (const entry of client.schedule.list({ pageSize: 100 })) {
+        if (entry.scheduleId.startsWith(TICK_ID_PREFIX)) {
+          artifacts.set(resourceIdOf(entry.scheduleId), {
+            note: entry.state.note ?? "",
+            paused: entry.state.paused,
+          });
+        } else if (entry.scheduleId.startsWith(PROBE_ID_PREFIX)) {
+          // Not ours: OSS creates no probes (names.ts PROBE_ID_PREFIX).
+        }
+        // Anything else is someone else's schedule (e.g. a user's own
+        // Temporal use on the shared dev server) — never touch it.
+      }
+    } catch (error) {
+      this.logger.error("Schedule reconciliation could not list artifacts", {
+        error: message(error),
+      });
+      counts.failures++;
+      return counts;
+    }
+
+    // Phase 2: walk every row; arm the unarmed, repair the drifted.
+    // Removal from the map is what leaves the orphans behind for phase 3.
+    let rows: Schedule[];
+    try {
+      rows = await this.listSchedules();
+    } catch (error) {
+      this.logger.error("Schedule reconciliation could not list rows", {
+        error: message(error),
+      });
+      counts.failures++;
+      return counts;
+    }
+    for (const row of rows) {
+      counts.rowsExamined++;
+      const resourceId = row.metadata?.id ?? "";
+      const actual = artifacts.get(resourceId);
+      artifacts.delete(resourceId);
+
+      if (actual === undefined) {
+        try {
+          await this.syncer.ensureAndRecord(row);
+        } catch (error) {
+          counts.failures++;
+          this.logger.error(
+            "Reconciliation failed to arm a schedule (pass continues)",
+            { schedule_id: resourceId, error: message(error) },
+          );
+          continue;
+        }
+        counts.armed++;
+        this.logger.info("Reconciliation armed a schedule without an artifact", {
+          schedule_id: resourceId,
+        });
+      } else if (actual.note !== note(row) || actual.paused !== desiredPaused(row)) {
+        try {
+          await this.syncer.ensureAndRecord(row);
+        } catch (error) {
+          counts.failures++;
+          this.logger.error(
+            "Reconciliation failed to repair a drifted artifact (pass continues)",
+            { schedule_id: resourceId, error: message(error) },
+          );
+          continue;
+        }
+        counts.repaired++;
+        this.logger.info("Reconciliation repaired a drifted artifact", {
+          schedule_id: resourceId,
+          actual_note: actual.note,
+          actual_paused: actual.paused,
+        });
+      }
+    }
+
+    // Phase 3: reap orphans — but ONLY after a targeted point read
+    // confirms the row is genuinely gone. A row created after phase 2's
+    // listing must never lose its just-armed clock (THE guard, pinned by
+    // test in both editions).
+    for (const resourceId of artifacts.keys()) {
+      try {
+        await this.store.getResource(
+          ApiResourceKind.schedule,
+          resourceId,
+          ScheduleSchema,
+        );
+        continue; // the row exists — not an orphan
+      } catch (error) {
+        if (!(error instanceof ResourceNotFoundError)) {
+          counts.failures++;
+          this.logger.error(
+            "Reconciliation could not confirm an orphan (leaving it; pass continues)",
+            { schedule_id: resourceId, error: message(error) },
+          );
+          continue;
+        }
+      }
+      try {
+        await this.syncer.teardown(resourceId);
+      } catch (error) {
+        counts.failures++;
+        this.logger.error(
+          "Reconciliation failed to delete an orphaned artifact (pass continues)",
+          { schedule_id: resourceId, error: message(error) },
+        );
+        continue;
+      }
+      counts.orphansDeleted++;
+      this.logger.info("Reconciliation deleted an orphaned artifact", {
+        schedule_id: resourceId,
+      });
+    }
+
+    // Phase 4: fire-ledger retention (DD-017 D-7) — the clock's one
+    // periodic hook, so the ledger's bound needs no machinery of its own.
+    await pruneRunLedger(
+      this.store,
+      this.logger,
+      this.config.resolvedRunHistoryRetentionDays(),
+    );
+
+    this.logger.info("Schedule reconciliation pass complete", {
+      counts: formatCounts(counts),
+    });
+    return counts;
+  }
+
+  /**
+   * Runs the convergence loop: an immediate first pass (the boot is itself
+   * a "reconnect" — the dev server may have restarted while the daemon was
+   * down), then one pass per interval, plus out-of-band passes requested
+   * through the returned kick function (wired to the Temporal manager's
+   * reconnect hook). The env kill-switch disables only the PERIODIC
+   * passes; kicked passes still run (Go StartReconciliation).
+   */
+  startReconciliation(): () => void {
+    void this.enqueuePass();
+
+    if (this.config.reconciliationEnabled) {
+      this.interval = setInterval(
+        () => void this.enqueuePass(),
+        this.config.reconciliationIntervalMinutes * 60_000,
+      );
+      // Unref'd like the manager's monitor: an unclosed reconciler must
+      // not keep the process alive past main's intent.
+      this.interval.unref();
+    } else {
+      this.logger.info(
+        "Periodic schedule reconciliation disabled (STIGMER_SCHEDULES_RECONCILIATION_ENABLED=false) — reconnect passes still run",
+      );
+    }
+
+    return () => {
+      void this.enqueuePass();
+    };
+  }
+
+  /**
+   * Stops the loop; in-flight and queued passes drain, nothing new starts
+   * (Go's context cancellation; called from the compose shutdown).
+   */
+  async stop(): Promise<void> {
+    this.stopped = true;
+    if (this.interval !== undefined) {
+      clearInterval(this.interval);
+      this.interval = undefined;
+    }
+    await this.running;
+  }
+
+  /**
+   * Serializes passes (Go's single goroutine consuming ticker + kicks): at
+   * most one pass runs at a time, and at most one further pass queues —
+   * exactly the 1-buffered kick channel's coalescing.
+   */
+  private enqueuePass(): Promise<void> {
+    if (this.stopped) {
+      return Promise.resolve();
+    }
+    if (this.kickQueued) {
+      return this.running; // a pass is already queued — one is enough
+    }
+    this.kickQueued = true;
+    this.running = this.running.then(async () => {
+      this.kickQueued = false;
+      if (this.stopped) {
+        return;
+      }
+      await this.runPass();
+    });
+    return this.running;
+  }
+
+  /**
+   * Loads every schedule row, skipping corrupt blobs (the lenient-read
+   * posture list endpoints use). OSS scale is a handful of schedules on
+   * one user's machine; the full listing per pass is noise (Go
+   * listSchedules).
+   */
+  private async listSchedules(): Promise<Schedule[]> {
+    const blobs = await this.store.listResources(ApiResourceKind.schedule);
+    const schedules: Schedule[] = [];
+    for (const data of blobs) {
+      try {
+        schedules.push(fromBinary(ScheduleSchema, data));
+      } catch (error) {
+        this.logger.warn("Schedule reconciliation skipped a corrupt row", {
+          error: message(error),
+        });
+      }
+    }
+    return schedules;
+  }
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/run-ledger.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/run-ledger.ts
@@ -1,0 +1,233 @@
+/**
+ * The fire ledger — ports pkg/domain/schedule/temporal/runledger.go
+ * (DD-017 D-7): every fire leaves a row — including fires that created no
+ * execution, which are the only durable trace of a refused launch gate
+ * below the auto-pause threshold.
+ *
+ * Writes ride INSIDE the existing activities, never the tick workflow
+ * body: activity implementations are invisible to recorded histories, so
+ * the ledger needs no version gate and cannot disturb the replay contract
+ * (workflows/tick.ts's FORWARD CONSTRAINT).
+ *
+ * Every write is BEST-EFFORT with a loud log line. The alternatives are
+ * both worse: failing the start activity on a bookkeeping error would
+ * retry a run that already achieved its outcome, and failing a verdict
+ * activity would error the tick before the streak write lands — a storage
+ * hiccup must never break streak semantics. The ledger upsert converges
+ * under the retries that do happen (fire-identity key, terminal rows
+ * immutable).
+ */
+import type { Logger } from "../../boot/logger.js";
+import type { ScheduleRunRecord, Store } from "../../store/interface.js";
+import type { RunOutcomeResult } from "./run-starter.js";
+import {
+  RUN_ALREADY_STARTED,
+  RUN_REFUSED,
+  RUN_SKIPPED,
+  RUN_STARTED,
+  RUN_TARGET_MISSING,
+  type RunStart,
+} from "./names.js";
+
+// Ledger vocabulary: the lowercase names of the
+// ai.stigmer.agentic.schedule.v1.ScheduleRunOutcome / ScheduleRunOrigin
+// enum values, shared byte-for-byte with the cloud edition's rows.
+export const RUN_LEDGER_ORIGIN_CRON = "cron";
+export const RUN_LEDGER_ORIGIN_MANUAL = "manual";
+
+export const RUN_LEDGER_OUTCOME_STARTED = "started";
+export const RUN_LEDGER_OUTCOME_REFUSED = "refused";
+export const RUN_LEDGER_OUTCOME_TARGET_MISSING = "target_missing";
+export const RUN_LEDGER_OUTCOME_SKIPPED = "skipped";
+export const RUN_LEDGER_OUTCOME_COMPLETED = "completed";
+export const RUN_LEDGER_OUTCOME_FAILED = "failed";
+export const RUN_LEDGER_OUTCOME_TIMED_OUT = "timed_out";
+
+/** Go time.RFC3339 with whole seconds — the ledger's house time format. */
+export function rfc3339Seconds(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * Writes the fire's row from the run-start outcome (Go
+ * recordRunLedgerStart). Start failures (refused / target missing) and
+ * skips are terminal at insert — no tracking follows them, so the reason
+ * must survive NOW. ALREADY_STARTED collapses into "started": the row is
+ * the same fire, re-found by an idempotent retry.
+ */
+export async function recordRunLedgerStart(
+  store: Store,
+  logger: Logger,
+  scheduleId: string,
+  org: string,
+  nominalFireTimeRfc3339: string,
+  origin: string,
+  runStart: RunStart,
+): Promise<void> {
+  const base = {
+    scheduleId,
+    org,
+    nominalFireTime: nominalFireTimeRfc3339,
+    origin,
+    executionId: runStart.executionId,
+    reason: runStart.failureReason,
+    recordedAt: "",
+  };
+  let record: ScheduleRunRecord;
+  switch (runStart.outcome) {
+    case RUN_STARTED:
+    case RUN_ALREADY_STARTED:
+      record = { ...base, outcome: RUN_LEDGER_OUTCOME_STARTED, completedAt: "" };
+      break;
+    case RUN_REFUSED:
+      record = {
+        ...base,
+        outcome: RUN_LEDGER_OUTCOME_REFUSED,
+        completedAt: rfc3339Seconds(new Date()),
+      };
+      break;
+    case RUN_TARGET_MISSING:
+      record = {
+        ...base,
+        outcome: RUN_LEDGER_OUTCOME_TARGET_MISSING,
+        completedAt: rfc3339Seconds(new Date()),
+      };
+      break;
+    case RUN_SKIPPED:
+      record = {
+        ...base,
+        outcome: RUN_LEDGER_OUTCOME_SKIPPED,
+        completedAt: rfc3339Seconds(new Date()),
+      };
+      break;
+    default:
+      return;
+  }
+  try {
+    await store.upsertScheduleRun(record);
+  } catch (error) {
+    logger.warn(
+      "Fire-ledger row not written (best-effort — the run itself is unaffected)",
+      {
+        schedule_id: scheduleId,
+        nominal_fire_time: nominalFireTimeRfc3339,
+        outcome: record.outcome,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}
+
+/**
+ * Stamps the terminal verdict on the schedule's in-flight CRON row (Go
+ * recordRunLedgerVerdict). Keyed on (schedule, cron) by necessity: the
+ * verdict activities' signatures are pinned by recorded Temporal
+ * histories, and the artifact's SKIP overlap plus the spanning tick
+ * guarantee at most one in-flight cron run per schedule. The origin filter
+ * keeps a newer manual fire's untracked row from stealing the verdict.
+ */
+export async function recordRunLedgerVerdict(
+  store: Store,
+  logger: Logger,
+  scheduleId: string,
+  outcome: string,
+  reason: string,
+): Promise<void> {
+  try {
+    await store.markLatestScheduleRunTerminal(
+      scheduleId,
+      RUN_LEDGER_ORIGIN_CRON,
+      outcome,
+      reason,
+      rfc3339Seconds(new Date()),
+    );
+  } catch (error) {
+    logger.warn(
+      "Fire-ledger verdict not written (best-effort — the streak write is unaffected)",
+      {
+        schedule_id: scheduleId,
+        outcome,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+  }
+}
+
+/**
+ * Writes the fire-ledger row for one trigger-command fire (origin=manual)
+ * — exported for the trigger controller, so the ledger vocabulary and the
+ * outcome mapping stay in ONE module (Go RecordManualFire). Manual rows
+ * for started runs stay non-terminal forever in storage: manual fires are
+ * untracked by design (the caller watches the execution), and listRuns
+ * resolves their outcome from the execution's live phase at read time.
+ * Start failures are terminal at insert, exactly like cron.
+ */
+export async function recordManualFire(
+  store: Store,
+  logger: Logger,
+  scheduleId: string,
+  org: string,
+  nominalFireTimeRfc3339: string,
+  outcome: RunOutcomeResult,
+): Promise<void> {
+  const runStart: RunStart = {
+    outcome: RUN_STARTED,
+    executionId: "",
+    trackingTimeoutMinutes: 0,
+    failureReason: "",
+  };
+  switch (outcome.kind) {
+    case "started":
+      runStart.outcome = RUN_STARTED;
+      runStart.executionId = outcome.executionId;
+      break;
+    case "targetMissing":
+      runStart.outcome = RUN_TARGET_MISSING;
+      runStart.failureReason = outcome.reason;
+      break;
+    case "refused":
+      runStart.outcome = RUN_REFUSED;
+      runStart.failureReason = `run refused: ${outcome.reason}`;
+      break;
+    default: {
+      const exhaustive: never = outcome;
+      throw new Error(`unknown run outcome ${String(exhaustive)}`);
+    }
+  }
+  await recordRunLedgerStart(
+    store,
+    logger,
+    scheduleId,
+    org,
+    nominalFireTimeRfc3339,
+    RUN_LEDGER_ORIGIN_MANUAL,
+    runStart,
+  );
+}
+
+/**
+ * Enforces the retention the table was born with; called from the
+ * reconciliation pass (the clock's one periodic hook). Go pruneRunLedger.
+ */
+export async function pruneRunLedger(
+  store: Store,
+  logger: Logger,
+  retentionDays: number,
+): Promise<void> {
+  const cutoff = rfc3339Seconds(
+    new Date(Date.now() - retentionDays * 24 * 3_600_000),
+  );
+  let pruned: number;
+  try {
+    pruned = await store.pruneScheduleRuns(cutoff);
+  } catch (error) {
+    logger.warn("Fire-ledger retention prune failed (retried next pass)", {
+      cutoff,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+  if (pruned > 0) {
+    logger.info("Fire-ledger retention prune complete", { pruned, cutoff });
+  }
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/run-starter.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/run-starter.ts
@@ -247,13 +247,23 @@ export class RunStarter {
     // fire at the same nominal time) finds the winner instead of sending
     // the reminder twice. The deterministic name IS the execution's slug
     // (every character is already slug-shaped, pinned by test).
-    const existing = await findResourceBySlug(
-      store,
-      ApiResourceKind.agent_execution,
-      AgentExecutionSchema,
-      executionName,
-      org,
-    );
+    let existing;
+    try {
+      existing = await findResourceBySlug(
+        store,
+        ApiResourceKind.agent_execution,
+        AgentExecutionSchema,
+        executionName,
+        org,
+      );
+    } catch (error) {
+      // Go's wrap label (runstarter.go): the activity retries either way;
+      // the label keeps history/trigger diagnostics identical.
+      throw new Error(
+        `look up execution ${executionName}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
     if (existing !== undefined) {
       const executionId = existing.metadata?.id ?? "";
       logger.info("Schedule fire already has its execution (idempotent retry)", {

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/run-starter.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/run-starter.ts
@@ -1,0 +1,505 @@
+/**
+ * The RunStarter — ports pkg/domain/schedule/temporal/runstarter.go: turns
+ * one schedule fire into one AgentExecution through the in-process gRPC
+ * client, so the FULL create pipeline runs (session auto-create, execution
+ * context, persist, workflow start). Where the cloud starter mints a
+ * schedule token and re-enters the pipeline behind FGA gates, OSS has no
+ * caller identity by design (DD-015 D-G): the org is stamped from the
+ * schedule's own metadata.
+ *
+ * Idempotency is the CLOCK's job here (DD-015 D-F): the OSS create
+ * pipeline deliberately has no duplicate check (it would tax every
+ * execution create in the product), so the starter looks up its own
+ * deterministic execution name before creating. Within one tick activity
+ * retries are sequential, and across fires the nominal time disambiguates —
+ * one reminder per fire, by construction.
+ *
+ * Serves BOTH fire paths: the tick's start-run activity (origin=cron) and
+ * the trigger RPC's direct-run step (origin=manual, DD-017 D-5).
+ */
+import { Code, ConnectError } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  AgentExecutionSpecSchema,
+  ExecutionConfigSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
+import { ApprovalMode } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import {
+  ServiceTier,
+  ThinkingMode,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { AgentInvocation } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/invocation_pb";
+import { Harness } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+import { SessionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceMetadataSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { findResourceBySlug } from "../../pipeline/steps/helpers.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+import type { ScheduleTemporalConfig } from "./config.js";
+import { scheduleModelPinningRefusal } from "./model-pinning.js";
+import { ensureStatus, bumpStatusAudit } from "./status-writes.js";
+
+/**
+ * The scheduled session's pinned subject prefix — cross-edition contract
+ * (an explicit subject also opts the session out of LLM titling,
+ * deliberately: a reminder session names itself). Go SessionSubjectPrefix.
+ */
+export const SESSION_SUBJECT_PREFIX = "Scheduled run: ";
+
+/**
+ * The audit link stamped on every schedule-created execution — the same
+ * key the cloud edition's scope step writes (Go ScheduleIDLabelKey).
+ *
+ * In OSS the label is also the environment-resolution key: the execution
+ * context step reads it to merge the schedule's environment_refs (DD-017
+ * D-4). Cloud deliberately resolves through the validated token claim
+ * instead — a client-suppliable label must not widen what a cloud sandbox
+ * reads — but OSS is single-user with no trust boundary, and it has no
+ * tokens to carry a claim (the DD-015 divergence posture).
+ */
+export const SCHEDULE_ID_LABEL_KEY = "stigmer.ai/schedule-id";
+
+/** The sealed outcome set of startRun (Go RunOutcomeResult). */
+export type RunOutcomeResult =
+  /** The run exists (created now, or found from a prior attempt at the same fire). */
+  | { kind: "started"; executionId: string; alreadyExisted: boolean }
+  /** The referenced agent no longer exists — the deterministic dangling-reference failure (no cascade by contract). */
+  | { kind: "targetMissing"; reason: string }
+  /** A launch gate refused deterministically — retrying cannot help, the streak should know. */
+  | { kind: "refused"; reason: string };
+
+/**
+ * The narrow slice of the in-process agent-execution client the run
+ * starter needs (Go ExecutionCreator; satisfied through
+ * src/boot/inprocess.ts).
+ */
+export interface ScheduleExecutionCreator {
+  create(execution: AgentExecution): Promise<AgentExecution>;
+}
+
+/**
+ * THE idempotency key: schedule id (lowercased, underscores to hyphens —
+ * already slug-safe) plus the nominal fire time truncated to whole seconds
+ * in the cloud's "yyyyMMdd't'HHmmss'z'" layout. Byte-identical to the
+ * cloud's scheduledExecutionName, pinned by tests on both sides: two
+ * editions must never name the same fire's run differently (Go
+ * ScheduledExecutionName).
+ */
+export function scheduledExecutionName(
+  scheduleResourceId: string,
+  nominalFireTime: Date,
+): string {
+  const idPart = scheduleResourceId.toLowerCase().replaceAll("_", "-");
+  return `${idPart}-${executionNameFireTime(nominalFireTime)}`;
+}
+
+/** Go executionNameFireTimeLayout "20060102t150405z", UTC whole seconds. */
+function executionNameFireTime(nominal: Date): string {
+  const p = utcParts(nominal);
+  return `${p.year}${p.month}${p.day}t${p.hour}${p.minute}${p.second}z`;
+}
+
+/**
+ * Appends the fire-context line to the schedule's message, rendered in the
+ * schedule's own time zone (an unloadable zone degrades to UTC — a
+ * slightly wrong-timezone reminder beats a dead fire). Format-pinned: Go
+ * and the cloud produce the identical bytes, and the runner injects no
+ * current date into any prompt — this line is the ONLY way the model knows
+ * "today" (Go ComposeMessage, fireContextLayout "Monday, 2006-01-02 15:04").
+ */
+export function composeMessage(
+  schedule: Schedule,
+  nominalFireTime: Date,
+): string {
+  const requested = schedule.spec?.timeZone ?? "";
+  const { zoneName, formatted } = fireContextLine(requested, nominalFireTime);
+  const baseMessage = invocationOf(schedule)?.message ?? "";
+  return `${baseMessage}\n\n(Scheduled fire time: ${formatted} (${zoneName}))`;
+}
+
+/**
+ * Renders "Monday, 2006-01-02 15:04" in the zone, with Go's zone-name
+ * echo: LoadLocation("") is UTC and prints "UTC"; an unloadable name
+ * degrades to UTC (ComposeMessage's fallback); a loadable name echoes
+ * byte-for-byte as given.
+ */
+function fireContextLine(
+  requestedZone: string,
+  nominal: Date,
+): { zoneName: string; formatted: string } {
+  let zone = requestedZone;
+  let parts: Intl.DateTimeFormatPart[];
+  try {
+    parts = fireContextFormatter(zone === "" ? "UTC" : zone).formatToParts(nominal);
+    if (zone === "") {
+      zone = "UTC";
+    }
+  } catch {
+    zone = "UTC";
+    parts = fireContextFormatter("UTC").formatToParts(nominal);
+  }
+  const get = (type: Intl.DateTimeFormatPart["type"]): string =>
+    parts.find((part) => part.type === type)?.value ?? "";
+  const formatted = `${get("weekday")}, ${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")}`;
+  return { zoneName: zone, formatted };
+}
+
+function fireContextFormatter(timeZone: string): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    weekday: "long",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+  });
+}
+
+function utcParts(date: Date): {
+  year: string;
+  month: string;
+  day: string;
+  hour: string;
+  minute: string;
+  second: string;
+} {
+  const pad = (value: number, width: number): string =>
+    String(value).padStart(width, "0");
+  return {
+    year: pad(date.getUTCFullYear(), 4),
+    month: pad(date.getUTCMonth() + 1, 2),
+    day: pad(date.getUTCDate(), 2),
+    hour: pad(date.getUTCHours(), 2),
+    minute: pad(date.getUTCMinutes(), 2),
+    second: pad(date.getUTCSeconds(), 2),
+  };
+}
+
+function invocationOf(schedule: Schedule): AgentInvocation | undefined {
+  return schedule.spec?.target.case === "agent"
+    ? schedule.spec.target.value
+    : undefined;
+}
+
+export interface RunStarterDeps {
+  readonly store: Store;
+  readonly config: ScheduleTemporalConfig;
+  readonly executions: ScheduleExecutionCreator;
+  readonly logger: Logger;
+}
+
+export class RunStarter {
+  constructor(private readonly deps: RunStarterDeps) {}
+
+  /**
+   * Starts (or finds) this fire's run and stamps status.last_execution_id.
+   * Deterministic refusals come back as outcomes (the streak should count
+   * them); infrastructure failures come back as thrown errors (the tick
+   * activity retries, the deterministic name absorbs it). Go StartRun.
+   */
+  async startRun(
+    schedule: Schedule,
+    nominalFireTime: Date,
+  ): Promise<RunOutcomeResult> {
+    const { store, logger } = this.deps;
+    const scheduleId = schedule.metadata?.id ?? "";
+    const org = schedule.metadata?.org ?? "";
+
+    const resolved = await this.resolveTargetAgent(schedule);
+    if (resolved.agent === undefined) {
+      logger.warn("Schedule fire has no target agent", {
+        schedule_id: scheduleId,
+        reason: resolved.missingReason,
+      });
+      return { kind: "targetMissing", reason: resolved.missingReason };
+    }
+
+    // Launch backstop of the unattended model-pinning rule (#362):
+    // write-time validation holds this bar on every create and update, but
+    // rows written before the rule existed must refuse here rather than
+    // run Auto at the account default's price. A deterministic refusal
+    // feeds the failure streak, so a broken config pauses the schedule
+    // instead of burning silently every fire.
+    const pinningRefusal = scheduleModelPinningRefusal(schedule.spec);
+    if (pinningRefusal !== "") {
+      logger.error("Schedule fire refused by the model-pinning backstop", {
+        schedule_id: scheduleId,
+        reason: pinningRefusal,
+      });
+      return { kind: "refused", reason: pinningRefusal };
+    }
+
+    const executionName = scheduledExecutionName(scheduleId, nominalFireTime);
+
+    // The clock's own idempotency: a retried activity (or a duplicated
+    // fire at the same nominal time) finds the winner instead of sending
+    // the reminder twice. The deterministic name IS the execution's slug
+    // (every character is already slug-shaped, pinned by test).
+    const existing = await findResourceBySlug(
+      store,
+      ApiResourceKind.agent_execution,
+      AgentExecutionSchema,
+      executionName,
+      org,
+    );
+    if (existing !== undefined) {
+      const executionId = existing.metadata?.id ?? "";
+      logger.info("Schedule fire already has its execution (idempotent retry)", {
+        schedule_id: scheduleId,
+        execution_id: executionId,
+      });
+      await this.stampLastExecutionId(scheduleId, executionId);
+      return { kind: "started", executionId, alreadyExisted: true };
+    }
+
+    let created: AgentExecution;
+    try {
+      created = await this.deps.executions.create(
+        this.buildExecutionRequest(schedule, resolved.agent, executionName, nominalFireTime),
+      );
+    } catch (error) {
+      if (!(error instanceof ConnectError)) {
+        throw error;
+      }
+      switch (error.code) {
+        case Code.AlreadyExists: {
+          // The session auto-create's duplicate check can refuse even
+          // though the execution create has none — re-read the winner.
+          const winner = await findResourceBySlug(
+            store,
+            ApiResourceKind.agent_execution,
+            AgentExecutionSchema,
+            executionName,
+            org,
+          );
+          if (winner === undefined) {
+            throw new Error(
+              `duplicate-check refusal but no execution row for ${executionName}: ${error.message}`,
+              { cause: error },
+            );
+          }
+          const executionId = winner.metadata?.id ?? "";
+          await this.stampLastExecutionId(scheduleId, executionId);
+          return { kind: "started", executionId, alreadyExisted: true };
+        }
+        case Code.FailedPrecondition:
+        case Code.PermissionDenied:
+        case Code.NotFound:
+        case Code.InvalidArgument:
+        case Code.ResourceExhausted:
+          logger.error("Schedule fire refused by a launch gate", {
+            schedule_id: scheduleId,
+            org,
+            code: Code[error.code],
+            reason: error.rawMessage,
+          });
+          return { kind: "refused", reason: error.rawMessage };
+        default:
+          throw error;
+      }
+    }
+
+    const executionId = created.metadata?.id ?? "";
+    await this.stampLastExecutionId(scheduleId, executionId);
+    return { kind: "started", executionId, alreadyExisted: false };
+  }
+
+  /**
+   * Loads the referenced agent, the reference's org defaulting to the
+   * schedule's own. An undefined agent with a reason means the
+   * deterministic dangling-reference failure (Go resolveTargetAgent).
+   */
+  private async resolveTargetAgent(
+    schedule: Schedule,
+  ): Promise<{ agent?: Agent; missingReason: string }> {
+    const ref = invocationOf(schedule)?.agentRef;
+    const slug = ref?.slug ?? "";
+    if (slug === "") {
+      return { missingReason: "schedule has no agent target" };
+    }
+    let org = ref?.org ?? "";
+    if (org === "") {
+      org = schedule.metadata?.org ?? "";
+    }
+    let agent: Agent | undefined;
+    try {
+      agent = await findResourceBySlug(
+        this.deps.store,
+        ApiResourceKind.agent,
+        AgentSchema,
+        slug,
+        org,
+      );
+    } catch (error) {
+      throw new Error(
+        `resolve target agent ${org}/${slug}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+    if (agent === undefined) {
+      // The deterministic start-failure copy — cross-edition contract (the
+      // conformance firing suite asserts the pause reason built from it,
+      // byte-for-byte).
+      return { missingReason: `target agent ${org}/${slug} not found` };
+    }
+    return { agent, missingReason: "" };
+  }
+
+  /**
+   * Shapes the run: fresh session per fire with the pinned subject, the
+   * fire-context message, and the unattended execution profile.
+   * approval_mode=UNATTENDED is a correctness requirement, not a
+   * preference: a gated tool with no approver would park the execution
+   * forever (the agent workflow deliberately has no run timeout), which
+   * under tracking becomes a silently-burned budget every fire (Go
+   * buildExecutionRequest).
+   */
+  private buildExecutionRequest(
+    schedule: Schedule,
+    agent: Agent,
+    executionName: string,
+    nominalFireTime: Date,
+  ): AgentExecution {
+    const invocation = invocationOf(schedule);
+    const runConfig = invocation?.runConfig;
+
+    const executionConfig = create(ExecutionConfigSchema, {
+      approvalMode: ApprovalMode.UNATTENDED,
+      // The platform profile, then the schedule's own run_config CLAMPED
+      // by it (DD-017 D-3): per field, min(owner, platform) when the
+      // platform cap is set; the owner value stands when the platform cap
+      // is unset. The owner can lower spend, never raise it past the
+      // platform.
+      maxToolRounds: clampedRunBound(
+        runConfig?.maxToolRounds ?? 0,
+        this.deps.config.executionProfileMaxToolRounds,
+      ),
+      maxCostUsd: clampedRunBound(
+        runConfig?.maxCostUsd ?? 0,
+        this.deps.config.executionProfileMaxCostUsd,
+      ),
+    });
+    const model = (runConfig?.modelName ?? "").trim();
+    if (model !== "") {
+      executionConfig.modelName = model;
+    }
+    // service_tier stamps when the owner set one — there is no platform
+    // tier knob (unset resolves to STANDARD in the runner, never the
+    // provider account default). Tier-model coherence was validated
+    // fail-closed at execution create (#357).
+    if (
+      runConfig !== undefined &&
+      runConfig.serviceTier !== ServiceTier.UNSPECIFIED
+    ) {
+      executionConfig.serviceTier = runConfig.serviceTier;
+    }
+    // thinking_mode under the same contract as service_tier: only when the
+    // owner set one; capability-model coherence was validated fail-closed
+    // at execution create (#772).
+    if (
+      runConfig !== undefined &&
+      runConfig.thinkingMode !== ThinkingMode.UNSPECIFIED
+    ) {
+      executionConfig.thinkingMode = runConfig.thinkingMode;
+    }
+
+    // The fresh per-fire session speaks the invocation's session half
+    // (DD-018 D-3): harness and workspace come from the owner's spec. An
+    // unspecified harness stays unset — the platform default applies (OSS:
+    // native). Workspace entries are git-only by write-time validation;
+    // credentials, when a repo is private, ride an org-shared environment
+    // holding GITHUB_TOKEN (DD-018 D-4).
+    const sessionSpec = create(SessionSpecSchema, {
+      subject: SESSION_SUBJECT_PREFIX + (schedule.metadata?.slug ?? ""),
+      workspaceEntries: invocation?.workspaceEntries ?? [],
+    });
+    if (
+      invocation !== undefined &&
+      invocation.harness !== Harness.UNSPECIFIED
+    ) {
+      sessionSpec.harness = invocation.harness;
+    }
+
+    return create(AgentExecutionSchema, {
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "AgentExecution",
+      metadata: create(ApiResourceMetadataSchema, {
+        name: executionName,
+        // Cloud deliberately omits the org (its token scope step forces it
+        // from the validated claim); OSS has no token, so the schedule's
+        // own org is stamped directly — it is load-bearing for the session
+        // and execution context.
+        org: schedule.metadata?.org ?? "",
+        // The audit link (DD-008 D4) AND this edition's
+        // environment-resolution key — see SCHEDULE_ID_LABEL_KEY.
+        labels: { [SCHEDULE_ID_LABEL_KEY]: schedule.metadata?.id ?? "" },
+      }),
+      spec: create(AgentExecutionSpecSchema, {
+        agentId: agent.metadata?.id ?? "",
+        message: composeMessage(schedule, nominalFireTime),
+        sessionSpec,
+        executionConfig,
+      }),
+    });
+  }
+
+  /**
+   * Records the run pointer on status. Failing this write throws so the
+   * activity retries and converges the pointer — the deterministic name
+   * makes the retry harmless (Go stampLastExecutionID).
+   */
+  private async stampLastExecutionId(
+    scheduleId: string,
+    executionId: string,
+  ): Promise<void> {
+    try {
+      await this.deps.store.updateResource(
+        ApiResourceKind.schedule,
+        scheduleId,
+        ScheduleSchema,
+        (live) => {
+          const status = ensureStatus(live);
+          status.lastExecutionId = executionId;
+          bumpStatusAudit(status);
+        },
+      );
+    } catch (error) {
+      if (error instanceof ResourceNotFoundError) {
+        return; // deleted mid-fire: nothing to stamp
+      }
+      throw new Error(
+        `stamp last_execution_id on schedule ${scheduleId}: ${error instanceof Error ? error.message : String(error)}`,
+        { cause: error },
+      );
+    }
+  }
+}
+
+/**
+ * Merges one owner-set run bound with its platform cap: zero (or negative)
+ * means "unset" on either side, and when both are set the LOWER value wins
+ * — the platform profile is a guardrail, never a floor (Go
+ * clampedRunBoundInt/Float, one function here because JS numbers carry
+ * both).
+ */
+export function clampedRunBound(owner: number, platform: number): number {
+  if (owner <= 0) {
+    return Math.max(platform, 0);
+  }
+  if (platform <= 0) {
+    return owner;
+  }
+  return Math.min(owner, platform);
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/run-starter.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/run-starter.ts
@@ -276,14 +276,24 @@ export class RunStarter {
       switch (error.code) {
         case Code.AlreadyExists: {
           // The session auto-create's duplicate check can refuse even
-          // though the execution create has none — re-read the winner.
-          const winner = await findResourceBySlug(
-            store,
-            ApiResourceKind.agent_execution,
-            AgentExecutionSchema,
-            executionName,
-            org,
-          );
+          // though the execution create has none — re-read the winner. A
+          // re-find ERROR carries the same diagnostic wrapper as a missing
+          // winner (Go wraps findErr != nil || !found identically).
+          let winner;
+          try {
+            winner = await findResourceBySlug(
+              store,
+              ApiResourceKind.agent_execution,
+              AgentExecutionSchema,
+              executionName,
+              org,
+            );
+          } catch (findError) {
+            throw new Error(
+              `duplicate-check refusal but no execution row for ${executionName}: ${findError instanceof Error ? findError.message : String(findError)}`,
+              { cause: findError },
+            );
+          }
           if (winner === undefined) {
             throw new Error(
               `duplicate-check refusal but no execution row for ${executionName}: ${error.message}`,

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/status-writes.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/status-writes.ts
@@ -1,0 +1,50 @@
+/**
+ * The clock's status-write helpers — port the ensureStatus/bumpStatusAudit
+ * pair of pkg/domain/schedule/temporal/syncer.go.
+ *
+ * bumpStatusAudit is DELIBERATELY narrower than the shared
+ * setAuditFieldsForUpdate: Go's clock stamps only status-audit
+ * updated_at + event ("the same two leaves every cloud runtime patch
+ * bumps") and never an actor — the clock is the platform, not an operator.
+ * Controller-side status writes (trigger's last_fire_at stamp, resume's
+ * clear) use the FULL shared helper instead, exactly as Go splits
+ * steps.SetAuditFieldsForUpdate from the clock's bump. Two flavors, two
+ * writers, both wire-visible — keep them distinct.
+ */
+import { create } from "@bufbuild/protobuf";
+import { timestampNow } from "@bufbuild/protobuf/wkt";
+
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ScheduleStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/status_pb";
+import type { ScheduleStatus } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/status_pb";
+import {
+  ApiResourceAuditInfoSchema,
+  ApiResourceAuditSchema,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/status_pb";
+
+/**
+ * Returns the schedule's status, materializing the nested message a fresh
+ * row may lack (Go ensureStatus).
+ */
+export function ensureStatus(schedule: Schedule): ScheduleStatus {
+  if (schedule.status === undefined) {
+    schedule.status = create(ScheduleStatusSchema);
+  }
+  return schedule.status;
+}
+
+/**
+ * Stamps the status-audit trail for a runtime write — updated_at + event
+ * "updated", nothing else (Go bumpStatusAudit; see the module header for
+ * why this is not setAuditFieldsForUpdate).
+ */
+export function bumpStatusAudit(status: ScheduleStatus): void {
+  if (status.audit === undefined) {
+    status.audit = create(ApiResourceAuditSchema);
+  }
+  if (status.audit.statusAudit === undefined) {
+    status.audit.statusAudit = create(ApiResourceAuditInfoSchema);
+  }
+  status.audit.statusAudit.updatedAt = timestampNow();
+  status.audit.statusAudit.event = "updated";
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/syncer.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/syncer.ts
@@ -1,0 +1,208 @@
+/**
+ * The Syncer — ports pkg/domain/schedule/temporal/syncer.go: converges one
+ * Schedule resource's Temporal artifact to its desired state and records
+ * the result on the resource's status. The ONE arming/teardown authority,
+ * shared by the write-path steps, the reconciliation pass, and the tick's
+ * next-fire refresh.
+ *
+ * The client arrives through a provider, not a field: the server hot-swaps
+ * its Temporal client on reconnect (src/temporal/manager.ts), and a
+ * component holding a stale client silently dies after the first blip.
+ * Reading through the provider on every call makes that entire bug class
+ * unrepresentable here.
+ *
+ * Status writes go through store.updateResource — the OSS equivalent of
+ * the cloud's targeted leaf patches (DD-015 D-C): SQLite stores one
+ * protobuf blob, so the atomic read-modify-write under the store's write
+ * lock is what keeps a concurrent `stigmer apply` from clobbering the
+ * stamp (and vice versa). status.next_fire_at is the contract's arming
+ * witness: stamped from Temporal's own answer when armed, cleared when the
+ * artifact is paused, absent while nothing has converged.
+ *
+ * Go's Clock/Syncer also carries a Trigger method (the DD-014
+ * artifact-trigger lane); DD-017 D-5 rewired the trigger RPC to the
+ * direct-run path and left it with zero production callers, so this port
+ * deliberately omits it (sub-project decision 2, owner-ratified at the
+ * plan gate; disclosed in the PR register).
+ */
+import type { Client, ScheduleDescription } from "@temporalio/client";
+import { ScheduleAlreadyRunning, ScheduleNotFoundError } from "@temporalio/client";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+
+import { ScheduleSchema } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import type { Schedule } from "@stigmer/protos/ai/stigmer/agentic/schedule/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+import type { Store } from "../../store/interface.js";
+import type { ScheduleArtifact } from "./artifact.js";
+import { desiredPaused, note } from "./artifact.js";
+import { artifactId } from "./names.js";
+import { bumpStatusAudit, ensureStatus } from "./status-writes.js";
+
+/**
+ * The syncer's answer when no Temporal client exists right now (Go
+ * ErrTemporalUnavailable). Callers on the write path treat it as "converge
+ * later" (arming is best-effort — DD-015 D-A).
+ */
+export class TemporalUnavailableError extends Error {
+  constructor() {
+    super("temporal is not connected");
+    this.name = "TemporalUnavailableError";
+  }
+}
+
+export class ScheduleSyncer {
+  constructor(
+    /** May return undefined (Temporal down or never connected). */
+    private readonly clientProvider: () => Client | undefined,
+    private readonly store: Store,
+    private readonly artifact: ScheduleArtifact,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Creates or updates the resource's artifact to the desired state, then
+   * stamps status.next_fire_at from Temporal's answer. Returns the stamped
+   * time (undefined when the artifact is paused) so write paths can mirror
+   * it into their response state (Go EnsureAndRecord).
+   */
+  async ensureAndRecord(schedule: Schedule): Promise<Date | undefined> {
+    const client = this.clientProvider();
+    if (client === undefined) {
+      throw new TemporalUnavailableError();
+    }
+
+    const resourceId = schedule.metadata?.id ?? "";
+    const id = artifactId(resourceId);
+
+    try {
+      await client.schedule.create(this.artifact.createOptions(schedule));
+      this.logger.info("Created schedule artifact", {
+        artifact_id: id,
+        note: note(schedule),
+        paused: desiredPaused(schedule),
+      });
+    } catch (error) {
+      if (!(error instanceof ScheduleAlreadyRunning)) {
+        throw new Error(`create schedule artifact ${id}: ${message(error)}`, {
+          cause: error,
+        });
+      }
+      // Create-or-update convergence: rewrite the existing artifact to the
+      // complete desired state. A lost race between two writers is benign —
+      // both write the same desired state.
+      try {
+        await client.schedule
+          .getHandle(id)
+          .update((previous: ScheduleDescription) =>
+            this.artifact.applyDesiredState(previous, schedule),
+          );
+      } catch (updateError) {
+        throw new Error(
+          `update schedule artifact ${id}: ${message(updateError)}`,
+          { cause: updateError },
+        );
+      }
+      this.logger.info("Updated schedule artifact", {
+        artifact_id: id,
+        note: note(schedule),
+        paused: desiredPaused(schedule),
+      });
+    }
+
+    return this.recordNextFireAt(schedule);
+  }
+
+  /**
+   * Reads the next fire time from the LIVE artifact — Temporal's answer is
+   * authoritative (it accounts for the catch-up window; the platform
+   * computes nothing). Undefined while paused, per status.next_fire_at's
+   * contract (Go PeekNextFireAt).
+   */
+  async peekNextFireAt(schedule: Schedule): Promise<Date | undefined> {
+    if (desiredPaused(schedule)) {
+      return undefined;
+    }
+    const client = this.clientProvider();
+    if (client === undefined) {
+      throw new TemporalUnavailableError();
+    }
+    let description: ScheduleDescription;
+    try {
+      description = await client.schedule
+        .getHandle(artifactId(schedule.metadata?.id ?? ""))
+        .describe();
+    } catch (error) {
+      throw new Error(`describe schedule artifact: ${message(error)}`, {
+        cause: error,
+      });
+    }
+    return description.info.nextActionTimes[0];
+  }
+
+  /**
+   * Deletes the resource's artifact. Not-found is success — delete is
+   * idempotent from the platform's point of view even though Temporal's is
+   * not (Go Teardown).
+   */
+  async teardown(resourceId: string): Promise<void> {
+    const client = this.clientProvider();
+    if (client === undefined) {
+      throw new TemporalUnavailableError();
+    }
+    const id = artifactId(resourceId);
+    try {
+      await client.schedule.getHandle(id).delete();
+    } catch (error) {
+      if (error instanceof ScheduleNotFoundError) {
+        this.logger.info("Schedule artifact already gone", { artifact_id: id });
+        return;
+      }
+      throw new Error(`delete schedule artifact ${id}: ${message(error)}`, {
+        cause: error,
+      });
+    }
+    this.logger.info("Deleted schedule artifact", { artifact_id: id });
+  }
+
+  /**
+   * Stamps status.next_fire_at from peekNextFireAt onto the LIVE row
+   * (updateResource re-reads inside the lock — the stamp can never
+   * resurrect a stale snapshot of the rest of status). Go recordNextFireAt.
+   */
+  private async recordNextFireAt(schedule: Schedule): Promise<Date | undefined> {
+    const nextFireAt = await this.peekNextFireAt(schedule);
+
+    try {
+      await this.store.updateResource(
+        ApiResourceKind.schedule,
+        schedule.metadata?.id ?? "",
+        ScheduleSchema,
+        (live) => {
+          const status = ensureStatus(live);
+          status.nextFireAt =
+            nextFireAt === undefined ? undefined : timestampFromDate(nextFireAt);
+          bumpStatusAudit(status);
+        },
+      );
+    } catch (error) {
+      if (error instanceof ResourceNotFoundError) {
+        // Deleted between arm and stamp: the orphaned artifact is harmless
+        // (revalidation no-ops it) and the reconciliation pass reaps it.
+        this.logger.info(
+          "Schedule row gone before next_fire_at stamp — skipping",
+          { schedule_id: schedule.metadata?.id ?? "" },
+        );
+        return nextFireAt;
+      }
+      throw new Error(`stamp next_fire_at: ${message(error)}`, { cause: error });
+    }
+    return nextFireAt;
+  }
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/worker.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/worker.ts
@@ -1,0 +1,81 @@
+/**
+ * The schedule-clock worker factory — ports the registration half of
+ * pkg/domain/schedule/temporal/worker_config.go.
+ *
+ * The tick runs on its own queue (schedule_stigmer): since a tick SPANS
+ * its run, a burst of long-tracking ticks must never starve the
+ * agent-execution queue's workers — and vice versa.
+ *
+ * The worker is created by the Temporal manager's factory list, which also
+ * RE-creates it on every reconnect. Components that merely call Temporal
+ * (the syncer, the reconciler) survive reconnects by reading the client
+ * through a provider; the worker is the one piece that must genuinely be
+ * rebuilt, because a worker is bound to the connection it was created
+ * with.
+ *
+ * The tick workflow registers under its byte-pinned slash type via the
+ * barrel's arbitrary export name (workflows/index.ts — Go's explicit
+ * RegisterWorkflowWithOptions{Name: TickWorkflowType} twin); the five
+ * activities register under their slash names as the activities object's
+ * keys.
+ */
+import { Worker } from "@temporalio/worker";
+
+import type { Logger } from "../../boot/logger.js";
+import type { Store } from "../../store/interface.js";
+import type { WorkerFactory } from "../manager.js";
+import { resolveWorkflowSource } from "../workflow-source.js";
+import { createScheduleTickActivities } from "./activities.js";
+import type { ScheduleTemporalConfig } from "./config.js";
+import type { RunStarter } from "./run-starter.js";
+import type { ScheduleSyncer } from "./syncer.js";
+
+export interface ScheduleWorkerDeps {
+  readonly store: Store;
+  readonly config: ScheduleTemporalConfig;
+  readonly syncer: ScheduleSyncer;
+  readonly runStarter: RunStarter;
+  readonly logger: Logger;
+}
+
+export function newScheduleWorkerFactory(deps: ScheduleWorkerDeps): WorkerFactory {
+  return async ({ nativeConnection, namespace, payloadCodecs }) => {
+    const activities = createScheduleTickActivities({
+      store: deps.store,
+      config: deps.config,
+      syncer: deps.syncer,
+      runStarter: deps.runStarter,
+      logger: deps.logger,
+    });
+
+    const workflowSource = resolveWorkflowSource({
+      workflowsEntryCandidates: [
+        // Compiled dist (how conformance and the CLI boot the server).
+        new URL("./workflows/index.js", import.meta.url),
+        // The tsx dev loop runs from src/ — the SDK bundler compiles TS.
+        new URL("./workflows/index.ts", import.meta.url),
+      ],
+      prebuiltSibling: new URL("./workflow-bundle-schedule.js", import.meta.url),
+    });
+
+    deps.logger.info("Creating schedule-clock Temporal worker", {
+      queue: deps.config.stigmerQueue,
+      workflow_source: workflowSource.kind,
+    });
+
+    return Worker.create({
+      connection: nativeConnection,
+      namespace,
+      taskQueue: deps.config.stigmerQueue,
+      activities,
+      ...(workflowSource.kind === "prebuilt"
+        ? { workflowBundle: { codePath: workflowSource.codePath } }
+        : { workflowsPath: workflowSource.workflowsPath }),
+      // The decode-only codec chain (manager.ts's choke-point note) — the
+      // tick's payloads are plain JSON today, but the worker's converter
+      // must match the client's so a future encrypted payload in history
+      // replays instead of wedging.
+      ...(payloadCodecs.length > 0 ? { dataConverter: { payloadCodecs } } : {}),
+    });
+  };
+}

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/workflows/index.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/workflows/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Workflow barrel — the entry point for Temporal's workflow bundler (the
+ * agentexecution precedent). ES2022 arbitrary module export names map the
+ * TypeScript function to the slash-delimited, byte-pinned workflow type
+ * the artifact's baked action starts ("schedule/tick", ../names.ts).
+ *
+ * WORKFLOW-BUNDLE IMPORT DISCIPLINE: everything reachable from this module
+ * runs in the deterministic sandbox — no node built-ins, no
+ * store/transport imports (see tick.ts's header).
+ */
+export { tick as "schedule/tick" } from "./tick.js";

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/workflows/tick.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/workflows/tick.ts
@@ -190,10 +190,14 @@ export async function tick(scheduleResourceId: string): Promise<void> {
     case RUN_ALREADY_STARTED:
       await trackRun(scheduleResourceId, nominalRfc3339, runStart);
       return;
-    default:
+    default: {
+      // Compile-time exhaustiveness; the runtime throw stands for
+      // deserialized history data outside the union.
+      const exhaustive: never = runStart.outcome;
       throw ApplicationFailure.nonRetryable(
-        `unknown run outcome "${runStart.outcome}"`,
+        `unknown run outcome "${String(exhaustive)}"`,
       );
+    }
   }
 }
 
@@ -289,9 +293,9 @@ async function trackRun(
  * recoveryBackoff's exact shape, the only backoff curve this platform runs
  * in production workflow code. It notices a 30-120s run (the common case)
  * within seconds and reaches its cap by cycle twelve, bounding poll volume
- * on long runs (Go trackingBackoff).
+ * on long runs (Go trackingBackoff). Exported for the curve's unit pin.
  */
-function trackingBackoffMs(cycle: number): number {
+export function trackingBackoffMs(cycle: number): number {
   const ms = cycle * 5_000;
   return ms > 60_000 ? 60_000 : ms;
 }

--- a/backend/services/stigmer-server-ts/src/temporal/schedule/workflows/tick.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/schedule/workflows/tick.ts
@@ -1,0 +1,390 @@
+/**
+ * The tick workflow — ports pkg/domain/schedule/temporal/tick_workflow.go:
+ * one schedule fire, spanning its run (DD-013 via DD-015): record the
+ * fire, start the run, poll it to a terminal phase, record the verdict.
+ * Spanning is what makes the artifact's overlap SKIP genuinely mean "never
+ * start a run while the last is active", and the verdict is what feeds the
+ * failure streak behind the platform auto-pause.
+ *
+ * WHY A TIMER-DRIVEN POLL AND NOT THE CALLBACK TOKEN — read before
+ * "fixing" this. The platform already uses async activity completion for
+ * call:agent, so the token is the tempting shape here too. It loses on
+ * grounds that are edition-neutral (DD-015 D-E): the token cannot be
+ * re-armed after a create-then-crash, and its completion fire is
+ * best-effort — two silent-hang modes on a surface where a hang is a
+ * silenced reminder. The poll holds no worker thread (the workflow is
+ * dormant between polls; each poll is a millisecond activity), is bounded
+ * twice (budget + MAX_TRACKING_CYCLES), and keeps ONE verdict matrix
+ * across both editions.
+ *
+ * FORWARD CONSTRAINT: ticks live for minutes-to-an-hour once tracking is
+ * real, and OSS releases cut every 1-3 days — an in-flight tick WILL
+ * straddle a binary upgrade. Any behavioral change to this workflow body
+ * must be gated with patched()/deprecatePatch() (OD-6 discipline), and the
+ * replay gate (__tests__/replay.test.ts) must stay green against the
+ * committed histories.
+ *
+ * ERROR POSTURE (the #18 panel lesson, applied from day one): Go's
+ * `return err` fails the WORKFLOW EXECUTION; a plain thrown Error in the
+ * TS sandbox fails only the workflow TASK and retries forever. Every Go
+ * error return is therefore an ApplicationFailure here. Cancellation
+ * (sleep throwing CancelledFailure) propagates untouched — Go's
+ * workflow.Sleep error return, same terminal outcome.
+ *
+ * WORKFLOW-BUNDLE IMPORT DISCIPLINE: this module runs in the deterministic
+ * sandbox — imports are limited to @temporalio/workflow, @temporalio/common,
+ * and the pure names module.
+ */
+import {
+  ApplicationFailure,
+  isCancellation,
+  proxyActivities,
+  sleep,
+  workflowInfo,
+  log,
+} from "@temporalio/workflow";
+import {
+  SearchAttributeType,
+  defineSearchAttributeKey,
+} from "@temporalio/common";
+
+import {
+  FAILURE_RUN_FAILED,
+  FAILURE_RUN_TIMED_OUT,
+  FAILURE_START_FAILED,
+  PHASE_COMPLETED,
+  PHASE_GONE,
+  PHASE_RUNNING,
+  RECORD_FAILED_RUN_ACTIVITY_NAME,
+  RECORD_SUCCESSFUL_RUN_ACTIVITY_NAME,
+  RECORD_TICK_ACTIVITY_NAME,
+  POLL_EXECUTION_PHASE_ACTIVITY_NAME,
+  RUN_ALREADY_STARTED,
+  RUN_REFUSED,
+  RUN_SKIPPED,
+  RUN_STARTED,
+  RUN_TARGET_MISSING,
+  START_SCHEDULED_RUN_ACTIVITY_NAME,
+  TICK_FIRED,
+  artifactId,
+  type FailureRecorded,
+  type RunPhase,
+  type RunStart,
+  type ScheduleTickActivities,
+} from "../names.js";
+
+/**
+ * The tracking loop's code-level backstop, on top of the per-fire budget:
+ * 240 polls at the capped backoff is ~3.9 hours and ~1,200 history
+ * events — the loop can never outgrow a workflow history even if a budget
+ * is misconfigured (Go MaxTrackingCycles; exported so the bound test can
+ * assert it).
+ */
+export const MAX_TRACKING_CYCLES = 240;
+
+/**
+ * The nominal fire time Temporal stamps on every schedule-started
+ * workflow — tier one of the nominal-time derivation (present on cron
+ * fires AND manual triggers alike; Go scheduledStartTimeKey).
+ */
+const SCHEDULED_START_TIME_KEY = defineSearchAttributeKey(
+  "TemporalScheduledStartTime",
+  SearchAttributeType.DATETIME,
+);
+
+// The three activity-option contexts (Go tick_workflow.go). Record stub:
+// short idempotent status writes, retried freely.
+const recordActivities = proxyActivities<ScheduleTickActivities>({
+  startToCloseTimeout: "30 seconds",
+  retry: {
+    maximumAttempts: 3,
+    initialInterval: "5 seconds",
+    backoffCoefficient: 2.0,
+  },
+});
+// Run-start stub: enters the full create pipeline (session, context,
+// workflow start) — minutes-scale timeout, still retried (the
+// deterministic execution name absorbs retries).
+const startActivities = proxyActivities<ScheduleTickActivities>({
+  startToCloseTimeout: "3 minutes",
+  retry: {
+    maximumAttempts: 3,
+    initialInterval: "5 seconds",
+    backoffCoefficient: 2.0,
+  },
+});
+// Failure-record stub: EXACTLY ONE attempt — the streak increment is the
+// clock's single non-idempotent write. A retry after a successful write
+// over-counts and pauses a healthy schedule early; a lost write
+// under-counts, which fails safe.
+const failureActivities = proxyActivities<ScheduleTickActivities>({
+  startToCloseTimeout: "30 seconds",
+  retry: { maximumAttempts: 1 },
+});
+
+/**
+ * Executes one tick (Go TickWorkflow.Run; registered as "schedule/tick"
+ * via the barrel). The single argument is the schedule resource id
+ * (Temporal bakes action args once — the nominal fire time is derived,
+ * never carried).
+ */
+export async function tick(scheduleResourceId: string): Promise<void> {
+  const nominal = nominalFireTime(scheduleResourceId);
+  const nominalRfc3339 = rfc3339Seconds(nominal);
+
+  const tickOutcome = await failing(
+    "record tick",
+    recordActivities[RECORD_TICK_ACTIVITY_NAME](
+      scheduleResourceId,
+      nominalRfc3339,
+    ),
+  );
+  if (tickOutcome !== TICK_FIRED) {
+    log.info("Schedule tick complete", {
+      schedule_id: scheduleResourceId,
+      nominal_fire_time: nominalRfc3339,
+      outcome: tickOutcome,
+    });
+    return;
+  }
+
+  const runStart = await failing(
+    "start scheduled run",
+    startActivities[START_SCHEDULED_RUN_ACTIVITY_NAME](
+      scheduleResourceId,
+      nominalRfc3339,
+    ),
+  );
+
+  switch (runStart.outcome) {
+    case RUN_SKIPPED:
+      log.info("Schedule tick complete", {
+        schedule_id: scheduleResourceId,
+        nominal_fire_time: nominalRfc3339,
+        run_outcome: runStart.outcome,
+      });
+      return;
+    case RUN_TARGET_MISSING:
+    case RUN_REFUSED: {
+      // The run never existed: the streak counts the fire, the completion
+      // verdicts do not.
+      const recorded = await failing(
+        "record start failure",
+        failureActivities[RECORD_FAILED_RUN_ACTIVITY_NAME](
+          scheduleResourceId,
+          runStart.failureReason,
+          FAILURE_START_FAILED,
+        ),
+      );
+      log.info("Schedule tick complete", {
+        schedule_id: scheduleResourceId,
+        nominal_fire_time: nominalRfc3339,
+        run_outcome: runStart.outcome,
+        verdict: "start_failed",
+        consecutive_failures: recorded.consecutiveFailures,
+        paused: recorded.paused,
+      });
+      return;
+    }
+    case RUN_STARTED:
+    case RUN_ALREADY_STARTED:
+      await trackRun(scheduleResourceId, nominalRfc3339, runStart);
+      return;
+    default:
+      throw ApplicationFailure.nonRetryable(
+        `unknown run outcome "${runStart.outcome}"`,
+      );
+  }
+}
+
+/**
+ * Polls the run to a terminal phase within this fire's budget and records
+ * the verdict (Go trackRun).
+ */
+async function trackRun(
+  scheduleResourceId: string,
+  nominalRfc3339: string,
+  runStart: RunStart,
+): Promise<void> {
+  const deadline = Date.now() + runStart.trackingTimeoutMinutes * 60_000;
+
+  let phase: RunPhase = PHASE_RUNNING;
+  let budgetExhausted = false;
+  // Poll-first, deadline checked after each poll and before each sleep: an
+  // ALREADY_STARTED retry may already be terminal, and the loop must never
+  // sleep past its own deadline.
+  for (let cycle = 1; ; cycle++) {
+    if (cycle > MAX_TRACKING_CYCLES) {
+      budgetExhausted = true;
+      break;
+    }
+    // DB unreachable past the activity's own retries: fail the tick with
+    // NO verdict — guessing "failed" during an outage could pause a
+    // healthy schedule. The artifact stays armed (PauseOnFailure=false);
+    // the next fire is unaffected.
+    phase = await failing(
+      "poll execution phase",
+      recordActivities[POLL_EXECUTION_PHASE_ACTIVITY_NAME](runStart.executionId),
+    );
+    if (phase !== PHASE_RUNNING) {
+      break;
+    }
+    if (Date.now() >= deadline) {
+      budgetExhausted = true;
+      break;
+    }
+    await sleep(trackingBackoffMs(cycle));
+  }
+
+  if (budgetExhausted) {
+    // The run is NOT cancelled: its own execution profile bounds spend,
+    // and a destructive act buys nothing. Under SKIP this budget is
+    // literally the maximum time one hung run may silence the schedule.
+    const reason = `run ${runStart.executionId} did not finish within ${runStart.trackingTimeoutMinutes} minutes`;
+    const recorded = await failing(
+      "record tracking timeout",
+      failureActivities[RECORD_FAILED_RUN_ACTIVITY_NAME](
+        scheduleResourceId,
+        reason,
+        FAILURE_RUN_TIMED_OUT,
+      ),
+    );
+    logVerdict(scheduleResourceId, nominalRfc3339, runStart, "timed_out", recorded);
+    return;
+  }
+  if (phase === PHASE_COMPLETED) {
+    await failing(
+      "record successful run",
+      recordActivities[RECORD_SUCCESSFUL_RUN_ACTIVITY_NAME](scheduleResourceId),
+    );
+    logVerdict(scheduleResourceId, nominalRfc3339, runStart, "completed");
+    return;
+  }
+  if (phase === PHASE_GONE) {
+    // Deleting a run must not brick its schedule: no verdict.
+    logVerdict(scheduleResourceId, nominalRfc3339, runStart, "gone");
+    return;
+  }
+  // FAILED, CANCELLED, TERMINATED.
+  const reason = `run ${runStart.executionId} ended ${phase.toLowerCase()}`;
+  const recorded = await failing(
+    "record failed run",
+    failureActivities[RECORD_FAILED_RUN_ACTIVITY_NAME](
+      scheduleResourceId,
+      reason,
+      FAILURE_RUN_FAILED,
+    ),
+  );
+  logVerdict(
+    scheduleResourceId,
+    nominalRfc3339,
+    runStart,
+    phase.toLowerCase(),
+    recorded,
+  );
+}
+
+/**
+ * The delay before the next phase poll: linear cycle×5s capped at 60s —
+ * recoveryBackoff's exact shape, the only backoff curve this platform runs
+ * in production workflow code. It notices a 30-120s run (the common case)
+ * within seconds and reaches its cap by cycle twelve, bounding poll volume
+ * on long runs (Go trackingBackoff).
+ */
+function trackingBackoffMs(cycle: number): number {
+  const ms = cycle * 5_000;
+  return ms > 60_000 ? 60_000 : ms;
+}
+
+/**
+ * Derives THE fire's nominal time, three tiers (Go nominalFireTime):
+ *  1. The TemporalScheduledStartTime search attribute (cron fires and
+ *     manual triggers both carry it — spike-verified on the Go side).
+ *  2. The workflow-id suffix Temporal appends to the artifact's base id.
+ *  3. Workflow time truncated to whole seconds (a hand-started tick).
+ *
+ * The nominal time is the fire's identity: last_fire_at records it and the
+ * execution name derives from it, so both idempotency keys agree on every
+ * retry.
+ */
+function nominalFireTime(scheduleResourceId: string): Date {
+  const attribute = workflowInfo().typedSearchAttributes.get(
+    SCHEDULED_START_TIME_KEY,
+  );
+  if (attribute !== undefined) {
+    return attribute;
+  }
+  const base = `${artifactId(scheduleResourceId)}-`;
+  const workflowId = workflowInfo().workflowId;
+  if (workflowId.startsWith(base)) {
+    const suffix = workflowId.slice(base.length);
+    // Go time.Parse(time.RFC3339) is strict; Date() is lenient — the
+    // pattern guard keeps a non-RFC3339 suffix falling to tier 3 exactly
+    // as Go's parse error does.
+    if (RFC3339_PATTERN.test(suffix)) {
+      const parsed = new Date(suffix);
+      if (!Number.isNaN(parsed.getTime())) {
+        return parsed;
+      }
+    }
+  }
+  // Date.now() is deterministic workflow time inside the sandbox — Go's
+  // workflow.Now twin.
+  return new Date(Math.floor(Date.now() / 1000) * 1000);
+}
+
+/**
+ * Maps a failed activity to Go's `return fmt.Errorf("<label>: %w", err)` —
+ * a WORKFLOW failure (see the module header's error posture). Cancellation
+ * failures propagate untouched.
+ */
+async function failing<T>(label: string, promise: Promise<T>): Promise<T> {
+  try {
+    return await promise;
+  } catch (error) {
+    if (error instanceof ApplicationFailure || isCancellation(error)) {
+      throw error;
+    }
+    throw ApplicationFailure.create({
+      message: `${label}: ${error instanceof Error ? error.message : String(error)}`,
+      cause: error instanceof Error ? error : undefined,
+    });
+  }
+}
+
+/** Anchored RFC-3339 shape (Z or numeric offset, optional fraction). */
+const RFC3339_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+/** Go time.RFC3339, UTC whole seconds (the wire shape the activities pin). */
+function rfc3339Seconds(date: Date): string {
+  return date.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function logVerdict(
+  scheduleResourceId: string,
+  nominalRfc3339: string,
+  runStart: RunStart,
+  verdict: string,
+  recorded?: FailureRecorded,
+): void {
+  if (recorded === undefined) {
+    log.info("Schedule tick complete", {
+      schedule_id: scheduleResourceId,
+      nominal_fire_time: nominalRfc3339,
+      run_outcome: runStart.outcome,
+      execution_id: runStart.executionId,
+      verdict,
+    });
+    return;
+  }
+  log.info("Schedule tick complete", {
+    schedule_id: scheduleResourceId,
+    nominal_fire_time: nominalRfc3339,
+    run_outcome: runStart.outcome,
+    execution_id: runStart.executionId,
+    verdict,
+    consecutive_failures: recorded.consecutiveFailures,
+    paused: recorded.paused,
+  });
+}

--- a/test/conformance/src/targets/local-ts-execution.ts
+++ b/test/conformance/src/targets/local-ts-execution.ts
@@ -22,13 +22,11 @@ import type { CapabilityFlags, PrivilegedScope, TargetProfile, TenancyContext } 
 
 export class LocalTsExecutionTarget implements TargetProfile {
   readonly name = "local-ts-execution";
-  // The local-go-execution matrix with ONE honest deviation: scheduleFiring
-  // stays false until the schedule clock ports (D4 #22 flips it) — the TS
-  // server has no Temporal Schedule reconciler yet, so declaring the
-  // capability would let a manually-selected firing suite run against an
-  // engine that cannot fire. Disclosed exactly like the documented
-  // workflowChildApprovalForwarding false-at-#18 → true-at-#23 path
-  // (sub-project 20260824.03 ratified brief #4).
+  // The local-go-execution matrix, byte-identical since D4 #22 ported the
+  // schedule clock (scheduleFiring was the one disclosed deviation while
+  // the TS server had no Temporal Schedule reconciler). The remaining
+  // false-at-#18 → true-at-#23 path is workflowChildApprovalForwarding —
+  // the ratified parity-plus delta, not a gap.
   readonly capabilities: CapabilityFlags = {
     multiTenant: false,
     externalOrgLookup: false,
@@ -39,8 +37,10 @@ export class LocalTsExecutionTarget implements TargetProfile {
     // so a gated agent_call child never surfaces its gate to the parent workflow
     // (DD-012). #23 flips this flag on THIS target — the parity-plus delta.
     workflowChildApprovalForwarding: false,
-    // False until D4 #22 ports the schedule clock (see the class comment).
-    scheduleFiring: false,
+    // True since D4 #22 ported the schedule clock (tick workflow +
+    // reconciler on the schedule_stigmer queue) — the firing suite runs
+    // against this engine exactly as against local-go-execution.
+    scheduleFiring: true,
     // Single-tenant OSS: the reserved-label write guard is cloud-only
     // (stigmer-cloud#320), so the caller may create labeled candidates.
     clientReservedLabelWrites: true,
@@ -73,9 +73,9 @@ export class LocalTsExecutionTarget implements TargetProfile {
       args: [entry],
       temporalHostPort: this.temporal.hostPort,
       env: {
-        // The schedule failure-streak override the Go target pins — inert
-        // until #22 ports the schedule clock, set now so the env contract
-        // stays byte-identical across both execution targets.
+        // The schedule failure-streak override the Go target pins — makes
+        // the auto-pause provable in two fires (active since #22 ported
+        // the schedule clock).
         STIGMER_SCHEDULES_MAX_CONSECUTIVE_FAILURES: "2",
       },
     });

--- a/test/conformance/vitest.local-ts-execution.config.ts
+++ b/test/conformance/vitest.local-ts-execution.config.ts
@@ -35,6 +35,11 @@ export default defineConfig({
       "src/suites-execution/open-computer-use.conformance.test.ts",
       "src/suites-execution/session-immutability.conformance.test.ts",
       "src/suites-execution/envmerge-agent.conformance.test.ts",
+      // schedule firing — sub-project #22 (sp.schedule): the synchronous
+      // trigger outcome, the manual-fires-never-feed-the-streak pin, and
+      // the listRuns history surface, active now that scheduleFiring
+      // flipped true on this target.
+      "src/suites-execution/schedule-firing.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts-execution.ts"],
     env: {

--- a/test/conformance/vitest.local-ts.config.ts
+++ b/test/conformance/vitest.local-ts.config.ts
@@ -90,6 +90,10 @@ export default defineConfig({
       "src/suites/github.conformance.test.ts",
       "src/suites/artifact.conformance.test.ts",
       "src/suites/project.conformance.test.ts",
+      // schedule — sub-project #22 (sp.schedule; the last Class B domain):
+      // the CW-6 CRUD + trigger/resume refusal contract. Temporal-free by
+      // design — the firing lanes roster on local-ts-execution.
+      "src/suites/schedule.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts.ts"],
     env: {


### PR DESCRIPTION
## Summary
The last Class B domain, closing the execution surface: `pkg/domain/schedule` ported whole to the TS server — the 11-RPC controller surface, the lexical cron/timezone validation, AND the Temporal clock (the `schedule/tick` workflow, five slash-namespaced activities, drift-fingerprint Schedule artifacts, the 4-phase reconciler, the fire ledger). `scheduleFiring` flips true on `local-ts-execution`: the capability matrix is now byte-identical to `local-go-execution` except the ratified #23 parity-plus flag.

Parent program: stigmer-cloud `20260822.01` (D4 entry #22, sub-project `20260825.05.sp.schedule`; plan gate owner-approved).

## What ports where
- `src/domain/schedule/` — controller (apply/create/update/delete/resume/trigger + get/getByReference/getByAgent/list/listRuns), the DD-009 C-4 lexical cron validator, the defaults resolver with the same-org anti-probing invariant, the update graft persist (NOT the generic Persist: the tick is a concurrent status writer), resume's atomic latch+streak clear, trigger's DD-017 D-5 direct-run path.
- `src/temporal/schedule/` — config (10 STIGMER_SCHEDULES_* knobs + clamps), artifact mapper (Overlap SKIP, PauseOnFailure false, the `cron=… tz=…` note fingerprint, one baked action arg), syncer (create-or-update on ScheduleAlreadyRunning; `next_fire_at` from Temporal's own `nextActionTimes`), RunStarter (deterministic execution name = THE idempotency key; min(owner,platform) clamps; UNATTENDED; the model-pinning launch backstop), tick workflow + activities (the `maximumAttempts: 1` failure-record pin — the clock's single non-idempotent write), run ledger, reconciler (boot + periodic + reconnect-kicked; loud containment on the pass chain), worker factory on its own `schedule_stigmer` queue.
- Wiring: the compose clock stage mirrors `server.go` 578–592; the worker joins the manager's factory list (the seam #18 reserved); the reconciler kick rides the reconnect hook; `inprocess.ts` gains the `scheduleExecutionCreator` edge — every fire enters the FULL execution create pipeline.

## Verification
- `local-ts`: 24 suites, 448 passed / 1 skipped — the schedule suite green on its FIRST rostered run.
- `local-ts-execution`: 8 files, 58 tests — the firing suite 4/4: a manual trigger drove a REAL agent execution end-to-end through the TS engine.
- Regression-free: `local-go` 492, `local-go-execution` 159.
- Unit: 1478/1478 (104 files; ~200 new — incl. the reconciler's 4-phase matrix with the phase-3 point-read orphan guard, the syncer's convergence arms, 15 tick-workflow scenarios against a live Temporal test server, and 23 composed-server tests).
- Replay gate: 3 committed histories mirroring Go's gold masters, exercising the tier-2 nominal-time derivation; fail-not-skip.
- Both bundles boot-verified; `tsc --noEmit` clean.
- Two-reviewer adversarial panel: quality side 2 BLOCKING (reconciler pass-chain rejection containment — a rejected pass could brick the kick queue, abort shutdown, or crash the daemon; and the untested reconciler/syncer, now 27 tests) + 8 minors, ALL fixed in-branch. Parity side ZERO blocking; 2 of 6 minors fixed (Go's wrap labels, guard copy), the rest disclosed below.

## Parity nuances disclosed (the register)
1. **Go `%q` vs plain quotes in validation copy**: Go escapes embedded quotes/backslashes in `%q`-rendered inputs; the TS port (like EVERY merged domain before it) interpolates raw. Divergent bytes only for adversarial inputs containing `"` or `\`. A port-wide `goQuote` helper is the fix if the byte contract should hold there — program-level decision, not this PR's.
2. **Timezone acceptance set**: TS guards case-variants of ICU-canonical zones (restoring Go's case-sensitive refusal) but (a) case-variants of ALIAS names (`asia/kolkata`, ICU canonical `Asia/Calcutta`) are accepted where Go refuses, and (b) tzdata-only names like `Factory` are refused where Go accepts. Both directions are placeholder/typo corners.
3. **Reconciliation-interval floor**: `STIGMER_SCHEDULES_RECONCILIATION_INTERVAL_MINUTES=0` clamps to 1 minute; Go's `time.NewTicker(0)` PANICS. The clamp follows the config file's sibling floors — a silent setInterval hot loop is the worse failure mode.
4. **Resume's no-op path** re-reads the row after the aborted atomic write; a concurrent delete in that window answers NOT_FOUND where Go (holding the pre-read out-param) answers success. Both honest; not deterministically observable.
5. **Env-parsing corners**: Go's `strconv` accepts `Inf`/hex floats and defaults on >int64; TS regex-gates ints and requires finite floats. Pathological values only.
6. **Engine-down trigger**: the in-process create's UNAVAILABLE re-mints through `rethrownStatusError` before reaching the outer wire — echoing the inner error corrupts HTTP/2 trailers (the #18 transport finding; caught live by this port's composed suite).

## Merge coordination
- **CI note**: this branch predates fix PR #875 (the zip-structure lane heals + the `orgOAuthAppConfiguration` flag). The `Conformance (local-ts)` lane and the conformance typecheck need #875 merged and this branch synced with main — local runs above used built lib dists and are unaffected.
- In-flight #19/#21 share the additive `compose.ts`/factory-list/roster seams; whichever merges second rebases (the #18/#20 protocol).

Made with [Cursor](https://cursor.com)