### PR TITLE
fix(tools/codegen): build @stigmer/protos before SDK codegen and drop tools-only bazel repos

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,10 +26,8 @@ go_deps.from_file(go_work = "//:go.work")
 use_repo(
     go_deps,
     "build_buf_gen_go_bufbuild_protovalidate_protocolbuffers_go",  # keep: Required for protovalidate protobuf types
-    "build_buf_go_protovalidate",  # keep: Required for protovalidate runtime validation
     "com_github_golang_jwt_jwt_v5",
     "com_github_google_uuid",
-    "com_github_jhump_protoreflect",
     "com_github_minio_minio_go_v7",
     "com_github_modelcontextprotocol_go_sdk",  # keep: Required for MCP server discovery in CLI
     "com_github_pkg_errors",  # keep: Required by the seedpack package

--- a/mcp-server/Makefile
+++ b/mcp-server/Makefile
@@ -12,8 +12,12 @@ codegen-apply: ## Generate apply-tool zod schemas + toProto bridges from proto s
 	@rm -rf src/gen
 	@mkdir -p src/gen
 	@# The generator runs from TypeScript source via the repo-pinned tsx
-	@# (never bare npx — oss#531).
+	@# (never bare npx — oss#531) and reads proto metadata from
+	@# @stigmer/protos, which must be built first (incremental; a no-op when
+	@# fresh). A bare CI checkout has no dist/ — skipping this fails module
+	@# resolution.
 	@cd .. && test -x node_modules/.bin/tsx || { echo "error: node_modules/.bin/tsx not found — run 'npm install' at the repo root"; exit 1; }
+	@cd .. && npm run build -w @stigmer/protos --silent
 	@cd .. && node_modules/.bin/tsx tools/codegen/src/generator/main.ts \
 		--schema-dir tools/codegen/schemas \
 		--output-dir mcp-server/src/gen \

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -83,8 +83,11 @@ codegen-clients: ## Generate SDK client code from service schemas (Stage 2)
 	@# The generator runs from TypeScript source via the repo-pinned tsx
 	@# (never bare npx — oss#531). It pipes generated Go through gofmt, so
 	@# the Go toolchain must be on PATH (it already is — the SDK build
-	@# follows).
+	@# follows), and it reads proto metadata from @stigmer/protos, which
+	@# must be built first (incremental; a no-op when fresh). A bare CI
+	@# checkout has no dist/ — skipping this fails module resolution.
 	@cd ../.. && test -x node_modules/.bin/tsx || { echo "error: node_modules/.bin/tsx not found — run 'npm install' at the repo root"; exit 1; }
+	@cd ../.. && npm run build -w @stigmer/protos --silent
 	@cd ../.. && node_modules/.bin/tsx tools/codegen/src/generator/main.ts \
 		--schema-dir tools/codegen/schemas \
 		--output-dir sdk/go/internal/gen \

--- a/sdk/java/Makefile
+++ b/sdk/java/Makefile
@@ -33,8 +33,12 @@ codegen-clients: ## Generate SDK client code from service schemas (Stage 2)
 	@rm -rf $(SDK_GEN_DIR)
 	@mkdir -p $(SDK_GEN_DIR)
 	@# The generator runs from TypeScript source via the repo-pinned tsx
-	@# (never bare npx — oss#531).
+	@# (never bare npx — oss#531) and reads proto metadata from
+	@# @stigmer/protos, which must be built first (incremental; a no-op when
+	@# fresh). A bare CI checkout has no dist/ — skipping this fails module
+	@# resolution.
 	@cd ../.. && test -x node_modules/.bin/tsx || { echo "error: node_modules/.bin/tsx not found — run 'npm install' at the repo root"; exit 1; }
+	@cd ../.. && npm run build -w @stigmer/protos --silent
 	@cd ../.. && node_modules/.bin/tsx tools/codegen/src/generator/main.ts \
 		--schema-dir tools/codegen/schemas \
 		--output-dir sdk/java/$(SDK_GEN_DIR) \

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -12,8 +12,12 @@ codegen-clients: ## Generate SDK client code from service schemas
 	@rm -rf src/stigmer/_gen
 	@mkdir -p src/stigmer/_gen
 	@# The generator runs from TypeScript source via the repo-pinned tsx
-	@# (never bare npx — oss#531).
+	@# (never bare npx — oss#531) and reads proto metadata from
+	@# @stigmer/protos, which must be built first (incremental; a no-op when
+	@# fresh). A bare CI checkout has no dist/ — skipping this fails module
+	@# resolution.
 	@cd ../.. && test -x node_modules/.bin/tsx || { echo "error: node_modules/.bin/tsx not found — run 'npm install' at the repo root"; exit 1; }
+	@cd ../.. && npm run build -w @stigmer/protos --silent
 	@cd ../.. && node_modules/.bin/tsx tools/codegen/src/generator/main.ts \
 		--schema-dir tools/codegen/schemas \
 		--output-dir sdk/python/src/stigmer/_gen \

--- a/sdk/typescript/Makefile
+++ b/sdk/typescript/Makefile
@@ -12,8 +12,12 @@ codegen-clients: ## Generate SDK client code from service schemas
 	@rm -rf src/gen
 	@mkdir -p src/gen
 	@# The generator runs from TypeScript source via the repo-pinned tsx
-	@# (never bare npx — oss#531).
+	@# (never bare npx — oss#531) and reads proto metadata from
+	@# @stigmer/protos, which must be built first (incremental; a no-op when
+	@# fresh). A bare CI checkout has no dist/ — skipping this fails module
+	@# resolution.
 	@cd ../.. && test -x node_modules/.bin/tsx || { echo "error: node_modules/.bin/tsx not found — run 'npm install' at the repo root"; exit 1; }
+	@cd ../.. && npm run build -w @stigmer/protos --silent
 	@cd ../.. && node_modules/.bin/tsx tools/codegen/src/generator/main.ts \
 		--schema-dir tools/codegen/schemas \
 		--output-dir sdk/typescript/src/gen \


### PR DESCRIPTION
## Summary

- Post-merge CI for the codegen TypeScript rewrite (#895) failed in ci.codegen, ci.go-sdk, ci.java-sdk, release.desktop, and ci.bazel.
- Four lanes shared one cause: the per-SDK Makefile codegen targets run the TS generator without building `@stigmer/protos` first, and a bare CI checkout has no `dist/` — `ERR_MODULE_NOT_FOUND` on `field_options_pb.js`. Each target (mcp-server, sdk/go, sdk/typescript, sdk/python, sdk/java) now runs `npm run build -w @stigmer/protos --silent` before the generator, matching the root Makefile targets.
- ci.bazel failed separately: `MODULE.bazel` still imported `build_buf_go_protovalidate` and `com_github_jhump_protoreflect` from the go_deps extension, but both repos were generated solely from the deleted `tools/go.mod`. Removed the two orphaned `use_repo` entries (`build_buf_gen_go_bufbuild_protovalidate_protocolbuffers_go` and `in_gopkg_yaml_v3` stay — still used by the SDK/seedpack/test modules).

## Test plan

- [x] Reproduced the CI state locally: fresh worktree, `npm ci`, no `@stigmer/protos` dist — all five swapped targets previously failed, now regenerate successfully with zero output drift.
- [x] `./bazelw query //...` evaluates the module graph cleanly (the failing step died at extension evaluation).
- [x] `./bazelw run //:gazelle -- -mode=diff` (the lane's freshness step) passes.
- [ ] Confirm the affected lanes go green on this PR / after merge.

Made with [Cursor](https://cursor.com)