### PR TITLE
fix(test,sdk/react,ci): heal the two red main CI lanes (four causes)

### DIFF
--- a/.github/workflows/ci.integration-offline.yaml
+++ b/.github/workflows/ci.integration-offline.yaml
@@ -231,6 +231,22 @@ jobs:
         working-directory: backend/services/runner
         run: npm ci && npm run build
 
+      # The memory feature's OSS lane spawns `stigmer mcp-server` as a stdio
+      # child (runner memory-attachment.ts), so the deterministic suite's
+      # memory tests need a runnable `stigmer` on PATH. In-tree the workspace
+      # packages export src/*.ts (publishConfig flips them to dist at publish
+      # time), so the CLI runs the repo's own dev way — tsx — via a PATH
+      # shim (stigmer#886).
+      - name: Put the stigmer CLI on PATH (memory MCP stdio server)
+        if: matrix.suite == 'offline'
+        run: |
+          mkdir -p "$RUNNER_TEMP/stigmer-cli-bin"
+          printf '#!/usr/bin/env bash\nexec "%s/node_modules/.bin/tsx" "%s/client-apps/cli/src/cli/stigmer.ts" "$@"\n' \
+            "$GITHUB_WORKSPACE" "$GITHUB_WORKSPACE" > "$RUNNER_TEMP/stigmer-cli-bin/stigmer"
+          chmod +x "$RUNNER_TEMP/stigmer-cli-bin/stigmer"
+          "$RUNNER_TEMP/stigmer-cli-bin/stigmer" --version
+          echo "$RUNNER_TEMP/stigmer-cli-bin" >> "$GITHUB_PATH"
+
       - name: Install Temporal CLI
         uses: temporalio/setup-temporal@v0
 

--- a/.github/workflows/ci.integration-offline.yaml
+++ b/.github/workflows/ci.integration-offline.yaml
@@ -238,8 +238,11 @@ jobs:
         run: go install gotest.tools/gotestsum@v1.13.0
 
       - name: Install OpenFGA CLI
+        # Pinned like gotestsum above: @latest re-resolves (and re-verifies
+        # against sum.golang.org) on every run — a pure flake surface and
+        # drift risk (stigmer#886).
         run: |
-          go install github.com/openfga/cli/cmd/fga@latest
+          go install github.com/openfga/cli/cmd/fga@v0.7.20
           fga version
 
       - name: Download FGA model

--- a/docs/sdk/react/execution.mdx
+++ b/docs/sdk/react/execution.mdx
@@ -3405,6 +3405,7 @@ render defeats that for its rows.
     PlanArtifactCard: { type: "ComponentType<PlanArtifactCardProps>", description: "Completed Plan turn that published a plan artifact." },
     PlanCompletionCard: { type: "ComponentType<PlanCompletionCardProps>", description: "Completed Plan turn without an artifact — the bare Implement CTA." },
     PlanStreamingCard: { type: "ComponentType<PlanStreamingCardProps>", description: "Live stand-in card while a Plan turn is writing its document." },
+    RecalledMemoriesCard: { type: "ComponentType<RecalledMemoriesCardProps>", description: "The retriever transparency card at a selection-active execution's segment start — \"Recalled N of M memories\" (DD-008 D5)." },
     SetupProgress: { type: "ComponentType<SetupProgressProps>", description: "Pre-first-token setup / \"Thinking…\" indicator." },
     TodoCard: { type: "ComponentType<TodoCardProps>", description: "The collapsible in-thread to-dos card." },
     TodoRow: { type: "ComponentType<TodoRowProps>", description: "One to-do row inside the built-in TodoCard's list. Ignored when `TodoCard` is also overridden (the replacement receives it via TodoCardProps.TodoRow and may forward or ignore it)." },
@@ -3614,6 +3615,40 @@ Props for [`PlanStreamingCard`](#planstreamingcard).
 />
 
 
+### RecalledMemoriesCard
+
+Inline timeline card disclosing the semantic retriever's selection for
+one execution: "Recalled N of M memories", expandable to the injected
+facts (stigmer/stigmer#293 Phase 3a, DD-008 D5's transparency promise).
+
+Renders at the top of the execution's [`MessageThread`](#messagethread) segment,
+right after the user's turn — `spec.message` is the query the
+retriever embedded, so the card reads as "for this message, these
+memories were most relevant".
+
+Renders NOTHING unless the report says selection was active: an
+absent report and `selection_active=false` both mean wholesale (every
+snapshot fact injected — the shipped Phase 2 behavior), and unchanged
+behavior earns no UI noise. The same rule is applied by the thread
+builder; it is repeated here so directly-embedding platform builders
+get the correct contract by construction.
+
+All visual properties flow through `--stgm-*` tokens.
+
+
+### RecalledMemoriesCardProps
+
+Props for [`RecalledMemoriesCard`](#recalledmemoriescard).
+
+<TypeTable
+  type={{
+    className: { type: "string", description: "Additional CSS classes for the root element." },
+    facts: { type: "readonly RecalledMemoryFact[]", description: "The full candidate set from `spec.recalled_memories.facts`.", required: true },
+    report: { type: "RecalledMemoriesReport", description: "The runner's injection report from the execution's status.", required: true },
+  }}
+/>
+
+
 ### registerToolPresenter
 
 Registers a custom presenter for a `ToolKind`, overriding the default
@@ -3656,6 +3691,23 @@ caller falls back to copy-to-clipboard).
 
 ```tsx
 function resolveGitBrowseUrl(gitUrl: string, branch: string, commit: string, relPath: string): string | null
+```
+
+
+### resolveInjectedFacts
+
+Resolve the report's injected memory ids against the execution's
+snapshot facts, preserving snapshot order (the stable prompt order —
+the selector re-sorts its subset the same way, so this join renders
+the facts exactly as the agent saw them).
+
+The contract guarantees injected ids are a subset of the snapshot
+(the merge path's never-invent pin), so an unknown id can only mean a
+bug upstream — it is skipped, never invented. The summary count stays
+the wire truth (`injectedMemoryIds.length`) regardless.
+
+```tsx
+function resolveInjectedFacts(report: RecalledMemoriesReport, facts: readonly RecalledMemoryFact[]): RecalledMemoryFact[]
 ```
 
 

--- a/sdk/react/src/workflow/__tests__/WorkflowExecutionViewer.reconciliation.test.tsx
+++ b/sdk/react/src/workflow/__tests__/WorkflowExecutionViewer.reconciliation.test.tsx
@@ -383,19 +383,21 @@ describe("WorkflowExecutionViewer (center-column Thread|Graph toggle, S9)", () =
   it("a thread card offers no selection or drill-down gesture — the card IS the surface (T06)", () => {
     renderViewer();
 
-    // build-report has kind 0 (unspecified → summary disclosure): its header
-    // is the expand gesture, never a selection.
-    const header = screen.getByRole("button", { name: /^build-report/ });
-    expect(header.getAttribute("aria-expanded")).toBe("false");
-    expect(header.getAttribute("aria-pressed")).toBeNull();
+    // build-report renders from the snapshot fallback (no events): kind 0
+    // (unspecified → summary disclosure) with nothing beyond what its
+    // header row already carries — so it is a PLAIN row (stigmer#886): no
+    // expand chevron, no selection, no Inspect drill-down. (Expansion
+    // being card-local for content-bearing summary cards is pinned in
+    // WorkflowTaskThread.test.tsx.)
+    expect(
+      screen.queryByRole("button", { name: /^build-report/ }),
+    ).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Inspect build-report" }),
     ).toBeNull();
 
-    fireEvent.click(header);
-
-    // Expansion is card-local; the panel never opens on a card gesture.
-    expect(header.getAttribute("aria-expanded")).toBe("true");
+    // Clicking the row is inert: the panel never opens on a card gesture.
+    fireEvent.click(screen.getByText("build-report"));
     expect(screen.queryByRole("radio", { name: "Inspect" })).toBeNull();
   });
 

--- a/sdk/react/src/workflow/__tests__/WorkflowTaskThread.test.tsx
+++ b/sdk/react/src/workflow/__tests__/WorkflowTaskThread.test.tsx
@@ -451,6 +451,48 @@ describe("WorkflowTaskThread", () => {
     expect(screen.getByText(/at dial tcp 10\.0\.0\.1:443/)).toBeTruthy();
   });
 
+  it("a summary-kind card with a body-less detail renders no expand gesture (stigmer#886)", () => {
+    // A settled wait card with nothing the header cannot carry — no retry,
+    // no usage, no error, no I/O. Since R6-6 moved Status/Duration onto
+    // the header, its detail body would be empty, so the header is a plain
+    // row: offering a chevron that reveals nothing is worse than none.
+    render(
+      <WorkflowTaskThread
+        taskStates={statesOf(
+          taskState({ taskName: "blocking_wait", taskKind: WorkflowTaskKind.wait }),
+        )}
+        totalTasks={1}
+        isRunning={false}
+      />,
+    );
+
+    expect(screen.getByText("blocking_wait")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^blocking_wait/ })).toBeNull();
+  });
+
+  it("the expand gesture returns the moment the detail body has content (stigmer#886)", () => {
+    // The same wait card with a retry behind it: the Attempt row gives the
+    // body content, so the header is the expand gesture again.
+    render(
+      <WorkflowTaskThread
+        taskStates={statesOf(
+          taskState({
+            taskName: "blocking_wait",
+            taskKind: WorkflowTaskKind.wait,
+            attemptNumber: 2,
+          }),
+        )}
+        totalTasks={1}
+        isRunning={false}
+      />,
+    );
+
+    const header = screen.getByRole("button", { name: /^blocking_wait/ });
+    fireEvent.click(header);
+    expect(screen.getByText("Attempt")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+  });
+
   it("shows the full error in a summary-kind card's expanded body", () => {
     render(
       <WorkflowTaskThread
@@ -471,9 +513,15 @@ describe("WorkflowTaskThread", () => {
   });
 
   it("keeps a card's expanded state across streaming updates (no remount)", () => {
+    // The wait card carries input so its detail body has content — a
+    // body-less summary card has no expand gesture at all (stigmer#886).
     const running = () =>
       statesOf(
-        taskState({ taskName: "settled", taskKind: WorkflowTaskKind.wait }),
+        taskState({
+          taskName: "settled",
+          taskKind: WorkflowTaskKind.wait,
+          inputSummary: { duration: "10s" },
+        }),
         taskState({ taskName: "live", status: "running", messagesCount: 1 }),
       );
     const { rerender } = render(
@@ -495,7 +543,11 @@ describe("WorkflowTaskThread", () => {
     rerender(
       <WorkflowTaskThread
         taskStates={statesOf(
-          taskState({ taskName: "settled", taskKind: WorkflowTaskKind.wait }),
+          taskState({
+            taskName: "settled",
+            taskKind: WorkflowTaskKind.wait,
+            inputSummary: { duration: "10s" },
+          }),
           taskState({ taskName: "live", status: "running", messagesCount: 2 }),
         )}
         totalTasks={2}

--- a/sdk/react/src/workflow/thread/WorkflowTaskThread.tsx
+++ b/sdk/react/src/workflow/thread/WorkflowTaskThread.tsx
@@ -288,7 +288,12 @@ function ThreadEmptyState({ isRunning }: { readonly isRunning: boolean }) {
  *   card chevron — `BoundedContent` owns its own in-place reveal, so the
  *   old "expand, then Show more" double control never comes back).
  * - `"summary"` kinds expand from the header — the session card's own
- *   gesture, the chevron appended by the shell (T06).
+ *   gesture, the chevron appended by the shell (T06) — but ONLY when the
+ *   detail body would carry content (stigmer#886): since R6-6 moved
+ *   Status/Duration onto the header, a settled wait card often has
+ *   nothing left to reveal, and a chevron that opens an empty body is
+ *   worse than no chevron. The gate is the summary twin of
+ *   `showPreviewBody` below.
  * - AGENT_CALL cards with a spawned child render the child's inline
  *   transcript as the body (T07) — keyed on the VARIANT, not the
  *   disclosure, so a platform builder's presenter override can never route
@@ -362,6 +367,17 @@ const ThreadTaskCard = memo(function ThreadTaskCard({
     !showTranscript &&
     isPreview &&
     (outputIO !== null || !!item.error || showApprovalSummary);
+  // The summary twin of that gate (stigmer#886): the expand gesture exists
+  // only when `ThreadTaskDetail` would render something. Short-circuits
+  // before the row build for preview/transcript cards, which never render
+  // the detail body.
+  const summaryHasDetail =
+    !isPreview &&
+    !showTranscript &&
+    (taskDetailRows(item).length > 0 ||
+      !!item.error ||
+      inputIO !== null ||
+      outputIO !== null);
 
   const meta = formatMetaChips({
     durationMs: item.durationMs,
@@ -378,19 +394,19 @@ const ThreadTaskCard = memo(function ThreadTaskCard({
       accent={item.status === "waiting_approval" ? "warning" : null}
       cursorTarget="workflow-task-row"
     >
-      {/* The session card's gestures exactly (T06): summary rows expand
-          from the header (chevron appended by the shell); preview and
-          transcript rows' bodies are always visible, so the header is a
-          plain layout row. */}
+      {/* The session card's gestures exactly (T06): summary rows with a
+          content-bearing detail expand from the header (chevron appended
+          by the shell); preview, transcript, and body-less summary rows
+          are plain layout rows. */}
       <ThreadCardHeader
         gesture={
-          isPreview || showTranscript
-            ? { kind: "none" }
-            : {
+          summaryHasDetail
+            ? {
                 kind: "expand",
                 expanded,
                 onToggle: () => setExpanded((v) => !v),
               }
+            : { kind: "none" }
         }
       >
         <StatusGlyph status={item.status} />
@@ -486,7 +502,7 @@ const ThreadTaskCard = memo(function ThreadTaskCard({
         </ThreadCardBody>
       )}
 
-      {!isPreview && !showTranscript && expanded && (
+      {summaryHasDetail && expanded && (
         <ThreadCardBody>
           <ThreadTaskDetail item={item} inputIO={inputIO} outputIO={outputIO} />
         </ThreadCardBody>
@@ -630,19 +646,15 @@ function ThreadTaskPreviewBody({
   );
 }
 
-function ThreadTaskDetail({
-  item,
-  inputIO,
-  outputIO,
-}: {
-  readonly item: WorkflowThreadItem;
-  readonly inputIO: TaskDetailIO | null;
-  readonly outputIO: TaskDetailIO | null;
-}) {
-  // No Status/Duration rows (R6-6): the card header is the single source
-  // for both — the status glyph and the duration meta chip. The detail
-  // body carries only what the header cannot: attempt count, usage, the
-  // agent slug.
+/**
+ * The detail body's label/value rows. No Status/Duration rows (R6-6): the
+ * card header is the single source for both — the status glyph and the
+ * duration meta chip. The detail carries only what the header cannot:
+ * attempt count, usage, the agent slug. Shared with the card's
+ * `summaryHasDetail` gate so "would the body render anything?" can never
+ * drift from what the body actually renders (stigmer#886).
+ */
+function taskDetailRows(item: WorkflowThreadItem): Array<[string, string]> {
   const rows: Array<[string, string]> = [];
   if (item.attemptNumber > 1) rows.push(["Attempt", String(item.attemptNumber)]);
   const costChip = formatMetaChips({
@@ -653,6 +665,19 @@ function ThreadTaskDetail({
   if (item.variant === "agent-call" && item.agentSlug) {
     rows.push(["Agent", item.agentSlug]);
   }
+  return rows;
+}
+
+function ThreadTaskDetail({
+  item,
+  inputIO,
+  outputIO,
+}: {
+  readonly item: WorkflowThreadItem;
+  readonly inputIO: TaskDetailIO | null;
+  readonly outputIO: TaskDetailIO | null;
+}) {
+  const rows = taskDetailRows(item);
 
   return (
     <div className="stg:flex stg:flex-col stg:gap-2">

--- a/test/e2e/tests/interactive/workflow-execution-thread.spec.ts
+++ b/test/e2e/tests/interactive/workflow-execution-thread.spec.ts
@@ -111,7 +111,7 @@ test.describe("Workflow execution thread", () => {
     }
   });
 
-  test("a summary-kind card expands from its header to reveal task detail", async ({
+  test("a body-less summary-kind card is a plain header row — status and duration live on the header", async ({
     page,
     stigmerClient,
     testWaitWorkflow,
@@ -127,18 +127,18 @@ test.describe("Workflow execution thread", () => {
       // The wait workflow blocks ~10s before completing.
       await waitForPhaseBadge(page, "Completed", { timeout: 45_000 });
 
-      // The retired inspector's promise, on its successor surface: task
-      // detail (status, duration) opens ON the card. Wait tasks are
-      // summary-kind — their header is the expand gesture (aria-expanded).
+      // The retired inspector's promise, on its successor surface: since
+      // R6-6 the card HEADER is the single source for a task's status
+      // (glyph) and duration (meta chip) — the old Status/Duration detail
+      // rows are gone. A settled wait task has nothing left for a detail
+      // body, so the card offers no expand gesture at all (stigmer#886) —
+      // the same no-toggle contract tool-call-disclosure.spec.ts pins for
+      // always-visible session cards.
       const card = getThreadTaskCard(page, "blocking_wait");
-      const header = card.getByRole("button", { expanded: false });
-      await expect(header).toBeVisible({ timeout: 15_000 });
-      await header.click();
-
-      await expect(card.getByRole("button", { expanded: true })).toBeVisible();
-      await expect(card).toContainText("Status");
-      await expect(card).toContainText("Completed");
-      await expect(card).toContainText("Duration");
+      await expect(card).toBeVisible({ timeout: 15_000 });
+      await expect(card).toContainText("Wait"); // kind label
+      await expect(card).toContainText(/\d+(\.\d+)?\s?(ms|s|m)/); // duration chip
+      await expect(card.locator('[role="button"][aria-expanded]')).toHaveCount(0);
     } finally {
       await execution.cleanup();
     }

--- a/test/integration-offline/memory_retrieval_offline_test.go
+++ b/test/integration-offline/memory_retrieval_offline_test.go
@@ -14,6 +14,7 @@ import (
 	sessionv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/agentic/session/v1"
 	apiresource "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/commons/apiresource"
 	identityaccountv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/iam/identityaccount/v1"
+	iampolicyv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/iam/iampolicy/v1"
 	organizationv1 "github.com/stigmer/stigmer/apis/stubs/go/ai/stigmer/tenancy/organization/v1"
 	"github.com/stigmer/stigmer/test/integration/harness"
 	"github.com/stretchr/testify/assert"
@@ -86,6 +87,15 @@ func TestOffline_MemoryRetrieval(t *testing.T) {
 		}
 	})
 
+	// Fund the fresh org — execution create is gated on the org's balance,
+	// so an unfunded org fails closed before recall ever runs (stigmer#886).
+	// The org id doubles as the idempotency-key discriminator: per-run
+	// unique, so a rerun re-provisions a fresh org and its credit seed is
+	// never deduplicated against the previous attempt.
+	require.NoError(t,
+		harness.ProvisionTestBillingAccount(ctx, grpcConn, orgID, "memory-retrieval-seed-"+orgID),
+		"fund the retrieval org's billing account")
+
 	// The user half: a real account opting in via self-service update, with
 	// a plain human JWT — the one credential shape recall admits.
 	account := harness.CreateIdentityAccount(t, ctx, machineClients,
@@ -115,6 +125,22 @@ func TestOffline_MemoryRetrieval(t *testing.T) {
 		agent.GetStatus().GetDefaultInstanceId(), sessionv1.Harness_HARNESS_NATIVE,
 		[]harness.SessionResourceOption{harness.WithSessionOrg(orgID)})
 	sessionID := session.GetMetadata().GetId()
+
+	// The offline harness hands the runner the MACHINE account's JWT, and
+	// agent_execution can_view/can_edit resolve strictly through the
+	// SESSION's owner — so on this human-owned session the runner's
+	// callbacks fail closed at FGA (stigmer#886). Bridge: the human session
+	// owner grants the machine account session owner through the real
+	// IamPolicy pipeline (session.owner is directly assignable;
+	// can_grant_access is owner-held). Production instead runs the
+	// embedded-runner credential lane, which this harness does not
+	// provision — the long-term follow-up recorded on stigmer#886.
+	_, err = humanClients.IamPolicyCommand.Create(ctx, &iampolicyv1.IamPolicySpec{
+		Principal: &iampolicyv1.ApiResourceRef{Kind: "identity_account", Id: harness.OwnerAccountID},
+		Resource:  &iampolicyv1.ApiResourceRef{Kind: "session", Id: sessionID},
+		Relation:  "owner",
+	})
+	require.NoError(t, err, "grant the runner's machine identity owner on the session")
 
 	_, err = mgr.AddSession(ctx, sessionID)
 	require.NoError(t, err, "AddSession should succeed")

--- a/test/integration-offline/workflow_task_io_test.go
+++ b/test/integration-offline/workflow_task_io_test.go
@@ -48,9 +48,13 @@ func TestOffline_TaskIO_PopulatesInputOutputTokens(t *testing.T) {
 	deployer := harness.NewFixtureDeployer(clients, "offline-task-io", suiteLogger)
 	defer deployer.Cleanup(ctx)
 
+	// SetTaskConfig is `variables: map<string,string>` — string literals only;
+	// anything richer is an expression (stigmer#886).
 	setVarsConfig, err := structpb.NewStruct(map[string]any{
-		"greeting": "hello",
-		"count":    float64(42),
+		"variables": map[string]any{
+			"greeting": "hello",
+			"count":    "42",
+		},
 	})
 	require.NoError(t, err)
 

--- a/test/integration/workflow_context_chain_test.go
+++ b/test/integration/workflow_context_chain_test.go
@@ -130,12 +130,12 @@ func TestWorkflow_ContextChain_StructuredOutputInSwitch(t *testing.T) {
 	deployer := harness.NewFixtureDeployer(clients, "ctx-struct-switch", suiteLogger)
 	defer deployer.Cleanup(ctx)
 
+	// SetTaskConfig values are strings (map<string,string>) — a structured
+	// variable is authored as a jq object-construction expression, which the
+	// runner's set executor evaluates to a real object in state (stigmer#886).
 	initConfig, err := structpb.NewStruct(map[string]any{
 		"variables": map[string]any{
-			"nested": map[string]any{
-				"field": "value",
-				"count": float64(5),
-			},
+			"nested": `${ {field: "value", count: 5} }`,
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

`ci.integration-offline` (red since Aug 18) and `ci.e2e-interactive` (red since Aug 22) have failed on every push to main. This PR heals both lanes: four test-side root causes fixed, plus the one real SDK gap the triage confirmed (a summary card offering an expand chevron over an empty body). Full triage on the issue.

Closes #886

## Context

The lanes run on PRs, but a red lane carries no signal — two of the four causes stacked *into* already-red lanes unseen. With the TS-server cutover soak using main health as a public signal (#883), a permanently red main can hide real regressions.

## Changes

**Cause 1 — `set_vars` fixtures vs the proto contract** (`SetTaskConfig.variables: map<string,string>`, strictly converted by the Java service this lane tests against):
- `workflow_task_io_test.go`: free-form keys moved under `variables` as strings.
- `workflow_context_chain_test.go`: the structured variable is now a jq object-construction expression (`${ {field: "value", count: 5} }`) — the contract's documented intent; the runner's set executor evaluates it to a real object, and the switch's nested-path read is asserted unchanged. No capability regression.

**Cause 2 — memory-retrieval test fixture gaps** (born failing into an already-red lane via #837; the billing fix unmasked a second gap beneath it):
- Fund the fresh org via the `ProvisionTestBillingAccount` idiom (execution create is billing-gated).
- Bridge runner authority over the human-owned session: the human session owner grants the machine account (the offline runner's callback identity) `owner` on the session through the real IamPolicy pipeline. The FGA model resolves `agent_execution` view/edit strictly through the session's owner; org grants have no path. Production instead uses the embedded-runner credential lane, which the offline harness does not provision — recorded on #886 as the honest long-term follow-up.

**Cause 3 — e2e spec drift from R6-6 + the dangling expander** (owner-ruled Option A):
- `WorkflowTaskThread.tsx`: the summary disclosure now has the same content gate the preview path already had (`showPreviewBody`) — a summary card whose detail body would render nothing gets no expand chevron. `taskDetailRows` is extracted and shared by the gate and the body so they can never drift.
- `workflow-execution-thread.spec.ts`: asserts the honest contract (header carries status glyph + duration chip; body-less wait card presents no `aria-expanded` toggle — the same no-toggle contract `tool-call-disclosure.spec.ts` pins for session cards).
- Both-arms unit coverage added (no content ⇒ no chevron; content ⇒ chevron + detail); the viewer reconciliation test updated to pin the plain-row contract on the snapshot-fallback path.

**Cause 4 — OpenFGA CLI install flake**:
- Pinned `fga@v0.7.20` in `ci.integration-offline.yaml` (the workflow already pins gotestsum; `@latest` re-resolves and re-verifies against sum.golang.org every run).

## Test plan

- `TestOffline_TaskIO_PopulatesInputOutputTokens`, `TestOffline_MemoryRetrieval` (all 3 subtests), and `TestWorkflow_ContextChain_StructuredOutputInSwitch` all PASS locally against today's CI-built cloud@main JAR with the FGA model provisioned — the first green runs of these tests in the lane's red window.
- sdk/react: typecheck clean; full suite 4788/4788; lint + prefix-classnames + tsdoc clean.
- e2e interactive: the updated spec file 7/7 across three local full-stack runs (Go server + runner + mock LLM + real browser); full interactive project 81–83 passed per run with the only local failures in session-flow specs untouched by this PR (they pass in CI; local stack flakiness under repeated boots — this PR's own `ci.e2e-interactive` run is the authority).
- Both healed lanes trigger on this PR's paths, so the healing is proven by this PR's checks before merge.

## Disclosures

- The sdk/react browser-mode a11y/layout suites do not run in my local environment (dynamic-import fetch failure, byte-identical on clean main) — covered by this PR's frontend CI.
- The runner emits no `input_summary` for wait tasks, so live wait cards have no preview line and no detail body — worth a look independently (would give the wait card an honest body and restore its chevron under the new gate).
- The offline harness's runner identity (machine JWT fallback) only works for machine-owned sessions; provisioning real embedded-runner credentials is the production-faithful follow-up, recorded on #886.

## Risks

- The SDK gate changes chevron presence for body-less summary cards only; content-bearing cards are untouched (both arms unit-pinned). Rollback is a revert — no data or wire changes anywhere in this PR.

Made with [Cursor](https://cursor.com)