### PR TITLE
ci(java-sdk): install Node before the TS-driven Java SDK codegen

### DIFF
--- a/.github/workflows/ci.java-sdk.yaml
+++ b/.github/workflows/ci.java-sdk.yaml
@@ -58,10 +58,17 @@ jobs:
           distribution: 'temurin'
           cache: maven
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      # The client generator runs from TypeScript source via the repo-pinned
+      # tsx (never bare npx — oss#531), so the root npm install must exist
+      # before the codegen step.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          go-version: '1.25'
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       # The SDK pom depends on stigmer-java-protos:0.0.1-SNAPSHOT, so the
       # stubs must be in the local repository before the SDK can compile

--- a/.github/workflows/release.maven.yaml
+++ b/.github/workflows/release.maven.yaml
@@ -120,10 +120,17 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      # The client generator runs from TypeScript source via the repo-pinned
+      # tsx (never bare npx — oss#531), so the root npm install must exist
+      # before the codegen step.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          go-version: '1.25'
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Generate SDK client code
         run: make -C sdk/java codegen


### PR DESCRIPTION
## Summary

- ci.java-sdk was the one lane still failing after #900: it runs `make -C sdk/java codegen` (the TypeScript generator via repo-pinned tsx) but never installs Node or runs `npm ci`, so the tsx guard fails. The now-unneeded `setup-go` step (a relic of the old `go run` generator) is replaced with `setup-node` + `npm ci`.
- `release.maven` had the same latent gap on its codegen step — it would have failed on the next Java SDK release — fixed identically.
- Audited every workflow that reaches a codegen target: all others already install Node.

## Test plan

- [x] Workflow-level fix mirrors the pattern already proven green in ci.go-sdk / ci.codegen on `c9cd5a700`.
- [ ] Confirm ci.java-sdk goes green on the push-to-main run after merge.

Made with [Cursor](https://cursor.com)