### PR TITLE
feat(backend/stigmer-server-ts): send child_approval_required from the HITL loop (D4 #23)

### DIFF
--- a/apis/ai/stigmer/agentic/agentexecution/docs/async-workflow-integration.md
+++ b/apis/ai/stigmer/agentic/agentexecution/docs/async-workflow-integration.md
@@ -165,15 +165,18 @@ execution := &agentexecutionv1.AgentExecution{
 ```
 Agent enters WAITING_FOR_APPROVAL
     │
-    ├── Java sends Temporal signal "child_approval_required" to parent workflow ID
+    ├── The control plane (cloud Java, or the OSS TS server since D4 #23)
+    │   sends Temporal signal "child_approval_required" to parent workflow ID
     │
-    ├── Signal payload (ChildApprovalNotification):
-    │   ├── execution_id: "aex_abc123"
-    │   └── pending_approvals: [all pending entries]
+    ├── Signal payload: the bare child execution id string, e.g. "aex_abc123"
+    │   (identity-only per DD-012; the legacy ChildApprovalNotification
+    │   full-payload shape was retired after stigmer-cloud#509 — proto-encoded
+    │   payloads poisoned the receiving workflow task)
     │
-    ├── Go workflow receives signal via signal channel
+    ├── The runner's call-agent orchestrator receives the signal
+    ├── Derives the gate from the child's persisted pending_approvals
     ├── Updates WorkflowTask status to WORKFLOW_TASK_WAITING_APPROVAL
-    └── Populates WorkflowExecution.status.pending_approvals
+    └── Populates WorkflowExecution.status.pending_approvals (per-child merge)
 ```
 
 The Go workflow then surfaces the approval to users. Once approved, it forwards the decision to the agent via `AgentExecution.submitApproval` RPC using the `child_agent_execution_id` from the pending approval.

--- a/backend/services/stigmer-server-ts/scripts/capture-replay-histories.ts
+++ b/backend/services/stigmer-server-ts/scripts/capture-replay-histories.ts
@@ -14,7 +14,7 @@
  * Usage: npx tsx scripts/capture-replay-histories.ts
  * (requires the `temporal` CLI on PATH — same as the workflow tests)
  */
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import proto from "@temporalio/proto";
 import { TestWorkflowEnvironment } from "@temporalio/testing";
@@ -85,6 +85,15 @@ async function main(): Promise<void> {
     input: Record<string, unknown>,
     drive: (handle: import("@temporalio/client").WorkflowHandle) => Promise<void>,
   ): Promise<void> {
+    // Committed histories are the replay gate's CONTRACT (replay.test.ts):
+    // regenerating one from current code silently hollows the gate out, so
+    // existing files are never overwritten. Adding a NEW scenario just works;
+    // deliberate regeneration (only when no producing release is still
+    // supported) is --force.
+    if (existsSync(`${OUT_DIR}/${name}.json`) && !process.argv.includes("--force")) {
+      console.log(`skipped ${name}.json (committed history — --force to regenerate)`);
+      return;
+    }
     const handle = await env.client.workflow.start(
       "stigmer/agent-execution/invoke",
       {
@@ -162,6 +171,33 @@ async function main(): Promise<void> {
       await handle.signal("resume");
       await handle.result();
       releaseHold?.();
+    },
+  );
+
+  // 4. Parented HITL cycle (D4 #23): same gate as scenario 2 but with a
+  //    parent_workflow_id, so the history carries the two parent
+  //    notifications (child_execution_started at start,
+  //    child_approval_required from the HITL loop) — the DD-012 sender
+  //    pinned in the replay gate. The parent id is deliberately
+  //    nonexistent: the sends fail non-fatally, which is itself part of
+  //    the recorded command shape.
+  executeBehaviors = [
+    async () => slim("EXECUTION_WAITING_FOR_APPROVAL"),
+    async () => slim("EXECUTION_COMPLETED"),
+  ];
+  loadResults = [executionWithPendingApproval()];
+  await capture(
+    "hitl-approval-parented",
+    {
+      execution_id: "exec-replay",
+      session_id: "ses-1",
+      agent_id: "agt-1",
+      parent_workflow_id: "replay-parent-probe",
+    },
+    async (handle) => {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+      await handle.signal("approvalGateResolved");
+      await handle.result();
     },
   );
 

--- a/backend/services/stigmer-server-ts/src/temporal/agentexecution/__tests__/invoke-workflow.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/agentexecution/__tests__/invoke-workflow.test.ts
@@ -45,6 +45,8 @@ import {
   INVOKE_AGENT_EXECUTION_WORKFLOW_NAME,
   MEMO_ACTIVITY_TASK_QUEUE,
   SIGNAL_APPROVAL_GATE_RESOLVED,
+  SIGNAL_CHILD_APPROVAL_REQUIRED,
+  SIGNAL_CHILD_EXECUTION_STARTED,
   SIGNAL_PAUSE,
   SIGNAL_RESUME,
 } from "../names.js";
@@ -275,6 +277,42 @@ async function startWorkflow(
     args: [input],
     memo: { [MEMO_ACTIVITY_TASK_QUEUE]: TASK_QUEUE },
   });
+}
+
+/**
+ * Every outbound external signal, straight from the workflow's own event
+ * history — SignalExternalWorkflowExecutionInitiated carries the wire
+ * exactly as sent (signal name, target workflow id, payload bytes), so
+ * the parent-notification contract is asserted without a live receiver.
+ */
+async function externalSignalsSent(
+  handle: import("@temporalio/client").WorkflowHandle,
+): Promise<
+  Array<{ signalName: string; targetWorkflowId: string; payload: unknown }>
+> {
+  const { defaultPayloadConverter } = await import("@temporalio/common");
+  const history = await handle.fetchHistory();
+  const sent: Array<{
+    signalName: string;
+    targetWorkflowId: string;
+    payload: unknown;
+  }> = [];
+  for (const event of history.events ?? []) {
+    const attrs = event.signalExternalWorkflowExecutionInitiatedEventAttributes;
+    if (!attrs) continue;
+    const payloads = attrs.input?.payloads ?? [];
+    sent.push({
+      signalName: attrs.signalName ?? "",
+      targetWorkflowId: attrs.workflowExecution?.workflowId ?? "",
+      payload:
+        payloads.length > 0
+          ? defaultPayloadConverter.fromPayload(
+              payloads[0] as import("@temporalio/common").Payload,
+            )
+          : undefined,
+    });
+  }
+  return sent;
 }
 
 /** Polls the recorder until a status with the given phase lands. */
@@ -634,5 +672,114 @@ describe("invoke-agent-execution workflow (TestWorkflowEnvironment)", () => {
     await handle.result();
 
     expect(script.executeCalls).toHaveLength(1);
+  }, 30_000);
+
+  // ─── The child_approval_required sender (DD-012, D4 #23) ───────────────
+  // The OSS half of the child-approval forwarding contract: the HITL loop
+  // notifies parent_workflow_id on EVERY cycle with an identity-only
+  // BARE-STRING payload (cloud#509 — the one shape every SDK's default
+  // converter decodes). Asserted from the workflow's own history, the
+  // exact wire a real parent would receive.
+
+  it("emits child_approval_required to the parent on every HITL cycle, including the zero-gate reconcile cycle", async (testCtx) => {    if (!envReady) return testCtx.skip();
+    script.executeBehaviors = [
+      async () => slimResult(ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL),
+      async () => slimResult(ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL),
+      async () => slimResult(ExecutionPhase.EXECUTION_COMPLETED),
+    ];
+    // Cycle 1: a real pending-approval gate (signal, then wait). Cycle 2:
+    // decided-awaiting-reconcile — the zero-gate immediate re-invoke, which
+    // must STILL notify (cloud calls notifyParentWorkflowOfApproval before
+    // its gate-count branch; the runner treats an empty derivation as
+    // "already resolved").
+    script.loadResults = [
+      executionJson(statusWithPendingApproval()),
+      executionJson(statusDecidedAwaitingReconcile()),
+    ];
+
+    // A nonexistent parent doubles as the non-fatal arm: every signal send
+    // fails, and the run must still complete.
+    const handle = await startWorkflow(
+      workflowInput({ parent_workflow_id: "parent-probe" }),
+    );
+    await waitForPersistedPhase(ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL);
+    await handle.signal(SIGNAL_APPROVAL_GATE_RESOLVED);
+    await handle.result();
+
+    const approvalSignals = (await externalSignalsSent(handle)).filter(
+      (signal) => signal.signalName === SIGNAL_CHILD_APPROVAL_REQUIRED,
+    );
+    expect(approvalSignals, "one notification per HITL cycle").toHaveLength(2);
+    for (const signal of approvalSignals) {
+      expect(signal.targetWorkflowId).toBe("parent-probe");
+      // The BARE-STRING wire shape — cloud's exact payload, NOT the
+      // {executionId} object child_execution_started carries.
+      expect(signal.payload).toBe("exec-1");
+    }
+
+    // Ordering pin (cloud parity): the notify happens BEFORE the gate wait —
+    // the first outbound child_approval_required must precede the inbound
+    // approvalGateResolved in the event history. A sender moved after the
+    // wait would deadlock the real round-trip (the parent never learns).
+    const events = (await handle.fetchHistory()).events ?? [];
+    const notifyIdx = events.findIndex(
+      (event) =>
+        event.signalExternalWorkflowExecutionInitiatedEventAttributes
+          ?.signalName === SIGNAL_CHILD_APPROVAL_REQUIRED,
+    );
+    const gateResolvedIdx = events.findIndex(
+      (event) =>
+        event.workflowExecutionSignaledEventAttributes?.signalName ===
+        SIGNAL_APPROVAL_GATE_RESOLVED,
+    );
+    expect(notifyIdx).toBeGreaterThanOrEqual(0);
+    expect(gateResolvedIdx).toBeGreaterThanOrEqual(0);
+    expect(
+      notifyIdx,
+      "the parent notification precedes the gate wait",
+    ).toBeLessThan(gateResolvedIdx);
+  }, 30_000);
+
+  it("does not emit child_approval_required when the run never gates", async (testCtx) => {    if (!envReady) return testCtx.skip();
+    script.executeBehaviors = [
+      async () => slimResult(ExecutionPhase.EXECUTION_COMPLETED),
+    ];
+
+    const handle = await startWorkflow(
+      workflowInput({ parent_workflow_id: "parent-probe" }),
+    );
+    await handle.result();
+
+    const signals = await externalSignalsSent(handle);
+    // The started notification is the parent-liveness lane and always fires;
+    // the approval notification is gate-scoped and must not.
+    const started = signals.filter(
+      (signal) => signal.signalName === SIGNAL_CHILD_EXECUTION_STARTED,
+    );
+    expect(started).toHaveLength(1);
+    // The sibling-signal payload asymmetry, pinned: started carries the
+    // {executionId} object (the shape the runner's handler tolerates),
+    // while child_approval_required carries cloud's bare string.
+    expect(started[0]!.payload).toEqual({ executionId: "exec-1" });
+    expect(
+      signals.filter((signal) => signal.signalName === SIGNAL_CHILD_APPROVAL_REQUIRED),
+    ).toHaveLength(0);
+  }, 30_000);
+
+  it("does not signal any parent when invoked directly (no parent_workflow_id)", async (testCtx) => {    if (!envReady) return testCtx.skip();
+    script.executeBehaviors = [
+      async () => slimResult(ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL),
+      async () => slimResult(ExecutionPhase.EXECUTION_COMPLETED),
+    ];
+    script.loadResults = [executionJson(statusWithPendingApproval())];
+
+    const handle = await startWorkflow(workflowInput());
+    await waitForPersistedPhase(ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL);
+    await handle.signal(SIGNAL_APPROVAL_GATE_RESOLVED);
+    await handle.result();
+
+    // Gated AND resumed, yet zero external signals of any kind: the guard
+    // keys on parent_workflow_id presence, not on the gate.
+    expect(await externalSignalsSent(handle)).toHaveLength(0);
   }, 30_000);
 });

--- a/backend/services/stigmer-server-ts/src/temporal/agentexecution/__tests__/replay-histories/hitl-approval-parented.json
+++ b/backend/services/stigmer-server-ts/src/temporal/agentexecution/__tests__/replay-histories/hitl-approval-parented.json
@@ -1,0 +1,1070 @@
+{
+  "events": [
+    {
+      "eventId": "1",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 116373000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_STARTED",
+      "taskId": "1048829",
+      "workflowExecutionStartedEventAttributes": {
+        "workflowType": {
+          "name": "stigmer/agent-execution/invoke"
+        },
+        "taskQueue": {
+          "name": "replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJleGVjdXRpb25faWQiOiJleGVjLXJlcGxheSIsInNlc3Npb25faWQiOiJzZXMtMSIsImFnZW50X2lkIjoiYWd0LTEiLCJwYXJlbnRfd29ya2Zsb3dfaWQiOiJyZXBsYXktcGFyZW50LXByb2JlIn0="
+            }
+          ]
+        },
+        "workflowTaskTimeout": {
+          "seconds": "10"
+        },
+        "originalExecutionRunId": "01a03934-64c4-75a5-a61c-f62c02cd4419",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "firstExecutionRunId": "01a03934-64c4-75a5-a61c-f62c02cd4419",
+        "attempt": 1,
+        "firstWorkflowTaskBackoff": {},
+        "memo": {
+          "fields": {
+            "activityTaskQueue": {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InJlcGxheS1jYXB0dXJlIg=="
+            }
+          }
+        },
+        "header": {},
+        "workflowId": "replay-hitl-approval-parented"
+      }
+    },
+    {
+      "eventId": "2",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 146152000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048830",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "3",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 227963000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048835",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "2",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "requestId": "990bb584-c834-4321-8dfa-48328ce932c0",
+        "historySizeBytes": "499",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        }
+      }
+    },
+    {
+      "eventId": "4",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 323503000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048839",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "2",
+        "startedEventId": "3",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        },
+        "sdkMetadata": {
+          "coreUsedFlags": [
+            2,
+            3,
+            1
+          ],
+          "sdkName": "temporal-typescript",
+          "sdkVersion": "1.16.2"
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "5",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 324349000
+      },
+      "eventType": "EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED",
+      "taskId": "1048840",
+      "signalExternalWorkflowExecutionInitiatedEventAttributes": {
+        "workflowTaskCompletedEventId": "4",
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "replay-parent-probe"
+        },
+        "signalName": "child_execution_started",
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJleGVjdXRpb25JZCI6ImV4ZWMtcmVwbGF5In0="
+            }
+          ]
+        },
+        "namespaceId": "01a03934-4bd1-7109-85d3-81717671485f"
+      }
+    },
+    {
+      "eventId": "6",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 324826000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048841",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "1",
+        "activityType": {
+          "name": "EnsureThread"
+        },
+        "taskQueue": {
+          "name": "replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InNlcy0xIg=="
+            },
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "ImFndC0xIg=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {
+          "seconds": "300"
+        },
+        "startToCloseTimeout": {
+          "seconds": "30"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "4",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "5"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "500"
+          },
+          "maximumAttempts": 3
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "7",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 341990000
+      },
+      "eventType": "EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED",
+      "taskId": "1048847",
+      "signalExternalWorkflowExecutionFailedEventAttributes": {
+        "cause": "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND",
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "replay-parent-probe"
+        },
+        "initiatedEventId": "5",
+        "namespaceId": "01a03934-4bd1-7109-85d3-81717671485f"
+      }
+    },
+    {
+      "eventId": "8",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 341995000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048848",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "64478@Sureshs-Mac-Studio.local-8e6c1cfe9a68437888df24404688ebfa",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "9",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 355484000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048854",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "8",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "requestId": "e21f7ed7-f323-4380-bcf8-1f816ad9a4cd",
+        "historySizeBytes": "1474",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        }
+      }
+    },
+    {
+      "eventId": "10",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 480236000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048858",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "8",
+        "startedEventId": "9",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "11",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 347601000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048859",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "6",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "requestId": "f496ffc3-089e-4ab0-ac25-22bafc542e37",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        }
+      }
+    },
+    {
+      "eventId": "12",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 369546000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048860",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "InRocmVhZC0xIg=="
+            }
+          ]
+        },
+        "scheduledEventId": "6",
+        "startedEventId": "11",
+        "identity": "64478@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "13",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 480429000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048861",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "64478@Sureshs-Mac-Studio.local-8e6c1cfe9a68437888df24404688ebfa",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "14",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 480444000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048862",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "13",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "requestId": "request-from-RespondWorkflowTaskCompleted",
+        "historySizeBytes": "1671",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        }
+      }
+    },
+    {
+      "eventId": "15",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 510952000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048865",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "13",
+        "startedEventId": "14",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "16",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 511064000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048866",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "2",
+        "activityType": {
+          "name": "GenerateSessionSubject"
+        },
+        "taskQueue": {
+          "name": "replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "ImV4ZWMtcmVwbGF5Ig=="
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {
+          "seconds": "30"
+        },
+        "startToCloseTimeout": {
+          "seconds": "60"
+        },
+        "heartbeatTimeout": {},
+        "workflowTaskCompletedEventId": "15",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "1"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "100"
+          },
+          "maximumAttempts": 1
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "17",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 511088000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048867",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "3",
+        "activityType": {
+          "name": "ExecuteDeepAgent"
+        },
+        "taskQueue": {
+          "name": "replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJleGVjdXRpb25faWQiOiJleGVjLXJlcGxheSIsInRocmVhZF9pZCI6InRocmVhZC0xIiwiaW52b2tlcl9pZGVudGl0eV9hY2NvdW50X2lkIjoiIiwidHVybl9zZXEiOjB9"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {
+          "seconds": "300"
+        },
+        "startToCloseTimeout": {
+          "seconds": "86400"
+        },
+        "heartbeatTimeout": {
+          "seconds": "120"
+        },
+        "workflowTaskCompletedEventId": "15",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "10"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "1000"
+          },
+          "maximumAttempts": 1
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "18",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 512488000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048875",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "17",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "requestId": "8fae04e3-1d4f-4304-888d-4c7c2e2e19e7",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        }
+      }
+    },
+    {
+      "eventId": "19",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 520880000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048876",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJwaGFzZSI6IkVYRUNVVElPTl9XQUlUSU5HX0ZPUl9BUFBST1ZBTCJ9"
+            }
+          ]
+        },
+        "scheduledEventId": "17",
+        "startedEventId": "18",
+        "identity": "64478@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "20",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 520892000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048877",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "64478@Sureshs-Mac-Studio.local-8e6c1cfe9a68437888df24404688ebfa",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "21",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 512812000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048881",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "16",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "requestId": "7e845d29-b46e-4dd7-bb3b-d2dcddaa6d0a",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        }
+      }
+    },
+    {
+      "eventId": "22",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 523122000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048882",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "scheduledEventId": "16",
+        "startedEventId": "21",
+        "identity": "64478@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "23",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 524395000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048884",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "20",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "requestId": "70cbafa7-27a9-4967-90e6-a26ad892aeca",
+        "historySizeBytes": "3757",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        }
+      }
+    },
+    {
+      "eventId": "24",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 566335000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048888",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "20",
+        "startedEventId": "23",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "25",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 566373000
+      },
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048889",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_local_activity",
+        "details": {
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "YmluYXJ5L251bGw="
+                }
+              }
+            ]
+          },
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJzZXEiOjQsImF0dGVtcHQiOjEsImFjdGl2aXR5X2lkIjoiNCIsImFjdGl2aXR5X3R5cGUiOiJVcGRhdGVFeGVjdXRpb25TdGF0dXMiLCJjb21wbGV0ZV90aW1lIjp7InNlY29uZHMiOjE3ODc2NjYxMzAsIm5hbm9zIjo1MjcxNDI1NDF9LCJiYWNrb2ZmIjpudWxsLCJvcmlnaW5hbF9zY2hlZHVsZV90aW1lIjp7InNlY29uZHMiOjE3ODc2NjYxMzAsIm5hbm9zIjo1MzUxNjkwMDB9fQ=="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "24"
+      }
+    },
+    {
+      "eventId": "26",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 566377000
+      },
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048890",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_local_activity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJzZXEiOjUsImF0dGVtcHQiOjEsImFjdGl2aXR5X2lkIjoiNSIsImFjdGl2aXR5X3R5cGUiOiJMb2FkQWdlbnRFeGVjdXRpb24iLCJjb21wbGV0ZV90aW1lIjp7InNlY29uZHMiOjE3ODc2NjYxMzAsIm5hbm9zIjo1MjkzOTI1ODJ9LCJiYWNrb2ZmIjpudWxsLCJvcmlnaW5hbF9zY2hlZHVsZV90aW1lIjp7InNlY29uZHMiOjE3ODc2NjYxMzAsIm5hbm9zIjo1NDY4MDcwMDB9fQ=="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJtZXRhZGF0YSI6eyJpZCI6ImV4ZWMtcmVwbGF5In0sInN0YXR1cyI6eyJwaGFzZSI6IkVYRUNVVElPTl9XQUlUSU5HX0ZPUl9BUFBST1ZBTCIsInBlbmRpbmdBcHByb3ZhbHMiOlt7InRvb2xDYWxsSWQiOiJ0Yy0xIiwidG9vbE5hbWUiOiJlY2hvIn1dfX0="
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "24"
+      }
+    },
+    {
+      "eventId": "27",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 566466000
+      },
+      "eventType": "EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED",
+      "taskId": "1048891",
+      "signalExternalWorkflowExecutionInitiatedEventAttributes": {
+        "workflowTaskCompletedEventId": "24",
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "replay-parent-probe"
+        },
+        "signalName": "child_approval_required",
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "ImV4ZWMtcmVwbGF5Ig=="
+            }
+          ]
+        },
+        "namespaceId": "01a03934-4bd1-7109-85d3-81717671485f"
+      }
+    },
+    {
+      "eventId": "28",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 570455000
+      },
+      "eventType": "EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED",
+      "taskId": "1048894",
+      "signalExternalWorkflowExecutionFailedEventAttributes": {
+        "cause": "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_EXTERNAL_WORKFLOW_EXECUTION_NOT_FOUND",
+        "namespace": "default",
+        "workflowExecution": {
+          "workflowId": "replay-parent-probe"
+        },
+        "initiatedEventId": "27",
+        "namespaceId": "01a03934-4bd1-7109-85d3-81717671485f"
+      }
+    },
+    {
+      "eventId": "29",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 570461000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048895",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "64478@Sureshs-Mac-Studio.local-8e6c1cfe9a68437888df24404688ebfa",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "30",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 575426000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048899",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "29",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "requestId": "2fd3040f-1994-41bd-8e0b-299f1c7a1f12",
+        "historySizeBytes": "5351",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        }
+      }
+    },
+    {
+      "eventId": "31",
+      "eventTime": {
+        "seconds": "1787666130",
+        "nanos": 589487000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048903",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "29",
+        "startedEventId": "30",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "32",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 735137000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED",
+      "taskId": "1048905",
+      "workflowExecutionSignaledEventAttributes": {
+        "signalName": "approvalGateResolved",
+        "input": {},
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "header": {}
+      }
+    },
+    {
+      "eventId": "33",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 735143000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048906",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "64478@Sureshs-Mac-Studio.local-8e6c1cfe9a68437888df24404688ebfa",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "34",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 738568000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048910",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "33",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "requestId": "06a56ec0-4618-42ea-8e56-e6932d92bc56",
+        "historySizeBytes": "5912",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        }
+      }
+    },
+    {
+      "eventId": "35",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 760790000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048914",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "33",
+        "startedEventId": "34",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        },
+        "sdkMetadata": {
+          "langUsedFlags": [
+            2
+          ]
+        },
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "36",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 761091000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_SCHEDULED",
+      "taskId": "1048915",
+      "activityTaskScheduledEventAttributes": {
+        "activityId": "6",
+        "activityType": {
+          "name": "ExecuteDeepAgent"
+        },
+        "taskQueue": {
+          "name": "replay-capture",
+          "kind": "TASK_QUEUE_KIND_NORMAL"
+        },
+        "header": {},
+        "input": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJleGVjdXRpb25faWQiOiJleGVjLXJlcGxheSIsInRocmVhZF9pZCI6InRocmVhZC0xIiwiaW52b2tlcl9pZGVudGl0eV9hY2NvdW50X2lkIjoiIiwidHVybl9zZXEiOjF9"
+            }
+          ]
+        },
+        "scheduleToCloseTimeout": {},
+        "scheduleToStartTimeout": {
+          "seconds": "300"
+        },
+        "startToCloseTimeout": {
+          "seconds": "86400"
+        },
+        "heartbeatTimeout": {
+          "seconds": "120"
+        },
+        "workflowTaskCompletedEventId": "35",
+        "retryPolicy": {
+          "initialInterval": {
+            "seconds": "10"
+          },
+          "backoffCoefficient": 2,
+          "maximumInterval": {
+            "seconds": "1000"
+          },
+          "maximumAttempts": 1
+        },
+        "useWorkflowBuildId": true
+      }
+    },
+    {
+      "eventId": "37",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 767387000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_STARTED",
+      "taskId": "1048921",
+      "activityTaskStartedEventAttributes": {
+        "scheduledEventId": "36",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "requestId": "f6429245-5970-4391-b045-c962ed5122bc",
+        "attempt": 1,
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        }
+      }
+    },
+    {
+      "eventId": "38",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 776281000
+      },
+      "eventType": "EVENT_TYPE_ACTIVITY_TASK_COMPLETED",
+      "taskId": "1048922",
+      "activityTaskCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "anNvbi9wbGFpbg=="
+              },
+              "data": "eyJwaGFzZSI6IkVYRUNVVElPTl9DT01QTEVURUQifQ=="
+            }
+          ]
+        },
+        "scheduledEventId": "36",
+        "startedEventId": "37",
+        "identity": "64478@Sureshs-Mac-Studio.local"
+      }
+    },
+    {
+      "eventId": "39",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 776287000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_SCHEDULED",
+      "taskId": "1048923",
+      "workflowTaskScheduledEventAttributes": {
+        "taskQueue": {
+          "name": "64478@Sureshs-Mac-Studio.local-8e6c1cfe9a68437888df24404688ebfa",
+          "kind": "TASK_QUEUE_KIND_STICKY",
+          "normalName": "replay-capture"
+        },
+        "startToCloseTimeout": {
+          "seconds": "10"
+        },
+        "attempt": 1
+      }
+    },
+    {
+      "eventId": "40",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 778906000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_STARTED",
+      "taskId": "1048927",
+      "workflowTaskStartedEventAttributes": {
+        "scheduledEventId": "39",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "requestId": "4e1d5428-fb13-4fdd-a279-7311acd035a3",
+        "historySizeBytes": "6957",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        }
+      }
+    },
+    {
+      "eventId": "41",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 822289000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_TASK_COMPLETED",
+      "taskId": "1048931",
+      "workflowTaskCompletedEventAttributes": {
+        "scheduledEventId": "39",
+        "startedEventId": "40",
+        "identity": "64478@Sureshs-Mac-Studio.local",
+        "workerVersion": {
+          "buildId": "@temporalio/worker@1.16.2+18509e6a4adfb64e6b4799c11f85560d74f4319fedd2b0046495698dc593ae2e"
+        },
+        "sdkMetadata": {},
+        "meteringMetadata": {}
+      }
+    },
+    {
+      "eventId": "42",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 822320000
+      },
+      "eventType": "EVENT_TYPE_MARKER_RECORDED",
+      "taskId": "1048932",
+      "markerRecordedEventAttributes": {
+        "markerName": "core_local_activity",
+        "details": {
+          "data": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "anNvbi9wbGFpbg=="
+                },
+                "data": "eyJzZXEiOjcsImF0dGVtcHQiOjEsImFjdGl2aXR5X2lkIjoiNyIsImFjdGl2aXR5X3R5cGUiOiJEZWxldGVFeGVjdXRpb25Db250ZXh0IiwiY29tcGxldGVfdGltZSI6eyJzZWNvbmRzIjoxNzg3NjY2MTMxLCJuYW5vcyI6NzgxNDQyMDg0fSwiYmFja29mZiI6bnVsbCwib3JpZ2luYWxfc2NoZWR1bGVfdGltZSI6eyJzZWNvbmRzIjoxNzg3NjY2MTMxLCJuYW5vcyI6ODA1NDU4MDAwfX0="
+              }
+            ]
+          },
+          "result": {
+            "payloads": [
+              {
+                "metadata": {
+                  "encoding": "YmluYXJ5L251bGw="
+                }
+              }
+            ]
+          }
+        },
+        "workflowTaskCompletedEventId": "41"
+      }
+    },
+    {
+      "eventId": "43",
+      "eventTime": {
+        "seconds": "1787666131",
+        "nanos": 822327000
+      },
+      "eventType": "EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED",
+      "taskId": "1048933",
+      "workflowExecutionCompletedEventAttributes": {
+        "result": {
+          "payloads": [
+            {
+              "metadata": {
+                "encoding": "YmluYXJ5L251bGw="
+              }
+            }
+          ]
+        },
+        "workflowTaskCompletedEventId": "41"
+      }
+    }
+  ]
+}

--- a/backend/services/stigmer-server-ts/src/temporal/agentexecution/__tests__/replay.test.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/agentexecution/__tests__/replay.test.ts
@@ -31,7 +31,9 @@ const historyFiles = readdirSync(HISTORY_DIR).filter((name) =>
 
 describe("invoke-agent-execution replay determinism", () => {
   it("has committed histories to replay (the gate cannot be empty)", () => {
-    expect(historyFiles.length).toBeGreaterThanOrEqual(3);
+    // 3 from #18 (happy, HITL, pause/resume) + the parented HITL history
+    // that pins the #23 child_approval_required sender.
+    expect(historyFiles.length).toBeGreaterThanOrEqual(4);
   });
 
   it("replays every committed history deterministically", async () => {

--- a/backend/services/stigmer-server-ts/src/temporal/agentexecution/names.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/agentexecution/names.ts
@@ -47,6 +47,18 @@ export const SIGNAL_APPROVAL_GATE_RESOLVED = "approvalGateResolved";
 export const SIGNAL_CHILD_EXECUTION_STARTED = "child_execution_started";
 
 /**
+ * The outbound parent notification the workflow fires from the HITL loop
+ * when it has a parent_workflow_id — the OSS half of the DD-012 forwarding
+ * contract (D4 #23, parity-plus: Go never sends this). Mirrors cloud's
+ * AgentExecutionTemporalWorkflowTypes.SIGNAL_CHILD_APPROVAL_REQUIRED; the
+ * receiver is the runner's call-agent orchestrator. The payload is a BARE
+ * STRING (the child execution id): proto-shaped payloads poisoned the
+ * receiving workflow task under the Java sender's json/protobuf encoding
+ * (stigmer-cloud#509), so the identity-only string is the pinned wire shape.
+ */
+export const SIGNAL_CHILD_APPROVAL_REQUIRED = "child_approval_required";
+
+/**
  * The ONLY memo key this domain writes (workflow_creator.go); the workflow
  * reads it back on every dispatch. workflowexecution's `runnerTaskQueue`
  * memo key arrives with #21 — it does not exist in this domain.

--- a/backend/services/stigmer-server-ts/src/temporal/agentexecution/workflows/invoke-agent-execution.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/agentexecution/workflows/invoke-agent-execution.ts
@@ -98,6 +98,7 @@ import {
   MEMO_ACTIVITY_TASK_QUEUE,
   READ_HARNESS_STATE_ID_ACTIVITY_NAME,
   SIGNAL_APPROVAL_GATE_RESOLVED,
+  SIGNAL_CHILD_APPROVAL_REQUIRED,
   SIGNAL_CHILD_EXECUTION_STARTED,
   SIGNAL_PAUSE,
   SIGNAL_RESUME,
@@ -544,6 +545,7 @@ async function executeDeepAgentFlow(
       executeWithHitlLoop({
         executionId,
         signals,
+        parentWorkflowId: input.parent_workflow_id ?? "",
         firstInvoke: () =>
           agentProxy[EXECUTE_DEEP_AGENT_ACTIVITY_NAME]({
             execution_id: executionId,
@@ -598,6 +600,7 @@ async function executeCursorFlow(
       executeWithHitlLoop({
         executionId,
         signals,
+        parentWorkflowId: input.parent_workflow_id ?? "",
         firstInvoke: async () => {
           let harnessStateId: string;
           try {
@@ -872,10 +875,63 @@ async function runPausableAttempt(
 interface HitlLoopOptions {
   readonly executionId: string;
   readonly signals: SignalBuffers;
+  /**
+   * The workflow input's parent_workflow_id ("" when invoked directly) —
+   * the HITL loop notifies this parent whenever the gate engages (D4 #23,
+   * DD-012). The loop cannot read the workflow input itself, so the flows
+   * thread it through.
+   */
+  readonly parentWorkflowId: string;
   readonly firstInvoke: () => Promise<RunnerActivityResult | null>;
   readonly reinvoke: (turnSeq: number) => Promise<RunnerActivityResult | null>;
   readonly nullResultMessage: string;
   readonly nullResultAfterApprovalMessage: string;
+}
+
+/**
+ * Notify the parent workflow that this child is gated — the OSS sender half
+ * of the DD-012 child-approval forwarding contract (D4 #23, parity-plus:
+ * cloud's InvokeAgentExecutionWorkflowImpl.notifyParentWorkflowOfApproval;
+ * Go OSS never sends it). Identity-only BARE-STRING payload — the parent
+ * (the runner's call-agent orchestrator) derives the gate from this
+ * execution's persisted pending_approvals, so approval details never travel
+ * through the signal (see SIGNAL_CHILD_APPROVAL_REQUIRED in names.ts).
+ *
+ * Fire-and-forget with the same posture as child_execution_started: a
+ * completed/missing parent must never affect this run — the user can still
+ * approve directly through AgentExecution.submitApproval.
+ */
+function signalParentApprovalRequired(
+  parentWorkflowId: string,
+  executionId: string,
+  loadedStatus: AgentExecutionStatus | undefined,
+): void {
+  if (parentWorkflowId === "") {
+    // Invoked directly (API/CLI/schedule) — no parent to notify.
+    return;
+  }
+
+  const pendingApprovals = loadedStatus?.pendingApprovals ?? [];
+  log.info("Notifying parent workflow of approval requirement", {
+    parentWorkflowId,
+    executionId,
+    pendingCount: pendingApprovals.length,
+    firstToolName: pendingApprovals[0]?.toolName ?? "unknown",
+  });
+
+  void (async () => {
+    try {
+      await getExternalWorkflowHandle(parentWorkflowId).signal(
+        SIGNAL_CHILD_APPROVAL_REQUIRED,
+        executionId,
+      );
+    } catch (error) {
+      log.warn("Failed to notify parent workflow of approval (non-fatal)", {
+        parentWorkflowId,
+        error: errorMessage(error),
+      });
+    }
+  })();
 }
 
 /**
@@ -948,6 +1004,13 @@ async function executeWithHitlLoop(
       cycle: approvalCycle,
       gateCount,
     });
+
+    // Cloud parity (both Java HITL loops call notifyParentWorkflowOfApproval
+    // here): the parent is notified on EVERY cycle — after the phase persist
+    // and gate re-read, BEFORE the gate-count branch — including zero-gate
+    // and file-review-only cycles. The runner derives from the persisted
+    // gate, so an empty derivation is a harmless "already resolved" no-op.
+    signalParentApprovalRequired(options.parentWorkflowId, executionId, loadedStatus);
 
     if (gateCount === 0) {
       if (loadedStatus !== undefined && hasDecidedAwaitingReconcile(loadedStatus)) {

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -216,11 +216,13 @@ with no IAM filtering), `versionTagging` is `true` (the dedicated `tagVersion`
 RPC is implemented in both editions; assigning a tag moves it to name exactly
 one version, and apply-time `metadata.version.tag` flows through the same
 single-holder primitive), and
-`workflowChildApprovalForwarding` is `false` (the `WorkflowExecution.submitApproval`
-forwarder is built in OSS, but the `child_approval_required` signal that surfaces a
-child agent's gate to its parent workflow is cloud-only, so the forwarder's
-happy path is unreachable against the Go server — see
-`design-decisions/012-workflowexecution-child-approval-forwarding-contract.md`).
+`workflowChildApprovalForwarding` splits by SERVER, not edition (the
+`WorkflowExecution.submitApproval` forwarder is built everywhere, but the
+`child_approval_required` signal that surfaces a child agent's gate to its
+parent workflow is sent only by cloud and — since D4 #23 — the TS server's
+HITL loop; the Go server never sends it, so the flag stays `false` on the
+`local-go*` targets and the forwarder's happy path stays unreachable there —
+see `design-decisions/012-workflowexecution-child-approval-forwarding-contract.md`).
 Capabilities are retired when a surface converges: secret redaction was gated
 per edition until the Environment (stigmer#405) and ExecutionContext
 (stigmer#535) surfaces converged, after which the suites assert redaction
@@ -347,20 +349,21 @@ approval FORWARDING** (`submitApproval`) contract — distinct from `human_input
 *child* AgentExecution gates on a tool, the gate surfaces at the parent's
 `status.pending_approvals` (carrying `child_agent_execution_id`); `submitApproval`
 routes the decision down to the child's `AgentExecution.submitApproval`. The
-forwarder is **half-built in OSS by design**: the receiver is complete, but the
-`child_approval_required` signal that populates the parent's `pending_approvals` is
-**cloud-only**, so a gated child never surfaces against the Go server (source-
-confirmed). The suite splits along the `workflowChildApprovalForwarding`
+forwarder is **half-built in the Go server by design**: the receiver is complete,
+but the `child_approval_required` signal that populates the parent's
+`pending_approvals` is sent only by cloud and — since D4 #23 — the TS server's
+HITL loop (the DD-012 derivation design: identity-only signal, the runner
+derives the gate from the child's persisted record). A gated child never
+surfaces against the Go server (source-confirmed), which never gains the
+sender. The suite splits along the `workflowChildApprovalForwarding`
 capability: the **negatives** never need a populated `pending_approvals` and run
-unconditionally against OSS today (empty `execution_id`/`tool_call_id` /
+unconditionally against every target (empty `execution_id`/`tool_call_id` /
 UNSPECIFIED action -> `InvalidArgument`; missing execution -> `NotFound`; a running
 *or* terminal execution with no pending approvals -> `FailedPrecondition`); the
-**happy path** is written in full but `describe.skipIf`-gated so it reports as
-genuinely **SKIPPED** (not a false green) on `local-go` — it needs both the
-forwarder *and* the local mock-LLM + MCP fixtures, which only the future
-`local-ts-execution` (T04) target has. The eventual OSS implementation lands in the
-T04 TS rewrite (not the retiring Go server) and should surface the child gate by
-**derivation** (identity-only signal + derive-from-child). See the project's
+**happy path** is `describe.skipIf`-gated so it reports as genuinely **SKIPPED**
+(not a false green) on the `local-go*` targets, and RUNS on `local-ts-execution`
+— the one deliberate capability divergence between the two execution targets
+(the D4 parity-plus delta). See the project's
 `design-decisions/012-workflowexecution-child-approval-forwarding-contract.md`.
 
 ## Layout

--- a/test/conformance/src/targets/cloud-execution.ts
+++ b/test/conformance/src/targets/cloud-execution.ts
@@ -62,11 +62,10 @@ export class CloudExecutionTarget implements TargetProfile {
 
   // Same service, same edition differences: capabilities are delegated to the
   // inner CloudTarget verbatim (having an engine is not a CapabilityFlag —
-  // the same reasoning local-go-execution records). Notably this makes
-  // workflowChildApprovalForwarding=true reachable for the first time: cloud
-  // is the only edition whose agent-execution workflow emits the
-  // child_approval_required signal (DD-012), and this target is the first
-  // with both that signal and a runner to drive it.
+  // the same reasoning local-go-execution records). This target was the FIRST
+  // with both the child_approval_required signal and a runner to drive it
+  // (DD-012); since D4 #23 the TS server's HITL loop emits the same signal,
+  // so local-ts-execution runs the identical forwarding round-trip.
   private readonly cloud = new CloudTarget();
 
   private runner: RunningRunner | undefined;

--- a/test/conformance/src/targets/local-ts-execution.ts
+++ b/test/conformance/src/targets/local-ts-execution.ts
@@ -22,21 +22,22 @@ import type { CapabilityFlags, PrivilegedScope, TargetProfile, TenancyContext } 
 
 export class LocalTsExecutionTarget implements TargetProfile {
   readonly name = "local-ts-execution";
-  // The local-go-execution matrix, byte-identical since D4 #22 ported the
-  // schedule clock (scheduleFiring was the one disclosed deviation while
-  // the TS server had no Temporal Schedule reconciler). The remaining
-  // false-at-#18 → true-at-#23 path is workflowChildApprovalForwarding —
-  // the ratified parity-plus delta, not a gap.
+  // The local-go-execution matrix plus exactly ONE deliberate difference:
+  // workflowChildApprovalForwarding is true here and false there — the D4
+  // ratified parity-plus delta (#23), not drift. Everything else is
+  // byte-identical since #22 ported the schedule clock.
   readonly capabilities: CapabilityFlags = {
     multiTenant: false,
     externalOrgLookup: false,
     organizationEnumeration: true,
     versionTagging: false,
     skillArtifactTransferLane: true,
-    // The engine runs here, but the child-approval signal sender is cloud-only,
-    // so a gated agent_call child never surfaces its gate to the parent workflow
-    // (DD-012). #23 flips this flag on THIS target — the parity-plus delta.
-    workflowChildApprovalForwarding: false,
+    // True since D4 #23: this server's agent-execution workflow emits the
+    // child_approval_required signal from its HITL loop (DD-012 identity-only
+    // sender), so a gated agent_call child surfaces at the parent workflow's
+    // pending_approvals. Go OSS never sends it — local-go-execution stays
+    // false forever; this is the one ratified capability divergence.
+    workflowChildApprovalForwarding: true,
     // True since D4 #22 ported the schedule clock (tick workflow +
     // reconciler on the schedule_stigmer queue) — the firing suite runs
     // against this engine exactly as against local-go-execution.

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -53,17 +53,19 @@ export interface CapabilityFlags {
   // False for local OSS: the *forwarder* is fully built (submit_approval.go, the
   // runner's call-agent orchestrator, all protos), but the upstream half — the
   // `child_approval_required` signal the agent-execution workflow emits when it
-  // gates — is cloud-only. The OSS Go agent-execution workflow never emits it, so
-  // a gated agent_call child never populates the parent's pending_approvals and
-  // the forwarder's happy path is structurally unreachable (source-confirmed, not
-  // a timing artifact; see DD-012). The reachable *negatives* (no pending
-  // approval, proto validation, missing execution) are edition-agnostic and are
-  // asserted unconditionally.
+  // gates — splits by SERVER: cloud's Java workflow and (since D4 #23) the TS
+  // server's HITL loop emit it; the Go agent-execution workflow never does, so
+  // against the Go server a gated agent_call child never populates the parent's
+  // pending_approvals and the forwarder's happy path is structurally
+  // unreachable (source-confirmed, not a timing artifact; see DD-012). The
+  // reachable *negatives* (no pending approval, proto validation, missing
+  // execution) are sender-independent and are asserted unconditionally.
   //
-  // True for cloud, which emits the signal and surfaces the gate to the parent.
-  // The forwarder happy-path assertions are gated on this flag so they run only
-  // where the full round-trip exists — including the future local-ts-execution
-  // (T04) target, which is where the OSS implementation will finally land.
+  // True for cloud and local-ts-execution, which emit the signal and surface
+  // the gate to the parent. The forwarder happy-path assertions are gated on
+  // this flag so they run only where the full round-trip exists — this is the
+  // one deliberate capability divergence between the local-go-execution and
+  // local-ts-execution matrices (the D4 parity-plus delta).
   workflowChildApprovalForwarding: boolean;
   // Schedules actually FIRE here: a trigger records status.last_fire_at,
   // repeated failed fires accumulate status.consecutive_failures into the

--- a/test/conformance/vitest.local-ts-execution.config.ts
+++ b/test/conformance/vitest.local-ts-execution.config.ts
@@ -39,6 +39,15 @@
 //   runner's stigmer/mcp-server/connect workflow (deterministic-ID
 //   attach, dead-runner warning), handshake completion against the mock
 //   authorization server, and the refresh-on-connect pre-flight.
+//
+//   #23 (2026-08-25, sp.child-approval-derivation): workflowexecution-
+//   child-approval — the June-written suite runs whole (negatives + the
+//   DD-012 forwarding round-trip) now that the TS HITL loop emits
+//   child_approval_required. Pre-flight debt cleared alongside it:
+//   harness.smoke (the target-agnostic set_vars engine smoke) was in the
+//   execution glob but never rostered by #20/#21 — proven green here.
+//   With both entries the roster EQUALS the execution glob: the Class B
+//   half of the cutover gate (D4 #24) is satisfied.
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -65,6 +74,15 @@ export default defineConfig({
       // the listRuns history surface, active now that scheduleFiring
       // flipped true on this target.
       "src/suites-execution/schedule-firing.conformance.test.ts",
+      // child-approval forwarding — sub-project #23 (the LAST roster entries
+      // before the #24 cutover gate): the June-written DD-012 suite, whole —
+      // the edition-agnostic submitApproval negatives AND the forwarding
+      // round-trip, active now that workflowChildApprovalForwarding flipped
+      // true on this target (the TS HITL loop emits child_approval_required).
+      "src/suites-execution/workflowexecution-child-approval.conformance.test.ts",
+      // The target-agnostic set_vars engine smoke — glob-resident since June,
+      // missed by #20/#21's rostering; carried in by #23 for glob equality.
+      "src/suites-execution/harness.smoke.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-ts-execution.ts"],
     env: {


### PR DESCRIPTION
## Summary

The OSS sender half of the DD-012 child-approval forwarding contract — D4 entry #23, the last pre-cutover entry. The TS server's agent-execution workflow now notifies `parent_workflow_id` from its HITL loop with the identity-only `child_approval_required` signal, so a gated `agent_call` child surfaces at the parent workflow's `pending_approvals` and `WorkflowExecution.submitApproval`'s forwarding round-trip works end to end on OSS. The June-written, skip-gated conformance happy path runs and passes on `local-ts-execution` — first run green.

## Context

Everything else in the chain already existed: the runner's call-agent orchestrator handles the signal and derives the gate from the child's persisted record (DD-012 derive-from-child), the `submitApproval` forwarder shipped with D4 #20, and the identity plumbing (`spec.parentWorkflowId` → workflow input) has been live since #17/#18. The one missing piece was the gate-time sender — present in cloud's Java workflow (`notifyParentWorkflowOfApproval`), deliberately absent from Go (parity-PLUS: Go never gains it; `local-go*` keep the capability false forever).

## Changes

- **Sender** (`invoke-agent-execution.ts`): `signalParentApprovalRequired` fires on EVERY HITL cycle — after the WAITING_FOR_APPROVAL persist and gate re-read, before the gate-count branch, including zero-gate reconcile cycles — matching cloud's placement exactly (`InvokeAgentExecutionWorkflowImpl.java:1322`/`1616`). Fire-and-forget external-handle signal, non-fatal on any failure; `parentWorkflowId` threads through `HitlLoopOptions`.
- **Wire pin** (`names.ts`): `SIGNAL_CHILD_APPROVAL_REQUIRED = "child_approval_required"`, bare-string payload doctrine documented (cloud#509).
- **Conformance**: `workflowChildApprovalForwarding: true` on `local-ts-execution` (the one ratified capability divergence from `local-go-execution`); the child-approval suite AND the never-rostered `harness.smoke` added to the roster — **the roster now equals the execution glob**, satisfying the Class B half of the #24 cutover gate.
- **Tests**: three new workflow arms pin the wire from event history (bare-string payload, every-cycle fire incl. zero-gate, notify-precedes-wait ordering, no-parent guard, sibling `{executionId}` asymmetry); a fourth committed replay history (`hitl-approval-parented`) pins the sender in the replay gate; the capture script now refuses to overwrite committed histories without `--force`.
- **Docs**: the conformance README, `target.ts`/`cloud-execution.ts` flag comments, and `async-workflow-integration.md` no longer claim the sender is cloud-only (and the latter's stale legacy full-payload description is corrected to the post-#509 bare string).

## Implementation notes (parity register)

- **Sender mechanism**: in-workflow `getExternalWorkflowHandle().signal()` (this server's `child_execution_started` idiom, Go's `SignalExternalWorkflow` shape) vs cloud's local-activity sender — wire-identical signal, delivery mechanism invisible to the receiver.
- **Payload asymmetry disclosed**: `child_approval_required` carries cloud's proven bare string; the pre-existing `child_execution_started` carries the tolerated `{executionId}` object. Both decoded by the runner's handler; pinned by test.
- **TS signals on gate-load-failure cycles** (load fails → gateCount defaults to 1 → notify still fires) — a cycle shape Java cannot reach (its load failure throws first); safe, the runner derives from the persisted gate.
- **Pre-existing persist/load order inversion** vs Java (TS persists the phase then loads the gate; Java loads then persists) — dates from #17/#18, unchanged here; the notify point is after both in both editions.
- **Stale proto narration** (pre-existing, docs-only follow-up): `approval.proto`/`spec.proto` comments still narrate the legacy Java→Go Phase-5.1 flow (full-payload `ChildApprovalNotification`, "parent Go workflow"); untouched here to avoid codegen churn across all stubs.

## Test plan

- Unit: 1694 tests / 125 files green (typecheck clean, Node 22.23.2); the 16 workflow arms incl. the three new sender pins; replay gate green with all four histories (the three #18 histories replay unchanged — verified none carries a `parent_workflow_id`).
- Conformance: `local-ts-execution` **19 files, 160 passed / 1 skipped** (the `STIGMER_DESKTOP_TESTS` opt-in, identical to Go) — the child-approval forwarding round-trip green on its first-ever run; `local-ts` 488/1 regression-free; `local-go` 492/1 regression-free; `local-go-execution` 159/2 regression-free (one of the two skips IS this suite's happy path on capability false — the ratified posture).
- Both artifacts boot-verified (`dist/main.js`, `dist-slim/main.js`).
- Two-reviewer adversarial panel: parity 0 blocking / 0 major (3 minors disclosed above); quality 4 major (all doc-staleness/process, fixed in-branch) + 3 minors (test hardenings, applied).

## Risks

- The signal is additive and fire-and-forget: a missing/completed parent is a warn-logged no-op, and users can always approve directly via `AgentExecution.submitApproval` (cloud's documented graceful degradation, now also OSS's).
- Rollback: revert the commit; no storage, proto, or Go changes.

Made with [Cursor](https://cursor.com)