### PR TITLE
fix(runner): include @stigmer/zip-structure in the sandbox image build

### DIFF
--- a/.github/workflows/release.sandbox-cloud.yaml
+++ b/.github/workflows/release.sandbox-cloud.yaml
@@ -54,6 +54,7 @@ jobs:
               - 'backend/services/runner/tsconfig*.json'
               - 'backend/services/runner/Dockerfile.sandbox'
               - 'apis/stubs/ts/**'
+              - 'backend/libs/ts/**'
 
       - name: Decide whether to build
         id: decide

--- a/backend/services/runner/Dockerfile.sandbox
+++ b/backend/services/runner/Dockerfile.sandbox
@@ -44,9 +44,18 @@ RUN cd backend/libs/ts/temporal-codecs && npm install --ignore-scripts
 COPY backend/libs/ts/temporal-codecs/ backend/libs/ts/temporal-codecs/
 RUN cd backend/libs/ts/temporal-codecs && npm run build
 
+# Build @stigmer/zip-structure (file: dependency of the runner) — the
+# shared structural ZIP parsing lib extracted from the runner. Same
+# treatment as the other libs: install, copy source, build dist.
+COPY backend/libs/ts/zip-structure/package.json backend/libs/ts/zip-structure/
+RUN cd backend/libs/ts/zip-structure && npm install --ignore-scripts
+COPY backend/libs/ts/zip-structure/ backend/libs/ts/zip-structure/
+RUN cd backend/libs/ts/zip-structure && npm run build
+
 # Install runner production dependencies.
-# The directory layout preserves the file:../../../apis/stubs/ts and
-# file:../../libs/ts/temporal-codecs references.
+# The directory layout preserves the file:../../../apis/stubs/ts,
+# file:../../libs/ts/temporal-codecs, and file:../../libs/ts/zip-structure
+# references.
 COPY backend/services/runner/package.json backend/services/runner/package-lock.json backend/services/runner/
 WORKDIR /build/backend/services/runner
 RUN npm ci --legacy-peer-deps
@@ -55,11 +64,11 @@ RUN npm ci --legacy-peer-deps
 COPY backend/services/runner/ .
 RUN npm run build
 
-# Strip dev dependencies and resolve the @stigmer/protos and
-# @stigmer/temporal-codecs symlinks into real copies so the runtime stage
-# doesn't need the stubs/libs directory trees.
+# Strip dev dependencies and resolve the @stigmer/protos,
+# @stigmer/temporal-codecs, and @stigmer/zip-structure symlinks into real
+# copies so the runtime stage doesn't need the stubs/libs directory trees.
 RUN npm prune --omit=dev --legacy-peer-deps && \
-    for dep in protos temporal-codecs; do \
+    for dep in protos temporal-codecs zip-structure; do \
       if [ -L "node_modules/@stigmer/$dep" ]; then \
         target="$(readlink -f "node_modules/@stigmer/$dep")" && \
         rm "node_modules/@stigmer/$dep" && \


### PR DESCRIPTION
## Summary

- `release.sandbox-cloud` has failed on every real build since PR #868 (D4 #8, `283b0b1d7`) made `@stigmer/zip-structure` the runner's third `file:` dependency: `Dockerfile.sandbox` only built `@stigmer/protos` and `@stigmer/temporal-codecs`, so the runner's `tsc` build fails with TS2307 on `attachment-injector.ts` and `zip-extract.ts`. The gap stayed invisible for two days because the workflow's `detect-changes` gate skipped the build job on every intervening main push; the Go-server retirement commit (`154180fe7`) touched runner paths and forced the first real build since.
- Fix mirrors the temporal-codecs precedent (`c9a0b8255`, PR #849): build `backend/libs/ts/zip-structure` in the builder stage (install, copy source, build dist) and add `zip-structure` to the symlink-resolution loop so the runtime stage gets a real copy.
- Also adds `backend/libs/ts/**` to the workflow's `dorny/paths-filter` list so future changes to the shared TS libs trigger the sandbox build at merge time instead of lying latent until an unrelated runner change surfaces the breakage.

## Verification

- `docker build --target builder -f backend/services/runner/Dockerfile.sandbox .` passes locally on this branch (it fails on main with the two TS2307 errors).
- Inside the built stage, `node_modules/@stigmer/zip-structure` is a real directory (not a symlink) with the built `dist/` — same as protos and temporal-codecs.
- Not verified here: the full runtime stage + Daytona smoke; the workflow's own run on this PR's merge covers that (the paths filter now includes the workflow-relevant paths).

Closes #889

Made with [Cursor](https://cursor.com)