### PR TITLE
feat(cli): launch the TypeScript server — the DD-006 cutover (D4 #24)

### DIFF
--- a/.github/workflows/ci.stigmer-server-ts.yaml
+++ b/.github/workflows/ci.stigmer-server-ts.yaml
@@ -87,5 +87,28 @@ jobs:
         working-directory: backend/services/stigmer-server-ts
         run: node scripts/bundle-slim.mjs && npm run verify:slim
 
+      # The deep slim gate at PR time (D4 #24 panel finding): verify:slim
+      # boots WITHOUT Temporal, so the slim-only machinery — prebuilt
+      # workflow-bundle discovery, the threaded-vm patch, per-platform
+      # core-bridge dispatch — never executes there. A drifted bundle would
+      # otherwise merge green and wedge the release train at publish time
+      # (the workers fail SOFT: manager.ts retries instead of crashing).
+      # This runs the isolated-copy + real-Temporal check the release lane
+      # gates publishing on.
+      - name: Set up Temporal CLI
+        uses: temporalio/setup-temporal@v0
+
+      - name: Deep-verify the slim artifact (isolated copy + Temporal workers)
+        working-directory: backend/services/stigmer-server-ts
+        run: |
+          temporal server start-dev --headless --log-level error &
+          TEMPORAL_PID=$!
+          trap "kill $TEMPORAL_PID" EXIT
+          for i in $(seq 1 30); do
+            temporal operator cluster health >/dev/null 2>&1 && break
+            sleep 1
+          done
+          node scripts/verify-slim-artifact.mjs
+
       - name: Run the vitest suite
         run: make test-server-ts

--- a/.github/workflows/release.npm-libs.yaml
+++ b/.github/workflows/release.npm-libs.yaml
@@ -247,3 +247,100 @@ jobs:
             (cd "$pkg" && npm publish --access public --tag "$NPM_TAG")
           done
           cd dist-slim-pkgs/runner-slim && npm publish --access public --tag "$NPM_TAG"
+
+  # The TS server's slim artifact (D4 #24 cli-cutover): @stigmer/server-slim
+  # plus per-platform native-bridge packages, the runner-slim pattern exactly.
+  # The CLI installs it on demand at `stigmer up` and launches `node main.js`
+  # as the local stack's server — the DD-006 cutover's distribution half.
+  # Runs after `publish` only for release-train symmetry: the slim artifact
+  # bundles everything, so it has no registry dependency on @stigmer/protos.
+  publish-server-slim:
+    needs: [determine-version, publish]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Buf
+        uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      # Builds the ts stubs + the server-linked lib dists (build-ts-stubs),
+      # installs the server's own deps, and compiles the server to dist/.
+      - name: Build TS server
+        run: make build-server-ts
+
+      # Stamp the release version into the package manifest; the bundle
+      # script propagates it into every generated slim manifest. The file:
+      # lib deps are NOT pinned to registry versions — the slim bundle
+      # compiles them in, so the published packages carry no @stigmer/* deps.
+      - name: Stamp version
+        working-directory: backend/services/stigmer-server-ts
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: |
+          node -e "
+            const fs = require('node:fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.version = process.env.VERSION;
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+            console.log('stamped @stigmer/server-slim@' + pkg.version);
+          "
+
+      # The defines are the Go build's ldflags equivalent (release.cli.yaml):
+      # the version for getServerInfo and the bundled GitHub OAuth app the
+      # local github broker defaults to.
+      - name: Build slim artifact packages
+        working-directory: backend/services/stigmer-server-ts
+        env:
+          STIGMER_SERVER_VERSION: ${{ needs.determine-version.outputs.version }}
+          STIGMER_GITHUB_CLIENT_ID: ${{ secrets.STIGMER_LOCAL_GITHUB_OAUTH_CLIENT_ID }}
+          STIGMER_GITHUB_CLIENT_SECRET: ${{ secrets.STIGMER_LOCAL_GITHUB_OAUTH_CLIENT_SECRET }}
+        run: node scripts/bundle-slim.mjs --emit-packages
+
+      # Gate the publish on the artifact actually working: an ISOLATED copy
+      # (nothing resolves from this checkout) must serve the transport AND
+      # start all three Temporal workers from the pre-built workflow bundles
+      # through the per-platform native bridge, against a real Temporal dev
+      # server, then shut down cleanly.
+      - name: Set up Temporal CLI
+        uses: temporalio/setup-temporal@v0
+
+      - name: Verify slim artifact boots and starts workers
+        working-directory: backend/services/stigmer-server-ts
+        run: |
+          temporal server start-dev --headless --log-level error &
+          TEMPORAL_PID=$!
+          trap "kill $TEMPORAL_PID" EXIT
+          for i in $(seq 1 30); do
+            temporal operator cluster health >/dev/null 2>&1 && break
+            sleep 1
+          done
+          node scripts/verify-slim-artifact.mjs
+
+      - name: Publish slim packages to npm
+        working-directory: backend/services/stigmer-server-ts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          VERSION="${{ needs.determine-version.outputs.version }}"
+          if [[ "$VERSION" == *-* ]]; then NPM_TAG="next"; else NPM_TAG="latest"; fi
+          # Platform packages first so the meta package's optionalDependencies
+          # resolve the moment it lands.
+          for pkg in dist-slim-pkgs/server-slim-*; do
+            (cd "$pkg" && npm publish --access public --tag "$NPM_TAG")
+          done
+          cd dist-slim-pkgs/server-slim && npm publish --access public --tag "$NPM_TAG"

--- a/Makefile
+++ b/Makefile
@@ -432,6 +432,10 @@ test-integration-all: ## Run all integration suites. PROVIDERS=true includes pro
 	$(MAKE) test-conformance
 	@echo "=== Conformance: execution engine (local-go-execution) ==="
 	$(MAKE) test-conformance-execution
+	@echo "=== Conformance: CRUD contract (local-ts / stigmer-server-ts) ==="
+	$(MAKE) test-conformance-ts
+	@echo "=== Conformance: execution engine (local-ts-execution / stigmer-server-ts) ==="
+	$(MAKE) test-conformance-ts-execution
 ifeq ($(PROVIDERS),true)
 	@echo "=== Provider: integration (LLM) ==="
 	$(MAKE) test-integration-providers
@@ -495,6 +499,14 @@ test-conformance-ts-execution: build-runner ## Run the local-ts-execution confor
 	}
 	@echo "=== conformance: execution engine (local-ts-execution / stigmer-server-ts) ==="
 	CONFORMANCE_TARGET=local-ts-execution npm run test:ts-execution -w @stigmer/conformance
+
+.PHONY: smoke-cli-cutover
+smoke-cli-cutover: build-runner build-server-ts ## Run the CLI cutover E2E smoke, both arms: the packaged TS entry AND the STIGMER_SERVER_BIN Go rollback (needs `temporal` on PATH for speed; bin/stigmer-server via `make build` for the go arm)
+	@command -v node >/dev/null 2>&1 || { echo "error: node not found"; exit 1; }
+	@test -f bin/stigmer-server || { echo "error: bin/stigmer-server missing — build the Go rollback binary first (cd backend/services/stigmer-server && go build -o ../../../bin/stigmer-server ./cmd/server)"; exit 1; }
+	@cd $(SERVER_TS_DIR) && node scripts/bundle-slim.mjs
+	node scripts/smoke-cli-cutover.mjs --arm=ts
+	node scripts/smoke-cli-cutover.mjs --arm=go
 
 .PHONY: test-conformance-cloud
 test-conformance-cloud: build-ts-stubs ## Run gRPC conformance CRUD suite against the Java cloud service (hermetic; needs Docker, `fga`, `temporal`, and the fat JAR)

--- a/backend/services/stigmer-server-ts/package.json
+++ b/backend/services/stigmer-server-ts/package.json
@@ -6,13 +6,14 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": "^22.13.0 || >=23.4.0"
+    "node": ">=22.13.0 <23 || >=24"
   },
   "scripts": {
     "build": "rm -rf dist && tsc -p tsconfig.build.json",
     "build:slim": "npm run build && node scripts/bundle-slim.mjs",
     "verify:dist": "node scripts/verify-boot.mjs dist/main.js",
     "verify:slim": "node scripts/verify-boot.mjs dist-slim/main.js",
+    "verify:slim-artifact": "node scripts/verify-slim-artifact.mjs",
     "start": "tsx src/main.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/backend/services/stigmer-server-ts/scripts/bundle-slim.mjs
+++ b/backend/services/stigmer-server-ts/scripts/bundle-slim.mjs
@@ -2,36 +2,155 @@
 
 /**
  * Builds the slim distribution artifact for stigmer-server-ts — the entry
- * the CLI's npm package will ship and the daemon will launch
- * (STIGMER_SERVER_ENTRY, D2 §6 cutover mechanics).
+ * the CLI daemon launches after the cutover (STIGMER_SERVER_ENTRY, D2 §6
+ * cutover mechanics; D4 #24).
  *
- * Deliberately simple next to the runner's bundle-slim.mjs: ConnectRPC,
- * protobuf, protovalidate, and the bundled registry JSON compile into one
- * platform-independent main.js. The @temporalio/* packages are EXTERNAL
- * (ratified sub-project 20260824.03 brief #7): @temporalio/worker carries
- * the native core-bridge that esbuild cannot bundle, so the slim entry
- * imports them from node_modules at runtime. Distribution-grade packaging
- * — the prebuilt workflow bundle, the bundled sandbox worker-thread
- * entry, per-platform core-bridge packages (the runner's five-step
- * bundle-slim machinery) — is #24 cli-cutover's scope; until then the
- * operative deployment mode runs from dist/ with node_modules present.
+ * This is the runner's bundle-slim.mjs recipe (stigmer/stigmer#170),
+ * adapted: the plain dist resolves @temporalio/* from node_modules at
+ * runtime, and @temporalio/worker alone drags in webpack/@swc (~45 MB dead
+ * weight once workflow bundles are pre-built) plus the all-platforms native
+ * core-bridge (~127 MB, of which one platform needs ~22 MB). The slim
+ * artifact bundles ALL JavaScript into one main.js and carries the native
+ * bridge as a per-platform package.
+ *
+ * Two output shapes, same contents:
+ *
+ * 1. Self-contained directory (default) — `dist-slim/`; run `node main.js`.
+ *
+ *    dist-slim/
+ *      main.js                                ← esbuild CJS bundle of the server
+ *      main.js.map                            ← external sourcemap
+ *      workflow-bundle-agent-execution.js     ← pre-built Temporal workflow
+ *      workflow-bundle-workflow-execution.js    bundles, one per domain worker,
+ *      workflow-bundle-schedule.js              discovered as siblings by
+ *                                               src/temporal/workflow-source.ts
+ *      workflow-worker-thread.cjs             ← Temporal's sandbox thread entry;
+ *                                               worker_threads needs a real file
+ *      mappings.wasm                          ← source-map's lazy-loaded wasm
+ *      node_modules/
+ *        @stigmer/server-slim-<platform>      ← Temporal native bridge, pruned
+ *                                               to ONE platform
+ *        @temporalio/common, @grpc/...        ← runtime deps of the native bridge
+ *
+ * 2. npm packages (`--emit-packages`) — `dist-slim-pkgs/` with publishable
+ *    directories: `@stigmer/server-slim` plus five
+ *    `@stigmer/server-slim-<platform>` packages installed selectively via
+ *    optionalDependencies + os/cpu. The platform packages carry only
+ *    core-bridge — whose releases for all five platforms ship in the npm
+ *    tarball — so `--emit-packages` works from any host.
+ *
+ * FORMAT NOTE: the bundle is CommonJS, not ESM like the package's own
+ * sources. The runner's temporal-bundling machinery reused here (the
+ * bundler stub, the threaded-vm patch, the core-bridge shim's dynamic
+ * platform require) is proven end-to-end on CJS output, and the shim's
+ * runtime `require(<computed name>)` has no reliable ESM-output
+ * equivalent (esbuild lowers unanalyzable requires in ESM output to a
+ * throwing stub). `import.meta.url` — which the workers use to discover
+ * their sibling workflow bundles — is mapped via `define` to the bundle's
+ * own file URL, exactly as the runner does, so sibling discovery lands
+ * next to main.js. Verified by `npm run verify:slim`.
  *
  * Build with `npm run build` first; this consumes the compiled dist/.
- * Verify with `npm run verify:slim` (boots the bundle with plain node —
- * which resolves the external @temporalio imports from this package's
- * node_modules).
+ *
+ * Usage:
+ *   node scripts/bundle-slim.mjs [--platform=<darwin-arm64|darwin-x64|linux-x64|linux-arm64|win32-x64>] [--emit-packages]
  */
+
 import { build } from "esbuild";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
 
 const serverRoot = fileURLToPath(new URL("..", import.meta.url));
 const distDir = join(serverRoot, "dist");
+const nodeModulesDir = join(serverRoot, "node_modules");
 const outDir = join(serverRoot, "dist-slim");
+const pkgsDir = join(serverRoot, "dist-slim-pkgs");
 
-rmSync(outDir, { recursive: true, force: true });
-mkdirSync(outDir, { recursive: true });
+/**
+ * The three domain workers and the sibling bundle names their
+ * workflow-source resolvers look for. The names are load-bearing: a drifted
+ * sibling fails SOFT at runtime (the worker falls through to the stubbed
+ * bundler and manager.ts retries instead of crashing), so
+ * buildWorkflowBundles verifies each name against the COMPILED worker
+ * module — drift fails the build, not the release train.
+ */
+const WORKFLOW_BUNDLES = [
+  {
+    entry: "temporal/agentexecution/workflows/index.js",
+    worker: "temporal/agentexecution/worker.js",
+    sibling: "workflow-bundle-agent-execution.js",
+  },
+  {
+    entry: "temporal/workflowexecution/workflows/index.js",
+    worker: "temporal/workflowexecution/worker.js",
+    sibling: "workflow-bundle-workflow-execution.js",
+  },
+  {
+    entry: "temporal/schedule/workflows/index.js",
+    worker: "temporal/schedule/worker.js",
+    sibling: "workflow-bundle-schedule.js",
+  },
+];
+
+/**
+ * Assets that bundled modules read from disk relative to their __dirname.
+ * (source-map powers @temporalio/worker's workflow stack-trace mapping and
+ * lazy-loads its wasm at first use.)
+ */
+const BUNDLED_MODULE_ASSETS = [
+  { from: "source-map/lib/mappings.wasm", to: "mappings.wasm" },
+];
+
+/** node platform-arch → Temporal core-bridge release triple. */
+const CORE_BRIDGE_TRIPLES = {
+  "darwin-arm64": "aarch64-apple-darwin",
+  "darwin-x64": "x86_64-apple-darwin",
+  "linux-x64": "x86_64-unknown-linux-gnu",
+  "linux-arm64": "aarch64-unknown-linux-gnu",
+  "win32-x64": "x86_64-pc-windows-msvc",
+};
+
+function parseArgs() {
+  const hostPlatform = `${process.platform}-${process.arch}`;
+  let platform = hostPlatform;
+  let emitPackages = false;
+  for (const arg of process.argv.slice(2)) {
+    const m = arg.match(/^--platform=(.+)$/);
+    if (m) platform = m[1];
+    else if (arg === "--emit-packages") emitPackages = true;
+    else fail(`unknown argument: ${arg}`);
+  }
+  if (!(platform in CORE_BRIDGE_TRIPLES)) {
+    fail(
+      `Unsupported platform "${platform}". Supported: ${Object.keys(CORE_BRIDGE_TRIPLES).join(", ")}`,
+    );
+  }
+  return { platform, emitPackages };
+}
+
+function fail(message) {
+  console.error(`bundle-slim: ${message}`);
+  process.exit(1);
+}
+
+function readPackageJson(dir) {
+  return JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+}
+
+const serverPkg = readPackageJson(serverRoot);
 
 // The ldflags equivalent (D4 #13): release lanes export these env vars and
 // the defines stamp them into their fallback chains
@@ -44,7 +163,7 @@ const defineFromEnv = (identifier, envName) => ({
       ? JSON.stringify(process.env[envName])
       : "undefined",
 });
-const versionDefine = {
+const stampDefines = {
   ...defineFromEnv("__STIGMER_SERVER_VERSION__", "STIGMER_SERVER_VERSION"),
   ...defineFromEnv("__STIGMER_GITHUB_CLIENT_ID__", "STIGMER_GITHUB_CLIENT_ID"),
   ...defineFromEnv(
@@ -53,41 +172,520 @@ const versionDefine = {
   ),
 };
 
-await build({
-  entryPoints: [join(distDir, "main.js")],
-  outfile: join(outDir, "main.js"),
-  bundle: true,
-  platform: "node",
-  format: "esm",
-  target: "node22",
-  define: versionDefine,
-  // The AWS SDK (the R2 driver, D4 #13) is CommonJS; bundled into ESM its
-  // internal require() calls hit esbuild's throwing __require stub unless a
-  // real require exists at top level. The banner installs one via
-  // createRequire — the canonical esbuild recipe for CJS deps in an ESM
-  // bundle (verified by `npm run verify:slim`, which caught the failure).
-  banner: {
-    js:
-      'import { createRequire as __stigmerCreateRequire } from "node:module";' +
-      "const require = __stigmerCreateRequire(import.meta.url);",
+// ─── Step 1: Pre-build the Temporal workflow bundles ────────────────────────
+
+/**
+ * One bundle per domain worker, emitted as siblings of main.js where
+ * workflow-source.ts's prebuilt discovery finds them. Pre-building here is
+ * what lets step 3 stub the runtime bundler and keep webpack/@swc out of
+ * the artifact entirely.
+ */
+async function buildWorkflowBundles() {
+  console.log("[1/5] Pre-building Temporal workflow bundles...");
+  const { bundleWorkflowCode } = await import("@temporalio/worker");
+  for (const { entry, worker, sibling } of WORKFLOW_BUNDLES) {
+    const workflowsPath = join(distDir, entry);
+    if (!existsSync(workflowsPath)) {
+      fail(
+        `workflows entry not found: ${workflowsPath} — run \`npm run build\` first`,
+      );
+    }
+    // The name contract, enforced statically: the compiled worker must
+    // reference this exact sibling in its prebuiltSibling URL.
+    const workerPath = join(distDir, worker);
+    if (!existsSync(workerPath)) {
+      fail(`worker module not found: ${workerPath} — run \`npm run build\` first`);
+    }
+    if (!readFileSync(workerPath, "utf8").includes(sibling)) {
+      fail(
+        `sibling-name drift: ${worker} does not reference "${sibling}". ` +
+          "Update WORKFLOW_BUNDLES to match the worker's prebuiltSibling URL (or vice versa).",
+      );
+    }
+    const { code } = await bundleWorkflowCode({ workflowsPath });
+    writeFileSync(join(outDir, sibling), code);
+  }
+}
+
+// ─── Step 2: Bundle Temporal's workflow sandbox worker-thread entry ─────────
+
+/**
+ * Temporal runs workflow isolates on a worker thread whose entry it locates
+ * with `require.resolve('./workflow-worker-thread')` — a real file on disk
+ * that a single-file bundle cannot provide. So that entry gets its own
+ * (pure-JS, self-contained) bundle, and the main bundle's copy of threaded-vm
+ * is patched to point at it (see the plugin below). Runner recipe verbatim.
+ */
+async function buildWorkerThreadBundle() {
+  console.log("[2/5] Bundling Temporal workflow worker-thread entry...");
+  await build({
+    entryPoints: [
+      join(
+        nodeModulesDir,
+        "@temporalio/worker/lib/workflow/workflow-worker-thread.js",
+      ),
+    ],
+    outfile: join(outDir, "workflow-worker-thread.cjs"),
+    bundle: true,
+    platform: "node",
+    format: "cjs",
+    target: "node22",
+    minifyWhitespace: true,
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    sourcemap: "linked",
+    // The sandbox thread reads the native bridge's monotonic clock (deadlock
+    // detection), so it dispatches through the same per-platform shim as the
+    // main bundle.
+    alias: {
+      "@temporalio/core-bridge": join(
+        serverRoot,
+        "scripts",
+        "core-bridge-shim.cjs",
+      ),
+    },
+    logLevel: "warning",
+  });
+}
+
+// ─── Step 3: Bundle the server itself ────────────────────────────────────────
+
+/**
+ * Replaces @temporalio/worker's runtime webpack bundler with a stub. Slim
+ * builds always ship pre-built workflow bundles (workflow-source.ts prefers
+ * them), so the bundler — and with it webpack, @swc/core, memfs and friends
+ * (~45 MB) — must never enter the module graph. The stub keeps the module's
+ * export shape and fails loudly if something calls it anyway.
+ */
+const stubTemporalBundlerPlugin = {
+  name: "stub-temporal-workflow-bundler",
+  setup(buildApi) {
+    buildApi.onLoad(
+      {
+        filter: /@temporalio[\\/]worker[\\/]lib[\\/]workflow[\\/]bundler\.js$/,
+      },
+      () => ({
+        contents: `
+        const UNAVAILABLE = "Runtime workflow bundling is unavailable in the slim server artifact; it ships pre-built workflow bundles (see workflow-source.ts)";
+        exports.defaultWorkflowInterceptorModules = [];
+        exports.allowedBuiltinModules = ["assert", "url", "util"];
+        exports.disallowedBuiltinModules = [];
+        exports.disallowedModules = [];
+        exports.moduleMatches = () => false;
+        exports.bundleWorkflowCode = () => { throw new Error(UNAVAILABLE); };
+        exports.WorkflowCodeBundler = class WorkflowCodeBundler {
+          constructor() { throw new Error(UNAVAILABLE); }
+        };
+      `,
+        loader: "js",
+      }),
+    );
   },
-  // Native core-bridge + the workflow sandbox make @temporalio/*
-  // unbundleable (see the header); resolved from node_modules at runtime.
-  external: ["@temporalio/*"],
-  // Identifiers stay readable in stack traces; the external sourcemap
-  // recovers file/line (runner precedent).
-  minifyWhitespace: true,
-  minifySyntax: true,
-  minifyIdentifiers: false,
-  sourcemap: "linked",
-  logLevel: "warning",
-});
+};
 
-// The module-type marker for `node main.js`: the bundle is ESM.
-writeFileSync(
-  join(outDir, "package.json"),
-  JSON.stringify({ name: "@stigmer/server-slim", type: "module" }, null, 2) +
-    "\n",
-);
+/**
+ * Redirects threaded-vm's `require.resolve('./workflow-worker-thread')` to
+ * the sibling bundle emitted in step 2. Exact-match replacement with a count
+ * assertion so a Temporal upgrade that moves this callsite breaks the build
+ * loudly instead of producing a server that cannot start workflow sandboxes.
+ */
+const patchThreadedVmPlugin = {
+  name: "patch-temporal-threaded-vm",
+  setup(buildApi) {
+    buildApi.onLoad(
+      {
+        filter:
+          /@temporalio[\\/]worker[\\/]lib[\\/]workflow[\\/]threaded-vm\.js$/,
+      },
+      (args) => {
+        const source = readFileSync(args.path, "utf8");
+        const needle = "require.resolve('./workflow-worker-thread')";
+        const occurrences = source.split(needle).length - 1;
+        if (occurrences !== 1) {
+          fail(
+            `expected exactly 1 occurrence of ${needle} in threaded-vm.js, found ${occurrences}. ` +
+              "The @temporalio/worker version likely changed; update bundle-slim.mjs.",
+          );
+        }
+        return {
+          contents: source.replace(
+            needle,
+            "globalThis.__stigmerWorkflowWorkerThreadPath()",
+          ),
+          loader: "js",
+        };
+      },
+    );
+  },
+};
 
-console.log("bundle-slim: dist-slim/main.js written");
+/**
+ * CJS-output preamble (runner recipe): `require`, `__filename`, `__dirname`
+ * are native under CJS. `import.meta.url` — used by the workers' sibling
+ * workflow-bundle discovery — is mapped to this banner's file URL of the
+ * bundle via esbuild `define`, so discovery resolves next to main.js. The
+ * worker-thread entry path for the threaded-vm patch is published on
+ * globalThis using the native __dirname.
+ */
+const CJS_BANNER = `
+const { pathToFileURL: __stigmerPathToFileURL } = require("node:url");
+const { join: __stigmerJoin } = require("node:path");
+const __stigmerImportMetaUrl = __stigmerPathToFileURL(__filename).href;
+globalThis.__stigmerWorkflowWorkerThreadPath = () => __stigmerJoin(__dirname, "workflow-worker-thread.cjs");
+`;
+
+async function buildMainBundle() {
+  console.log("[3/5] Bundling server entry (dist/main.js)...");
+  const result = await build({
+    entryPoints: [join(distDir, "main.js")],
+    outfile: join(outDir, "main.js"),
+    bundle: true,
+    platform: "node",
+    format: "cjs",
+    target: "node22",
+    // Identifiers are kept so stack traces stay readable; the external
+    // sourcemap recovers original file/line.
+    minifyWhitespace: true,
+    minifySyntax: true,
+    minifyIdentifiers: false,
+    sourcemap: "linked",
+    define: {
+      ...stampDefines,
+      // `import.meta.url` is empty under CJS; map it to the banner-computed
+      // file URL of the bundle (see CJS_BANNER).
+      "import.meta.url": "__stigmerImportMetaUrl",
+    },
+    // The native bridge import dispatches to the per-platform package at
+    // runtime instead of upstream's all-platforms-in-one package.
+    alias: {
+      "@temporalio/core-bridge": join(
+        serverRoot,
+        "scripts",
+        "core-bridge-shim.cjs",
+      ),
+    },
+    banner: { js: CJS_BANNER },
+    plugins: [stubTemporalBundlerPlugin, patchThreadedVmPlugin],
+    metafile: true,
+    logLevel: "warning",
+  });
+  writeFileSync(join(outDir, "meta.json"), JSON.stringify(result.metafile));
+
+  for (const asset of BUNDLED_MODULE_ASSETS) {
+    const src = join(nodeModulesDir, asset.from);
+    if (!existsSync(src)) {
+      fail(`bundled-module asset not found: node_modules/${asset.from}`);
+    }
+    cpSync(src, join(outDir, asset.to));
+  }
+}
+
+// ─── Platform packages: pruned @temporalio/core-bridge ──────────────────────
+
+/**
+ * core-bridge ships native libraries for all five platforms (~120 MB of its
+ * ~127 MB) plus vendored Rust sources (~7 MB). The runtime needs exactly:
+ * the JS loader (index.js / common.js / lib/) and ONE platform's prebuilt
+ * release. Temporal's own prebuilt-path loader stays byte-for-byte intact
+ * inside the platform package's core-bridge/ directory.
+ */
+const CORE_BRIDGE_RUNTIME_PATHS = [
+  "package.json",
+  "index.js",
+  "common.js",
+  "lib",
+  "README.md",
+  "LICENSE",
+];
+
+function buildPlatformPackage(platform, destDir) {
+  const coreBridgeSrc = join(nodeModulesDir, "@temporalio/core-bridge");
+  const coreBridgePkg = readPackageJson(coreBridgeSrc);
+  const triple = CORE_BRIDGE_TRIPLES[platform];
+  if (!existsSync(join(coreBridgeSrc, "releases", triple))) {
+    fail(`core-bridge has no prebuilt release for ${triple}`);
+  }
+
+  rmSync(destDir, { recursive: true, force: true });
+  mkdirSync(destDir, { recursive: true });
+
+  cpSync(coreBridgeSrc, join(destDir, "core-bridge"), {
+    recursive: true,
+    dereference: true,
+    filter: (src) => {
+      const rel = relative(coreBridgeSrc, src);
+      if (rel === "") return true;
+      const [head, second] = rel.split(/[\\/]/);
+      if (head === "releases") return second === undefined || second === triple;
+      return CORE_BRIDGE_RUNTIME_PATHS.includes(head);
+    },
+  });
+
+  writeFileSync(
+    join(destDir, "index.cjs"),
+    `// Re-exports the vendored @temporalio/core-bridge (MIT), pruned to the\n` +
+      `// ${triple} prebuilt release. Loaded via @stigmer/server-slim's\n` +
+      `// core-bridge shim — never import this package directly.\n` +
+      `module.exports = require("./core-bridge/index.js");\n`,
+  );
+
+  const [os, cpu] = platform.split("-");
+  writeFileSync(
+    join(destDir, "package.json"),
+    JSON.stringify(
+      {
+        name: `@stigmer/server-slim-${platform}`,
+        version: serverPkg.version,
+        description: `Temporal native bridge for the slim Stigmer TS server (${platform})`,
+        license: "MIT",
+        main: "index.cjs",
+        os: [os],
+        cpu: [cpu],
+        // The vendored loader resolves these by name at runtime; declared so
+        // npm hoists them where the platform package can reach them. Copied
+        // verbatim from core-bridge's own manifest (the ranges upstream
+        // declares) so the bridge and its JS halves resolve exactly as they
+        // do in upstream's install.
+        dependencies: {
+          "@temporalio/common":
+            coreBridgePkg.dependencies["@temporalio/common"],
+          "@grpc/grpc-js": coreBridgePkg.dependencies["@grpc/grpc-js"],
+        },
+        repository: serverPkg.repository,
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+  writeFileSync(
+    join(destDir, "README.md"),
+    `# @stigmer/server-slim-${platform}\n\n` +
+      `Platform support package for [@stigmer/server-slim](https://www.npmjs.com/package/@stigmer/server-slim). ` +
+      `Contains [@temporalio/core-bridge](https://www.npmjs.com/package/@temporalio/core-bridge) ` +
+      `${coreBridgePkg.version} (MIT) pruned to the ${triple} prebuilt release. ` +
+      `Installed automatically on ${os}/${cpu}; never depend on it directly.\n`,
+  );
+}
+
+// ─── Meta package manifest ───────────────────────────────────────────────────
+
+/**
+ * The slim artifact's package.json. Doubles as the npm meta-package manifest
+ * and the self-contained directory's module-type marker.
+ *
+ * NOTE: there is intentionally NO "type": "module" — main.js is a CommonJS
+ * bundle (see the FORMAT NOTE in the header); an untyped package is what
+ * makes `node main.js` run it as CJS.
+ *
+ * NOTE: there is intentionally NO "bin". The CLI daemon spawns
+ * `node <entry>` directly, and a PATH-visible `stigmer-server` bin would
+ * shadow the Go binary in the rollback ladder's `which` step — the exact
+ * confusion the coexistence period must avoid.
+ *
+ * Dependency versions come from the installed tree (the lockfile's truth),
+ * so the published artifact runs exactly what was tested here.
+ */
+function metaPackageJson() {
+  const installedVersion = (name) =>
+    readPackageJson(join(nodeModulesDir, name)).version;
+  const optionalDependencies = {};
+  for (const platform of Object.keys(CORE_BRIDGE_TRIPLES)) {
+    optionalDependencies[`@stigmer/server-slim-${platform}`] =
+      serverPkg.version;
+  }
+  return {
+    name: "@stigmer/server-slim",
+    version: serverPkg.version,
+    description:
+      "Self-contained build of the Stigmer TypeScript control plane, launched by the stigmer CLI's local stack",
+    license: serverPkg.license,
+    engines: serverPkg.engines,
+    dependencies: {
+      // Exact: must not skew from the platform packages' native bridge.
+      "@temporalio/common": installedVersion("@temporalio/common"),
+      "@grpc/grpc-js": `^${installedVersion("@grpc/grpc-js")}`,
+    },
+    optionalDependencies,
+    repository: serverPkg.repository,
+  };
+}
+
+// ─── Step 4: Stage node_modules for the self-contained shape ────────────────
+
+/**
+ * Unlike the runner, the server has zero JS runtime externals — everything
+ * bundles. The staged node_modules carries only the per-platform native
+ * bridge plus the packages its vendored loader resolves by name, walked
+ * TRANSITIVELY (the runner's staging walk): @grpc/grpc-js alone pulls in
+ * @js-sdsl/ordered-map and friends, and a missing transitive dependency is
+ * exactly the failure verify-slim-artifact.mjs exists to catch.
+ */
+function stageSelfContained(platform) {
+  console.log("[4/5] Staging native bridge packages...");
+  const stagedRoot = join(outDir, "node_modules");
+  const staged = new Set();
+
+  function stage(name, requiredFromDir) {
+    if (name.startsWith("@types/")) return;
+
+    // Node resolution, scoped to the two layouts npm produces here: a copy
+    // nested under the requiring package wins (it rode along with its
+    // parent's tree), else the top-level package.
+    const nestedDir =
+      requiredFromDir && join(requiredFromDir, "node_modules", name);
+    if (nestedDir && existsSync(nestedDir)) {
+      const nestedPkg = readPackageJson(nestedDir);
+      for (const dep of Object.keys(nestedPkg.dependencies ?? {})) {
+        stage(dep, nestedDir);
+      }
+      return;
+    }
+    if (staged.has(name)) return;
+    staged.add(name);
+
+    const srcDir = join(nodeModulesDir, name);
+    if (!existsSync(srcDir)) {
+      fail(`cannot stage "${name}" — not present in node_modules`);
+    }
+    cpSync(srcDir, join(stagedRoot, name), {
+      recursive: true,
+      dereference: true,
+    });
+
+    const pkg = readPackageJson(srcDir);
+    for (const dep of Object.keys(pkg.dependencies ?? {})) {
+      stage(dep, srcDir);
+    }
+  }
+
+  const platformPkgDir = join(
+    stagedRoot,
+    "@stigmer",
+    `server-slim-${platform}`,
+  );
+  buildPlatformPackage(platform, platformPkgDir);
+  for (const dep of Object.keys(readPackageJson(platformPkgDir).dependencies)) {
+    stage(dep, null);
+  }
+
+  writeFileSync(
+    join(outDir, "package.json"),
+    JSON.stringify(metaPackageJson(), null, 2) + "\n",
+  );
+}
+
+// ─── Step 5 (optional): publishable npm package directories ─────────────────
+
+// Files that ship in the published @stigmer/server-slim tarball. Sourcemaps
+// are deliberately EXCLUDED (runner precedent, stigmer/stigmer#170) — still
+// generated into dist-slim/ for our own debugging, but they dominate install
+// size and identifiers stay un-minified anyway.
+const META_PACKAGE_FILES = [
+  "main.js",
+  ...WORKFLOW_BUNDLES.map(({ sibling }) => sibling),
+  "workflow-worker-thread.cjs",
+  "mappings.wasm",
+];
+
+function emitNpmPackages() {
+  console.log("[5/5] Emitting npm package directories...");
+  rmSync(pkgsDir, { recursive: true, force: true });
+
+  const metaDir = join(pkgsDir, "server-slim");
+  mkdirSync(metaDir, { recursive: true });
+  for (const file of META_PACKAGE_FILES) {
+    const src = join(outDir, file);
+    const dest = join(metaDir, file);
+    if (file.endsWith(".js") || file.endsWith(".cjs")) {
+      // We don't ship the .map files, so strip the trailing sourceMappingURL
+      // pragma rather than leave the published bundle pointing at a 404.
+      const code = readFileSync(src, "utf8").replace(
+        /\n\/\/# sourceMappingURL=\S*\s*$/,
+        "\n",
+      );
+      writeFileSync(dest, code);
+    } else {
+      cpSync(src, dest);
+    }
+  }
+  writeFileSync(
+    join(metaDir, "package.json"),
+    JSON.stringify(metaPackageJson(), null, 2) + "\n",
+  );
+  writeFileSync(
+    join(metaDir, "README.md"),
+    `# @stigmer/server-slim\n\n` +
+      `Self-contained build of the Stigmer TypeScript control plane (\`backend/services/stigmer-server-ts\`). ` +
+      `The [stigmer CLI](https://www.npmjs.com/package/@stigmer/cli) installs this package on demand and ` +
+      `launches \`node node_modules/@stigmer/server-slim/main.js\` as the local stack's server — same port, ` +
+      `same database, same behavior as the Go \`stigmer-server\` it replaces (parity-gated by the repo's ` +
+      `test/conformance suite). You should not need to depend on this package directly.\n`,
+  );
+
+  for (const platform of Object.keys(CORE_BRIDGE_TRIPLES)) {
+    buildPlatformPackage(platform, join(pkgsDir, `server-slim-${platform}`));
+  }
+}
+
+// ─── Size report ─────────────────────────────────────────────────────────────
+
+function directorySize(path) {
+  const stat = statSync(path);
+  if (!stat.isDirectory()) return stat.size;
+  let total = 0;
+  for (const entry of readdirSync(path)) {
+    total += directorySize(join(path, entry));
+  }
+  return total;
+}
+
+function printSizeReport(platform) {
+  console.log(`\nSlim artifact for ${platform} — size report:`);
+  const rows = [];
+  for (const entry of readdirSync(outDir).sort()) {
+    if (entry === "meta.json") continue;
+    if (entry === "node_modules") {
+      for (const scope of readdirSync(join(outDir, "node_modules")).sort()) {
+        const scopeDir = join(outDir, "node_modules", scope);
+        if (scope.startsWith("@")) {
+          for (const pkg of readdirSync(scopeDir).sort()) {
+            rows.push([
+              `node_modules/${scope}/${pkg}`,
+              directorySize(join(scopeDir, pkg)),
+            ]);
+          }
+        } else {
+          rows.push([`node_modules/${scope}`, directorySize(scopeDir)]);
+        }
+      }
+    } else {
+      rows.push([entry, directorySize(join(outDir, entry))]);
+    }
+  }
+  const total = rows.reduce((sum, [, size]) => sum + size, 0);
+  for (const [name, size] of rows) {
+    console.log(`  ${(size / 1024 / 1024).toFixed(1).padStart(7)} MB  ${name}`);
+  }
+  console.log(`  ${"─".repeat(40)}`);
+  console.log(`  ${(total / 1024 / 1024).toFixed(1).padStart(7)} MB  total`);
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+const { platform, emitPackages } = parseArgs();
+
+if (!existsSync(join(distDir, "main.js"))) {
+  fail("dist/main.js not found — run `npm run build` first");
+}
+
+rmSync(outDir, { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+
+await buildWorkflowBundles();
+await buildWorkerThreadBundle();
+await buildMainBundle();
+stageSelfContained(platform);
+if (emitPackages) {
+  emitNpmPackages();
+}
+printSizeReport(platform);

--- a/backend/services/stigmer-server-ts/scripts/core-bridge-shim.cjs
+++ b/backend/services/stigmer-server-ts/scripts/core-bridge-shim.cjs
@@ -1,0 +1,35 @@
+/**
+ * Bundled in place of `@temporalio/core-bridge` by scripts/bundle-slim.mjs
+ * (the runner's core-bridge-shim.cjs pattern, adapted for the server's own
+ * platform packages).
+ *
+ * Upstream core-bridge ships native libraries for all five platforms in one
+ * npm package (~120 MB). The slim artifact instead carries ONE platform's
+ * pruned copy inside `@stigmer/server-slim-<platform>` (e.g.
+ * server-slim-darwin-arm64; published as npm optionalDependencies, or staged
+ * into node_modules for directory-style embedding — both layouts resolve
+ * identically from here).
+ *
+ * The server deliberately does NOT reuse `@stigmer/runner-slim-<platform>`:
+ * sharing native packages would couple the two artifacts' @temporalio
+ * version bumps forever (owner ruling, sub-project 20260825.07 T01).
+ *
+ * The dynamic require is intentional: esbuild leaves it as a runtime lookup,
+ * which is exactly what platform dispatch needs.
+ */
+
+const platformPackage = `@stigmer/server-slim-${process.platform}-${process.arch}`;
+
+let bridge;
+try {
+  bridge = require(platformPackage);
+} catch (err) {
+  throw new Error(
+    `Failed to load the Temporal native bridge from ${platformPackage}. ` +
+      `Either ${process.platform}-${process.arch} is an unsupported platform, or the slim ` +
+      `server artifact was staged without its platform package. ` +
+      `Original error: ${err && err.message}`,
+  );
+}
+
+module.exports = bridge;

--- a/backend/services/stigmer-server-ts/scripts/verify-slim-artifact.mjs
+++ b/backend/services/stigmer-server-ts/scripts/verify-slim-artifact.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+/**
+ * Deep verification of the slim artifact — the release gate before the
+ * server-slim packages publish (the runner's verify-slim-artifact.mjs
+ * analogue).
+ *
+ * verify-boot.mjs proves the transport lifecycle, but WITHOUT Temporal the
+ * workers never start, so the slim-only machinery — the pre-built workflow
+ * bundles, the per-platform core-bridge dispatch, the patched sandbox
+ * worker-thread entry — never executes. This script boots the artifact from
+ * an ISOLATED copy (nothing resolves from this checkout's node_modules)
+ * against a REAL Temporal dev server and requires, in order:
+ *
+ *   1. the "listening" transport log,
+ *   2. "All Temporal workers started" — all three workers created from the
+ *      pre-built bundles through the native bridge,
+ *   3. SIGTERM → clean exit 0.
+ *
+ * Usage: node scripts/verify-slim-artifact.mjs
+ *        (expects a Temporal dev server on TEMPORAL_HOST_PORT, default
+ *        127.0.0.1:7233, and a built dist-slim/)
+ */
+import { spawn } from "node:child_process";
+import { cpSync, existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const serverRoot = fileURLToPath(new URL("..", import.meta.url));
+const slimDir = join(serverRoot, "dist-slim");
+const BOOT_TIMEOUT_MS = 60_000;
+// After both markers: the shutdown itself gets a deadline too — a wedged
+// worker drain is exactly the class of bug this gate exists to find, and
+// must fail the job, not hang it to the CI job timeout.
+const SHUTDOWN_TIMEOUT_MS = 20_000;
+const WORKERS_MARKER = "All Temporal workers started";
+
+if (!existsSync(join(slimDir, "main.js"))) {
+  console.error(
+    "verify-slim-artifact: dist-slim/main.js not found — run `npm run build:slim` first",
+  );
+  process.exit(1);
+}
+
+// The isolation is the point: a copy outside the repo cannot accidentally
+// resolve @temporalio/* (or anything else) from this checkout's node_modules,
+// so a missing staged dependency fails HERE instead of in a user's install.
+const isolated = mkdtempSync(join(tmpdir(), "verify-slim-artifact-"));
+cpSync(slimDir, isolated, { recursive: true });
+
+const scratch = mkdtempSync(join(tmpdir(), "verify-slim-scratch-"));
+
+const child = spawn(process.execPath, [join(isolated, "main.js")], {
+  env: {
+    ...process.env,
+    GRPC_PORT: "0",
+    LOG_LEVEL: "info",
+    ENV: "ci",
+    TEMPORAL_HOST_PORT: process.env.TEMPORAL_HOST_PORT ?? "127.0.0.1:7233",
+    DB_PATH: join(scratch, "stigmer.db"),
+    STORAGE_PATH: join(scratch, "storage"),
+    ARTIFACT_LOCAL_BASE_PATH: join(scratch, "artifacts"),
+  },
+  stdio: ["ignore", "inherit", "pipe"],
+});
+
+let stderr = "";
+let sawListening = false;
+let sawWorkers = false;
+let shutdownTimer = null;
+
+const timer = setTimeout(() => {
+  console.error(
+    `verify-slim-artifact: markers not seen within ${BOOT_TIMEOUT_MS}ms ` +
+      `(listening=${sawListening}, workers=${sawWorkers})\n${stderr}\n` +
+      (sawWorkers
+        ? ""
+        : `hint: the workers marker requires a reachable Temporal dev server on ` +
+          `TEMPORAL_HOST_PORT (${process.env.TEMPORAL_HOST_PORT ?? "127.0.0.1:7233"}) — is it running?`),
+  );
+  child.kill("SIGKILL");
+  process.exit(1);
+}, BOOT_TIMEOUT_MS);
+
+child.on("error", (err) => {
+  clearTimeout(timer);
+  console.error(`verify-slim-artifact: failed to spawn ${process.execPath}: ${err}`);
+  process.exit(1);
+});
+
+child.stderr.on("data", (chunk) => {
+  stderr += String(chunk);
+  if (!sawListening && stderr.includes("listening")) sawListening = true;
+  if (!sawWorkers && stderr.includes(WORKERS_MARKER)) sawWorkers = true;
+  if (sawListening && sawWorkers && shutdownTimer === null) {
+    clearTimeout(timer);
+    child.kill("SIGTERM");
+    shutdownTimer = setTimeout(() => {
+      console.error(
+        `verify-slim-artifact: shutdown did not complete within ${SHUTDOWN_TIMEOUT_MS}ms after SIGTERM\n${stderr}`,
+      );
+      child.kill("SIGKILL");
+      process.exit(1);
+    }, SHUTDOWN_TIMEOUT_MS);
+  }
+});
+
+child.on("exit", (code, signal) => {
+  clearTimeout(timer);
+  if (shutdownTimer !== null) clearTimeout(shutdownTimer);
+  if (sawListening && sawWorkers && code === 0) {
+    console.log(
+      "verify-slim-artifact: isolated slim artifact served, started all workers, and shut down cleanly",
+    );
+    // Success-path hygiene: each run copies the full slim artifact.
+    rmSync(isolated, { recursive: true, force: true });
+    rmSync(scratch, { recursive: true, force: true });
+    process.exit(0);
+  }
+  console.error(
+    `verify-slim-artifact: failed (listening=${sawListening}, workers=${sawWorkers}, code=${code}, signal=${signal})\n${stderr}`,
+  );
+  process.exit(1);
+});

--- a/backend/services/stigmer-server-ts/src/temporal/manager.ts
+++ b/backend/services/stigmer-server-ts/src/temporal/manager.ts
@@ -234,6 +234,10 @@ export class TemporalManager {
     }
     try {
       await this.createAndRunWorkers();
+      // This exact wording is LOAD-BEARING: scripts/verify-slim-artifact.mjs
+      // (the slim-artifact CI/release gate) waits for it, and the Go server
+      // emits the identical line (temporal_manager.go). Reword all three
+      // together or the gate fails as an opaque timeout.
       this.logger.info("All Temporal workers started", {
         worker_count: this.workers.length,
       });

--- a/client-apps/cli/src/local/daemon/components.test.ts
+++ b/client-apps/cli/src/local/daemon/components.test.ts
@@ -11,7 +11,7 @@ const config: DaemonConfig = {
   temporalAddress: "127.0.0.1:7233",
   serverOnly: false,
   noWeb: false,
-  serverBin: "/bin/stigmer-server",
+  server: { kind: "node", nodeBin: "/bin/node", entryPath: "/repo/server-ts/dist/main.js", appDir: "/repo/server-ts" },
   runner: { nodeBin: "/bin/node", entryPath: "/repo/runner/dist/main.js", appDir: "/repo/runner" },
 };
 
@@ -131,6 +131,28 @@ describe("buildComponents", () => {
     expect(runner.gate).toBeUndefined();
     expect(runner.resolve().readinessMarker).toBe(RUNNER_READY_MARKER);
     expect(runner.resolve().args).toEqual(["/repo/runner/dist/main.js"]);
+  });
+
+  // The TS server child is `node <entry>` — the runner's launch shape.
+  it("spawns the node-shape server as node + entry", () => {
+    const [server] = buildComponents(config, {});
+    const spawn = server.resolve();
+    expect(spawn.command).toBe("/bin/node");
+    expect(spawn.args).toEqual(["/repo/server-ts/dist/main.js"]);
+  });
+
+  // The rollback path: identical child contract, only the command differs.
+  it("spawns the binary-shape server as the bare executable", () => {
+    const rollback: DaemonConfig = { ...config, server: { kind: "binary", bin: "/bin/stigmer-server" } };
+    const [server] = buildComponents(rollback, {});
+    const spawn = server.resolve();
+    expect(spawn.command).toBe("/bin/stigmer-server");
+    expect(spawn.args).toEqual([]);
+    // Everything except the command is byte-identical across the two shapes —
+    // the cutover's zero-visible-change guarantee at the daemon layer.
+    const tsSpawn = buildComponents(config, {})[0].resolve();
+    expect(spawn.env).toEqual(tsSpawn.env);
+    expect(spawn.logFile).toBe(tsSpawn.logFile);
   });
 
   it("omits the runner in server-only mode", () => {

--- a/client-apps/cli/src/local/daemon/components.ts
+++ b/client-apps/cli/src/local/daemon/components.ts
@@ -91,9 +91,15 @@ export function buildComponents(config: DaemonConfig, base: NodeJS.ProcessEnv = 
       name: "stigmer-server",
       pidFile: join(config.dataDir, SERVER_PID_FILE),
       critical: true,
+      // Two launch shapes, one child contract: the TS server is `node <entry>`
+      // (the runner's shape, the served implementation since the DD-006
+      // cutover); the Go binary is the rollback path. Name, pid file, log
+      // file, env, and readiness gate are identical either way — that
+      // sameness IS the cutover's zero-visible-change guarantee.
       resolve: () => ({
-        command: config.serverBin,
-        args: [],
+        ...(config.server.kind === "binary"
+          ? { command: config.server.bin, args: [] }
+          : { command: config.server.nodeBin, args: [config.server.entryPath] }),
         env: buildServerEnv(config, base),
         logFile: join(config.logDir, "stigmer-server.log"),
       }),

--- a/client-apps/cli/src/local/daemon/daemon.integration.test.ts
+++ b/client-apps/cli/src/local/daemon/daemon.integration.test.ts
@@ -128,7 +128,7 @@ describe("runInternalDaemon (full body with fakes)", () => {
       temporalAddress: "127.0.0.1:7233",
       serverOnly: false,
       noWeb: true,
-      serverBin: "server-cmd",
+      server: { kind: "node", nodeBin: "node-cmd", entryPath: join(data, "server-entry.js"), appDir: data },
       runner: { nodeBin: "node-cmd", entryPath: join(data, "entry.js"), appDir: data },
     };
 

--- a/client-apps/cli/src/local/daemon/env.test.ts
+++ b/client-apps/cli/src/local/daemon/env.test.ts
@@ -8,12 +8,18 @@ const baseInputs: DaemonEnvInputs = {
   temporalAddress: "127.0.0.1:7233",
   serverOnly: false,
   noWeb: false,
-  serverBin: "/usr/local/bin/stigmer-server",
+  // The node shape is the served default since the DD-006 cutover (D4 #24).
+  server: {
+    kind: "node",
+    nodeBin: "/usr/bin/node",
+    entryPath: "/repo/server-ts/dist/main.js",
+    appDir: "/repo/server-ts",
+  },
   runner: { nodeBin: "/usr/bin/node", entryPath: "/repo/runner/dist/main.js", appDir: "/repo/runner" },
 };
 
 describe("buildDaemonEnv + readDaemonConfig", () => {
-  it("round-trips the full launcher -> daemon contract", () => {
+  it("round-trips the full launcher -> daemon contract (node server shape)", () => {
     const env = buildDaemonEnv(baseInputs, {});
     const config = readDaemonConfig(env);
     expect(config).toEqual({
@@ -23,7 +29,12 @@ describe("buildDaemonEnv + readDaemonConfig", () => {
       temporalAddress: "127.0.0.1:7233",
       serverOnly: false,
       noWeb: false,
-      serverBin: "/usr/local/bin/stigmer-server",
+      server: {
+        kind: "node",
+        nodeBin: "/usr/bin/node",
+        entryPath: "/repo/server-ts/dist/main.js",
+        appDir: "/repo/server-ts",
+      },
       runner: { nodeBin: "/usr/bin/node", entryPath: "/repo/runner/dist/main.js", appDir: "/repo/runner" },
       cursorApiKey: undefined,
       anthropicApiKey: undefined,
@@ -31,6 +42,44 @@ describe("buildDaemonEnv + readDaemonConfig", () => {
       operatorEmail: undefined,
       operatorName: undefined,
     });
+  });
+
+  it("round-trips the binary server shape (the Go rollback path)", () => {
+    const env = buildDaemonEnv({ ...baseInputs, server: { kind: "binary", bin: "/usr/local/bin/stigmer-server" } }, {});
+    const config = readDaemonConfig(env);
+    expect(config.server).toEqual({ kind: "binary", bin: "/usr/local/bin/stigmer-server" });
+  });
+
+  // The rollback lever's delivery guarantee, both directions:
+  // - a caller-exported STIGMER_SERVER_BIN must not leak past a launcher that
+  //   resolved the node shape (the launcher already honored the override
+  //   upstream — a node-shape contract means it was NOT set);
+  // - when both shapes somehow reach the daemon, the binary override wins,
+  //   because setting it means "run the Go server".
+  it("scrubs a stale STIGMER_SERVER_BIN from the base env when the node shape was resolved", () => {
+    const env = buildDaemonEnv(baseInputs, { STIGMER_SERVER_BIN: "/stale/go-server" });
+    expect(env.STIGMER_SERVER_BIN).toBeUndefined();
+    expect(readDaemonConfig(env).server.kind).toBe("node");
+  });
+
+  it("prefers the binary override when both shapes are present in the env", () => {
+    const env = buildDaemonEnv(baseInputs, {});
+    env.STIGMER_SERVER_BIN = "/operator/override/stigmer-server";
+    expect(readDaemonConfig(env).server).toEqual({
+      kind: "binary",
+      bin: "/operator/override/stigmer-server",
+    });
+  });
+
+  it("scrubs a stale node triple from the base env when the binary shape was resolved", () => {
+    const env = buildDaemonEnv(
+      { ...baseInputs, server: { kind: "binary", bin: "/usr/local/bin/stigmer-server" } },
+      { STIGMER_SERVER_NODE_BIN: "/stale/node", STIGMER_SERVER_ENTRY: "/stale/main.js", STIGMER_SERVER_APP_DIR: "/stale" },
+    );
+    expect(env.STIGMER_SERVER_NODE_BIN).toBeUndefined();
+    expect(env.STIGMER_SERVER_ENTRY).toBeUndefined();
+    expect(env.STIGMER_SERVER_APP_DIR).toBeUndefined();
+    expect(readDaemonConfig(env).server.kind).toBe("binary");
   });
 
   it("omits runner coordinates in server-only mode", () => {
@@ -90,8 +139,13 @@ describe("buildDaemonEnv + readDaemonConfig", () => {
     expect(readDaemonConfig(env)).not.toHaveProperty("openaiApiKey");
   });
 
-  it("requires the data dir and server binary", () => {
+  it("requires the data dir and one server launch shape", () => {
     expect(() => readDaemonConfig({})).toThrow(/STIGMER_DATA_DIR/);
+    // Neither the binary override nor the full node triple: actionable throw
+    // naming both shapes.
     expect(() => readDaemonConfig({ STIGMER_DATA_DIR: "/x" })).toThrow(/STIGMER_SERVER_BIN/);
+    expect(() => readDaemonConfig({ STIGMER_DATA_DIR: "/x", STIGMER_SERVER_NODE_BIN: "/usr/bin/node" })).toThrow(
+      /STIGMER_SERVER_ENTRY/,
+    );
   });
 });

--- a/client-apps/cli/src/local/daemon/env.ts
+++ b/client-apps/cli/src/local/daemon/env.ts
@@ -13,6 +13,9 @@ export const DaemonEnvVar = {
   ServerOnly: "STIGMER_SERVER_ONLY",
   NoWeb: "STIGMER_NO_WEB",
   ServerBin: "STIGMER_SERVER_BIN",
+  ServerNodeBin: "STIGMER_SERVER_NODE_BIN",
+  ServerEntry: "STIGMER_SERVER_ENTRY",
+  ServerAppDir: "STIGMER_SERVER_APP_DIR",
   RunnerNodeBin: "STIGMER_RUNNER_NODE_BIN",
   RunnerEntry: "STIGMER_RUNNER_ENTRY",
   RunnerAppDir: "STIGMER_RUNNER_APP_DIR",
@@ -30,6 +33,17 @@ export interface RunnerLaunch {
   appDir: string;
 }
 
+/**
+ * Resolved server launch coordinates — a modeled state, not an inference
+ * (D4 #24). "node" is the TypeScript server (the served implementation
+ * since the DD-006 cutover): a node binary + bundled entry, the runner's
+ * launch shape. "binary" is the Go stigmer-server executable — the
+ * rollback path, selected by the STIGMER_SERVER_BIN override.
+ */
+export type ServerLaunch =
+  | { kind: "binary"; bin: string }
+  | { kind: "node"; nodeBin: string; entryPath: string; appDir: string };
+
 /** The daemon's resolved configuration, parsed from the environment. */
 export interface DaemonConfig {
   dataDir: string;
@@ -38,7 +52,7 @@ export interface DaemonConfig {
   temporalAddress: string;
   serverOnly: boolean;
   noWeb: boolean;
-  serverBin: string;
+  server: ServerLaunch;
   runner?: RunnerLaunch;
   cursorApiKey?: string;
   anthropicApiKey?: string;
@@ -55,7 +69,7 @@ export interface DaemonEnvInputs {
   temporalAddress: string;
   serverOnly: boolean;
   noWeb: boolean;
-  serverBin: string;
+  server: ServerLaunch;
   runner?: RunnerLaunch;
   // Anthropic API key resolved by the launcher (env > config file). Must be
   // written into the daemon env explicitly: unlike a shell-exported key, a key
@@ -83,7 +97,23 @@ export function buildDaemonEnv(inputs: DaemonEnvInputs, base: NodeJS.ProcessEnv 
   env[DaemonEnvVar.LogDir] = inputs.logDir;
   env[DaemonEnvVar.TemporalManaged] = String(inputs.temporalManaged);
   env[DaemonEnvVar.TemporalAddress] = inputs.temporalAddress;
-  env[DaemonEnvVar.ServerBin] = inputs.serverBin;
+  if (inputs.server.kind === "binary") {
+    env[DaemonEnvVar.ServerBin] = inputs.server.bin;
+    // Symmetric scrub: a stale node triple inherited from the caller's shell
+    // must not ride the base spread into the children's environments.
+    delete env[DaemonEnvVar.ServerNodeBin];
+    delete env[DaemonEnvVar.ServerEntry];
+    delete env[DaemonEnvVar.ServerAppDir];
+  } else {
+    env[DaemonEnvVar.ServerNodeBin] = inputs.server.nodeBin;
+    env[DaemonEnvVar.ServerEntry] = inputs.server.entryPath;
+    env[DaemonEnvVar.ServerAppDir] = inputs.server.appDir;
+    // A caller-exported STIGMER_SERVER_BIN must not leak through the base
+    // spread when the launcher resolved the node shape — the daemon prefers
+    // the binary override precisely because setting it means "run the Go
+    // server", and the launcher already honored that upstream.
+    delete env[DaemonEnvVar.ServerBin];
+  }
   if (inputs.serverOnly) env[DaemonEnvVar.ServerOnly] = "true";
   if (inputs.noWeb) env[DaemonEnvVar.NoWeb] = "1";
   if (inputs.runner !== undefined && !inputs.serverOnly) {
@@ -112,7 +142,7 @@ export function readDaemonConfig(env: NodeJS.ProcessEnv = process.env): DaemonCo
     temporalAddress: env[DaemonEnvVar.TemporalAddress] ?? "127.0.0.1:7233",
     serverOnly,
     noWeb: env[DaemonEnvVar.NoWeb] === "1",
-    serverBin: required(env, DaemonEnvVar.ServerBin),
+    server: readServer(env),
     runner: serverOnly ? undefined : runner,
     cursorApiKey: nonEmpty(env[DaemonEnvVar.CursorApiKey]),
     anthropicApiKey: nonEmpty(env[DaemonEnvVar.AnthropicApiKey]),
@@ -120,6 +150,25 @@ export function readDaemonConfig(env: NodeJS.ProcessEnv = process.env): DaemonCo
     operatorEmail: nonEmpty(env[DaemonEnvVar.OperatorEmail]),
     operatorName: nonEmpty(env[DaemonEnvVar.OperatorName]),
   };
+}
+
+// The binary override wins when both shapes are present: STIGMER_SERVER_BIN
+// is the no-code-change rollback lever (D2 §6), and buildDaemonEnv never
+// writes both, so a both-present env means an operator override.
+function readServer(env: NodeJS.ProcessEnv): ServerLaunch {
+  const bin = env[DaemonEnvVar.ServerBin];
+  if (bin !== undefined && bin !== "") {
+    return { kind: "binary", bin };
+  }
+  const nodeBin = env[DaemonEnvVar.ServerNodeBin];
+  const entryPath = env[DaemonEnvVar.ServerEntry];
+  const appDir = env[DaemonEnvVar.ServerAppDir];
+  if (!nodeBin || !entryPath || !appDir) {
+    throw new Error(
+      `${DaemonEnvVar.ServerBin} or the ${DaemonEnvVar.ServerNodeBin}/${DaemonEnvVar.ServerEntry}/${DaemonEnvVar.ServerAppDir} triple is required for the daemon process`,
+    );
+  }
+  return { kind: "node", nodeBin, entryPath, appDir };
 }
 
 function readRunner(env: NodeJS.ProcessEnv): RunnerLaunch | undefined {

--- a/client-apps/cli/src/local/daemon/launch.ts
+++ b/client-apps/cli/src/local/daemon/launch.ts
@@ -2,7 +2,7 @@
 // `down` (signal + wait + safety-net cleanup), and a liveness check.
 //
 // `up` resolves every heavy dependency in the foreground (Temporal binary,
-// server binary, runner entry) so failures surface with a clear message before
+// server launch, runner entry) so failures surface with a clear message before
 // a detached daemon is spawned, then re-execs this same CLI as the hidden
 // `internal-daemon` and waits until the server's gRPC port answers.
 
@@ -24,7 +24,7 @@ import { rotateLogs } from "../state/log-rotation.js";
 import { resolveApiKey, resolveProvider } from "../llm-config.js";
 import { resolveOperatorIdentity } from "../operator-config.js";
 import { ensureRunner } from "../runtime/runner.js";
-import { ensureServerBinary } from "../runtime/server.js";
+import { ensureServer } from "../runtime/server-ts.js";
 import { TemporalManager } from "../temporal/manager.js";
 import { buildDaemonEnv, type DaemonEnvInputs } from "./env.js";
 
@@ -64,7 +64,10 @@ export async function up(options: UpOptions = {}, home: string = homedir()): Pro
     await temporal.ensureInstalled();
   }
 
-  const serverBin = await ensureServerBinary({ home });
+  // THE cutover switch (D4 #24): resolves the TS server (repo tree or the
+  // acquired @stigmer/server-slim), or the Go binary when STIGMER_SERVER_BIN
+  // is set — the rollback lever.
+  const server = ensureServer({ home });
   const runner = options.serverOnly === true ? undefined : ensureRunner({ home });
 
   const env = buildDaemonEnv(
@@ -75,7 +78,7 @@ export async function up(options: UpOptions = {}, home: string = homedir()): Pro
       temporalAddress: temporal.address,
       serverOnly: options.serverOnly === true,
       noWeb: options.noWeb === true,
-      serverBin,
+      server,
       runner,
       ...resolveLlmKeyInputs(config),
       ...resolveOperatorIdentityInputs(config),

--- a/client-apps/cli/src/local/runtime/index.ts
+++ b/client-apps/cli/src/local/runtime/index.ts
@@ -1,6 +1,6 @@
 // Public surface of the runtime-acquisition seams (DD-002/003/007).
 
-export { resolveNode } from "./node.js";
+export { resolveNode, resolveServerNode } from "./node.js";
 export {
   type EnsureRunnerOptions,
   type RunnerResolution,
@@ -8,8 +8,16 @@ export {
   ensureRunner,
   resolveRunner,
 } from "./runner.js";
+// The TS server — the served implementation since the DD-006 cutover (D4 #24).
 export {
   type EnsureServerOptions,
+  acquireServer,
+  ensureServer,
+  resolveServerTs,
+} from "./server-ts.js";
+// The Go binary ladder — the rollback path until #25 go-server-retirement.
+export {
+  type EnsureServerBinaryOptions,
   type ServerDownloadTarget,
   downloadServerBinary,
   ensureServerBinary,

--- a/client-apps/cli/src/local/runtime/node.ts
+++ b/client-apps/cli/src/local/runtime/node.ts
@@ -1,4 +1,5 @@
-// Resolution of the Node.js runtime used to launch the runner subprocess.
+// Resolution of the Node.js runtime used to launch the runner and TS-server
+// subprocesses.
 //
 // We reuse the very Node that is running the CLI (process.execPath). The CLI is
 // itself an npm package with `engines: node >= 22.13`, so a suitable Node is
@@ -8,16 +9,26 @@
 // (`spawn(process.execPath, ...)`). An explicit STIGMER_NODE_BIN override is
 // honored and capability-checked for advanced/multi-runtime setups.
 //
-// The gate is a CAPABILITY probe, not a version check. The runner's durable
-// local checkpointer imports Node's built-in `node:sqlite`, available unflagged
-// from 22.13 in the 22.x line and only from 23.4 in the 23.x line — a gap
-// (23.0–23.3) that a previous version-table gate here missed, letting those
-// Nodes through to crash at runner boot with a raw ERR_UNKNOWN_BUILTIN_MODULE.
-// Probing "can this binary provide node:sqlite?" directly cannot drift; the
-// version floors survive only in the error message, where staleness is
-// harmless. The runner performs the same probe on its own boot (see
-// backend/services/runner/src/preflight.ts) — this one exists to fail at
-// resolve time with CLI-appropriate guidance instead of a subprocess crash.
+// The gates are CAPABILITY probes, not version checks. Two probes, because the
+// two children need different sqlite capabilities:
+//
+// - The RUNNER's durable local checkpointer imports Node's built-in
+//   `node:sqlite`, available unflagged from 22.13 in the 22.x line and only
+//   from 23.4 in the 23.x line — a gap (23.0–23.3) that a previous
+//   version-table gate here missed, letting those Nodes through to crash at
+//   runner boot with a raw ERR_UNKNOWN_BUILTIN_MODULE.
+// - The SERVER additionally needs `node:sqlite` compiled WITH FTS5 (its
+//   search index; migration v3 creates an fts5 virtual table at boot). Node
+//   23.4 PROVIDES node:sqlite but its sqlite build LACKS FTS5 — found by
+//   D4 #14 and the reason the module-presence probe alone is insufficient
+//   for the server. Probing "can this binary create an fts5 table?" directly
+//   cannot drift; the version floors survive only in the error messages,
+//   where staleness is harmless.
+//
+// The runner performs the module-presence probe on its own boot (see
+// backend/services/runner/src/preflight.ts); the server fails at migration
+// time. Both probes here exist to fail at resolve time with CLI-appropriate
+// guidance instead of a subprocess crash.
 
 import { execFileSync } from "node:child_process";
 import { CliExitError } from "../../errors/cli-exit-error.js";
@@ -39,6 +50,16 @@ import { ExitCode } from "../../errors/exit-codes.js";
 const NODE_SQLITE_PROBE =
   "process.exit(process.getBuiltinModule?.('node:sqlite') === undefined ? 1 : 0)";
 
+// Exits 0 when the binary's `node:sqlite` can create an FTS5 virtual table,
+// 1 otherwise. Strictly stronger than NODE_SQLITE_PROBE: it exercises the
+// exact operation the server's migration v3 performs, in memory. The
+// try/catch covers both failure shapes — module absent (TypeError on the
+// undefined module) and FTS5 absent (the exec throws "no such module: fts5").
+const NODE_SQLITE_FTS5_PROBE =
+  "try{const{DatabaseSync}=process.getBuiltinModule('node:sqlite');" +
+  "new DatabaseSync(':memory:').exec('CREATE VIRTUAL TABLE t USING fts5(x)');" +
+  "process.exit(0)}catch{process.exit(1)}";
+
 /**
  * Resolve the Node binary to launch the runner with. Honors STIGMER_NODE_BIN;
  * otherwise returns the current runtime. Either way the binary is probed for
@@ -47,10 +68,48 @@ const NODE_SQLITE_PROBE =
  * runner-launch paths only (ensureRunner), never on ordinary CLI commands.
  */
 export function resolveNode(): string {
-  const override = process.env.STIGMER_NODE_BIN;
-  const bin = override !== undefined && override !== "" ? override : process.execPath;
-  assertProvidesNodeSqlite(bin);
+  const bin = nodeCandidate();
+  assertCapability(bin, NODE_SQLITE_PROBE, {
+    subject: "the runner",
+    capability: "the built-in node:sqlite module",
+    floor: "Node >= 22.13 (>= 23.4 in the 23.x line)",
+    detail: [
+      "The runner's durable checkpointer requires node:sqlite, which is available",
+      "unflagged from Node 22.13 (22.x line) and 23.4 (23.x and later) — note that",
+      "23.0-23.3 lack it.",
+    ],
+  });
   return bin;
+}
+
+/**
+ * Resolve the Node binary to launch the TS server with. Same
+ * STIGMER_NODE_BIN/execPath resolution as {@link resolveNode}, but probes for
+ * `node:sqlite` WITH FTS5 — the server's search index needs it and some Node
+ * builds (e.g. 23.4) ship node:sqlite without it. Runs on server-launch paths
+ * only (ensureServer).
+ */
+export function resolveServerNode(): string {
+  const bin = nodeCandidate();
+  assertCapability(bin, NODE_SQLITE_FTS5_PROBE, {
+    subject: "the stigmer server",
+    capability: "the built-in node:sqlite module with FTS5",
+    floor: "Node 22.13+ in the 22.x line (23.x builds lack FTS5)",
+    detail: [
+      "The server's search index requires node:sqlite compiled with FTS5.",
+      "The 22.x line from 22.13 is known-good; 23.x builds ship node:sqlite",
+      "WITHOUT FTS5 and cannot run the server. Newer majors work if their",
+      "sqlite build includes FTS5 — this probe is the authority.",
+    ],
+  });
+  return bin;
+}
+
+function nodeCandidate(): string {
+  const override = process.env.STIGMER_NODE_BIN;
+  return override !== undefined && override !== ""
+    ? override
+    : process.execPath;
 }
 
 /** Best-effort `--version` for error messages only; null when the spawn fails. */
@@ -66,10 +125,27 @@ function probeNodeVersion(bin: string): string | null {
   }
 }
 
-function assertProvidesNodeSqlite(bin: string): void {
+interface CapabilityErrorCopy {
+  /** What is being launched, e.g. "the runner". */
+  subject: string;
+  /** The missing capability, in user terms. */
+  capability: string;
+  /** The known-good version floor, per probe — the two probes differ (the
+   * runner accepts 23.4+; the server does not). Error copy only; the probe
+   * is the authority. */
+  floor: string;
+  /** Guidance lines explaining the requirement. */
+  detail: string[];
+}
+
+function assertCapability(
+  bin: string,
+  probe: string,
+  copy: CapabilityErrorCopy,
+): void {
   let exitStatus: number | null;
   try {
-    execFileSync(bin, ["-e", NODE_SQLITE_PROBE], { stdio: "ignore" });
+    execFileSync(bin, ["-e", probe], { stdio: "ignore" });
     return;
   } catch (err) {
     // execFileSync reports a nonzero exit via `status`; a spawn failure
@@ -78,19 +154,19 @@ function assertProvidesNodeSqlite(bin: string): void {
   }
 
   if (exitStatus === null) {
-    throw new CliExitError(`could not run ${bin} to verify the runner's Node requirements`, ExitCode.General, [
-      `Ensure ${bin} is a working Node >= 22.13 runtime (>= 23.4 in the 23.x line).`,
-    ]);
+    throw new CliExitError(
+      `could not run ${bin} to verify ${copy.subject}'s Node requirements`,
+      ExitCode.General,
+      [`Ensure ${bin} is a working ${copy.floor} runtime.`],
+    );
   }
 
   const version = probeNodeVersion(bin) ?? "unknown version";
   throw new CliExitError(
-    `Node at ${bin} (${version}) cannot run the runner: it does not provide the built-in node:sqlite module`,
+    `Node at ${bin} (${version}) cannot run ${copy.subject}: it does not provide ${copy.capability}`,
     ExitCode.General,
     [
-      "The runner's durable checkpointer requires node:sqlite, which is available",
-      "unflagged from Node 22.13 (22.x line) and 23.4 (23.x and later) — note that",
-      "23.0-23.3 lack it.",
+      ...copy.detail,
       "Upgrade Node, or point STIGMER_NODE_BIN at a suitable runtime.",
     ],
   );

--- a/client-apps/cli/src/local/runtime/runner.ts
+++ b/client-apps/cli/src/local/runtime/runner.ts
@@ -17,8 +17,7 @@
 // launch contract (`node main.js`) is identical to the repo-tree runner, so the
 // daemon spawns either the same way.
 
-import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -28,6 +27,7 @@ import { log } from "../../logger.js";
 import { VERSION } from "../../version.js";
 import { runtimesDir } from "../paths.js";
 import { resolveNode } from "./node.js";
+import { ensureRuntimesRoot, isAcquirableRelease, npmInstallIntoRuntimes, type NpmInstall } from "./runtimes-install.js";
 
 const SLIM_PACKAGE = "@stigmer/runner-slim";
 
@@ -48,7 +48,7 @@ export interface EnsureRunnerOptions {
   /** Node resolver (injectable for tests). */
   node?: () => string;
   /** npm install implementation (injectable for tests). */
-  install?: (installDir: string, spec: string) => void;
+  install?: NpmInstall;
 }
 
 /**
@@ -111,14 +111,8 @@ export function acquireRunner(opts: EnsureRunnerOptions = {}): RunnerResolution 
 
   if (!existsSync(entryPath)) {
     log.info(`acquiring ${SLIM_PACKAGE}`, { version, dir: installDir });
-    mkdirSync(installDir, { recursive: true });
-    // A stable package.json root makes the install deterministic and records the
-    // pinned dependency rather than letting npm synthesize an ad-hoc root.
-    writeFileSync(
-      join(installDir, "package.json"),
-      `${JSON.stringify({ name: "stigmer-runtime", private: true, version: "0.0.0" }, null, 2)}\n`,
-    );
-    const install = opts.install ?? installRunnerSlim;
+    ensureRuntimesRoot(installDir);
+    const install = opts.install ?? npmInstallIntoRuntimes;
     install(installDir, `${SLIM_PACKAGE}@${version}`);
   }
 
@@ -132,24 +126,6 @@ export function acquireRunner(opts: EnsureRunnerOptions = {}): RunnerResolution 
   return { nodeBin: node(), entryPath, appDir: dirname(entryPath) };
 }
 
-// Install the slim package (plus its platform-native optional dependency) into an
-// isolated prefix. `--omit=dev` drops devDependencies while keeping the optional
-// native package npm selects by os/cpu; output is inherited so the user sees the
-// one-time download progress.
-function installRunnerSlim(installDir: string, spec: string): void {
-  try {
-    execFileSync("npm", ["install", spec, "--prefix", installDir, "--omit=dev", "--no-audit", "--no-fund"], {
-      stdio: "inherit",
-    });
-  } catch (err) {
-    throw new CliExitError(`failed to install ${spec}`, ExitCode.General, [
-      `Command: npm install ${spec} --prefix ${installDir}`,
-      "Ensure npm is on PATH and the network is reachable.",
-      String(err),
-    ]);
-  }
-}
-
 function resolveBuiltRunner(appDir: string, node: () => string): RunnerResolution {
   const entryPath = join(appDir, "dist", "main.js");
   if (!existsSync(entryPath)) {
@@ -160,13 +136,6 @@ function resolveBuiltRunner(appDir: string, node: () => string): RunnerResolutio
     ]);
   }
   return { nodeBin: node(), entryPath, appDir };
-}
-
-// A source build reports "0.0.0-dev" and the dev npm channel stamps "<v>-dev.<stamp>"
-// versions; neither publishes a matching @stigmer/runner-slim, so they are not
-// acquirable. Release and rc/next versions are.
-function isAcquirableRelease(version: string): boolean {
-  return !version.includes("-dev");
 }
 
 function hasPackageJson(dir: string): boolean {

--- a/client-apps/cli/src/local/runtime/runtime.test.ts
+++ b/client-apps/cli/src/local/runtime/runtime.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CliExitError } from "../../errors/cli-exit-error.js";
-import { resolveNode } from "./node.js";
+import { resolveNode, resolveServerNode } from "./node.js";
 import { acquireRunner, resolveRunner } from "./runner.js";
 import { resolveServerBinary } from "./server.js";
 import { which } from "./which.js";
@@ -52,12 +52,19 @@ describe("which", () => {
 
 // A fake "node" whose --version and capability-probe behavior the test
 // controls, making these tests deterministic regardless of which Node runs
-// the suite itself.
-function fakeNodeBinary(opts: { version: string; hasSqlite: boolean }): string {
+// the suite itself. The fake INSPECTS the probe script it receives ("fts5"
+// in the source distinguishes the server's FTS5 probe from the runner's
+// module-presence probe), so a mutation that wires resolveServerNode to the
+// weaker probe — or neuters the FTS5 probe's failure exit — fails here.
+function fakeNodeBinary(opts: { version: string; hasSqlite: boolean; hasFts5?: boolean }): string {
   const bin = join(tempDir("stigmer-node-"), "node");
+  const fts5Exit = (opts.hasFts5 ?? opts.hasSqlite) ? 0 : 1;
   writeFileSync(
     bin,
-    `#!/bin/sh\nif [ "$1" = "--version" ]; then echo "${opts.version}"; exit 0; fi\nexit ${opts.hasSqlite ? 0 : 1}\n`,
+    `#!/bin/sh\n` +
+      `if [ "$1" = "--version" ]; then echo "${opts.version}"; exit 0; fi\n` +
+      `case "$2" in *fts5*) exit ${fts5Exit};; esac\n` +
+      `exit ${opts.hasSqlite ? 0 : 1}\n`,
   );
   chmodSync(bin, 0o755);
   return bin;
@@ -95,6 +102,55 @@ describe("resolveNode", () => {
     expect(() => resolveNode()).toThrow(/node:sqlite/);
     expect(() => resolveNode()).toThrow(/v23\.1\.0/);
   });
+});
+
+describe("resolveServerNode", () => {
+  it("honors an override that passes the FTS5 capability probe", () => {
+    const bin = fakeNodeBinary({ version: "v22.13.0", hasSqlite: true });
+    process.env.STIGMER_NODE_BIN = bin;
+    expect(resolveServerNode()).toBe(bin);
+  });
+
+  it("rejects a Node whose sqlite lacks FTS5, naming the capability (the 23.4 trap)", () => {
+    // The shape of a REAL 23.4 binary: node:sqlite present (the module probe
+    // would pass), FTS5 absent (the fts5 probe fails) — pinning that the
+    // server resolution dispatches the STRONGER probe (D4 #14).
+    process.env.STIGMER_NODE_BIN = fakeNodeBinary({ version: "v23.4.0", hasSqlite: true, hasFts5: false });
+
+    expect(() => resolveServerNode()).toThrow(/FTS5/);
+    expect(() => resolveServerNode()).toThrow(/v23\.4\.0/);
+  });
+
+  it("the runner resolution still accepts the 23.4 shape (module present, FTS5 absent)", () => {
+    // The two probes deliberately differ: the runner needs only node:sqlite.
+    const bin = fakeNodeBinary({ version: "v23.4.0", hasSqlite: true, hasFts5: false });
+    process.env.STIGMER_NODE_BIN = bin;
+    expect(resolveNode()).toBe(bin);
+  });
+
+  it("runs the real FTS5 probe against the current runtime", () => {
+    // The one place the REAL probe script executes end-to-end (the fake-node
+    // tests above only exercise the dispatch and error copy). Conditional on
+    // the runtime's own capability — the resolveNode own-runtime pattern —
+    // so a no-FTS5 Node (e.g. 23.4) asserts the throw instead of the pass.
+    delete process.env.STIGMER_NODE_BIN;
+    if (currentRuntimeHasFts5()) {
+      expect(resolveServerNode()).toBe(process.execPath);
+    } else {
+      expect(() => resolveServerNode()).toThrow(/FTS5/);
+    }
+  });
+
+  function currentRuntimeHasFts5(): boolean {
+    const sqlite = process.getBuiltinModule?.("node:sqlite");
+    if (sqlite === undefined) return false;
+    try {
+      new sqlite.DatabaseSync(":memory:").exec("CREATE VIRTUAL TABLE t USING fts5(x)");
+      return true;
+    } catch {
+      return false;
+    }
+  }
 });
 
 describe("resolveServerBinary", () => {

--- a/client-apps/cli/src/local/runtime/runtimes-install.test.ts
+++ b/client-apps/cli/src/local/runtime/runtimes-install.test.ts
@@ -1,0 +1,56 @@
+// Pins the shared runtimes-install contract both acquirers depend on: the
+// no-clobber root manifest (the runner and the server install into ONE
+// per-version root), the dev-version gate, and the actionable install
+// failure.
+
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CliExitError } from "../../errors/cli-exit-error.js";
+import { ensureRuntimesRoot, isAcquirableRelease, npmInstallIntoRuntimes } from "./runtimes-install.js";
+
+function tempDir(): string {
+  return mkdtempSync(join(tmpdir(), "stigmer-runtimes-"));
+}
+
+describe("ensureRuntimesRoot", () => {
+  it("creates the root with the stable manifest when absent", () => {
+    const dir = join(tempDir(), "0.5.0");
+    ensureRuntimesRoot(dir);
+    const manifest = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
+    expect(manifest).toEqual({ name: "stigmer-runtime", private: true, version: "0.0.0" });
+  });
+
+  it("never clobbers an existing root manifest — the shared-root contract", () => {
+    const dir = tempDir();
+    writeFileSync(join(dir, "package.json"), '{"name":"stigmer-runtime","marker":"first-installer"}\n');
+    ensureRuntimesRoot(dir);
+    expect(readFileSync(join(dir, "package.json"), "utf8")).toContain("first-installer");
+  });
+});
+
+describe("isAcquirableRelease", () => {
+  it("admits releases and rc/next versions, refuses dev builds", () => {
+    expect(isAcquirableRelease("0.5.0")).toBe(true);
+    expect(isAcquirableRelease("0.5.0-rc.1")).toBe(true);
+    expect(isAcquirableRelease("0.0.0-dev")).toBe(false);
+    expect(isAcquirableRelease("0.5.0-dev.20260825")).toBe(false);
+  });
+});
+
+describe("npmInstallIntoRuntimes", () => {
+  it("wraps an install failure in an actionable CliExitError with remediation hints", () => {
+    // /dev/null/x is unwritable on every POSIX system, so the real npm spawn
+    // fails deterministically without network access.
+    const attempt = (): void => npmInstallIntoRuntimes("/dev/null/x", "@stigmer/nonexistent@0.0.0");
+    expect(attempt).toThrow(CliExitError);
+    try {
+      attempt();
+    } catch (err) {
+      const hints = (err as CliExitError).hints?.join("\n") ?? "";
+      expect(hints).toMatch(/npm install/);
+      expect(hints).toMatch(/remove/i);
+    }
+  });
+});

--- a/client-apps/cli/src/local/runtime/runtimes-install.ts
+++ b/client-apps/cli/src/local/runtime/runtimes-install.ts
@@ -1,0 +1,72 @@
+// Shared npm-install mechanics for on-demand-acquired runtime packages
+// (~/.stigmer/runtimes/<version>/). Extracted when the TS server became the
+// second consumer (D4 #24) — the runner and the server acquire different
+// packages into the SAME per-version install root, so the root bootstrap and
+// the install invocation must not drift between them.
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { CliExitError } from "../../errors/cli-exit-error.js";
+import { ExitCode } from "../../errors/exit-codes.js";
+
+/** The install implementation, injectable for tests. */
+export type NpmInstall = (installDir: string, spec: string) => void;
+
+/**
+ * Ensure the per-version install root exists with a stable package.json.
+ * A stable root makes installs deterministic and records the pinned
+ * dependencies rather than letting npm synthesize an ad-hoc root; both the
+ * runner and the server packages install into this one root, so the file is
+ * written once and shared.
+ */
+export function ensureRuntimesRoot(installDir: string): void {
+  mkdirSync(installDir, { recursive: true });
+  const rootManifest = join(installDir, "package.json");
+  if (!existsSync(rootManifest)) {
+    writeFileSync(
+      rootManifest,
+      `${JSON.stringify({ name: "stigmer-runtime", private: true, version: "0.0.0" }, null, 2)}\n`,
+    );
+  }
+}
+
+// Install a package (plus its platform-native optional dependency) into an
+// isolated prefix. `--omit=dev` drops devDependencies while keeping the
+// optional native package npm selects by os/cpu; output is inherited so the
+// user sees the one-time download progress.
+export function npmInstallIntoRuntimes(installDir: string, spec: string): void {
+  try {
+    execFileSync(
+      "npm",
+      [
+        "install",
+        spec,
+        "--prefix",
+        installDir,
+        "--omit=dev",
+        "--no-audit",
+        "--no-fund",
+      ],
+      {
+        stdio: "inherit",
+      },
+    );
+  } catch (err) {
+    throw new CliExitError(`failed to install ${spec}`, ExitCode.General, [
+      `Command: npm install ${spec} --prefix ${installDir}`,
+      "Ensure npm is on PATH and the network is reachable.",
+      "If npm reported EBADENGINE, this Node line is outside the package's",
+      "supported range. If a previous install was interrupted, remove",
+      `${installDir} and retry.`,
+      String(err),
+    ]);
+  }
+}
+
+// A source build reports "0.0.0-dev" and the dev npm channel stamps
+// "<v>-dev.<stamp>" versions; neither publishes matching runtime packages,
+// so they are not acquirable. Release and rc/next versions are.
+export function isAcquirableRelease(version: string): boolean {
+  return !version.includes("-dev");
+}

--- a/client-apps/cli/src/local/runtime/server-ts.test.ts
+++ b/client-apps/cli/src/local/runtime/server-ts.test.ts
@@ -1,0 +1,253 @@
+// Pins the cutover switch (D4 #24): STIGMER_SERVER_BIN selects the Go
+// rollback binary before anything else; otherwise the TS server resolves
+// exactly like the runner (explicit dir → repo tree → acquired slim package).
+
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { acquireServer, ensureServer, resolveServerTs } from "./server-ts.js";
+
+function tempDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+const fakeNode = (): string => "/usr/bin/node";
+
+// Snapshot and restore the env vars the switch reads, so tests don't leak.
+const TOUCHED = [
+  "STIGMER_SERVER_BIN",
+  "STIGMER_SERVER_DIR",
+  "STIGMER_NODE_BIN",
+] as const;
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = {};
+  for (const key of TOUCHED) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of TOUCHED) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+function builtServerDir(): string {
+  const dir = tempDir("stigmer-server-ts-");
+  writeFileSync(join(dir, "package.json"), "{}");
+  mkdirSync(join(dir, "dist"));
+  writeFileSync(join(dir, "dist", "main.js"), "//");
+  return dir;
+}
+
+describe("ensureServer (the switch)", () => {
+  it("selects the Go binary when STIGMER_SERVER_BIN is set — the rollback lever", () => {
+    const dir = tempDir("stigmer-go-");
+    const bin = join(dir, "stigmer-server");
+    writeFileSync(bin, "#!/bin/sh\n");
+    chmodSync(bin, 0o755);
+    process.env.STIGMER_SERVER_BIN = bin;
+
+    expect(ensureServer({ node: fakeNode })).toEqual({ kind: "binary", bin });
+  });
+
+  it("prefers the binary override even when a TS server dir is also set", () => {
+    const dir = tempDir("stigmer-go-");
+    const bin = join(dir, "stigmer-server");
+    writeFileSync(bin, "#!/bin/sh\n");
+    chmodSync(bin, 0o755);
+    process.env.STIGMER_SERVER_BIN = bin;
+    process.env.STIGMER_SERVER_DIR = builtServerDir();
+
+    expect(ensureServer({ node: fakeNode }).kind).toBe("binary");
+  });
+
+  it("rejects a binary override that does not exist, with rollback guidance", () => {
+    process.env.STIGMER_SERVER_BIN = "/nonexistent/stigmer-server";
+    expect(() => ensureServer({ node: fakeNode })).toThrow(
+      /STIGMER_SERVER_BIN does not exist/,
+    );
+  });
+
+  it("resolves the TS server when no override is set", () => {
+    const dir = builtServerDir();
+    process.env.STIGMER_SERVER_DIR = dir;
+
+    expect(ensureServer({ node: fakeNode })).toEqual({
+      kind: "node",
+      nodeBin: "/usr/bin/node",
+      entryPath: join(dir, "dist", "main.js"),
+      appDir: dir,
+    });
+  });
+});
+
+describe("resolveServerTs", () => {
+  it("resolves a built server from STIGMER_SERVER_DIR", () => {
+    const dir = builtServerDir();
+    process.env.STIGMER_SERVER_DIR = dir;
+
+    expect(resolveServerTs(fakeNode)).toEqual({
+      kind: "node",
+      nodeBin: "/usr/bin/node",
+      entryPath: join(dir, "dist", "main.js"),
+      appDir: dir,
+    });
+  });
+
+  it("errors with build guidance (and the rollback hint) when dist/main.js is missing", () => {
+    const dir = tempDir("stigmer-server-ts-");
+    writeFileSync(join(dir, "package.json"), "{}");
+    process.env.STIGMER_SERVER_DIR = dir;
+
+    expect(() => resolveServerTs(fakeNode)).toThrow(/not built/);
+    // Remediation rides in hints, not the message: the build command and the
+    // Go rollback lever must both be offered.
+    const hints = captureHints(() => resolveServerTs(fakeNode));
+    expect(hints.join("\n")).toMatch(/make build-server-ts/);
+    expect(hints.join("\n")).toMatch(/STIGMER_SERVER_BIN/);
+  });
+
+  it("rejects an override that is not a server package", () => {
+    const dir = tempDir("stigmer-server-ts-");
+    process.env.STIGMER_SERVER_DIR = join(dir, "no-package-here"); // no package.json
+    expect(() => resolveServerTs(fakeNode)).toThrow(/not a server package/);
+  });
+});
+
+describe("acquireServer", () => {
+  it("installs the slim package and resolves its main.js entry", () => {
+    const home = tempDir("stigmer-home-");
+    const installed: Array<{ dir: string; spec: string }> = [];
+    const install = (dir: string, spec: string): void => {
+      installed.push({ dir, spec });
+      // Simulate the npm install laying down the slim package.
+      const pkgDir = join(dir, "node_modules", "@stigmer", "server-slim");
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(join(pkgDir, "main.js"), "// slim bundle");
+    };
+
+    const launch = acquireServer({
+      home,
+      version: "0.5.0",
+      node: fakeNode,
+      install,
+    });
+
+    const installDir = join(home, ".stigmer", "runtimes", "0.5.0");
+    expect(launch).toEqual({
+      kind: "node",
+      nodeBin: "/usr/bin/node",
+      entryPath: join(
+        installDir,
+        "node_modules",
+        "@stigmer",
+        "server-slim",
+        "main.js",
+      ),
+      appDir: join(installDir, "node_modules", "@stigmer", "server-slim"),
+    });
+    expect(installed).toEqual([
+      { dir: installDir, spec: "@stigmer/server-slim@0.5.0" },
+    ]);
+  });
+
+  it("reuses a prior install without reinstalling", () => {
+    const home = tempDir("stigmer-home-");
+    const pkgDir = join(
+      home,
+      ".stigmer",
+      "runtimes",
+      "0.5.0",
+      "node_modules",
+      "@stigmer",
+      "server-slim",
+    );
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, "main.js"), "// slim bundle");
+
+    const install = vi.fn();
+    const launch = acquireServer({
+      home,
+      version: "0.5.0",
+      node: fakeNode,
+      install,
+    });
+
+    expect(launch.kind).toBe("node");
+    expect(install).not.toHaveBeenCalled();
+  });
+
+  // The runner and the server share one per-version install root; acquiring
+  // the server after the runner must ADD to it, never clobber the root
+  // manifest the runner's install already wrote.
+  it("shares the runtimes install root with the runner without clobbering it", () => {
+    const home = tempDir("stigmer-home-");
+    const installDir = join(home, ".stigmer", "runtimes", "0.5.0");
+    mkdirSync(installDir, { recursive: true });
+    writeFileSync(
+      join(installDir, "package.json"),
+      '{"name":"stigmer-runtime","marker":"pre-existing"}\n',
+    );
+
+    const install = (dir: string): void => {
+      const pkgDir = join(dir, "node_modules", "@stigmer", "server-slim");
+      mkdirSync(pkgDir, { recursive: true });
+      writeFileSync(join(pkgDir, "main.js"), "// slim bundle");
+    };
+    acquireServer({ home, version: "0.5.0", node: fakeNode, install });
+
+    expect(readFileSync(join(installDir, "package.json"), "utf8")).toContain(
+      "pre-existing",
+    );
+  });
+
+  // The hunted npm failure shape: the install runs but the platform-native
+  // package was skipped (unsupported OS/arch), so the entry never appears.
+  it("errors actionably when the install produces no entry", () => {
+    const home = tempDir("stigmer-home-");
+    const install = vi.fn(); // runs, lays down nothing
+    const attempt = (): unknown => acquireServer({ home, version: "0.5.0", node: fakeNode, install });
+    expect(attempt).toThrow(/install did not produce/);
+    expect(install).toHaveBeenCalledOnce();
+    const hints = captureHints(attempt).join("\n");
+    expect(hints).toMatch(/platform-native/);
+    expect(hints).toMatch(/Remove .* and retry/);
+  });
+
+  it("refuses to acquire for a non-release (dev) build, naming both fallbacks", () => {
+    const home = tempDir("stigmer-home-");
+    const attempt = (): unknown =>
+      acquireServer({
+        home,
+        version: "0.0.0-dev",
+        node: fakeNode,
+        install: vi.fn(),
+      });
+    expect(attempt).toThrow(/non-release build/);
+    // Both escape hatches ride in the hints: the TS dir and the Go rollback.
+    const hints = captureHints(attempt);
+    expect(hints.join("\n")).toMatch(/STIGMER_SERVER_DIR/);
+    expect(hints.join("\n")).toMatch(/STIGMER_SERVER_BIN/);
+  });
+});
+
+function captureHints(attempt: () => unknown): readonly string[] {
+  try {
+    attempt();
+  } catch (err) {
+    return (err as { hints?: readonly string[] }).hints ?? [];
+  }
+  throw new Error("expected the attempt to throw");
+}

--- a/client-apps/cli/src/local/runtime/server-ts.ts
+++ b/client-apps/cli/src/local/runtime/server-ts.ts
@@ -1,0 +1,217 @@
+// Resolution and on-demand acquisition of the TypeScript stigmer server —
+// the served implementation since the DD-006 cutover (D4 #24) — plus the
+// cutover switch itself (ensureServer).
+//
+// The server is launched exactly like the runner: a compiled `node main.js`,
+// never `tsx src/main.ts` (the workers bundle Temporal workflows on boot in
+// dev shape, and the slim artifact ships pre-built bundles — either way the
+// entry must be compiled; see backend/services/stigmer-server-ts's
+// workflow-source.ts).
+//
+// Resolution order (the D2 §6 switch semantics):
+//   1. STIGMER_SERVER_BIN — the Go binary, the no-code-change ROLLBACK lever.
+//      Checked before anything else, deliberately before the Node capability
+//      probe: rollback must work even on a Node the TS server rejects.
+//   2. STIGMER_SERVER_DIR — an explicit TS server package dir (dist/main.js
+//      required), the STIGMER_RUNNER_DIR mirror.
+//   3. The repo-tree backend/services/stigmer-server-ts (dev; build required).
+//   4. The published `@stigmer/server-slim`, installed on demand into
+//      ~/.stigmer/runtimes/<version>/ alongside the runner's package — one
+//      CJS main.js, pre-built workflow bundles, and the per-platform
+//      Temporal native bridge selected by npm via optionalDependencies.
+//
+// The Go binary ladder (./server.ts) remains intact behind the override —
+// re-flipping ensureServer back to it is the whole rollback (D2 §6). The
+// Go ladder and its GitHub-release download die with #25 go-server-retirement.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { CliExitError } from "../../errors/cli-exit-error.js";
+import { ExitCode } from "../../errors/exit-codes.js";
+import { log } from "../../logger.js";
+import { VERSION } from "../../version.js";
+import { runtimesDir } from "../paths.js";
+import type { ServerLaunch } from "../daemon/env.js";
+import { resolveServerNode } from "./node.js";
+import {
+  ensureRuntimesRoot,
+  isAcquirableRelease,
+  npmInstallIntoRuntimes,
+  type NpmInstall,
+} from "./runtimes-install.js";
+
+const SLIM_PACKAGE = "@stigmer/server-slim";
+
+export interface EnsureServerOptions {
+  home?: string;
+  /** Release version of the slim server to acquire (defaults to the CLI version). */
+  version?: string;
+  /** Node resolver (injectable for tests). */
+  node?: () => string;
+  /** npm install implementation (injectable for tests). */
+  install?: NpmInstall;
+}
+
+/**
+ * THE cutover switch (D4 #24): resolve what the daemon launches as
+ * `stigmer-server`. Honors the STIGMER_SERVER_BIN rollback override first;
+ * otherwise resolves the TS server (explicit dir → repo tree → acquire the
+ * published slim package). Throws actionable guidance on a missing build, an
+ * invalid override, or a non-release CLI build with nothing local.
+ */
+export function ensureServer(opts: EnsureServerOptions = {}): ServerLaunch {
+  const binOverride = process.env.STIGMER_SERVER_BIN;
+  if (binOverride !== undefined && binOverride !== "") {
+    if (!existsSync(binOverride)) {
+      throw new CliExitError(
+        `STIGMER_SERVER_BIN does not exist: ${binOverride}`,
+        ExitCode.General,
+        [
+          "Point STIGMER_SERVER_BIN at a stigmer-server executable (the Go rollback",
+          "binary), or unset it to launch the TypeScript server.",
+        ],
+      );
+    }
+    return { kind: "binary", bin: binOverride };
+  }
+
+  const node = opts.node ?? resolveServerNode;
+  const local = resolveServerTs(node);
+  if (local !== null) return local;
+  return acquireServer({ ...opts, node });
+}
+
+/**
+ * Resolve a repo-tree TS server (dev) or an explicit STIGMER_SERVER_DIR, or
+ * null when neither is present (the caller then acquires the slim package).
+ * Throws when an override is set but invalid, or when a found server is not
+ * built — both are actionable user-facing conditions, not a reason to
+ * silently download. `node` is injectable for tests.
+ */
+export function resolveServerTs(
+  node: () => string = resolveServerNode,
+): ServerLaunch | null {
+  const override = process.env.STIGMER_SERVER_DIR;
+  if (override !== undefined && override !== "") {
+    if (!hasPackageJson(override)) {
+      throw new CliExitError(
+        `STIGMER_SERVER_DIR is not a server package: ${override}`,
+        ExitCode.General,
+        [
+          "Point STIGMER_SERVER_DIR at the @stigmer/server package directory (the one with package.json).",
+        ],
+      );
+    }
+    return resolveBuiltServer(override, node);
+  }
+
+  const root = repoRoot();
+  if (root !== null) {
+    const candidate = join(root, "backend", "services", "stigmer-server-ts");
+    if (hasPackageJson(candidate)) return resolveBuiltServer(candidate, node);
+  }
+  return null;
+}
+
+/**
+ * Acquire the published `@stigmer/server-slim@<version>` into
+ * ~/.stigmer/runtimes/<version>/ (idempotent: reuses a prior install; shares
+ * the install root with the runner's package) and resolve its `main.js`
+ * entry. The version is pinned to the CLI's own version so the server's
+ * protos and behavior stay in lockstep with the CLI and the runner.
+ */
+export function acquireServer(opts: EnsureServerOptions = {}): ServerLaunch {
+  const home = opts.home ?? homedir();
+  const version = opts.version ?? VERSION;
+  if (!isAcquirableRelease(version)) {
+    throw new CliExitError(
+      `cannot acquire ${SLIM_PACKAGE} for a non-release build (${version})`,
+      ExitCode.General,
+      [
+        "Run from the repo with a built server (make build-server-ts), or set",
+        "STIGMER_SERVER_DIR — or STIGMER_SERVER_BIN for the Go rollback binary.",
+        "On-demand acquisition is only available for published releases.",
+      ],
+    );
+  }
+
+  // Probe the Node capability BEFORE the download: a user on an FTS5-less
+  // Node must not fetch the full slim artifact only to be rejected after.
+  const node = opts.node ?? resolveServerNode;
+  const nodeBin = node();
+  const installDir = join(runtimesDir(home), version);
+  const entryPath = join(
+    installDir,
+    "node_modules",
+    "@stigmer",
+    "server-slim",
+    "main.js",
+  );
+
+  if (!existsSync(entryPath)) {
+    log.info(`acquiring ${SLIM_PACKAGE}`, { version, dir: installDir });
+    ensureRuntimesRoot(installDir);
+    const install = opts.install ?? npmInstallIntoRuntimes;
+    install(installDir, `${SLIM_PACKAGE}@${version}`);
+  }
+
+  if (!existsSync(entryPath)) {
+    throw new CliExitError(
+      `${SLIM_PACKAGE} install did not produce ${entryPath}`,
+      ExitCode.General,
+      [
+        "The install may have skipped the platform-native package for this OS/arch.",
+        `Remove ${installDir} and retry, or set STIGMER_SERVER_DIR to a built server.`,
+      ],
+    );
+  }
+
+  return {
+    kind: "node",
+    nodeBin,
+    entryPath,
+    appDir: dirname(entryPath),
+  };
+}
+
+function resolveBuiltServer(appDir: string, node: () => string): ServerLaunch {
+  const entryPath = join(appDir, "dist", "main.js");
+  if (!existsSync(entryPath)) {
+    throw new CliExitError(
+      `TS server not built: ${entryPath} is missing`,
+      ExitCode.General,
+      [
+        "Build it with: make build-server-ts",
+        "The server must be compiled — it cannot run from source via tsx (its",
+        "Temporal workers bundle workflow code from the compiled dist).",
+        "STIGMER_SERVER_DIR expects the source package (dist/main.js); to run an",
+        "acquired @stigmer/server-slim install, unset it — the CLI resolves that",
+        "shape itself. To launch the Go server instead, set STIGMER_SERVER_BIN.",
+      ],
+    );
+  }
+  return { kind: "node", nodeBin: node(), entryPath, appDir };
+}
+
+function hasPackageJson(dir: string): boolean {
+  return existsSync(join(dir, "package.json"));
+}
+
+// Walk up from this module to a repo root containing the TS server package.
+function repoRoot(): string | null {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 10; i += 1) {
+    if (
+      existsSync(
+        join(dir, "backend", "services", "stigmer-server-ts", "package.json"),
+      )
+    )
+      return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}

--- a/client-apps/cli/src/local/runtime/server.ts
+++ b/client-apps/cli/src/local/runtime/server.ts
@@ -1,4 +1,11 @@
-// Resolution and on-demand acquisition of the `stigmer-server` control plane.
+// Resolution and on-demand acquisition of the GO `stigmer-server` binary —
+// the ROLLBACK path since the DD-006 cutover (D4 #24; see ./server-ts.ts for
+// the served TypeScript implementation and the switch itself).
+//
+// This ladder is no longer walked by `stigmer up` unless STIGMER_SERVER_BIN
+// selects a binary explicitly; it remains intact, code and download included,
+// so re-flipping ensureServer back to it is the whole rollback. It dies with
+// #25 go-server-retirement.
 //
 // DD-003: a TypeScript CLI cannot `go:embed` a Go binary, so it resolves an
 // existing `stigmer-server` (dev build / Homebrew / a prior download) and, when
@@ -47,7 +54,7 @@ export function resolveServerBinary(home: string = homedir()): string | null {
   return which(SERVER_BINARY);
 }
 
-export interface EnsureServerOptions {
+export interface EnsureServerBinaryOptions {
   home?: string;
   /** Release version to download if needed (defaults to the CLI's own version). */
   version?: string;
@@ -62,7 +69,7 @@ export interface EnsureServerOptions {
  * exists and a download is not possible (a source/dev build, or an unsupported
  * platform).
  */
-export async function ensureServerBinary(opts: EnsureServerOptions = {}): Promise<string> {
+export async function ensureServerBinary(opts: EnsureServerBinaryOptions = {}): Promise<string> {
   const home = opts.home ?? homedir();
   const existing = resolveServerBinary(home);
   if (existing !== null) return existing;

--- a/scripts/smoke-cli-cutover.mjs
+++ b/scripts/smoke-cli-cutover.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+
+/**
+ * CLI cutover E2E smoke (D4 #24): `stigmer up` → apply → run → stream →
+ * `stigmer down`, against an ISOLATED home, proving the daemon launches the
+ * intended server implementation end-to-end. Nothing before this script
+ * exercised `stigmer up` whole — the e2e suites boot the server binary
+ * directly, bypassing the CLI (verified during #24 planning).
+ *
+ * Two arms, same assertions — the rollback exercise the cutover gate
+ * requires is literally this script's other arm:
+ *
+ *   --arm=ts (default): stages the SLIM server artifact (dist-slim) as a
+ *     server package and launches it through the daemon's node+entry path —
+ *     the exact packaged entry users get from @stigmer/server-slim.
+ *   --arm=go: sets STIGMER_SERVER_BIN to the repo's Go build — the
+ *     no-code-change rollback lever, proven live.
+ *
+ * The arm is verified, not assumed: after `up`, the server child's real
+ * command line (via its PID file) must match the arm.
+ *
+ * The workflow under test is a single deterministic set_vars task — no LLM,
+ * no API keys, no network beyond npm/Temporal's own machinery. What it
+ * proves: CLI daemon → server (gRPC gate) → seedpack apply → workflow apply
+ * → Temporal orchestration → runner execution → event streaming → clean
+ * shutdown.
+ *
+ * The CLI itself runs from source under tsx — the repo's documented dev
+ * launch (its `start` script; the daemon re-exec replays the loader via
+ * process.execArgv, see daemon/launch.ts). The CLI's own packaging is
+ * unchanged by the cutover; the packaged artifact under test here is the
+ * SERVER slim bundle, which the ts arm stages byte-for-byte.
+ *
+ * Prereqs (the gate's build steps): backend/services/runner built (dist/),
+ * and per arm: stigmer-server-ts dist-slim/ (ts) or bin/stigmer-server (go).
+ *
+ * Usage: node scripts/smoke-cli-cutover.mjs [--arm=ts|go]
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const cliDir = join(repoRoot, "client-apps", "cli");
+const cliEntry = join(cliDir, "src", "cli", "stigmer.ts");
+// tsx is hoisted to the workspace root's bin by npm workspaces.
+const tsxBin = join(repoRoot, "node_modules", ".bin", "tsx");
+const runnerEntry = join(
+  repoRoot,
+  "backend",
+  "services",
+  "runner",
+  "dist",
+  "main.js",
+);
+const slimDir = join(
+  repoRoot,
+  "backend",
+  "services",
+  "stigmer-server-ts",
+  "dist-slim",
+);
+const goBinary = join(repoRoot, "bin", "stigmer-server");
+
+/** The seedpack's default local org — created by `stigmer up` itself. */
+const ORG = "stigmer";
+const UP_TIMEOUT_MS = 300_000; // first `up` may download the Temporal CLI
+const RUN_TIMEOUT_MS = 120_000;
+
+// Set once the smoke reaches the point where a daemon COULD exist. fail()
+// exits the process directly, which would otherwise leak a live daemon
+// holding port 7234 into the next run. Teardown is unconditional once the
+// `up` attempt starts (panel finding): `up` spawns the daemon DETACHED
+// before its readiness wait, so even a failed/timed-out `up` can leave a
+// live stack behind — and `stigmer down` is idempotent when nothing runs.
+let upAttempted = false;
+
+function fail(message) {
+  console.error(`smoke-cli-cutover: ${message}`);
+  if (upAttempted) teardownBestEffort();
+  process.exit(1);
+}
+
+function parseArm() {
+  let arm = "ts";
+  for (const arg of process.argv.slice(2)) {
+    const m = arg.match(/^--arm=(ts|go)$/);
+    if (m) arm = m[1];
+    else fail(`unknown argument: ${arg} (usage: --arm=ts|go)`);
+  }
+  return arm;
+}
+
+const arm = parseArm();
+
+// ─── Preflight ───────────────────────────────────────────────────────────────
+
+if (!existsSync(cliEntry)) fail(`CLI source not found: ${cliEntry}`);
+if (!existsSync(tsxBin)) fail(`tsx not installed: ${tsxBin} (npm ci)`);
+if (!existsSync(runnerEntry))
+  fail(`runner not built: ${runnerEntry} (make build-runner)`);
+if (arm === "ts" && !existsSync(join(slimDir, "main.js"))) {
+  fail(
+    `slim server artifact not built: ${slimDir}/main.js (npm run build:slim in stigmer-server-ts)`,
+  );
+}
+if (arm === "go" && !existsSync(goBinary)) {
+  fail(`Go server not built: ${goBinary} (make build)`);
+}
+
+// ─── Isolated home ───────────────────────────────────────────────────────────
+
+const home = mkdtempSync(join(tmpdir(), "stigmer-smoke-"));
+console.log(`smoke-cli-cutover: arm=${arm} home=${home}`);
+
+// Seed a PATH-resolvable Temporal binary into the managed location when the
+// host has one, so the smoke skips the manager's one-time download. Purely an
+// accelerator — absent it, `up` downloads exactly as a real first run does.
+try {
+  const hostTemporal = execFileSync("which", ["temporal"], {
+    encoding: "utf8",
+  }).trim();
+  if (hostTemporal !== "") {
+    mkdirSync(join(home, ".stigmer", "bin"), { recursive: true });
+    cpSync(hostTemporal, join(home, ".stigmer", "bin", "temporal"));
+  }
+} catch {
+  // No host temporal — the manager downloads its own.
+}
+
+const env = { ...process.env, HOME: home };
+// The arms must not cross-contaminate through the caller's shell.
+delete env.STIGMER_SERVER_BIN;
+delete env.STIGMER_SERVER_DIR;
+delete env.STIGMER_RUNNER_DIR;
+
+if (arm === "ts") {
+  // Stage the slim artifact in the server-package shape resolveServerTs
+  // expects (dist/main.js under a package dir). The staged dist keeps the
+  // artifact's own siblings — workflow bundles, worker-thread entry, staged
+  // node_modules, and its untyped package.json (the CJS marker) — exactly as
+  // an acquired @stigmer/server-slim install lays them out.
+  const pkgDir = join(home, "server-pkg");
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(
+    join(pkgDir, "package.json"),
+    JSON.stringify({ name: "@stigmer/server", private: true }, null, 2),
+  );
+  cpSync(slimDir, join(pkgDir, "dist"), { recursive: true });
+  env.STIGMER_SERVER_DIR = pkgDir;
+} else {
+  env.STIGMER_SERVER_BIN = goBinary;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function cli(args, opts = {}) {
+  const label = `stigmer ${args.join(" ")}`;
+  console.log(`smoke-cli-cutover: ${label}`);
+  const result = spawnSync(tsxBin, [cliEntry, ...args], {
+    env,
+    encoding: "utf8",
+    timeout: opts.timeoutMs ?? 60_000,
+    // A timed-out child must not outlive the smoke (the go arm EXPECTS a
+    // lingering client after COMPLETED, #884 — SIGTERM alone might not do).
+    killSignal: "SIGKILL",
+  });
+  if (result.error && opts.allowFailure !== true)
+    fail(`${label} failed: ${result.error}`);
+  if (result.status !== 0 && opts.allowFailure !== true) {
+    fail(
+      `${label} exited ${result.status}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+  }
+  return result;
+}
+
+function teardownBestEffort() {
+  spawnSync(tsxBin, [cliEntry, "down"], {
+    env,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+}
+
+// ─── The smoke ───────────────────────────────────────────────────────────────
+
+try {
+  // 1. Up — the daemon resolves the arm's server, gates on the gRPC port,
+  //    and applies the seedpack (which creates the org).
+  upAttempted = true;
+  cli(["up", "--no-web"], { timeoutMs: UP_TIMEOUT_MS });
+
+  // 2. Prove WHICH server is running: the server child's command line must
+  //    match the arm. The PID file is the daemon's own record.
+  const pidFile = join(home, ".stigmer", "data", "stigmer-server.pid");
+  const pid = readFileSync(pidFile, "utf8").trim().split("\n")[0].trim();
+  const command = execFileSync("ps", ["-p", pid, "-o", "command="], {
+    encoding: "utf8",
+  }).trim();
+  console.log(`smoke-cli-cutover: server pid ${pid}: ${command}`);
+  if (arm === "ts") {
+    if (!(command.includes("node") && command.includes("main.js"))) {
+      fail(`expected a node+entry server process for arm=ts, got: ${command}`);
+    }
+  } else if (!command.includes("stigmer-server")) {
+    fail(`expected the Go stigmer-server binary for arm=go, got: ${command}`);
+  }
+
+  // 3. Apply the deterministic workflow.
+  const workflowPath = join(home, "cutover-smoke.yaml");
+  writeFileSync(
+    workflowPath,
+    `apiVersion: agentic.stigmer.ai/v1
+kind: Workflow
+metadata:
+  name: cutover-smoke
+spec:
+  description: Deterministic no-LLM workflow for the CLI cutover smoke.
+  document:
+    dsl: "1.0.0"
+    namespace: stigmer
+    name: cutover-smoke
+    version: "1.0.0"
+  tasks:
+    - name: set_greeting
+      kind: set_vars
+      task_config:
+        variables:
+          greeting: hello-from-the-cutover-smoke
+      export:
+        as: "\${ . }"
+`,
+  );
+  // --org is a root-level global option, so it precedes the subcommand.
+  cli(["--org", ORG, "apply", "-f", workflowPath]);
+
+  // 4. Run it and stream to completion (JSON events on stdout).
+  //
+  // The ts arm requires a CLEAN EXIT — the cutover's behavior. The go arm
+  // tolerates a lingering process after the completed result: the shipped
+  // CLI never exits after runs against the Go server (pre-existing,
+  // stigmer/stigmer#884 — found by this smoke; the server side is clean),
+  // so the rollback arm asserts the streamed COMPLETED result within a
+  // bounded wait instead.
+  const run = cli(
+    ["--org", ORG, "run", "workflow", "cutover-smoke", "--json"],
+    {
+      timeoutMs: RUN_TIMEOUT_MS,
+      allowFailure: arm === "go",
+    },
+  );
+  if (arm === "go" && run.status !== 0) {
+    const timedOut =
+      run.error !== undefined && /ETIMEDOUT/.test(String(run.error));
+    if (!(timedOut && /completed/i.test(run.stdout))) {
+      fail(
+        `go-arm run neither exited cleanly nor streamed COMPLETED within the bounded wait\n` +
+          `status=${run.status} error=${run.error}\nstdout:\n${run.stdout}\nstderr:\n${run.stderr}`,
+      );
+    }
+    console.log(
+      "smoke-cli-cutover: go arm streamed COMPLETED; lingering process tolerated (stigmer/stigmer#884)",
+    );
+  }
+  if (!/completed/i.test(run.stdout)) {
+    fail(
+      `run did not reach COMPLETED\nstdout:\n${run.stdout}\nstderr:\n${run.stderr}`,
+    );
+  }
+
+  // 5. Down — clean teardown, port released.
+  cli(["down"]);
+  const status = cli(["status"], { allowFailure: true });
+  if (
+    /running/i.test(status.stdout) &&
+    !/not running|stopped/i.test(status.stdout)
+  ) {
+    fail(`stack still reports running after down\n${status.stdout}`);
+  }
+
+  console.log(`smoke-cli-cutover: PASS (arm=${arm})`);
+  // Success-path hygiene: the isolated home carries a full slim copy plus a
+  // Temporal binary (~100 MB per arm) — keep failures around for debugging,
+  // never successes.
+  rmSync(home, { recursive: true, force: true });
+} catch (err) {
+  teardownBestEffort();
+  throw err;
+}


### PR DESCRIPTION
## What

`stigmer up` now launches the TypeScript server (`backend/services/stigmer-server-ts`) instead of downloading and spawning the Go binary. Zero user-visible change: same port (7234), same env contract (`buildServerEnv` reused untouched), same database inherited in place, same commands, same behavior — the parity is enforced by `test/conformance/` (rosters equal between the Go and TS targets, all green below). The Go ladder and the `STIGMER_SERVER_BIN` override remain intact as the rollback path until the post-soak retirement decision (#25).

Tracking issue: #883.

## How

- **Distribution (the runner pattern)**: `@stigmer/server-slim` — a self-contained CJS `main.js` + three prebuilt Temporal workflow bundles + the bundled sandbox worker-thread entry + five `@stigmer/server-slim-<platform>` packages carrying the pruned native core-bridge (npm os/cpu selection). The CLI installs it on demand into `~/.stigmer/runtimes/<version>/` alongside `@stigmer/runner-slim`, pinned to the CLI's version. 67.8 MB per platform. Publishing rides `release.npm-libs.yaml` (new `publish-server-slim` job, gated on `verify-slim-artifact.mjs`: an ISOLATED copy must serve AND start all three workers against a real Temporal before anything publishes).
- **The switch** (`client-apps/cli/src/local/runtime/server-ts.ts`): `STIGMER_SERVER_BIN` (Go rollback — checked before Node probing, so rollback works on any Node) → `STIGMER_SERVER_DIR` → repo-tree dist (dev) → acquire. The daemon models the launch as a discriminated `ServerLaunch` (binary | node); the child contract (name, pid file, log file, env, 30s TCP gate) is identical across shapes.
- **Node capability**: the server launch probes `node:sqlite` WITH FTS5 (Node 23.4 ships node:sqlite without FTS5 and would fail at migration v3 — the #14 finding); engines floor settled to `^22.13.0`. Node 24+ re-admission is a follow-up pending an FTS5 check there.
- **Gate wiring**: `make test-integration-all` now runs the TS conformance rosters after the Go ones.
- **E2E smoke** (`scripts/smoke-cli-cutover.mjs`): the repo's first end-to-end `stigmer up` exercise — isolated home, PID-verified server identity, seedpack, deterministic workflow run streamed to COMPLETED, clean `down`. Two arms; the `--arm=go` rollback arm is the deliberate rollback exercise the gate requires.

## Test plan (all green on this tree)

- conformance `local-ts` 488/1-skipped (27 files) — roster == `local-go` config
- conformance `local-go` 492/1-skipped — regression-free (rollback path healthy)
- conformance `local-ts-execution` 160/1-skipped — roster == execution glob (Class B gate)
- conformance `local-go-execution` 159/2-skipped — regression-free
- `stigmer-server-ts` 1694 unit tests; CLI 962 tests (incl. new switch/env/probe coverage)
- `verify:slim` (no Temporal) + `verify-slim-artifact` (isolated + Temporal, 3 workers from prebuilt bundles)
- `smoke-cli-cutover --arm=ts` PASS (PID-verified `node <slim entry>`)
- `smoke-cli-cutover --arm=go` PASS — **rollback exercised deliberately** (PID-verified Go binary)

## Disclosures (the register)

1. **oss#884 (pre-existing, found by the new smoke)**: the shipped CLI never exits after `stigmer run workflow` completes against the GO server (both output modes; server side clean — terminal status persisted, stream closed). The TS path exits cleanly, so the cutover incidentally fixes this for users. No run-stack changes here; the smoke's rollback arm tolerates the lingering process citing the issue.
2. **Slim bundle is CJS** while the package's own sources are ESM: deliberate — the runner's proven temporal-bundling recipe (threaded-vm patch, bundler stub, core-bridge dynamic platform require) is CJS-shaped, and `import.meta.url` (sibling workflow-bundle discovery) is mapped via define exactly as the runner does. Artifact-internal; invisible on the wire.
3. **Platform claims**: none made at cutover (owner ruling). The `SUPPORTED_PLATFORMS` refusal no longer applies to the TS path by construction; linux-arm64/Windows validation + announcement is a follow-up. delta-8's "supported-by-construction" claim is amended by this ruling.
4. **Dev-tree behavior flip**: in a repo checkout with a built Go server but an unbuilt TS server, `stigmer up` now errors with build guidance (`make build-server-ts`, or `STIGMER_SERVER_BIN` for Go) instead of silently booting Go — deliberate: the served implementation is the TS server.
5. **First-run acquisition**: the GitHub-release binary download disappears; the server rides the same npm acquisition step as the runner (one `npm install` into the shared per-version runtimes root).
6. **Node-surface narrowing (panel finding, needs the register)**: `stigmer up` now requires a Node whose `node:sqlite` includes FTS5. Pre-cutover, 23.x users ran fine (the Go server needed no Node; the runner's probe passes on 23.4+); post-cutover those users get an actionable resolve-time error unless they set `STIGMER_SERVER_BIN`. The 22.x line from 22.13 is known-good; future majors are admitted by the probe when capable. This is a real delta beyond the pre-ratified set — flagged for the parity-exceptions register and the cutover release note.
7. **Engines expression**: `>=22.13.0 <23 || >=24` (server package + published manifest). Amends the T01 Ruling-3 literal (`^22.13.0`) while preserving its intent (drop the broken 23.x window); avoids banning future FTS5-capable majors and the engine-strict acquisition hard-fail. Owner sign-off requested at merge.

## Panel

Two-reviewer adversarial panel (parity + quality), zero BLOCKING. All eight MAJOR findings fixed in-branch:

- **PR-time gap for the prebuilt-workflow path** (a drifted bundle name fails SOFT at runtime and would have merged green, wedging the release train): fixed twice over — a static check in `bundle-slim.mjs` verifies each sibling name against the COMPILED worker module, and `ci.stigmer-server-ts` now runs the isolated-copy + real-Temporal deep gate at PR time.
- **Survivable probe mutation**: the fake-node test binary now inspects the probe script it receives, so wiring the server to the weaker module-presence probe (or neutering the FTS5 probe's failure exit) fails the suite. Added the inverse pin: the runner still accepts the 23.4 shape.
- **Engines pin** (`^22.13.0` banned every future Node major, propagated into the published manifest, and hard-failed engine-strict npm with misleading error copy): re-expressed as `>=22.13.0 <23 || >=24` — drops exactly the broken 23.x window, per the ruling's intent; the capability probe stays the authority. **This amends the T01 Ruling-3 expression; flagged for owner sign-off at merge.** Install-failure hints now mention EBADENGINE and interrupted-install remediation.
- **Node-surface narrowing disclosed** (see disclosure 6 below) with honest probe copy: the 22.x line is named as known-good, 23.x as unable to run the server, newer majors admitted when their sqlite has FTS5.
- **Smoke daemon leak on `up` timeout** (the daemon spawns detached before the readiness wait): teardown is now unconditional once `up` is attempted. Timed-out children are SIGKILLed.
- **verify-slim-artifact hang risk**: the post-marker shutdown now has its own 20s deadline; spawn failures are handled; the no-Temporal failure names the actual prerequisite.
- **Smoke wired to the build**: `make smoke-cli-cutover` runs both arms reproducibly.
- **Untested error paths closed**: the acquire post-install guard (npm skipped the platform package), the shared runtimes-root no-clobber contract (own co-located test file), the binary-shape env scrub (now symmetric, with a test).

Minor findings applied: probe-before-download in acquire, per-probe version-floor error copy (the runner's 23.4+ nuance restored), `STIGMER_SERVER_DIR` error copy names both accepted shapes, WORKERS_MARKER coupling documented at the emit site (three-way with the Go server), success-path temp cleanup in both harnesses, comment corrections (shim naming, core-bridge dependency pinning claim).

Disclosed, not fixed (dispositions):
- The repo-tree→acquire fallthrough in `ensureServer` has no direct test: the repo-tree branch short-circuits in any in-repo test run, and the program precedent rejects test-only injection seams. The acquire body itself is fully tested via direct calls.
- **Release ordering** (parity m5): `publish-server-slim` runs after the CLI publishes, so a slim-gate failure could leave CLI@X live with no server-slim@X — the exact shape runner-slim already has, but the server is now on `up`'s critical path. Program-level follow-up candidate (a pre-publish ordering inversion touches the whole release train).
- **Rollback runbook note** (parity m6): the `STIGMER_SERVER_BIN` lever requires a Go binary already on disk; the ladder's checksum-verified download is no longer reachable from any command. A fresh npm-only user's rollback is the code-level re-flip (a release). The Go binary keeps publishing to GitHub releases either way.