### PR TITLE
fix(backend/stigmer-server): fence the invoke-workflow test flake (oss#892)

### DIFF
--- a/backend/services/stigmer-server/src/domain/workflowexecution/lifecycle.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/lifecycle.ts
@@ -398,7 +398,8 @@ function newRecreateExecutionContextStep<Desc extends DescMessage>(
       const executionOrg = execution.metadata?.org ?? "";
       const workflowInstanceId = execution.spec?.workflowInstanceId ?? "";
 
-      // Delete a stale EC if the TTL has not reclaimed it (best-effort).
+      // Delete a stale EC left by the interrupted run (best-effort; no
+      // TTL sweep exists — a leftover row stays until deleted, oss#892).
       await deleteStaleExecutionContext(deps, executionId);
 
       let instance: WorkflowInstance;

--- a/backend/services/stigmer-server/src/temporal/agentexecution/__tests__/invoke-workflow.test.ts
+++ b/backend/services/stigmer-server/src/temporal/agentexecution/__tests__/invoke-workflow.test.ts
@@ -22,6 +22,14 @@
  *     oss#861: the TS error completion WORKS);
  *   - the cursor flow's harness_state_id re-read discipline.
  *
+ * Recorder discipline (oss#892): Temporal activities are at-least-once —
+ * a workflow task whose completion fails to commit re-executes its local
+ * activities (their markers never landed), so count-exact recorder pins
+ * flake under CI load. Delete-recorder assertions therefore pin
+ * identity + at-least-once, every test mints a unique execution id, and
+ * afterEach settles every started workflow so none outlives its script
+ * window.
+ *
  * Follows the runner's golden-e2e precedent: TestWorkflowEnvironment
  * .createLocal (needs the `temporal` CLI on PATH); every test skips
  * gracefully when the local test server cannot start.
@@ -112,10 +120,20 @@ interface ActivityScript {
 
 let script: ActivityScript;
 
+/**
+ * Per-test execution identity (oss#892): a workflow that outlives its
+ * test window keeps pushing into the CURRENT test's recorders. Unique
+ * ids make any such leak attributable to its test — with a shared id, a
+ * foreign push is indistinguishable from a legitimate one.
+ */
+let executionSeq = 0;
+let currentExecutionId = "exec-0";
+
 function resetScript(): void {
   for (const release of script?.releaseBlocked ?? []) {
     release();
   }
+  currentExecutionId = `exec-${++executionSeq}`;
   script = {
     executeBehaviors: [],
     executeCalls: [],
@@ -155,7 +173,7 @@ function executionJson(status: AgentExecutionStatus): JsonValue {
   return toJson(
     AgentExecutionSchema,
     create(AgentExecutionSchema, {
-      metadata: { id: "exec-1" },
+      metadata: { id: currentExecutionId },
       status,
     }),
   );
@@ -180,7 +198,7 @@ function statusDecidedAwaitingReconcile(): AgentExecutionStatus {
     phase: ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
     fileChangeSets: [
       {
-        id: "exec-1:1",
+        id: `${currentExecutionId}:1`,
         status: FileChangeSetStatus.DECIDED,
       },
     ],
@@ -257,7 +275,7 @@ function workflowInput(
   overrides: Partial<InvokeAgentExecutionWorkflowInput> = {},
 ): InvokeAgentExecutionWorkflowInput {
   return {
-    execution_id: "exec-1",
+    execution_id: currentExecutionId,
     session_id: "ses-1",
     agent_id: "agt-1",
     ...overrides,
@@ -266,17 +284,25 @@ function workflowInput(
 
 let workflowSeq = 0;
 
+/** Every started workflow, settled by afterEach (oss#892). */
+const startedHandles: Array<import("@temporalio/client").WorkflowHandle> = [];
+
 async function startWorkflow(
   input: InvokeAgentExecutionWorkflowInput,
 ): Promise<import("@temporalio/client").WorkflowHandle> {
   if (!env) throw new Error("TestWorkflowEnvironment not initialized");
   workflowSeq++;
-  return env.client.workflow.start(INVOKE_AGENT_EXECUTION_WORKFLOW_NAME, {
-    taskQueue: TASK_QUEUE,
-    workflowId: `invoke-test-${workflowSeq}-${Date.now()}`,
-    args: [input],
-    memo: { [MEMO_ACTIVITY_TASK_QUEUE]: TASK_QUEUE },
-  });
+  const handle = await env.client.workflow.start(
+    INVOKE_AGENT_EXECUTION_WORKFLOW_NAME,
+    {
+      taskQueue: TASK_QUEUE,
+      workflowId: `invoke-test-${workflowSeq}-${Date.now()}`,
+      args: [input],
+      memo: { [MEMO_ACTIVITY_TASK_QUEUE]: TASK_QUEUE },
+    },
+  );
+  startedHandles.push(handle);
+  return handle;
 }
 
 /**
@@ -333,6 +359,27 @@ async function waitForPersistedPhase(
   );
 }
 
+/**
+ * The EC-delete pin, honest to Temporal's contract (oss#892):
+ * DeleteExecutionContext is a LOCAL activity, and local activities are
+ * at-least-once — a workflow task whose completion fails to commit
+ * re-executes them (their markers never landed), so an exactly-once
+ * count assertion flakes under CI load while the production delete is
+ * idempotent by design. The pin is "fired, and only ever for THIS
+ * execution": a duplicate is legal; a foreign id is a test-isolation
+ * leak and must fail loudly.
+ */
+function expectExecutionContextDeleted(): void {
+  expect(
+    script.deletedExecutionContexts.length,
+    "the ExecutionContext delete must fire",
+  ).toBeGreaterThanOrEqual(1);
+  expect(
+    script.deletedExecutionContexts.filter((id) => id !== currentExecutionId),
+    "every recorded delete must belong to this test's execution",
+  ).toEqual([]);
+}
+
 describe("invoke-agent-execution workflow (TestWorkflowEnvironment)", () => {
   beforeAll(async () => {
     try {
@@ -365,9 +412,22 @@ describe("invoke-agent-execution workflow (TestWorkflowEnvironment)", () => {
     if (env) await env.teardown();
   }, 30_000);
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Settle every workflow this test started BEFORE the script resets:
+    // a workflow that outlives its test re-enters the NEXT test's script
+    // (observed on CI as "test script exhausted" activity retries plus a
+    // foreign recorder push — oss#892). Terminating an already-terminal
+    // workflow throws; that is the common case and is ignored.
+    for (const handle of startedHandles.splice(0)) {
+      try {
+        await handle.terminate("test window closed (oss#892 settle fence)");
+      } catch {
+        // Already terminal.
+      }
+      await handle.result().catch(() => {});
+    }
     resetScript();
-  });
+  }, 15_000);
 
   it("completes the deep-agent happy path and cleans up the ExecutionContext", async (testCtx) => {    if (!envReady) return testCtx.skip();
     script.executeBehaviors = [
@@ -378,7 +438,7 @@ describe("invoke-agent-execution workflow (TestWorkflowEnvironment)", () => {
     await handle.result();
 
     expect(script.executeCalls).toEqual([{ thread_id: "thread-1", turn_seq: 0 }]);
-    expect(script.deletedExecutionContexts).toEqual(["exec-1"]);
+    expectExecutionContextDeleted();
     expect(script.completions).toEqual([]);
   }, 30_000);
 
@@ -406,7 +466,7 @@ describe("invoke-agent-execution workflow (TestWorkflowEnvironment)", () => {
           entry.status.phase === ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
       ),
     ).toBe(true);
-    expect(script.deletedExecutionContexts).toEqual(["exec-1"]);
+    expectExecutionContextDeleted();
   }, 30_000);
 
   it("re-invokes immediately without a signal when the gate is decided-awaiting-reconcile (DD-28)", async (testCtx) => {    if (!envReady) return testCtx.skip();
@@ -525,7 +585,7 @@ describe("invoke-agent-execution workflow (TestWorkflowEnvironment)", () => {
     );
     expect(failed.length).toBeGreaterThan(0);
     expect(failed[0]!.status.error).toBe("agent blew up");
-    expect(script.deletedExecutionContexts).toEqual(["exec-1"]);
+    expectExecutionContextDeleted();
   }, 30_000);
 
   it("cancellation persists CANCELLED quietly and still deletes the ExecutionContext (stigmer#282)", async (testCtx) => {    if (!envReady) return testCtx.skip();
@@ -554,7 +614,7 @@ describe("invoke-agent-execution workflow (TestWorkflowEnvironment)", () => {
     expect(cancelled.status.messages.map((message) => message.content)).toEqual([
       "Execution was cancelled.",
     ]);
-    expect(script.deletedExecutionContexts).toEqual(["exec-1"]);
+    expectExecutionContextDeleted();
   }, 60_000);
 
   it("completes the callback token with the result on success", async (testCtx) => {    if (!envReady) return testCtx.skip();
@@ -569,7 +629,7 @@ describe("invoke-agent-execution workflow (TestWorkflowEnvironment)", () => {
       toJson(
         AgentExecutionSchema,
         create(AgentExecutionSchema, {
-          metadata: { id: "exec-1" },
+          metadata: { id: currentExecutionId },
           status: {
             phase: ExecutionPhase.EXECUTION_COMPLETED,
             streamingUsage: { totalTokens: 1234n, estimatedCostUsd: 0.05 },
@@ -587,7 +647,7 @@ describe("invoke-agent-execution workflow (TestWorkflowEnvironment)", () => {
     const completion = script.completions[0]!;
     expect(completion.errorMessage).toBeUndefined();
     expect(completion.result).toEqual({
-      agent_execution_id: "exec-1",
+      agent_execution_id: currentExecutionId,
       structured: { verdict: "ok" },
       final_text: "done",
       // total_tokens is a JSON NUMBER (the cross-component contract; the
@@ -714,7 +774,7 @@ describe("invoke-agent-execution workflow (TestWorkflowEnvironment)", () => {
       expect(signal.targetWorkflowId).toBe("parent-probe");
       // The BARE-STRING wire shape — cloud's exact payload, NOT the
       // {executionId} object child_execution_started carries.
-      expect(signal.payload).toBe("exec-1");
+      expect(signal.payload).toBe(currentExecutionId);
     }
 
     // Ordering pin (cloud parity): the notify happens BEFORE the gate wait —
@@ -760,7 +820,7 @@ describe("invoke-agent-execution workflow (TestWorkflowEnvironment)", () => {
     // The sibling-signal payload asymmetry, pinned: started carries the
     // {executionId} object (the shape the runner's handler tolerates),
     // while child_approval_required carries cloud's bare string.
-    expect(started[0]!.payload).toEqual({ executionId: "exec-1" });
+    expect(started[0]!.payload).toEqual({ executionId: currentExecutionId });
     expect(
       signals.filter((signal) => signal.signalName === SIGNAL_CHILD_APPROVAL_REQUIRED),
     ).toHaveLength(0);

--- a/backend/services/stigmer-server/src/temporal/agentexecution/workflows/invoke-agent-execution.ts
+++ b/backend/services/stigmer-server/src/temporal/agentexecution/workflows/invoke-agent-execution.ts
@@ -1275,7 +1275,10 @@ async function readHarnessStateId(sessionId: string): Promise<string> {
  * Deletes the ephemeral ExecutionContext (fully-merged environment incl.
  * secrets) on a non-cancellable scope so cleanup runs even after
  * cancellation. Best-effort; the delete activity itself never throws on
- * missing contexts (#15's seam).
+ * missing contexts (#15's seam). A failed cleanup is never retried — no
+ * TTL sweep exists (oss#892; the retired Go server's log claimed one
+ * that never did) — the row stays encrypted at rest (oss#535) and this
+ * WARN is the operator's signal.
  */
 async function deleteExecutionContext(executionId: string): Promise<void> {
   await CancellationScope.nonCancellable(async () => {
@@ -1283,10 +1286,13 @@ async function deleteExecutionContext(executionId: string): Promise<void> {
       await localActivities[DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME](executionId);
       log.info("ExecutionContext cleaned up", { executionId });
     } catch (error) {
-      log.warn("ExecutionContext cleanup failed (will rely on TTL backup)", {
-        executionId,
-        error: errorMessage(error),
-      });
+      log.warn(
+        "ExecutionContext cleanup failed — nothing retries it; any remaining row stays encrypted at rest (operator cleanup)",
+        {
+          executionId,
+          error: errorMessage(error),
+        },
+      );
     }
   });
 }

--- a/backend/services/stigmer-server/src/temporal/workflowexecution/__tests__/invoke-workflow.test.ts
+++ b/backend/services/stigmer-server/src/temporal/workflowexecution/__tests__/invoke-workflow.test.ts
@@ -21,6 +21,9 @@
  * Follows #18's discipline: TestWorkflowEnvironment.createLocal (needs
  * the `temporal` CLI); every test skips VISIBLY when the local test
  * server cannot start — never a vacuous green (panel finding B3).
+ * Delete-recorder pins are at-least-once-honest (oss#892): Temporal
+ * activities re-execute when a completion fails to commit, so the pin is
+ * identity + at-least-once, never an exact count.
  */
 import { fromJson } from "@bufbuild/protobuf";
 import type { JsonValue } from "@bufbuild/protobuf";
@@ -144,6 +147,27 @@ function persistedPhases(): ExecutionPhase[] {
 }
 
 /**
+ * The EC-delete pin, honest to Temporal's contract (oss#892): every
+ * activity is at-least-once — a completion that fails to commit
+ * re-executes code that already ran (the delete here is a REGULAR
+ * activity, but the transient class is the same one observed on the
+ * agentexecution twin's local activity), so an exactly-once count
+ * assertion flakes under CI load while the production delete is
+ * idempotent by design. The pin is "fired, and only ever for THIS
+ * execution".
+ */
+function expectExecutionContextDeleted(executionId: string): void {
+  expect(
+    deletedExecutionContexts.length,
+    "the ExecutionContext delete must fire",
+  ).toBeGreaterThanOrEqual(1);
+  expect(
+    deletedExecutionContexts.filter((id) => id !== executionId),
+    "every recorded delete must belong to this test's execution",
+  ).toEqual([]);
+}
+
+/**
  * Releases a holding stub child THROUGH the orchestrator's relay lane —
  * the orchestrator has no test-release handler of its own; the envelope
  * is exactly how any task-specific signal reaches the child in
@@ -199,7 +223,7 @@ describe("invoke-workflow-execution workflow (TestWorkflowEnvironment)", () => {
     const handle = await startOrchestrator("wfe-ok");
     await handle.result();
 
-    expect(deletedExecutionContexts).toEqual(["wfe-ok"]);
+    expectExecutionContextDeleted("wfe-ok");
     // The runner streams real statuses via gRPC; the orchestrator's own
     // persists exist only for the failure/cancel/pause lanes.
     expect(persistedStatuses).toEqual([]);
@@ -218,7 +242,7 @@ describe("invoke-workflow-execution workflow (TestWorkflowEnvironment)", () => {
     // Go: "Workflow execution failed: %s" over the child's error text.
     expect(failed.status.error).toMatch(/^Workflow execution failed: /);
     expect(failed.status.error).toContain("child engine boom");
-    expect(deletedExecutionContexts).toEqual(["wfe-fail"]);
+    expectExecutionContextDeleted("wfe-fail");
   }, 30_000);
 
   it("cancellation persists a QUIET CANCELLED (no error) and cleans up the EC", async (testCtx) => {
@@ -233,7 +257,7 @@ describe("invoke-workflow-execution workflow (TestWorkflowEnvironment)", () => {
     // stigmer#282: a user cancel is a quiet terminal state — display
     // layers key error styling on status.error.
     expect(persistedStatuses[0]!.status.error).toBe("");
-    expect(deletedExecutionContexts).toEqual(["wfe-hold-cancel"]);
+    expectExecutionContextDeleted("wfe-hold-cancel");
   }, 30_000);
 
   it("pause then resume: persists PAUSED/IN_PROGRESS in order and relays reach the child in arrival order", async (testCtx) => {
@@ -271,7 +295,7 @@ describe("invoke-workflow-execution workflow (TestWorkflowEnvironment)", () => {
       "pause:take a break",
       "resume",
     ]);
-    expect(deletedExecutionContexts).toEqual(["wfe-hold-pr"]);
+    expectExecutionContextDeleted("wfe-hold-pr");
   }, 30_000);
 
   it("forwards relaySignal envelopes to the child's task-specific channel with the payload", async (testCtx) => {
@@ -309,7 +333,7 @@ describe("invoke-workflow-execution workflow (TestWorkflowEnvironment)", () => {
     await handle.result();
 
     expect(childEvents).toContain("recovery-mode");
-    expect(deletedExecutionContexts).toEqual(["wfe-hold-recovery"]);
+    expectExecutionContextDeleted("wfe-hold-recovery");
   }, 30_000);
 
   it("ignores a malformed relay envelope without failing the workflow", async (testCtx) => {
@@ -325,6 +349,6 @@ describe("invoke-workflow-execution workflow (TestWorkflowEnvironment)", () => {
     await handle.result();
 
     expect(childEvents.filter((event) => event !== "started")).toEqual([]);
-    expect(deletedExecutionContexts).toEqual(["wfe-hold-badrelay"]);
+    expectExecutionContextDeleted("wfe-hold-badrelay");
   }, 30_000);
 });

--- a/backend/services/stigmer-server/src/temporal/workflowexecution/workflows/invoke-workflow-execution.ts
+++ b/backend/services/stigmer-server/src/temporal/workflowexecution/workflows/invoke-workflow-execution.ts
@@ -498,7 +498,10 @@ async function updateStatusOnCancellation(executionId: string): Promise<void> {
  * exit path, cancellation included (Go's disconnected context). REGULAR
  * activity (Go's v1 arm — agentexecution's Go uses a local activity here;
  * this domain's Go does not, and the port follows ITS source). Errors are
- * logged, never propagated.
+ * logged, never propagated. A failed cleanup is never retried — no TTL
+ * sweep exists (oss#892; the retired Go server's log claimed one that
+ * never did) — the row stays encrypted at rest (oss#535) and the WARN is
+ * the operator's signal.
  */
 async function deleteExecutionContext(executionId: string): Promise<void> {
   await CancellationScope.nonCancellable(async () => {
@@ -508,10 +511,13 @@ async function deleteExecutionContext(executionId: string): Promise<void> {
       );
       log.info("ExecutionContext cleaned up", { executionId });
     } catch (error) {
-      log.warn("ExecutionContext cleanup failed (will rely on TTL backup)", {
-        executionId,
-        error: errorMessage(error),
-      });
+      log.warn(
+        "ExecutionContext cleanup failed — nothing retries it; any remaining row stays encrypted at rest (operator cleanup)",
+        {
+          executionId,
+          error: errorMessage(error),
+        },
+      );
     }
   });
 }


### PR DESCRIPTION
## Summary

Fixes the recurring `ci.stigmer-server` flake: the invoke-workflow orchestration tests pinned exactly-once counts on Temporal activities, which are at-least-once by contract. Also fences the cross-test recorder-contamination class found in the same CI log, and corrects the false "TTL backup" claim in both workflows' cleanup logs.

Closes #892

## Context

On main commit `2580be48b` (comments-only), the happy-path test saw `DeleteExecutionContext` record `['exec-1','exec-1']` against a `toEqual(['exec-1'])` pin. The failed run's log proves the mechanism: the final workflow task's first completion never committed, Temporal re-dispatched it, and the re-execution (not a replay — nothing was recorded) re-ran the local activity. Second occurrence of the flake the go-server-retirement register pre-recorded with the remedy "Recurs → relax the pin to at-least-once or fence the double-fire." Full forensics on #892.

## Changes

- **At-least-once-honest delete pins (7 sites, both twin files)**: `expectExecutionContextDeleted()` asserts the delete fired AND every recorded id belongs to this test's execution — a duplicate is legal; a foreign id is a test-isolation leak and fails loudly, with a comment carrying the semantics rationale.
- **Per-test execution identity (agentexecution file)**: `resetScript()` mints `exec-N` per test (adopting the workflowexecution twin's existing unique-id idiom), so a leaked workflow's pushes are attributable instead of colliding on a shared `exec-1`.
- **Test-window settle fence (agentexecution file)**: `afterEach` terminates and drains every workflow the test started before the script resets — the same CI log showed workflow `invoke-test-10` outliving its test ("test script exhausted" retries) and pushing its failure-path cleanup into test 11's recorder.
- **Honest cleanup-failure copy (both workflows + one lifecycle comment)**: the WARN claimed "will rely on TTL backup"; no TTL sweep exists — the delete module's own header says "nothing retries it later, so the WARN is the operator's signal." Copy now matches reality (rows stay encrypted at rest, oss#535). This closes the never-executed follow-up from the ExecutionContext port session, inherited from the retired Go server.

## Implementation notes

- The delete is a LOCAL activity in agentexecution and a REGULAR activity in workflowexecution (the Go-SDK history-shape contract) — both are at-least-once under the observed transient class (a completion RPC failing to commit), so both twins get the honest pin.
- Deliberate boundary, disclosed: the twin's phase-order pins (`[PAUSED, IN_PROGRESS]`, `[FAILED]`, `[CANCELLED]`) and child-event count pins stay STRICT. They pin load-bearing FIFO/count contracts where deduplication would mask real duplicate-send regressions; the trade is a theoretically possible rare flake over blindness to a real bug class. If one of those sites ever flakes with the same signature, this PR's helper is the pre-agreed disposition path.
- No behavior, wire, or history-shape change: log strings are not Temporal commands; the committed replay histories replay clean.

## Test plan

- `make build-ts-stubs` → `make test-server`: **1692/1692** across 124 files (baseline-exact), Node 22.23.2.
- `tsc --noEmit` clean.
- 10/10 loops of both twin test files, all green.

## Risks

- Test-only + log copy. Rollback is a revert. The settle fence adds ~0–2s per test file (terminates already-terminal workflows, which no-op).

## Checklist

- [x] Tests added/updated
- [x] Backward compatible
- [x] Docs: intent comments carry the at-least-once rationale in-file

Made with [Cursor](https://cursor.com)