### PR TITLE
docs(backend/stigmer-server): record ratified error-mapping and quoting conventions

### DIFF
--- a/.cursor/rules/backend/ts-server-guidelines.mdc
+++ b/.cursor/rules/backend/ts-server-guidelines.mdc
@@ -83,8 +83,26 @@ eventually violate creatively.
 - Errors are API surface: correct codes (`NotFound`, `AlreadyExists`,
   `InvalidArgument`, `FailedPrecondition`), never `Internal` as a catch-all,
   messages in domain terms with the identifying handle
-  (`agent "x" not found`), byte-pinned copy in one constants module per
+  (`agent 'x' not found`), byte-pinned copy in one constants module per
   domain.
+- **Store-fault mapping (ratified 2026-08-26)**: a typed store not-found
+  (`ResourceNotFoundError`, `AuditNotFoundError` — `instanceof` check) maps
+  to `NotFound`; ANY other store failure is an infrastructure fault —
+  rethrow in pipeline steps (the executor answers a sanitized `Internal`,
+  see `src/pipeline/pipeline.ts`) or throw
+  `internalError(cause, "failed to <do thing>")` in direct handlers. This
+  is a classified infrastructure fault, not a catch-all. The retired Go
+  server mapped ANY store error to NotFound (`load_target.go`, git
+  history) — a fidelity bug deliberately not ported: presenting a locked
+  file or corrupted page as "not found" invites clients to discard real
+  state. The idiom applies at every store-read site.
+- **Quoting in error copy (ratified 2026-08-26)**: NEW messages quote
+  identifiers single-quote `'${x}'` and render lists with `quoteJoin`
+  (`domain/mcpserver/enabledtools/`). The 11 legacy double-quote `"${x}"`
+  sites (e.g. `domain/schedule/cron.ts`) are FROZEN wire constants shared
+  with the cloud edition — contract, not style to imitate. No `goQuote`
+  helper: its only purpose was emulating Go's `%q` escaping, retired with
+  the Go server.
 - Log the real error; the wire carries the sanitized message. Never log
   secrets — the redaction doctrine (`***REDACTED***`, `enc:v1:`) extends to
   logs and Temporal payloads.

--- a/backend/services/stigmer-server/src/pipeline/steps/delete.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/delete.ts
@@ -2,6 +2,13 @@
  * Delete steps — port steps/delete.go: ExtractResourceId (ID-wrapper →
  * context), LoadExistingForDelete (loads the doomed resource so Delete can
  * return it; NotFound when absent), DeleteResource (the store delete).
+ *
+ * Deliberate divergence from the Go source (ratified 2026-08-26): Go
+ * mapped ANY store error on the load to NotFound. Here only the typed
+ * ResourceNotFoundError is NotFound; other store failures surface as
+ * sanitized Internal — rethrown from the load (the executor converts,
+ * see pipeline.ts) or thrown directly by DeleteResource. Same narrowing
+ * as load-target.ts, applied at every store-read site.
  */
 import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
 

--- a/backend/services/stigmer-server/src/pipeline/steps/load-existing.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/load-existing.ts
@@ -3,6 +3,12 @@
  * by id when provided (direct lookup), else by org-scoped slug (the
  * fallback populates the id back into metadata so merge/persist have it).
  * NotFound FAILS here — apply's tolerant probe is LoadForApply.
+ *
+ * Deliberate divergence from the Go source (ratified 2026-08-26): Go
+ * mapped ANY store error to NotFound. Here only the typed
+ * ResourceNotFoundError is NotFound; other store failures rethrow to the
+ * executor's sanitized Internal (see pipeline.ts and load-target.ts —
+ * the same narrowing, applied at every store-read site).
  */
 import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
 

--- a/backend/services/stigmer-server/src/pipeline/steps/load-target.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/load-target.ts
@@ -2,6 +2,14 @@
  * LoadTarget — ports steps/load_target.go. Get's loader for ID-wrapper
  * inputs (OrganizationId, AgentId, …): loads by id into the
  * TargetResource context key; NotFound when absent.
+ *
+ * Deliberate divergence from the Go source (ratified 2026-08-26): Go
+ * mapped ANY store error to NotFound — a locked file or corrupted page
+ * presented as a missing resource, inviting clients to discard real
+ * state. Here only the store's typed ResourceNotFoundError is NotFound;
+ * anything else rethrows, and the pipeline executor answers a sanitized
+ * Internal (see pipeline.ts). The idiom applies at every store-read site
+ * (guidelines §Errors).
  */
 import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
 


### PR DESCRIPTION
## Summary

Records two program-level conventions ratified by the owner on 2026-08-26 where in-repo agents actually look: divergence-rationale comments on the three shared pipeline load/delete steps, and both conventions in the TS server guidelines rule. Comments and one rule file only — zero behavior, message-byte, or test changes.

## Context

The Go-to-TS port left two program-level dispositions owed:

1. **Store-failure error mapping.** The retired Go server mapped ANY store error on a load to NotFound (`load_target.go`, git history) — a locked file or corrupted page presented as a missing resource. The TS port deliberately narrowed this: only the store's typed `ResourceNotFoundError` maps to NotFound; any other store failure surfaces as a sanitized Internal (the #478 doctrine). Ratified as canonical. The in-repo guidelines mandate that deliberate port divergences carry a rationale comment — the three shared steps embodying this one had none.
2. **Error-message quoting.** There is no `goQuote` helper and never was: existing messages are frozen cross-edition wire constants (the cloud edition emits and tests identical copy), including 11 legacy double-quote `"${x}"` sites. Ratified: NEW messages use the single-quote `'${x}'` majority style with `quoteJoin` for lists; no `goQuote` helper (its only purpose was emulating Go's `%q` escaping, retired with the Go server); no sweep of the legacy sites.

## Changes

- `src/pipeline/steps/load-target.ts`, `load-existing.ts`, `delete.ts`: intent-header addendum stating the deliberate divergence from the Go source and why (self-contained — no external records needed).
- `.cursor/rules/backend/ts-server-guidelines.mdc` §Errors: the store-fault mapping idiom (stated once, idiom-wide — it applies at every store-read site, not just the shared steps) and the quoting convention (with the explicit warning that the legacy double-quote sites are contract, not style to imitate). The section's illustrative example aligned to the single-quote style.

## Breaking changes

- None. Comments and rule text only.

## Test plan

- `make build-ts-stubs` then `make test-server`: **1692/1692 passed** (baseline-exact vs the retirement proof).
- `npm run typecheck` in `backend/services/stigmer-server`: clean.
- `git diff` confirms no non-comment source lines changed.

## Risks

- None identified; revert is a single-commit revert.

## Checklist

- [x] Docs updated
- [x] Tests added/updated (not needed — no behavior change)
- [x] Backward compatible

Made with [Cursor](https://cursor.com)