### PR TITLE
feat(backend/stigmer-server): serve the web console from unified-port lane 4 (DD-012)

### DIFF
--- a/.github/workflows/ci.stigmer-server.yaml
+++ b/.github/workflows/ci.stigmer-server.yaml
@@ -24,11 +24,20 @@
 
 name: ci.stigmer-server
 
+# client-apps/web/nginx.conf rides the filter because it is a CONTRACT
+# input here since the console lane landed: the server's nginx-equivalence
+# test (src/transport/console/__tests__/) holds the lane's resolver to the
+# parsed nginx model, so a serving-rule change must run this gate in its
+# own PR, not redden main later. Route-tree changes need no filter entry —
+# the resolver implements the model generically, and unmodelled router
+# constructs already fail verify-web in the web PR itself.
 on:
   pull_request:
     paths:
       - "backend/services/stigmer-server/**"
       - "apis/stubs/ts/**"
+      - "client-apps/web/nginx.conf"
+      - "scripts/verify-static-export-routes.mjs"
       - "Makefile"
       - ".github/workflows/ci.stigmer-server.yaml"
   push:
@@ -36,6 +45,8 @@ on:
     paths:
       - "backend/services/stigmer-server/**"
       - "apis/stubs/ts/**"
+      - "client-apps/web/nginx.conf"
+      - "scripts/verify-static-export-routes.mjs"
       - "Makefile"
       - ".github/workflows/ci.stigmer-server.yaml"
 
@@ -74,6 +85,11 @@ jobs:
       - name: Install server dependencies
         working-directory: backend/services/stigmer-server
         run: npm ci
+
+      # The slim artifact ships the console's static export (DD-012);
+      # bundle-slim loud-fails without a built client-apps/web/out.
+      - name: Build the web console static export
+        run: make build-web
 
       - name: Typecheck
         working-directory: backend/services/stigmer-server
@@ -144,6 +160,11 @@ jobs:
       - name: Install server dependencies
         working-directory: backend/services/stigmer-server
         run: npm ci
+
+      # Same DD-012 requirement as the x64 job: the slim bundle stages the
+      # console export and loud-fails without it.
+      - name: Build the web console static export
+        run: make build-web
 
       - name: Build and boot-check the compiled dist
         working-directory: backend/services/stigmer-server

--- a/.github/workflows/release.npm-libs.yaml
+++ b/.github/workflows/release.npm-libs.yaml
@@ -283,6 +283,12 @@ jobs:
       - name: Build TS server
         run: make build-server
 
+      # The slim artifact ships the web console's static export (DD-012:
+      # console and server travel in ONE artifact, so no version skew can
+      # exist); bundle-slim loud-fails without a built client-apps/web/out.
+      - name: Build the web console static export
+        run: make build-web
+
       # Stamp the release version into the package manifest; the bundle
       # script propagates it into every generated slim manifest. The file:
       # lib deps are NOT pinned to registry versions — the slim bundle
@@ -315,7 +321,9 @@ jobs:
       # (nothing resolves from this checkout) must serve the transport AND
       # start all three Temporal workers from the pre-built workflow bundles
       # through the per-platform native bridge, against a real Temporal dev
-      # server, then shut down cleanly.
+      # server, answer the console lane's live-HTTP probes (config.json,
+      # documents, flight payloads, the 404 posture — DD-012), then shut
+      # down cleanly.
       - name: Set up Temporal CLI
         uses: temporalio/setup-temporal@v0
 

--- a/Makefile
+++ b/Makefile
@@ -462,8 +462,11 @@ test-conformance-execution: build-runner ## Run gRPC conformance execution suite
 	@echo "=== conformance: execution engine (local-execution) ==="
 	CONFORMANCE_TARGET=local-execution npm run test:execution -w @stigmer/conformance
 
+# build-web rides the dependency list because bundle-slim stages the web
+# console's static export into the artifact (DD-012) and loud-fails
+# without a built client-apps/web/out.
 .PHONY: smoke-cli-cutover
-smoke-cli-cutover: build-runner build-server ## Run the CLI E2E smoke: `stigmer up` against the packaged slim server artifact (needs `temporal` on PATH for speed)
+smoke-cli-cutover: build-runner build-server build-web ## Run the CLI E2E smoke: `stigmer up` against the packaged slim server artifact (needs `temporal` on PATH for speed)
 	@command -v node >/dev/null 2>&1 || { echo "error: node not found"; exit 1; }
 	@cd $(SERVER_DIR) && node scripts/bundle-slim.mjs
 	node scripts/smoke-cli-cutover.mjs

--- a/backend/services/stigmer-server/scripts/bundle-slim.mjs
+++ b/backend/services/stigmer-server/scripts/bundle-slim.mjs
@@ -27,6 +27,13 @@
  *      workflow-worker-thread.cjs             ← Temporal's sandbox thread entry;
  *                                               worker_threads needs a real file
  *      mappings.wasm                          ← source-map's lazy-loaded wasm
+ *      console/                               ← the web console's static export
+ *                                               (client-apps/web/out), served on
+ *                                               the unified port's lane 4 and
+ *                                               discovered as a main.js sibling
+ *                                               by src/transport/console/assets.ts
+ *                                               (DD-012: the console ships INSIDE
+ *                                               this artifact — no skew possible)
  *      node_modules/
  *        @stigmer/server-slim-<platform>      ← Temporal native bridge, pruned
  *                                               to ONE platform
@@ -114,6 +121,23 @@ const BUNDLED_MODULE_ASSETS = [
   { from: "source-map/lib/mappings.wasm", to: "mappings.wasm" },
 ];
 
+/**
+ * The web console's static export, built by `npm run build -w
+ * client-apps/web` (`make build-web`). Its ABSENCE fails the build: a
+ * slim artifact without the console would resurrect the version-skew
+ * failure mode DD-012 dissolved by shipping both in one artifact — and
+ * would ship a `stigmer up` that silently lost its console again.
+ */
+const CONSOLE_EXPORT_DIR = join(
+  serverRoot,
+  "..",
+  "..",
+  "..",
+  "client-apps",
+  "web",
+  "out",
+);
+
 /** node platform-arch → Temporal core-bridge release triple. */
 const CORE_BRIDGE_TRIPLES = {
   "darwin-arm64": "aarch64-apple-darwin",
@@ -181,7 +205,7 @@ const stampDefines = {
  * the artifact entirely.
  */
 async function buildWorkflowBundles() {
-  console.log("[1/5] Pre-building Temporal workflow bundles...");
+  console.log("[1/6] Pre-building Temporal workflow bundles...");
   const { bundleWorkflowCode } = await import("@temporalio/worker");
   for (const { entry, worker, sibling } of WORKFLOW_BUNDLES) {
     const workflowsPath = join(distDir, entry);
@@ -217,7 +241,7 @@ async function buildWorkflowBundles() {
  * is patched to point at it (see the plugin below). Runner recipe verbatim.
  */
 async function buildWorkerThreadBundle() {
-  console.log("[2/5] Bundling Temporal workflow worker-thread entry...");
+  console.log("[2/6] Bundling Temporal workflow worker-thread entry...");
   await build({
     entryPoints: [
       join(
@@ -335,7 +359,7 @@ globalThis.__stigmerWorkflowWorkerThreadPath = () => __stigmerJoin(__dirname, "w
 `;
 
 async function buildMainBundle() {
-  console.log("[3/5] Bundling server entry (dist/main.js)...");
+  console.log("[3/6] Bundling server entry (dist/main.js)...");
   const result = await build({
     entryPoints: [join(distDir, "main.js")],
     outfile: join(outDir, "main.js"),
@@ -510,7 +534,38 @@ function metaPackageJson() {
   };
 }
 
-// ─── Step 4: Stage node_modules for the self-contained shape ────────────────
+// ─── Step 4: Stage the web console's static export ──────────────────────────
+
+/**
+ * Copies client-apps/web/out into dist-slim/console/, where the console
+ * lane's asset discovery (src/transport/console/assets.ts) finds it as a
+ * main.js sibling. The two sanity files are the lane's own load-bearing
+ * documents: index.html (the root route) and 404.html (the not-found
+ * posture — nginx.conf's error_page and the lane both serve it).
+ */
+function stageConsoleExport() {
+  console.log("[4/6] Staging web console static export...");
+  if (!existsSync(join(CONSOLE_EXPORT_DIR, "index.html"))) {
+    fail(
+      `web console export not found at ${CONSOLE_EXPORT_DIR} — ` +
+        "run `npm run build -w client-apps/web` (make build-web) first. " +
+        "The console ships INSIDE this artifact (DD-012); an artifact " +
+        "without it would silently lose `stigmer up`'s web console.",
+    );
+  }
+  if (!existsSync(join(CONSOLE_EXPORT_DIR, "404.html"))) {
+    fail(
+      `web console export at ${CONSOLE_EXPORT_DIR} has no 404.html — ` +
+        "the export looks partial; rebuild with `npm run build -w client-apps/web`.",
+    );
+  }
+  cpSync(CONSOLE_EXPORT_DIR, join(outDir, "console"), {
+    recursive: true,
+    dereference: true,
+  });
+}
+
+// ─── Step 5: Stage node_modules for the self-contained shape ────────────────
 
 /**
  * Unlike the runner, the server has zero JS runtime externals — everything
@@ -521,7 +576,7 @@ function metaPackageJson() {
  * exactly the failure verify-slim-artifact.mjs exists to catch.
  */
 function stageSelfContained(platform) {
-  console.log("[4/5] Staging native bridge packages...");
+  console.log("[5/6] Staging native bridge packages...");
   const stagedRoot = join(outDir, "node_modules");
   const staged = new Set();
 
@@ -585,10 +640,13 @@ const META_PACKAGE_FILES = [
   ...WORKFLOW_BUNDLES.map(({ sibling }) => sibling),
   "workflow-worker-thread.cjs",
   "mappings.wasm",
+  // The console export rides the meta package (DD-012): it is platform-
+  // independent, so it ships once here, never in the platform packages.
+  "console",
 ];
 
 function emitNpmPackages() {
-  console.log("[5/5] Emitting npm package directories...");
+  console.log("[6/6] Emitting npm package directories...");
   rmSync(pkgsDir, { recursive: true, force: true });
 
   const metaDir = join(pkgsDir, "server-slim");
@@ -605,7 +663,8 @@ function emitNpmPackages() {
       );
       writeFileSync(dest, code);
     } else {
-      cpSync(src, dest);
+      // recursive covers the console/ directory entry; a no-op for files.
+      cpSync(src, dest, { recursive: true });
     }
   }
   writeFileSync(
@@ -684,6 +743,7 @@ mkdirSync(outDir, { recursive: true });
 await buildWorkflowBundles();
 await buildWorkerThreadBundle();
 await buildMainBundle();
+stageConsoleExport();
 stageSelfContained(platform);
 if (emitPackages) {
   emitNpmPackages();

--- a/backend/services/stigmer-server/scripts/verify-slim-artifact.mjs
+++ b/backend/services/stigmer-server/scripts/verify-slim-artifact.mjs
@@ -15,7 +15,16 @@
  *   1. the "listening" transport log,
  *   2. "All Temporal workers started" — all three workers created from the
  *      pre-built bundles through the native bridge,
- *   3. SIGTERM → clean exit 0.
+ *   3. the console lane answers over live HTTP (DD-012; the #24 lesson —
+ *      packaging gaps are invisible at PR time unless a gate exercises
+ *      the artifact): /config.json synthesizes with a Host-derived
+ *      apiUrl, the root and a dynamic deep link serve documents, an
+ *      unknown URL serves the export's 404 page WITH a 404 status, and a
+ *      flight .txt request serves its placeholder payload,
+ *   4. SIGTERM → clean exit 0.
+ *
+ * The console assets themselves are asserted present in the isolated copy
+ * before boot — a missing console/ is a packaging failure by itself.
  *
  * Usage: node scripts/verify-slim-artifact.mjs
  *        (expects a Temporal dev server on TEMPORAL_HOST_PORT, default
@@ -48,6 +57,18 @@ if (!existsSync(join(slimDir, "main.js"))) {
 // so a missing staged dependency fails HERE instead of in a user's install.
 const isolated = mkdtempSync(join(tmpdir(), "verify-slim-artifact-"));
 cpSync(slimDir, isolated, { recursive: true });
+
+// Console assets must ride the artifact (DD-012): assert the lane's two
+// load-bearing documents before boot so a staging regression names itself.
+for (const consoleFile of ["console/index.html", "console/404.html"]) {
+  if (!existsSync(join(isolated, consoleFile))) {
+    console.error(
+      `verify-slim-artifact: ${consoleFile} missing from the slim artifact — ` +
+        "the console staging step (bundle-slim.mjs stageConsoleExport) did not run or was gutted",
+    );
+    process.exit(1);
+  }
+}
 
 const scratch = mkdtempSync(join(tmpdir(), "verify-slim-scratch-"));
 
@@ -89,20 +110,99 @@ child.on("error", (err) => {
   process.exit(1);
 });
 
+/**
+ * Live-HTTP console probes (GRPC_PORT=0 binds ephemeral; the bound port
+ * rides the structured "stigmer-server listening" log line). Each probe
+ * asserts the status and a body/header property that only the real lane
+ * produces — a 200 with the wrong document would pass a status-only check.
+ */
+async function probeConsole() {
+  const portMatch = stderr
+    .split("\n")
+    .find((line) => line.includes("stigmer-server listening"))
+    ?.match(/"port":\s*(\d+)/);
+  if (!portMatch) {
+    throw new Error(
+      `could not parse the bound port from the listening log line`,
+    );
+  }
+  const baseUrl = `http://127.0.0.1:${portMatch[1]}`;
+
+  const config = await fetch(`${baseUrl}/config.json`);
+  if (config.status !== 200) {
+    throw new Error(`/config.json answered ${config.status}`);
+  }
+  const configBody = await config.json();
+  if (configBody.authMode !== "disabled" || configBody.apiUrl !== baseUrl) {
+    throw new Error(
+      `/config.json synthesized wrong (authMode=${configBody.authMode}, apiUrl=${configBody.apiUrl}, expected apiUrl ${baseUrl})`,
+    );
+  }
+
+  const root = await fetch(`${baseUrl}/`);
+  if (
+    root.status !== 200 ||
+    !(root.headers.get("content-type") ?? "").includes("text/html")
+  ) {
+    throw new Error(`/ answered ${root.status} ${root.headers.get("content-type")}`);
+  }
+
+  // A dynamic deep link and its flight payload: /sessions/[id] is a core
+  // route; if the route tree ever drops it, update this probe with it.
+  const deepLink = await fetch(`${baseUrl}/sessions/zz-verify-probe`);
+  if (
+    deepLink.status !== 200 ||
+    !(deepLink.headers.get("content-type") ?? "").includes("text/html")
+  ) {
+    throw new Error(
+      `dynamic deep link answered ${deepLink.status} ${deepLink.headers.get("content-type")} — the placeholder rewrite is not serving`,
+    );
+  }
+  const flight = await fetch(`${baseUrl}/sessions/zz-verify-probe.txt`);
+  if (flight.status !== 200) {
+    throw new Error(
+      `flight payload answered ${flight.status} — the RSC .txt rewrite is not serving`,
+    );
+  }
+
+  const notFound = await fetch(`${baseUrl}/zz-no-such-route`);
+  if (
+    notFound.status !== 404 ||
+    !(notFound.headers.get("content-type") ?? "").includes("text/html")
+  ) {
+    throw new Error(
+      `unknown URL answered ${notFound.status} ${notFound.headers.get("content-type")} — expected the export's 404 page WITH a 404 status`,
+    );
+  }
+  console.log("verify-slim-artifact: console lane probes passed");
+}
+
 child.stderr.on("data", (chunk) => {
   stderr += String(chunk);
   if (!sawListening && stderr.includes("listening")) sawListening = true;
   if (!sawWorkers && stderr.includes(WORKERS_MARKER)) sawWorkers = true;
   if (sawListening && sawWorkers && shutdownTimer === null) {
     clearTimeout(timer);
-    child.kill("SIGTERM");
+    // Arm the deadline over probes + shutdown so a hung probe fails the
+    // job instead of hanging it (the same posture as the boot timeout).
     shutdownTimer = setTimeout(() => {
       console.error(
-        `verify-slim-artifact: shutdown did not complete within ${SHUTDOWN_TIMEOUT_MS}ms after SIGTERM\n${stderr}`,
+        `verify-slim-artifact: probes/shutdown did not complete within ${SHUTDOWN_TIMEOUT_MS}ms\n${stderr}`,
       );
       child.kill("SIGKILL");
       process.exit(1);
     }, SHUTDOWN_TIMEOUT_MS);
+    probeConsole()
+      .then(() => {
+        child.kill("SIGTERM");
+      })
+      .catch((error) => {
+        console.error(
+          `verify-slim-artifact: console probe failed — ${error instanceof Error ? error.message : String(error)}\n${stderr}`,
+        );
+        child.kill("SIGKILL");
+        process.exit(1);
+      });
   }
 });
 

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -93,6 +93,8 @@ import { newWorkflowExecutionConfigFromEnv } from "../domain/workflowexecution/t
 import { newWorkflowExecutionEngineStateProvider } from "../temporal/workflowexecution/engine-client.js";
 import { newWorkflowExecutionWorkerFactory } from "../temporal/workflowexecution/worker.js";
 import { HealthState, registerHealthService } from "../transport/health.js";
+import { resolveConsoleAssets } from "../transport/console/assets.js";
+import { createConsoleLane } from "../transport/console/handler.js";
 import { createRegistryLanes } from "../transport/registry/lanes.js";
 import { createUnifiedPortServer } from "../transport/server.js";
 import type { ServerConfig } from "./config.js";
@@ -357,6 +359,27 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     skillArtifactStorage,
     logger,
   );
+  // The console lane (lane 4, DD-012): present only when a static export
+  // is bundled (slim artifacts) or configured (STIGMER_CONSOLE_DIR) —
+  // "not bundled" is a modeled state, logged once, with the router
+  // behaving exactly as it did before the lane existed.
+  const consoleAssets = resolveConsoleAssets(config.consoleDir, logger);
+  if (consoleAssets !== undefined) {
+    logger.info("web console serving from unified port", {
+      dir: consoleAssets.root,
+      files: consoleAssets.fileCount,
+    });
+  } else {
+    logger.debug("no web console export bundled; console lane disabled");
+  }
+  const consoleLane =
+    consoleAssets !== undefined
+      ? createConsoleLane({
+          assets: consoleAssets,
+          grpcPort: options.portOverride ?? config.grpcPort,
+          logger,
+        })
+      : undefined;
   // The search read side (#14): the 13-kind extractor registry, the query
   // store over the driver's index read (OD-3 — no DB() escape hatch), and
   // the CQRS handler. Registry validation is warn-only, Go server.go:509's
@@ -640,6 +663,7 @@ export function composeServer(options: ComposeOptions): ComposedServer {
     taskKindRegistryLane: registryLanes.taskKindRegistryLane,
     modelRegistryLane: registryLanes.modelRegistryLane,
     skillTransferLane,
+    consoleLane,
   });
 
   return {

--- a/backend/services/stigmer-server/src/boot/config.ts
+++ b/backend/services/stigmer-server/src/boot/config.ts
@@ -110,6 +110,15 @@ export interface ServerConfig {
    * idiom, Go config.go:52-58).
    */
   readonly skillTransferBaseUrl: string;
+  /**
+   * Web console asset directory override (STIGMER_CONSOLE_DIR). Empty —
+   * the default — discovers the export as a `console/` sibling of the
+   * running bundle (slim artifacts ship it there; dev dist trees have
+   * none, so dev/test servers boot without the console lane). The
+   * override serves a local `client-apps/web/out` build in development
+   * and pins fixture exports in tests.
+   */
+  readonly consoleDir: string;
 }
 
 // The bundled "Stigmer Local" OAuth App credentials (callback:
@@ -205,6 +214,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
       DEFAULT_GITHUB_OAUTH_CLIENT_SECRET,
     ),
     oauthRedirectUri: envString(env, "STIGMER_OAUTH_REDIRECT_URI", ""),
+    consoleDir: envString(env, "STIGMER_CONSOLE_DIR", ""),
   };
 }
 

--- a/backend/services/stigmer-server/src/transport/__tests__/server.test.ts
+++ b/backend/services/stigmer-server/src/transport/__tests__/server.test.ts
@@ -10,6 +10,12 @@
  *   - the skill-transfer prefix is a seam: with no handler installed it
  *     falls through to 404 exactly like an unknown path;
  *   - shutdown drains promptly with idle keepalive clients connected.
+ *
+ * This suite boots WITHOUT a console lane, so its arms also pin the
+ * lane-absent posture (no bundled export → the router behaves exactly as
+ * before lane 4 existed). The with-console behavior — including the guard
+ * that keeps RPC and /v1/* flowing to the adapter — is pinned in
+ * console/__tests__/handler.test.ts through this same composed server.
  */
 import { createClient } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";

--- a/backend/services/stigmer-server/src/transport/console/__tests__/handler.test.ts
+++ b/backend/services/stigmer-server/src/transport/console/__tests__/handler.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Console lane HTTP contract, proven through the real unified-port server
+ * against a fixture export in a temp directory:
+ *
+ *   - documents, flight payloads, redirects, and the 404 posture arrive
+ *     with the right status, Content-Type, and Cache-Control;
+ *   - /config.json is synthesized per request with a Host-derived apiUrl;
+ *   - the guard: RPC (POST and service-shaped GET), /v1/* paths, and
+ *     OPTIONS preflights flow exactly as they do WITHOUT the lane — the
+ *     wire-invisibility half of the P3 acceptance;
+ *   - both protocol stacks serve the lane (the demux routes browsers to
+ *     HTTP/1.1, but HTTP/2 clients share the same lane router);
+ *   - asset discovery models "not bundled" as absence, not an error.
+ */
+import { createClient } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import {
+  Health,
+  HealthCheckResponse_ServingStatus as ServingStatus,
+} from "@stigmer/protos/grpc/health/v1/health_pb";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { connect as http2Connect } from "node:http2";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createLogger } from "../../../boot/logger.js";
+import { HealthState, registerHealthService } from "../../health.js";
+import {
+  createUnifiedPortServer,
+  type UnifiedPortServer,
+} from "../../server.js";
+import { resolveConsoleAssets } from "../assets.js";
+import { createConsoleLane } from "../handler.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+/** The fixture export: path → content. Mirrors client-apps/web/out's shape. */
+const FIXTURE_FILES: Record<string, string> = {
+  "index.html": "<html>app shell</html>",
+  "404.html": "<html>not found page</html>",
+  "embed.js": "// embed loader",
+  "conversations.html": "<html>conversations</html>",
+  "conversations.txt": "flight:conversations",
+  "sessions/__placeholder__.html": "<html>session detail</html>",
+  "sessions/__placeholder__.txt": "flight:session",
+  "sessions/__placeholder__/__next.sessions.txt": "flight:nested-session",
+  "_next/static/chunks/app-1a2b3c.js": "// hashed chunk",
+};
+
+let fixtureRoot: string;
+let server: UnifiedPortServer;
+let port: number;
+let baseUrl: string;
+
+beforeAll(async () => {
+  fixtureRoot = mkdtempSync(path.join(tmpdir(), "console-lane-fixture-"));
+  for (const [file, content] of Object.entries(FIXTURE_FILES)) {
+    const target = path.join(fixtureRoot, ...file.split("/"));
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, content);
+  }
+
+  const assets = resolveConsoleAssets(fixtureRoot, silentLogger);
+  if (assets === undefined) {
+    throw new Error("fixture export was not discovered");
+  }
+  const healthState = new HealthState();
+  healthState.setOverall(ServingStatus.SERVING);
+  server = createUnifiedPortServer({
+    logger: silentLogger,
+    routes: (router) => registerHealthService(router, healthState),
+    interceptors: [],
+    taskKindRegistryLane: (_request, response) => {
+      response.setHeader("x-lane", "task-kind");
+      response.end("{}");
+    },
+    modelRegistryLane: (_request, response) => {
+      response.setHeader("x-lane", "model");
+      response.end("{}");
+    },
+    consoleLane: createConsoleLane({
+      assets,
+      grpcPort: 7234,
+      logger: silentLogger,
+    }),
+  });
+  port = await server.listen(0, "127.0.0.1");
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+describe("document serving", () => {
+  it("serves the root document with the app shell and no-cache", async () => {
+    const response = await fetch(`${baseUrl}/`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(response.headers.get("cache-control")).toBe("no-cache");
+    expect(await response.text()).toBe(FIXTURE_FILES["index.html"]);
+  });
+
+  it("serves a dynamic deep link its placeholder document", async () => {
+    const response = await fetch(`${baseUrl}/sessions/ses_abc123`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(
+      FIXTURE_FILES["sessions/__placeholder__.html"],
+    );
+  });
+
+  it("serves RSC flight payloads for dynamic routes as text/plain", async () => {
+    const flat = await fetch(`${baseUrl}/sessions/ses_abc123.txt`);
+    expect(flat.status).toBe(200);
+    expect(flat.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(await flat.text()).toBe("flight:session");
+
+    const nested = await fetch(
+      `${baseUrl}/sessions/ses_abc123/__next.sessions.txt`,
+    );
+    expect(nested.status).toBe(200);
+    expect(await nested.text()).toBe("flight:nested-session");
+  });
+
+  it("serves unknown URLs the real 404 page WITH a 404 status", async () => {
+    const response = await fetch(`${baseUrl}/zz-definitely/zz-not/zz-here`);
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).toBe(
+      "text/html; charset=utf-8",
+    );
+    expect(await response.text()).toBe(FIXTURE_FILES["404.html"]);
+  });
+
+  it("301s trailing slashes to the canonical URL, query intact", async () => {
+    const response = await fetch(`${baseUrl}/conversations/?tab=all`, {
+      redirect: "manual",
+    });
+    expect(response.status).toBe(301);
+    expect(response.headers.get("location")).toBe("/conversations?tab=all");
+  });
+
+  it("marks hashed build assets immutable and the embed loader short-lived", async () => {
+    const chunk = await fetch(`${baseUrl}/_next/static/chunks/app-1a2b3c.js`);
+    expect(chunk.status).toBe(200);
+    expect(chunk.headers.get("cache-control")).toBe(
+      "public, max-age=31536000, immutable",
+    );
+    const embed = await fetch(`${baseUrl}/embed.js`);
+    expect(embed.headers.get("cache-control")).toBe("public, max-age=300");
+  });
+
+  it("answers HEAD with the document's headers and no body", async () => {
+    const response = await fetch(`${baseUrl}/conversations`, {
+      method: "HEAD",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-length")).toBe(
+      String(FIXTURE_FILES["conversations.html"]!.length),
+    );
+    expect(await response.text()).toBe("");
+  });
+
+  it("rejects malformed percent-escapes with the 404 page", async () => {
+    const response = await fetch(`${baseUrl}/%zz`);
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe(FIXTURE_FILES["404.html"]);
+  });
+});
+
+describe("/config.json synthesis", () => {
+  it("derives apiUrl from the request Host and forbids caching", async () => {
+    const response = await fetch(`${baseUrl}/config.json`);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("cache-control")).toBe(
+      "no-cache, no-store, must-revalidate",
+    );
+    expect(await response.json()).toEqual({
+      apiUrl: `http://127.0.0.1:${port}`,
+      appUrl: "",
+      authMode: "disabled",
+      oidcIssuer: "",
+      oidcClientId: "",
+      oidcAudience: "",
+    });
+  });
+});
+
+describe("the guard: RPC and /v1/* flow exactly as without the lane", () => {
+  it("keeps the adapter's terse 404 for unknown /v1/proxy/* (CW-10)", async () => {
+    const response = await fetch(`${baseUrl}/v1/proxy/does-not-exist`);
+    expect(response.status).toBe(404);
+    expect(response.headers.get("content-type")).not.toBe(
+      "text/html; charset=utf-8",
+    );
+  });
+
+  it("leaves service-shaped GETs to the adapter, not the 404 page", async () => {
+    const response = await fetch(`${baseUrl}/grpc.health.v1.Health/Check`);
+    expect(response.headers.get("content-type")).not.toBe(
+      "text/html; charset=utf-8",
+    );
+  });
+
+  it("answers RPC preflights on console-looking paths (CORS untouched)", async () => {
+    const response = await fetch(`${baseUrl}/conversations`, {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:3000",
+        "Access-Control-Request-Method": "POST",
+      },
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      "http://localhost:3000",
+    );
+  });
+
+  it("serves native gRPC through the adapter with the lane installed", async () => {
+    const client = createClient(Health, createGrpcTransport({ baseUrl }));
+    const check = await client.check({});
+    expect(check.status).toBe(ServingStatus.SERVING);
+  });
+});
+
+describe("HTTP/2 stack", () => {
+  it("serves console documents over a prior-knowledge h2c session", async () => {
+    const session = http2Connect(baseUrl);
+    try {
+      const { status, body } = await new Promise<{
+        status: number;
+        body: string;
+      }>((resolve, reject) => {
+        session.on("error", reject);
+        const stream = session.request({
+          ":method": "GET",
+          ":path": "/sessions/ses_abc123",
+        });
+        let status = 0;
+        stream.on("response", (headers) => {
+          status = Number(headers[":status"]);
+        });
+        const chunks: Buffer[] = [];
+        stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+        stream.on("end", () =>
+          resolve({ status, body: Buffer.concat(chunks).toString("utf8") }),
+        );
+        stream.on("error", reject);
+      });
+      expect(status).toBe(200);
+      expect(body).toBe(FIXTURE_FILES["sessions/__placeholder__.html"]);
+    } finally {
+      session.close();
+    }
+  });
+});
+
+describe("asset discovery", () => {
+  it("models a missing or empty export as absence, not an error", () => {
+    expect(
+      resolveConsoleAssets(
+        path.join(fixtureRoot, "zz-does-not-exist"),
+        silentLogger,
+      ),
+    ).toBeUndefined();
+    const empty = mkdtempSync(path.join(tmpdir(), "console-empty-"));
+    try {
+      expect(resolveConsoleAssets(empty, silentLogger)).toBeUndefined();
+    } finally {
+      rmSync(empty, { recursive: true, force: true });
+    }
+  });
+});

--- a/backend/services/stigmer-server/src/transport/console/__tests__/nginx-equivalence.test.ts
+++ b/backend/services/stigmer-server/src/transport/console/__tests__/nginx-equivalence.test.ts
@@ -1,0 +1,144 @@
+/**
+ * The one-contract gate: proves the console resolver serves every real
+ * route to the SAME document as the nginx model in
+ * scripts/verify-static-export-routes.mjs — the module that already holds
+ * nginx.conf and the App Router route tree together in CI. With this test
+ * in the server suite, the repo's two serving implementations (the cloud
+ * nginx config and this server's lane 4) cannot drift apart silently: a
+ * new route, a changed nginx rule, or a resolver edit that lands them on
+ * different documents fails here by name.
+ *
+ * Hermetic by construction: the export file set is SYNTHESIZED from the
+ * enumerated routes via the gate's own exportFileOf (each page's .html
+ * plus its .txt flight twin plus /404.html — the gate's out-less mode),
+ * so this test never needs a built client-apps/web/out.
+ *
+ * The RSC flight arms assert against the derived twins directly (the
+ * nginx model is NOT the oracle there: nginx never handled flight
+ * rewrites — the disclosed cloud-side gap this lane deliberately fixes).
+ */
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildServerModel,
+  enumerateRoutes,
+  exportFileOf,
+  parseNginxConfig,
+  representativeUrlOf,
+  resolveRequest,
+} from "../../../../../../../scripts/verify-static-export-routes.mjs";
+import { buildConsoleFileIndex, resolveConsoleRequest } from "../resolver.js";
+
+const repoRoot = new URL("../../../../../../../", import.meta.url);
+const webAppDir = fileURLToPath(new URL("client-apps/web/src/app", repoRoot));
+const nginxConfPath = fileURLToPath(
+  new URL("client-apps/web/nginx.conf", repoRoot),
+);
+
+const routes = enumerateRoutes(webAppDir);
+const model = buildServerModel(
+  parseNginxConfig(readFileSync(nginxConfPath, "utf8")),
+);
+
+// The gate's own synthesis (verifyRoutes): every page's .html, its .txt
+// flight twin, and the export's always-emitted 404 document.
+const files = new Set<string>();
+for (const route of routes) {
+  const html = exportFileOf(route);
+  files.add(html);
+  files.add(html.replace(/\.html$/, ".txt"));
+}
+if (model.errorPage) {
+  files.add(model.errorPage.uri);
+}
+const index = buildConsoleFileIndex(files);
+
+/**
+ * The document the TS resolver ultimately serves for a URL: redirects are
+ * followed (the browser re-requests), notFound maps to the error page —
+ * the same terminal-document view resolveRequest answers for nginx.
+ */
+function tsResolverDocumentOf(url: string): string | null {
+  let pathname = url;
+  for (let hop = 0; hop < 6; hop++) {
+    const resolution = resolveConsoleRequest(pathname, index);
+    switch (resolution.kind) {
+      case "file":
+        return resolution.file;
+      case "redirect":
+        pathname = resolution.location;
+        continue;
+      case "notFound":
+        return model.errorPage?.uri ?? null;
+      default: {
+        const exhaustive: never = resolution;
+        throw new Error(`unhandled resolution ${String(exhaustive)}`);
+      }
+    }
+  }
+  throw new Error(`redirect loop resolving "${url}"`);
+}
+
+describe("console resolver ≡ nginx model (the route-tree equivalence)", () => {
+  it("enumerated a non-trivial route tree", () => {
+    expect(routes.length).toBeGreaterThan(10);
+    expect(routes.some((route) => route.segments.some((s) => s.dynamic))).toBe(
+      true,
+    );
+  });
+
+  it("serves every route's representative URL to the same document as nginx", () => {
+    for (const route of routes) {
+      const url = representativeUrlOf(route);
+      const nginxDocument = resolveRequest(model, url, files);
+      expect(tsResolverDocumentOf(url), `route ${route.url} (${url})`).toBe(
+        nginxDocument,
+      );
+      // And both must be the route's own export — anything else is the
+      // blank-page class the gate exists to prevent.
+      expect(nginxDocument, `route ${route.url} (${url})`).toBe(
+        exportFileOf(route),
+      );
+    }
+  });
+
+  it("canonicalizes trailing slashes to the same document as nginx", () => {
+    for (const route of routes) {
+      if (route.segments.length === 0) continue; // "/" has no slashless twin
+      const url = `${representativeUrlOf(route)}/`;
+      expect(tsResolverDocumentOf(url), `route ${route.url} (${url})`).toBe(
+        resolveRequest(model, url, files),
+      );
+    }
+  });
+
+  it("lands unknown URLs on the error document, like nginx, never the app shell", () => {
+    for (const url of [
+      "/zz-no-such-route",
+      "/zz-no/zz-such",
+      "/zz-no/zz-such/zz-route",
+      "/zz-no/zz-such/zz-route/zz-deep",
+    ]) {
+      const nginxDocument = resolveRequest(model, url, files);
+      expect(nginxDocument, url).not.toBe("/index.html");
+      expect(tsResolverDocumentOf(url), url).toBe(nginxDocument);
+    }
+  });
+});
+
+describe("RSC flight payloads across the whole route tree", () => {
+  it("serves every route's flight request its export's .txt twin", () => {
+    for (const route of routes) {
+      if (route.segments.length === 0) continue; // the root's payloads are literal __next.* files
+      const url = `${representativeUrlOf(route)}.txt`;
+      const expected = exportFileOf(route).replace(/\.html$/, ".txt");
+      const resolution = resolveConsoleRequest(url, index);
+      expect(
+        resolution.kind === "file" ? resolution.file : resolution.kind,
+        `route ${route.url} (${url})`,
+      ).toBe(expected);
+    }
+  });
+});

--- a/backend/services/stigmer-server/src/transport/console/__tests__/resolver.test.ts
+++ b/backend/services/stigmer-server/src/transport/console/__tests__/resolver.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Pins the console resolver's two contracts against a realistic export
+ * shape (the file inventory mirrors client-apps/web/out):
+ *
+ *   - the PAGE contract: nginx.conf's try_files chain — literal, .html
+ *     sibling, directory index, placeholder candidates most-literal-first,
+ *     trailing-slash canonicalization, 404 posture (the full route-tree
+ *     equivalence against the parsed nginx model lives in
+ *     nginx-equivalence.test.ts; these arms pin the semantics readably);
+ *   - the RSC FLIGHT contract: the retired Go handler's `.txt` rewrites
+ *     (page-level twins and nested `__next.*.txt` payloads), including the
+ *     two-dynamic-segment routes the Go handler's single-substitution
+ *     loop could not resolve.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildConsoleFileIndex,
+  resolveConsoleRequest,
+  type ConsoleResolution,
+} from "../resolver.js";
+
+// The realistic export inventory: static pages, one- and two-dynamic-
+// segment routes, a literal-beats-dynamic sibling pair under /workflows,
+// root-level RSC payloads, and build assets.
+const index = buildConsoleFileIndex([
+  "/index.html",
+  "/index.txt",
+  "/404.html",
+  "/embed.js",
+  "/Icon-bw.svg",
+  "/__next._tree.txt",
+  "/conversations.html",
+  "/conversations.txt",
+  "/auth/github/callback.html",
+  "/sessions/__placeholder__.html",
+  "/sessions/__placeholder__.txt",
+  "/sessions/__placeholder__/__next.sessions.txt",
+  "/workflows/executions/__placeholder__.html",
+  "/workflows/executions/__placeholder__.txt",
+  "/workflows/__placeholder__/__placeholder__.html",
+  "/workflows/__placeholder__/__placeholder__.txt",
+  "/workflows/__placeholder__/__placeholder__/__next.workflows.txt",
+  "/_next/static/chunks/app-1a2b3c.js",
+]);
+
+function resolve(pathname: string): ConsoleResolution {
+  return resolveConsoleRequest(pathname, index);
+}
+
+function servedFile(pathname: string): string | null {
+  const resolution = resolve(pathname);
+  return resolution.kind === "file" ? resolution.file : null;
+}
+
+describe("page contract (the nginx chain)", () => {
+  it("serves the root route through the directory index", () => {
+    expect(servedFile("/")).toBe("/index.html");
+  });
+
+  it("serves literal files directly", () => {
+    expect(servedFile("/embed.js")).toBe("/embed.js");
+    expect(servedFile("/Icon-bw.svg")).toBe("/Icon-bw.svg");
+    expect(servedFile("/404.html")).toBe("/404.html");
+  });
+
+  it("serves static routes via the .html sibling", () => {
+    expect(servedFile("/conversations")).toBe("/conversations.html");
+    expect(servedFile("/auth/github/callback")).toBe(
+      "/auth/github/callback.html",
+    );
+  });
+
+  it("resolves one trailing dynamic segment to its placeholder document", () => {
+    expect(servedFile("/sessions/ses_abc123")).toBe(
+      "/sessions/__placeholder__.html",
+    );
+  });
+
+  it("prefers the more-literal candidate: a literal segment beats a dynamic one", () => {
+    // /workflows/executions/[id] and /workflows/[org]/[slug] are both
+    // three segments — the filesystem, not the segment count, decides
+    // (the F-12 lesson nginx.conf documents).
+    expect(servedFile("/workflows/executions/wfe_123")).toBe(
+      "/workflows/executions/__placeholder__.html",
+    );
+    expect(servedFile("/workflows/acme/my-flow")).toBe(
+      "/workflows/__placeholder__/__placeholder__.html",
+    );
+  });
+
+  it("serves a literal placeholder request through the .html sibling", () => {
+    expect(servedFile("/sessions/__placeholder__")).toBe(
+      "/sessions/__placeholder__.html",
+    );
+  });
+
+  it("301s trailing slashes to the canonical URL, one strip per hop", () => {
+    expect(resolve("/conversations/")).toEqual({
+      kind: "redirect",
+      location: "/conversations",
+    });
+    // nginx's ^(.+)/$ strips exactly one slash; the client walks the rest.
+    expect(resolve("/conversations//")).toEqual({
+      kind: "redirect",
+      location: "/conversations/",
+    });
+    // "/" has no slashless twin and never redirects.
+    expect(resolve("/").kind).toBe("file");
+  });
+
+  it("answers notFound for unknown URLs at every depth", () => {
+    expect(resolve("/zz-no-such-route").kind).toBe("notFound");
+    expect(resolve("/zz-no/zz-such/zz-route/zz-deep").kind).toBe("notFound");
+    // Two placeholder candidates are exhaustive: three trailing dynamic
+    // segments cannot resolve (MAX_DYNAMIC_SEGMENTS in the routing gate).
+    expect(resolve("/workflows/a/b/c").kind).toBe("notFound");
+  });
+
+  it("never resolves top-level paths through placeholders", () => {
+    // The nginx regexes require a non-empty static prefix.
+    expect(resolve("/ses_abc123").kind).toBe("notFound");
+  });
+
+  it("serves /_next/ assets literally and nothing else", () => {
+    expect(servedFile("/_next/static/chunks/app-1a2b3c.js")).toBe(
+      "/_next/static/chunks/app-1a2b3c.js",
+    );
+    expect(resolve("/_next/static/chunks/missing.js").kind).toBe("notFound");
+  });
+
+  it("cannot be traversed out of the index", () => {
+    expect(resolve("/../etc/passwd").kind).toBe("notFound");
+    expect(resolve("/sessions/../../secret").kind).toBe("notFound");
+  });
+});
+
+describe("RSC flight contract (the Go handler's rewrites)", () => {
+  it("serves static-route flight payloads directly", () => {
+    expect(servedFile("/conversations.txt")).toBe("/conversations.txt");
+    expect(servedFile("/__next._tree.txt")).toBe("/__next._tree.txt");
+  });
+
+  it("rewrites a dynamic route's flight payload to the placeholder twin", () => {
+    expect(servedFile("/sessions/ses_abc123.txt")).toBe(
+      "/sessions/__placeholder__.txt",
+    );
+  });
+
+  it("rewrites two-dynamic-segment flight payloads (beyond the Go handler)", () => {
+    expect(servedFile("/workflows/acme/my-flow.txt")).toBe(
+      "/workflows/__placeholder__/__placeholder__.txt",
+    );
+    expect(servedFile("/workflows/executions/wfe_123.txt")).toBe(
+      "/workflows/executions/__placeholder__.txt",
+    );
+  });
+
+  it("rewrites nested __next.*.txt payloads into the placeholder directory", () => {
+    expect(servedFile("/sessions/ses_abc123/__next.sessions.txt")).toBe(
+      "/sessions/__placeholder__/__next.sessions.txt",
+    );
+    expect(servedFile("/workflows/acme/my-flow/__next.workflows.txt")).toBe(
+      "/workflows/__placeholder__/__placeholder__/__next.workflows.txt",
+    );
+  });
+
+  it("answers notFound for flight requests on unknown routes", () => {
+    expect(resolve("/zz-nope/zz-nope.txt").kind).toBe("notFound");
+    expect(resolve("/zz-nope/zz-nope/__next.x.txt").kind).toBe("notFound");
+    // A known parent whose payload file is absent must not fall back to
+    // some other document.
+    expect(resolve("/sessions/ses_abc/__next.missing.txt").kind).toBe(
+      "notFound",
+    );
+  });
+
+  it("keeps /_next/ .txt requests literal-only", () => {
+    expect(resolve("/_next/static/zz.txt").kind).toBe("notFound");
+  });
+});

--- a/backend/services/stigmer-server/src/transport/console/assets.ts
+++ b/backend/services/stigmer-server/src/transport/console/assets.ts
@@ -1,0 +1,80 @@
+/**
+ * Console asset discovery — locates the web console's static export and
+ * indexes it for the console lane. The discovery rule is the workflow
+ * bundles' sibling idiom (src/temporal/workflow-source.ts): the slim
+ * packaging emits `console/` next to main.js, where the bundled
+ * import.meta.url shim resolves it; in the tsc dist the sibling never
+ * exists, so dev/test servers boot without the lane unless
+ * STIGMER_CONSOLE_DIR points somewhere explicitly (the conformance and
+ * unit-test posture — the lane is wire-invisible when assets are absent).
+ *
+ * The export is indexed ONCE at composition: it is immutable for the
+ * server's lifetime (it shipped inside the same artifact — DD-012's
+ * no-skew property), so a boot-time scan buys O(1) resolution, an exact
+ * availability answer, and a pure resolver.
+ */
+import { readdirSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { Logger } from "../../boot/logger.js";
+import { buildConsoleFileIndex, type ConsoleFileIndex } from "./resolver.js";
+
+export interface ConsoleAssets {
+  /** Absolute filesystem root of the static export. */
+  readonly root: string;
+  /** "/"-rooted, "/"-separated file index the resolver consumes. */
+  readonly index: ConsoleFileIndex;
+  readonly fileCount: number;
+}
+
+/**
+ * Resolve and index the console export. Returns undefined — the modeled
+ * "not bundled" state, not an error — when neither the override nor the
+ * sibling exists.
+ */
+export function resolveConsoleAssets(
+  overrideDir: string,
+  logger: Logger,
+): ConsoleAssets | undefined {
+  const sibling = fileURLToPath(new URL("./console/", import.meta.url));
+  const root = overrideDir !== "" ? path.resolve(overrideDir) : sibling;
+
+  let rootStat;
+  try {
+    rootStat = statSync(root);
+  } catch {
+    return undefined;
+  }
+  if (!rootStat.isDirectory()) {
+    return undefined;
+  }
+
+  const files: string[] = [];
+  scan(root, "", files);
+  if (files.length === 0) {
+    // An empty directory serves nothing but would report "available" —
+    // treat it as absent and say why.
+    logger.warn("console asset directory is empty; console lane disabled", {
+      dir: root,
+    });
+    return undefined;
+  }
+  return {
+    root,
+    index: buildConsoleFileIndex(files),
+    fileCount: files.length,
+  };
+}
+
+/** Depth-first scan into "/"-separated index paths (never path.sep). */
+function scan(absoluteDir: string, indexPrefix: string, out: string[]): void {
+  for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+    const indexPath = `${indexPrefix}/${entry.name}`;
+    if (entry.isDirectory()) {
+      scan(path.join(absoluteDir, entry.name), indexPath, out);
+    } else if (entry.isFile()) {
+      out.push(indexPath);
+    }
+  }
+}

--- a/backend/services/stigmer-server/src/transport/console/handler.ts
+++ b/backend/services/stigmer-server/src/transport/console/handler.ts
@@ -1,0 +1,309 @@
+/**
+ * The console lane — lane 4 of the unified port (DD-005; DD-012 in the
+ * parent program's records): serves the web console's static export and
+ * synthesizes its runtime /config.json, restoring the local console the
+ * June CLI migration lost. Routing decisions live in resolver.ts (pure,
+ * nginx-equivalence-gated); this module owns the HTTP half: the lane
+ * guard, header policy, config synthesis, and file streaming.
+ *
+ * Lane guard (consoleLaneEligible): the lane claims GET/HEAD only — RPC
+ * traffic is POST on service-qualified paths, and OPTIONS preflights keep
+ * flowing to the RPC lane's CORS handling — and it never claims:
+ *   - `/v1/*`: the registry/skill lanes' namespace; unknown paths there
+ *     must keep reaching the adapter's 404 (the CW-10 pinned contract).
+ *   - service-shaped paths (`/<package.Service>/<Method>` — exactly two
+ *     segments with a dotted first): even though no RPC answers GET today
+ *     (zero no_side_effects methods), the adapter must stay the authority
+ *     for its own namespace if one ever does.
+ *
+ * Header policy follows nginx.conf's four explicit postures byte-for-byte
+ * (immutable /_next/static/, no-cache index.html, no-store config.json,
+ * max-age=300 embed.js). Everything else is served `no-cache` — a
+ * deliberate divergence from nginx, which falls back to default validator
+ * behavior (ETag/Last-Modified) this handler does not emit; no-cache
+ * keeps every document fresh across server upgrades at the cost of
+ * revalidating tiny files, while the heavy assets all live under the
+ * immutable /_next/static/ rule.
+ */
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import path from "node:path";
+
+import type { Logger } from "../../boot/logger.js";
+import type { LaneHandler, LaneRequest, LaneResponse } from "../lanes.js";
+import type { ConsoleAssets } from "./assets.js";
+import { resolveConsoleRequest } from "./resolver.js";
+
+/** The runtime-config route the ConfigGate fetches before first render. */
+const CONFIG_JSON_PATH = "/config.json";
+
+/** nginx: runtime config must never be cached (config changes propagate immediately). */
+const CONFIG_JSON_CACHE_CONTROL = "no-cache, no-store, must-revalidate";
+
+/** nginx: Next.js hashed assets are safe to cache indefinitely. */
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+/** nginx: the embed loader rides an unversioned URL; a short TTL lets fixes reach embedders in minutes. */
+const EMBED_JS_CACHE_CONTROL = "public, max-age=300";
+
+/** Everything else (see the module header for the divergence rationale). */
+const DEFAULT_CACHE_CONTROL = "no-cache";
+
+/**
+ * Whether the console lane may claim this request. Exported for the lane
+ * router (server.ts), which stays a thin if-chain — the guard's knowledge
+ * of RPC path shapes belongs to this module.
+ */
+export function consoleLaneEligible(request: LaneRequest): boolean {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    return false;
+  }
+  const pathname = (request.url ?? "").split("?", 1)[0] ?? "";
+  if (pathname === "" || !pathname.startsWith("/")) {
+    return false;
+  }
+  if (pathname.startsWith("/v1/")) {
+    return false;
+  }
+  return !isServiceShapedPath(pathname);
+}
+
+/** `/<package.Service>/<Method>` — exactly two segments, dotted first. */
+function isServiceShapedPath(pathname: string): boolean {
+  const segments = pathname.split("/").filter((segment) => segment !== "");
+  return segments.length === 2 && (segments[0] ?? "").includes(".");
+}
+
+export interface ConsoleLaneOptions {
+  readonly assets: ConsoleAssets;
+  /**
+   * Fallback port for the synthesized apiUrl when a request carries no
+   * Host/:authority (technically possible on HTTP/1.0-style clients).
+   */
+  readonly grpcPort: number;
+  readonly logger: Logger;
+}
+
+export function createConsoleLane(options: ConsoleLaneOptions): LaneHandler {
+  const { assets, grpcPort, logger } = options;
+
+  return (request: LaneRequest, response: LaneResponse): void => {
+    const url = request.url ?? "";
+    const queryStart = url.indexOf("?");
+    const rawPath = queryStart === -1 ? url : url.slice(0, queryStart);
+    const query = queryStart === -1 ? "" : url.slice(queryStart);
+
+    if (rawPath === CONFIG_JSON_PATH) {
+      serveConfigJson(request, response, grpcPort);
+      return;
+    }
+
+    let pathname: string;
+    try {
+      pathname = decodeURIComponent(rawPath);
+    } catch {
+      // Malformed percent-escapes are a client error (the artifact file
+      // server's posture); the export's own 404 document still answers.
+      serveNotFound(request, response, assets, logger);
+      return;
+    }
+
+    const resolution = resolveConsoleRequest(pathname, assets.index);
+    switch (resolution.kind) {
+      case "redirect":
+        // Relative Location (nginx absolute_redirect off: an absolute form
+        // would embed this listener's port, wrong behind any proxy). The
+        // query rides through, as nginx's `$is_args$args` spells out.
+        response.statusCode = 301;
+        response.setHeader("Location", `${resolution.location}${query}`);
+        response.end();
+        return;
+      case "file":
+        serveFile(request, response, assets, resolution.file, 200, logger);
+        return;
+      case "notFound":
+        serveNotFound(request, response, assets, logger);
+        return;
+      default: {
+        const exhaustive: never = resolution;
+        throw new Error(`unhandled resolution ${String(exhaustive)}`);
+      }
+    }
+  };
+}
+
+/**
+ * The runtime config the cloud container's entrypoint.sh generates from
+ * env — synthesized here from the server's own knowledge instead (DD-012:
+ * the nginx entrypoint script is not ported). apiUrl derives from the
+ * request's own Host so the answer is correct wherever the browser
+ * reached us from (localhost, a LAN address, a self-host name) — the
+ * console cannot express "same origin" itself (its config loader maps
+ * empty fields to a localhost default). TLS-terminating proxies
+ * (x-forwarded-proto) are out of scope until a tier serves TLS.
+ */
+function serveConfigJson(
+  request: LaneRequest,
+  response: LaneResponse,
+  grpcPort: number,
+): void {
+  // HTTP/1.1 carries Host; Node maps HTTP/2's :authority into the same
+  // headers view (and Http2ServerRequest.authority falls back to it).
+  const host = request.headers.host ?? request.headers[":authority"];
+  const apiUrl =
+    typeof host === "string" && host !== ""
+      ? `http://${host}`
+      : `http://localhost:${grpcPort}`;
+  const body = JSON.stringify({
+    apiUrl,
+    appUrl: "",
+    authMode: "disabled",
+    oidcIssuer: "",
+    oidcClientId: "",
+    oidcAudience: "",
+  });
+  response.statusCode = 200;
+  response.setHeader("Content-Type", "application/json");
+  response.setHeader("Cache-Control", CONFIG_JSON_CACHE_CONTROL);
+  response.setHeader("Content-Length", String(Buffer.byteLength(body)));
+  if (request.method === "HEAD") {
+    response.end();
+    return;
+  }
+  response.end(body);
+}
+
+function serveNotFound(
+  request: LaneRequest,
+  response: LaneResponse,
+  assets: ConsoleAssets,
+  logger: Logger,
+): void {
+  // The export's real not-found page, WITH the 404 status (nginx
+  // error_page semantics) — never the blank app shell, and never the
+  // adapter's terse 404 once a console is bundled.
+  if (assets.index.hasFile("/404.html")) {
+    serveFile(request, response, assets, "/404.html", 404, logger);
+    return;
+  }
+  response.statusCode = 404;
+  response.end("404 page not found\n");
+}
+
+function serveFile(
+  request: LaneRequest,
+  response: LaneResponse,
+  assets: ConsoleAssets,
+  file: string,
+  statusCode: number,
+  logger: Logger,
+): void {
+  // Containment by construction: `file` is an INDEX member (produced by
+  // the boot-time scan), never raw request input — a traversal path can
+  // only miss the index and 404 in the resolver. The join below therefore
+  // cannot escape the asset root.
+  const filePath = path.join(assets.root, ...file.split("/").filter(Boolean));
+
+  streamFile(request, response, file, filePath, statusCode).catch(
+    (error: unknown) => {
+      // Detached-async terminal catch (the skill transfer lane's
+      // load-bearing pattern): an escape here would be process-fatal.
+      logger.error("console lane failed to serve file", {
+        file,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      if (!response.headersSent) {
+        response.statusCode = 500;
+      }
+      response.end();
+    },
+  );
+}
+
+async function streamFile(
+  request: LaneRequest,
+  response: LaneResponse,
+  file: string,
+  filePath: string,
+  statusCode: number,
+): Promise<void> {
+  // The index said the file exists; a stat failure means the artifact was
+  // mutilated underneath us — the terminal catch answers 500.
+  const info = await stat(filePath);
+  response.statusCode = statusCode;
+  response.setHeader("Content-Type", contentTypeOf(file));
+  response.setHeader("Cache-Control", cacheControlOf(file, statusCode));
+  response.setHeader("Content-Length", String(info.size));
+  if (request.method === "HEAD") {
+    response.end();
+    return;
+  }
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(filePath);
+    stream.on("error", (error) => {
+      response.destroy();
+      reject(error);
+    });
+    response.on("close", () => resolve());
+    stream.pipe(response);
+  });
+}
+
+/**
+ * Cache policy keyed on the SERVED document (nginx keys locations on the
+ * request URI, but its internal try_files redirects re-enter location
+ * matching, so the effective key is the final document there too).
+ * nginx's explicit `index.html → no-cache` rule is subsumed by the
+ * default here. Only 200 responses carry cache headers beyond the
+ * default — nginx's add_header skips error statuses, and a cached 404
+ * page would mask a later upgrade that adds the route.
+ */
+function cacheControlOf(file: string, statusCode: number): string {
+  if (statusCode !== 200) {
+    return DEFAULT_CACHE_CONTROL;
+  }
+  if (file.startsWith("/_next/static/")) {
+    return IMMUTABLE_CACHE_CONTROL;
+  }
+  if (file === "/embed.js") {
+    return EMBED_JS_CACHE_CONTROL;
+  }
+  return DEFAULT_CACHE_CONTROL;
+}
+
+/**
+ * Explicit type map: the artifact file server deliberately omits
+ * Content-Type (clients sniff), but a BROWSER document target must be
+ * typed — an untyped .html deep link would download instead of render.
+ * Extensions are the export's observed inventory; unknowns fall back to
+ * octet-stream rather than guessing.
+ */
+const CONTENT_TYPES: Readonly<Record<string, string>> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json",
+  ".map": "application/json",
+  ".txt": "text/plain; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".ico": "image/x-icon",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".avif": "image/avif",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
+  ".wasm": "application/wasm",
+  ".xml": "application/xml",
+  ".webmanifest": "application/manifest+json",
+};
+
+function contentTypeOf(file: string): string {
+  const extension = path.posix.extname(file).toLowerCase();
+  return CONTENT_TYPES[extension] ?? "application/octet-stream";
+}

--- a/backend/services/stigmer-server/src/transport/console/resolver.ts
+++ b/backend/services/stigmer-server/src/transport/console/resolver.ts
@@ -1,0 +1,199 @@
+/**
+ * The console static-export route resolver — the PURE routing half of the
+ * unified port's console lane (DD-005 lane 4; DD-012 in the parent
+ * program's records). Given a decoded request path and an index of the
+ * export's files, it answers WHICH document serves — no I/O, so the
+ * contract is exhaustively unit-testable and machine-checkable against
+ * the nginx model (see __tests__/nginx-equivalence.test.ts).
+ *
+ * The contract merges the correct half of each prior implementation:
+ *
+ * - PAGE resolution reproduces client-apps/web/nginx.conf (the cloud
+ *   serving rules, hardened after the channel-conversations F-12
+ *   blank-page failures): try the literal file, its `.html` sibling, the
+ *   directory index, then the Next.js `__placeholder__.html` candidates —
+ *   most-literal first, at most two trailing dynamic segments — and
+ *   unknown URLs land on /404.html WITH a 404 status, never the blank app
+ *   shell. Trailing slashes 301 to the canonical slashless URL.
+ *   scripts/verify-static-export-routes.mjs holds nginx.conf and the route
+ *   tree together; the equivalence test holds THIS resolver to the same
+ *   model, so the two serving paths cannot drift.
+ *
+ * - RSC FLIGHT resolution restores the retired Go CLI handler's rewrites
+ *   (client-apps/cli/embedded/webconsole/handler.go at 8dc9df7e4~1,
+ *   deleted with the June CLI migration): a soft navigation to a dynamic
+ *   route fetches `<path>.txt` (and nested `<path>/__next.*.txt`) flight
+ *   payloads that exist on disk only in `__placeholder__` form. nginx
+ *   never handled these (filed as a cloud-side follow-up); without the
+ *   rewrite every soft navigation to a dynamic route degrades to a full
+ *   page load. Formulated here as "resolve the stem as a page, serve the
+ *   resolved document's twin" — one candidate discipline for both
+ *   contracts, which also covers the two-dynamic-segment routes the Go
+ *   handler's single-substitution loop predated.
+ */
+
+/** The literal Next.js static-export sentinel for dynamic segments. */
+const PLACEHOLDER = "__placeholder__";
+
+/** Nested RSC payload files: `__next.<segment-path>.txt` siblings. */
+const FLIGHT_SEGMENT_PREFIX = "__next.";
+
+/**
+ * The export's files and the directories they imply, both as "/"-rooted,
+ * "/"-separated paths (e.g. "/sessions/__placeholder__.html"). Built once
+ * per asset root by {@link buildConsoleFileIndex}; filesystem separators
+ * are the serving layer's concern, never the resolver's.
+ */
+export interface ConsoleFileIndex {
+  hasFile(path: string): boolean;
+  hasDirectory(path: string): boolean;
+}
+
+export function buildConsoleFileIndex(
+  files: Iterable<string>,
+): ConsoleFileIndex {
+  const fileSet = new Set<string>();
+  // The export root itself is a directory, so "/" resolves through the
+  // directory-index candidate (the root route's own serving path).
+  const directorySet = new Set<string>(["/"]);
+  for (const file of files) {
+    fileSet.add(file);
+    let parent = file;
+    for (;;) {
+      const slash = parent.lastIndexOf("/");
+      if (slash <= 0) break;
+      parent = parent.slice(0, slash);
+      if (directorySet.has(parent)) break;
+      directorySet.add(parent);
+    }
+  }
+  return {
+    hasFile: (path) => fileSet.has(path),
+    hasDirectory: (path) => directorySet.has(path),
+  };
+}
+
+export type ConsoleResolution =
+  /** 301 to the canonical URL (the handler carries the query through). */
+  | { readonly kind: "redirect"; readonly location: string }
+  /** Serve this export file with a 200. */
+  | { readonly kind: "file"; readonly file: string }
+  /** Serve /404.html (when the export has one) WITH a 404 status. */
+  | { readonly kind: "notFound" };
+
+/**
+ * Resolve a decoded, query-less request path against the export index.
+ * Redirects resolve one step per call, exactly as nginx's single
+ * `^(.+)/$` rewrite does — the client (or a test) follows them.
+ */
+export function resolveConsoleRequest(
+  pathname: string,
+  index: ConsoleFileIndex,
+): ConsoleResolution {
+  // Trailing-slash canonicalization (nginx `location ~ ^(.+)/$`): the
+  // export writes sibling .html files, never directory indexes, so a
+  // trailing-slash deep link would miss every candidate below. "/" itself
+  // cannot match (the capture needs one character before the slash).
+  if (pathname.length > 1 && pathname.endsWith("/")) {
+    return { kind: "redirect", location: pathname.slice(0, -1) };
+  }
+
+  const lastSegment = pathname.slice(pathname.lastIndexOf("/") + 1);
+
+  // Nested RSC flight payload: /<dir>/__next.<x>.txt. Direct hits cover
+  // static parents (and the root-level __next.*.txt family); otherwise
+  // resolve the parent as a page and serve the payload from the resolved
+  // (placeholder-substituted) document's directory.
+  if (
+    lastSegment.startsWith(FLIGHT_SEGMENT_PREFIX) &&
+    lastSegment.endsWith(".txt")
+  ) {
+    if (index.hasFile(pathname)) {
+      return { kind: "file", file: pathname };
+    }
+    const parent = pathname.slice(0, pathname.lastIndexOf("/"));
+    const parentDocument = parent === "" ? null : resolvePage(parent, index);
+    if (parentDocument !== null && parentDocument.endsWith(".html")) {
+      const candidate = `${parentDocument.slice(0, -".html".length)}/${lastSegment}`;
+      if (index.hasFile(candidate)) {
+        return { kind: "file", file: candidate };
+      }
+    }
+    return { kind: "notFound" };
+  }
+
+  // Page-level RSC flight payload: /<path>.txt is the twin of the
+  // document /<path> resolves to (the export writes a .txt beside every
+  // page's .html). Excludes _next/ internals, which are literal files.
+  if (
+    lastSegment.endsWith(".txt") &&
+    !pathname.startsWith("/_next/") &&
+    index.hasFile(pathname) === false
+  ) {
+    const stemDocument = resolvePage(pathname.slice(0, -".txt".length), index);
+    if (stemDocument !== null && stemDocument.endsWith(".html")) {
+      const twin = `${stemDocument.slice(0, -".html".length)}.txt`;
+      if (index.hasFile(twin)) {
+        return { kind: "file", file: twin };
+      }
+    }
+    return { kind: "notFound" };
+  }
+
+  const document = resolvePage(pathname, index);
+  return document === null
+    ? { kind: "notFound" }
+    : { kind: "file", file: document };
+}
+
+/**
+ * The nginx try_files chain, generalized: literal file, `.html` sibling,
+ * directory index, then the placeholder candidates — substitute the last
+ * segment, then the last two (nginx's declaration order: the more-literal
+ * candidate first, mirroring Next.js route priority where a literal
+ * segment beats a dynamic one). Returns the served document or null.
+ *
+ * `/_next/` build assets are literal-only (nginx's `^~ /_next/static/`
+ * location has no try_files): the placeholder candidates could never hit
+ * there — no export writes placeholder documents under /_next/ — so the
+ * short-circuit changes no outcome, it just refuses to pretend those
+ * candidates make sense.
+ */
+function resolvePage(pathname: string, index: ConsoleFileIndex): string | null {
+  if (index.hasFile(pathname)) {
+    return pathname;
+  }
+  if (pathname.startsWith("/_next/")) {
+    return null;
+  }
+  if (pathname !== "/" && index.hasFile(`${pathname}.html`)) {
+    return `${pathname}.html`;
+  }
+  // nginx `$uri/` + `index index.html`: a directory serves its index.
+  if (index.hasDirectory(pathname)) {
+    const indexFile =
+      pathname === "/" ? "/index.html" : `${pathname}/index.html`;
+    if (index.hasFile(indexFile)) {
+      return indexFile;
+    }
+  }
+
+  const segments = pathname.split("/").filter((segment) => segment !== "");
+  for (const dynamicCount of [1, 2]) {
+    // Substituting the last k segments needs at least k+1 segments: the
+    // nginx regexes require a non-empty static prefix (`(.+)/…`), so a
+    // top-level path never resolves through placeholders.
+    if (segments.length < dynamicCount + 1) {
+      break;
+    }
+    const candidate = [
+      "",
+      ...segments.slice(0, -dynamicCount),
+      ...Array<string>(dynamicCount).fill(PLACEHOLDER),
+    ].join("/");
+    if (index.hasFile(`${candidate}.html`)) {
+      return `${candidate}.html`;
+    }
+  }
+  return null;
+}

--- a/backend/services/stigmer-server/src/transport/server.ts
+++ b/backend/services/stigmer-server/src/transport/server.ts
@@ -9,8 +9,10 @@
  *   2. exact match  /v1/proxy/model-registry       (registry proxy)
  *   3. prefix       /v1/skill-artifacts            (seam — lands with the
  *                                                   skill domain sub-project)
- *   4. [reserved]   console statics                (phase 2, DD-005 — the
- *                                                   branch slot exists, no code)
+ *   4. guarded      console statics                (phase 2, DD-005/DD-012 —
+ *                                                   GET/HEAD only, never RPC
+ *                                                   or /v1/* paths; absent
+ *                                                   when no export is bundled)
  *   5. RPC adapter  gRPC + gRPC-Web + Connect      (replaces Go's lanes
  *                                                   4–5; WebSocket retired
  *                                                   per ratified delta 1)
@@ -39,6 +41,7 @@ import {
   SKILL_ARTIFACTS_PATH_PREFIX,
   TASK_KIND_REGISTRY_PATH,
 } from "./constants.js";
+import { consoleLaneEligible } from "./console/handler.js";
 import {
   applyRpcCorsHeaders,
   handleRpcPreflight,
@@ -65,6 +68,14 @@ export interface UnifiedPortServerOptions {
    * the adapter's 404, which is also what Go answers for unknown paths.
    */
   skillTransferLane?: LaneHandler;
+  /**
+   * Lane 4: console statics + /config.json (DD-012). Present only when a
+   * console export is bundled/configured — absent, every request flows
+   * exactly as before the lane existed. The eligibility guard lives with
+   * the handler (console/handler.ts): GET/HEAD only, never /v1/* or
+   * service-shaped paths.
+   */
+  consoleLane?: LaneHandler;
 }
 
 export interface UnifiedPortServer {
@@ -102,7 +113,10 @@ export function createUnifiedPortServer(
       options.skillTransferLane(request, response);
       return;
     }
-    // Reserved: console statics branch (phase 2, DD-005) slots in here.
+    if (options.consoleLane !== undefined && consoleLaneEligible(request)) {
+      options.consoleLane(request, response);
+      return;
+    }
 
     if (isRpcPreflight(request)) {
       // Go answers preflights for ALL endpoints, registered or not

--- a/client-apps/cli/src/commands/up.ts
+++ b/client-apps/cli/src/commands/up.ts
@@ -6,9 +6,11 @@
 // outcome. The launcher (and the heavy resolvers it pulls in) load lazily so
 // `--help` stays fast (DD-001).
 
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { Command } from "commander";
 import { CommandResult, type OutputFlags, renderResult } from "../output/index.js";
-import { SERVER_PORT } from "../local/constants.js";
+import { HEALTH_STATE_FILE, SERVER_PORT } from "../local/constants.js";
 import { addResultFlags, resultFormat } from "./shared.js";
 
 interface UpFlags extends OutputFlags {
@@ -16,15 +18,17 @@ interface UpFlags extends OutputFlags {
   web?: boolean; // false when --no-web is passed
 }
 
+// The server serves the web console from its unified port (DD-012); the
+// flag suppresses probing/reporting it, not the serving itself (one
+// process, one origin — there is no separate console to not-start).
+const NO_WEB_HELP = "don't report the web console URL";
+
 export function registerUp(program: Command): void {
   const up = program
     .command("up")
     .description("start the local Stigmer stack (server, runner, Temporal)")
     .option("--server-only", "start only the control plane (no runners)")
-    // Accepted for compatibility with the Go CLI; this CLI does not bundle a
-    // local web console, so the stack is headless either way (use the cloud
-    // console at app.stigmer.ai for a UI).
-    .option("--no-web", "no-op: this CLI does not serve a local web console")
+    .option("--no-web", NO_WEB_HELP)
     .action((options: UpFlags) =>
       runUp({ serverOnly: options.serverOnly === true, noWeb: options.web === false }, options),
     );
@@ -33,7 +37,7 @@ export function registerUp(program: Command): void {
   const server = up
     .command("server")
     .description("start only the control plane (no runners)")
-    .option("--no-web", "no-op: this CLI does not serve a local web console")
+    .option("--no-web", NO_WEB_HELP)
     .action((options: UpFlags) => runUp({ serverOnly: true, noWeb: options.web === false }, options));
   addResultFlags(server);
 }
@@ -46,6 +50,20 @@ async function runUp(opts: { serverOnly: boolean; noWeb: boolean }, flags: Outpu
   const result = CommandResult.success(opts.serverOnly ? "Stigmer control plane is up" : "Stigmer local stack is up");
   const section = result.addSection("Endpoints");
   section.field("server", `http://localhost:${SERVER_PORT}`);
+  if (await consoleReported()) {
+    // Same origin as the API: the server serves the console (DD-012). Only
+    // printed when the daemon's probe found a bundled export — a dev-tree
+    // server without one must not advertise a dead URL.
+    section.field("console", `http://localhost:${SERVER_PORT}`);
+  }
   result.hint("Check status with: stigmer status").hint("Stop it with:    stigmer down");
   renderResult(result, resultFormat(flags));
+}
+
+/** Whether the daemon recorded the web console as running (its own probe). */
+async function consoleReported(): Promise<boolean> {
+  const { dataDir } = await import("../local/paths.js");
+  const { loadHealthState } = await import("../local/state/health-state.js");
+  const health = loadHealthState(join(dataDir(homedir()), HEALTH_STATE_FILE));
+  return health?.components["web-console"]?.state === "running";
 }

--- a/client-apps/cli/src/config/resolve.test.ts
+++ b/client-apps/cli/src/config/resolve.test.ts
@@ -109,7 +109,7 @@ describe("resolveConsoleURL", () => {
   });
 
   it("uses the local web-console port for the local backend", () => {
-    expect(resolveConsoleURL("local", {} as NodeJS.ProcessEnv)).toBe("http://localhost:8234");
+    expect(resolveConsoleURL("local", {} as NodeJS.ProcessEnv)).toBe("http://localhost:7234");
   });
 
   it("uses the cloud console URL for the cloud backend", () => {

--- a/client-apps/cli/src/config/resolve.ts
+++ b/client-apps/cli/src/config/resolve.ts
@@ -3,7 +3,7 @@
 // precedence keeps every call site consistent (mirrors the Go CLI's Resolve*).
 
 import { CliExitError, ExitCode } from "../errors/index.js";
-import { WEB_CONSOLE_PORT } from "../local/constants.js";
+import { SERVER_PORT } from "../local/constants.js";
 import { type BackendType, type Config, isCloudMode } from "./config.js";
 
 const DEFAULT_CLOUD_ENDPOINT = "api.stigmer.ai:443";
@@ -76,17 +76,20 @@ export function resolveOrganization(config: Config, flagOrg?: string): string {
 /**
  * Resolve the web console URL:
  *   1. `STIGMER_CONSOLE_URL` (explicit override)
- *   2. local backend → `http://localhost:{WEB_CONSOLE_PORT}`
+ *   2. local backend → `http://localhost:{SERVER_PORT}` — the server's own
+ *      unified port serves the console since DD-012 (one origin for UI and
+ *      API; the Go-era separate 8234 listener is retired)
  *   3. cloud backend → {@link DEFAULT_CLOUD_CONSOLE_URL}
  *
  * The console origin is also the app origin that serves the hosted chat
  * page (`/chat/<org>/<slug>`) and the embed loader (`/embed.js`), so
- * share-link builders use this same resolver.
+ * share-link builders use this same resolver — both routes live in the
+ * same static export the server serves.
  */
 export function resolveConsoleURL(backendType: BackendType, env: NodeJS.ProcessEnv = process.env): string {
   const override = env.STIGMER_CONSOLE_URL;
   if (override !== undefined && override !== "") return override;
-  if (backendType === "local") return `http://localhost:${WEB_CONSOLE_PORT}`;
+  if (backendType === "local") return `http://localhost:${SERVER_PORT}`;
   return DEFAULT_CLOUD_CONSOLE_URL;
 }
 

--- a/client-apps/cli/src/local/constants.ts
+++ b/client-apps/cli/src/local/constants.ts
@@ -7,11 +7,15 @@
 // runner-poll can never drift (see the T05 plan's "Critical correctness
 // finding").
 
-/** Port `stigmer-server` listens on (gRPC). Matches the Go CLI's `DaemonPort`. */
+/**
+ * Port `stigmer-server` listens on (gRPC). Matches the Go CLI's `DaemonPort`.
+ *
+ * This is also the web console's origin: since DD-012 the server serves the
+ * console's static export on this same unified port (lane 4), so the Go-era
+ * WEB_CONSOLE_PORT (8234, a separate CLI-embedded listener) is retired —
+ * one process, one origin, no CORS hop.
+ */
 export const SERVER_PORT = 7234;
-
-/** Port the embedded web console is served on (7xxx=API, 8xxx=UI convention). */
-export const WEB_CONSOLE_PORT = 8234;
 
 /** Temporal frontend gRPC port (dev server default). */
 export const TEMPORAL_PORT = 7233;

--- a/client-apps/cli/src/local/daemon/process.ts
+++ b/client-apps/cli/src/local/daemon/process.ts
@@ -103,15 +103,18 @@ export async function runInternalDaemon(deps: InternalDaemonDeps): Promise<numbe
   await clock.sleep(SETTLE_DELAY_MS);
   supervisor.settleCheck();
 
-  // Web console: detect-and-skip until T06 wires real serving.
+  // Web console: the SERVER serves it from its unified port (DD-012); the
+  // daemon probes and records what a browser would actually find. pid 0 is
+  // truthful — there is no separate console process to supervise.
+  const consoleAvailable = config.noWeb ? false : await isWebConsoleAvailable();
   healthState.components["web-console"] = {
     pid: 0,
-    state: config.noWeb || !isWebConsoleAvailable() ? "stopped" : "running",
+    state: consoleAvailable ? "running" : "stopped",
     started_at: "",
     restart_count: 0,
   };
-  if (config.noWeb) log.info("web console disabled via --no-web");
-  else if (!isWebConsoleAvailable()) log.debug("web console not bundled in this build, skipping");
+  if (config.noWeb) log.info("web console suppressed via --no-web");
+  else if (!consoleAvailable) log.debug("server did not answer the console probe (no export bundled), skipping");
   persist();
 
   // --- Health monitor: sync Temporal + drive one supervisor tick per interval. ---

--- a/client-apps/cli/src/local/status.ts
+++ b/client-apps/cli/src/local/status.ts
@@ -12,7 +12,7 @@ import { join } from "node:path";
 import { load as loadConfig } from "../config/config.js";
 import { configPath } from "../config/paths.js";
 import { CommandResult } from "../output/command-result.js";
-import { SERVER_PORT, TEMPORAL_UI_PORT, WEB_CONSOLE_PORT } from "./constants.js";
+import { SERVER_PORT, TEMPORAL_UI_PORT } from "./constants.js";
 import { resolveApiKey, resolveProvider } from "./llm-config.js";
 import { tcpConnects } from "./net/tcp.js";
 import { dataDir } from "./paths.js";
@@ -144,7 +144,9 @@ function addWebUiSection(result: CommandResult, health: HealthState): void {
   if (!temporalRunning && !webRunning) return;
 
   const section = result.addSection("Web UI");
-  if (webRunning) section.field("Console", `http://localhost:${WEB_CONSOLE_PORT}`);
+  // The console shares the server's unified port (DD-012) — same origin as
+  // the API, served by the server itself.
+  if (webRunning) section.field("Console", `http://localhost:${SERVER_PORT}`);
   if (temporalRunning) section.field("Temporal", `http://localhost:${TEMPORAL_UI_PORT}`);
 }
 

--- a/client-apps/cli/src/local/webconsole/index.ts
+++ b/client-apps/cli/src/local/webconsole/index.ts
@@ -1,13 +1,30 @@
-// Embedded web-console availability.
+// Web-console availability against the server's unified port.
 //
-// The Go CLI embeds the console's static assets via go:embed and serves them on
-// :8234. There is no TS equivalent bundled in T05, so the daemon detects the
-// console as unavailable and skips it cleanly (recording a "stopped" state),
-// exactly as the Go daemon does when built without assets. Real serving — and
-// the asset-bundling decision behind it — is deferred to T06.
+// Since DD-012 (oss sub-project console-serving) the SERVER serves the
+// console: the static export ships inside @stigmer/server-slim and the
+// unified port's lane 4 serves it, synthesizing /config.json in-process.
+// The CLI therefore PROBES rather than serves — /config.json answers 200
+// exactly when a console export is bundled with the running server (a
+// dev-tree server without the export falls through to the RPC adapter's
+// 404), so the daemon's component state reports what a browser would
+// actually find. The Go-era embedded console (go:embed on :8234) and the
+// T05/T06 stub this file used to be are both retired by that design.
 
-/** Whether an embedded web console is available to serve. Always false until
- * T06 wires asset bundling + an HTTP handler. */
-export function isWebConsoleAvailable(): boolean {
-  return false;
+import { SERVER_PORT } from "../constants.js";
+
+/** Keep the daemon's settle path snappy: a hung probe must not stall `stigmer up`. */
+const PROBE_TIMEOUT_MS = 3000;
+
+/** Whether the running server serves a bundled web console. */
+export async function isWebConsoleAvailable(
+  serverPort: number = SERVER_PORT,
+): Promise<boolean> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${serverPort}/config.json`, {
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
 }

--- a/client-apps/cli/src/resources/connect/oauth.test.ts
+++ b/client-apps/cli/src/resources/connect/oauth.test.ts
@@ -127,6 +127,6 @@ describe("runOAuthFlow", () => {
       sleep: noopSleep,
       log: () => {},
     });
-    expect(openBrowser).toHaveBeenCalledWith("http://localhost:8234/acme/mcp-servers/github");
+    expect(openBrowser).toHaveBeenCalledWith("http://localhost:7234/acme/mcp-servers/github");
   });
 });

--- a/client-apps/cli/src/resources/share.test.ts
+++ b/client-apps/cli/src/resources/share.test.ts
@@ -12,7 +12,7 @@ import { classify, ExitCode, UsageError } from "../errors/index.js";
 import { shareAgent } from "./share.js";
 
 const CLOUD = { appOrigin: "https://app.stigmer.ai", isLocal: false };
-const LOCAL = { appOrigin: "http://localhost:8234", isLocal: true };
+const LOCAL = { appOrigin: "http://localhost:7234", isLocal: true };
 
 function makeAgent(): Agent {
   return create(AgentSchema, {
@@ -350,7 +350,7 @@ describe("shareAgent output", () => {
     const result = await shareAgent(client, "acme/support-agent", "acme", { enabled: true, ...LOCAL });
 
     const link = result.sections.find((s) => s.title === "Public chat link");
-    expect(link?.items).toEqual(["http://localhost:8234/chat/acme/support-agent"]);
+    expect(link?.items).toEqual(["http://localhost:7234/chat/acme/support-agent"]);
     expect(result.hints.some((h) => h.includes("Stigmer Cloud"))).toBe(true);
   });
 

--- a/docs/getting-started/connect-tools.mdx
+++ b/docs/getting-started/connect-tools.mdx
@@ -17,7 +17,7 @@ everything into your code.
 
 <Callout type="info">
   **Running locally?** Your web console is at
-  [`http://localhost:8234`](http://localhost:8234). Wherever these steps say
+  [`http://localhost:7234`](http://localhost:7234). Wherever these steps say
   `app.stigmer.ai`, use your local address instead. Drop the
   `STIGMER_API_KEY=sk_your_key` prefix from run commands — your local server
   doesn't require it.

--- a/docs/getting-started/create-agent.mdx
+++ b/docs/getting-started/create-agent.mdx
@@ -16,7 +16,7 @@ conversation results, fewer moving parts.
 
 <Callout type="info">
   **Running locally?** Your web console is at
-  [`http://localhost:8234`](http://localhost:8234). Wherever these steps say
+  [`http://localhost:7234`](http://localhost:7234). Wherever these steps say
   `app.stigmer.ai`, use your local address instead. Drop the
   `STIGMER_API_KEY=sk_your_key` prefix from run commands — your local server
   doesn't require it.

--- a/docs/getting-started/first-skill.mdx
+++ b/docs/getting-started/first-skill.mdx
@@ -17,7 +17,7 @@ your code, and watch the same question produce a completely different answer.
 
 <Callout type="info">
   **Running locally?** Your web console is at
-  [`http://localhost:8234`](http://localhost:8234). Wherever these steps say
+  [`http://localhost:7234`](http://localhost:7234). Wherever these steps say
   `app.stigmer.ai`, use your local address instead. Drop the
   `STIGMER_API_KEY=sk_your_key` prefix from run commands — your local server
   doesn't require it.

--- a/scripts/smoke-cli-cutover.mjs
+++ b/scripts/smoke-cli-cutover.mjs
@@ -20,7 +20,10 @@
  * no API keys, no network beyond npm/Temporal's own machinery. What it
  * proves: CLI daemon → server (gRPC gate) → seedpack apply → workflow apply
  * → Temporal orchestration → runner execution → event streaming → clean
- * shutdown.
+ * shutdown. Since the console restoration (DD-012) it also proves the
+ * unified port serves the bundled web console: /config.json synthesis, a
+ * dynamic deep link, and the 404 posture — the P3 acceptance's
+ * "`stigmer up` serves the console end-to-end" arm.
  *
  * The CLI itself runs from source under tsx — the repo's documented dev
  * launch (its `start` script; the daemon re-exec replays the loader via
@@ -191,7 +194,40 @@ try {
     fail(`expected a node+entry server process, got: ${command}`);
   }
 
-  // 3. Apply the deterministic workflow.
+  // 3. Console restoration (DD-012): the slim artifact ships the web
+  //    console and the server serves it from the unified port. Probe the
+  //    three load-bearing arms a browser exercises: the synthesized
+  //    /config.json (Host-derived apiUrl), a dynamic deep link resolving
+  //    to its placeholder document, and the 404 posture (the export's
+  //    not-found page WITH a 404 status — never the blank app shell).
+  //    `--no-web` only suppresses URL reporting; serving is unconditional.
+  const consoleBase = `http://127.0.0.1:7234`;
+  const config = await fetch(`${consoleBase}/config.json`);
+  if (config.status !== 200) {
+    fail(`console /config.json answered ${config.status}`);
+  }
+  const configBody = await config.json();
+  if (configBody.authMode !== "disabled" || configBody.apiUrl !== consoleBase) {
+    fail(
+      `console /config.json synthesized wrong: ${JSON.stringify(configBody)}`,
+    );
+  }
+  const deepLink = await fetch(`${consoleBase}/sessions/zz-smoke-probe`);
+  if (
+    deepLink.status !== 200 ||
+    !(deepLink.headers.get("content-type") ?? "").includes("text/html")
+  ) {
+    fail(
+      `console deep link answered ${deepLink.status} ${deepLink.headers.get("content-type")}`,
+    );
+  }
+  const notFound = await fetch(`${consoleBase}/zz-no-such-route`);
+  if (notFound.status !== 404) {
+    fail(`console unknown URL answered ${notFound.status}, expected 404`);
+  }
+  console.log("smoke-cli-cutover: console serving verified");
+
+  // 4. Apply the deterministic workflow.
   const workflowPath = join(home, "cutover-smoke.yaml");
   writeFileSync(
     workflowPath,
@@ -219,7 +255,7 @@ spec:
   // --org is a root-level global option, so it precedes the subcommand.
   cli(["--org", ORG, "apply", "-f", workflowPath]);
 
-  // 4. Run it and stream to completion (JSON events on stdout) — a clean
+  // 5. Run it and stream to completion (JSON events on stdout) — a clean
   //    exit is required.
   const run = cli(["--org", ORG, "run", "workflow", "cutover-smoke", "--json"], {
     timeoutMs: RUN_TIMEOUT_MS,
@@ -230,7 +266,7 @@ spec:
     );
   }
 
-  // 5. Down — clean teardown, port released.
+  // 6. Down — clean teardown, port released.
   cli(["down"]);
   const status = cli(["status"], { allowFailure: true });
   if (

--- a/scripts/verify-static-export-routes.d.mts
+++ b/scripts/verify-static-export-routes.d.mts
@@ -1,0 +1,51 @@
+/**
+ * Type surface of verify-static-export-routes.mjs for TypeScript
+ * importers. The TS server's console lane implements the same serving
+ * contract nginx.conf encodes, and its equivalence test
+ * (backend/services/stigmer-server/src/transport/console/__tests__/
+ * nginx-equivalence.test.ts) imports this gate's exported model as the
+ * oracle — one route contract, one gate, two verified implementations.
+ * Keep these signatures in step with the module's exports.
+ */
+
+export interface GateRouteSegment {
+  readonly name: string;
+  readonly dynamic: boolean;
+}
+
+export interface GateRoute {
+  readonly url: string;
+  readonly segments: readonly GateRouteSegment[];
+  readonly pageFile: string;
+}
+
+export interface GateServerModel {
+  readonly indexFile: string;
+  readonly errorPage: { readonly code: number; readonly uri: string } | null;
+}
+
+/** Enumerate every App Router route; refuses unmodelled constructs. */
+export function enumerateRoutes(appDir: string): GateRoute[];
+
+/** The HTML file a route's static export produces (placeholder form). */
+export function exportFileOf(route: GateRoute): string;
+
+/** A real-value request URL for a route — what a browser actually asks for. */
+export function representativeUrlOf(route: GateRoute): string;
+
+/** Parse nginx config text into directive nodes. */
+export function parseNginxConfig(source: string): unknown[];
+
+/** Build the routing model, refusing unmodelled directives. */
+export function buildServerModel(nodes: unknown[]): GateServerModel;
+
+/**
+ * Resolve a request against the model and a file set: the document the
+ * browser ends up with, or null (bare 404 with no error page).
+ */
+export function resolveRequest(
+  model: GateServerModel,
+  uri: string,
+  files: ReadonlySet<string>,
+  depth?: number,
+): string | null;


### PR DESCRIPTION
## Summary

Restores the local web console lost at the June CLI TypeScript migration: the TS server now serves the console's Next.js static export from the unified port's reserved lane 4, the export ships inside `@stigmer/server-slim`, `/config.json` is synthesized in-process, and the CLI reconnects (`stigmer up` prints a working console URL again). Self-hosting inherits the identical implementation (Phase-2 P3, DD-012).

## Context

DD-012 (parent program `20260822.01`, ratified 2026-08-26): the console ships INSIDE the server artifact — one artifact, one release train, no version skew possible — served on the router's reserved lane-4 slot, both tiers. This is a RESTORATION: the Go-era CLI embedded the console (`webconsole_embed.go`, deleted at the June migration); the TS CLI stub deferred to a "T06" that never came.

## Changes

**Server (`src/transport/console/`)**
- `resolver.ts` — pure route resolver merging the correct half of each prior implementation: nginx.conf's page contract (try-files chain, `__placeholder__.html` substitution most-literal-first, `404.html` WITH 404 status, trailing-slash 301) plus the retired Go handler's RSC flight rewrites (`<stem>.txt` → placeholder twin, nested `__next.*.txt`), formulated as "resolve the stem as a page, serve the resolved document's twin" — which also covers the two-dynamic-segment routes the Go handler's single-substitution loop predated.
- `handler.ts` — the lane: guard (GET/HEAD only; `/v1/*` and service-shaped paths excluded so every RPC/registry byte is untouched), nginx's four Cache-Control postures, explicit Content-Type map, per-request `/config.json` synthesis with a **Host-derived `apiUrl`** (works from localhost, LAN, and self-host names; the console's config loader maps empty fields to a localhost default, so same-origin cannot be expressed console-side).
- `assets.ts` — sibling `console/` discovery next to the running bundle (the workflow-bundle idiom); `STIGMER_CONSOLE_DIR` override; assets absent → lane absent → router behaves exactly as before (wire-invisible).

**One route contract, one gate**
- `__tests__/nginx-equivalence.test.ts` imports `scripts/verify-static-export-routes.mjs`'s exported model (route enumeration + parsed nginx.conf), synthesizes the export set via the gate's own `exportFileOf` (hermetic — no web build needed in `make test-server`), and asserts the TS resolver lands every route, trailing-slash form, and unknown URL on the SAME document as the nginx model. nginx.conf, the route tree, and this lane can no longer drift apart silently. (`scripts/verify-static-export-routes.d.mts` types the gate for the TS importer.)

**Packaging + gates**
- `bundle-slim.mjs` stages `client-apps/web/out` → `dist-slim/console/` (new step 4/6, loud-fail when the export is missing) and ships it in the `@stigmer/server-slim` tarball.
- `verify-slim-artifact.mjs` asserts console assets in the isolated copy and probes the booted artifact over live HTTP: `/config.json` (Host-derived apiUrl), root, a dynamic deep link, a flight `.txt`, and the 404 posture.
- `ci.stigmer-server.yaml` (both jobs) and `release.npm-libs.yaml` gain the console build before bundling; `client-apps/web/nginx.conf` + the routing gate join the server workflow's path filter (they are contract inputs to the equivalence test now).
- `smoke-cli-cutover.mjs` gains the console arm: config.json + deep link + 404 through a real `stigmer up` of the packaged artifact.

**CLI reconnection**
- `isWebConsoleAvailable()` is a real probe of the unified port's `/config.json`; the daemon records what a browser would actually find.
- `resolveConsoleURL` (also the share-link/embed origin) points at the unified port; `WEB_CONSOLE_PORT` (8234) retires with a rationale comment; status and `stigmer up` print the console URL (up only when the daemon's probe found one); `--no-web` help corrected (it suppresses reporting; serving is one process, one origin).
- Getting-started docs repointed from 8234 to 7234.

## Implementation notes

- Flight rewriting is deliberately BEYOND nginx: nginx serves placeholder HTML for `.txt` flight requests today, silently degrading cloud soft-navigation to full page loads — filed as #897 rather than fixed here (the routing gate's parser must grow with any nginx change).
- Cache posture for documents outside nginx's four explicit rules is `no-cache` (deliberate divergence with rationale comment: this handler emits no validators, and upgrades must be instantly visible; the heavy assets are all under the immutable `/_next/static/` rule).
- With assets present, unknown GET paths serve the export's `404.html` (status still 404) instead of the adapter's terse 404 — no existing test or conformance suite pins that body (verified); unit tests without staged assets pin today's exact lane-absent behavior.
- TLS-fronted deployments (`x-forwarded-proto`) are out of scope for the `apiUrl` derivation until a tier serves TLS.

## Breaking changes

- None on the wire. `WEB_CONSOLE_PORT` (8234) is retired from the CLI: the console URL is now the server's own port.

## Test plan

- Server suite: **1733/1733** (37 new: resolver arms, composed lane HTTP contract on BOTH protocol stacks, nginx equivalence across all 52 routes / 12 dynamic), typecheck clean (Node 22.23.2).
- CLI suite: **954/954** (retirement baseline), typecheck clean.
- Routing gate green incl. real-export cross-check; the gate's own node:test suite green.
- `verify:dist` + `verify:slim` boot checks pass; deep slim verify (isolated copy + real Temporal + console HTTP probes) passes.
- `make smoke-cli-cutover` PASS including the console arm — a real `stigmer up` of the packaged slim artifact serves config.json, a dynamic deep link, and the 404 posture.
- Conformance regression-free: `local` **492/1-skipped**, `local-execution` **160/1-skipped** — both baseline-exact (the wire-invisibility proof).
- Measured size: the console adds **23 MB** to the slim artifact (dist-slim total 89.5 MB for darwin-arm64, from ~66.5 MB).

## Risks

- Release/CI lanes now build the web console before bundling (added CI time; a broken web build fails the server gate loudly instead of shipping a console-less artifact).
- Rollback: revert the PR — the lane is absent without staged assets and the router is byte-identical to before.

## Checklist

- [x] Docs updated (getting-started console URLs)
- [x] Tests added/updated
- [x] Backward compatible (wire-identical without bundled assets; conformance baseline-exact)

Made with [Cursor](https://cursor.com)