### PR TITLE
feat(backend/stigmer-server): ship the official multi-arch server Docker image (DD-014, Phase-2 P4)

### DIFF
--- a/.github/workflows/ci.stigmer-server.yaml
+++ b/.github/workflows/ci.stigmer-server.yaml
@@ -152,6 +152,29 @@ jobs:
           done
           node scripts/verify-slim-artifact.mjs
 
+      # The Docker image smoke (DD-014, Phase-2 P4): the SAME dist-slim the
+      # deep verify just proved, packaged by the service's Dockerfile and
+      # proven as a container — HEALTHCHECK reaches healthy, Connect-JSON
+      # health answers SERVING, the console lane serves, a CRUD round-trip
+      # lands, state survives a restart, SIGTERM exits clean. Native amd64;
+      # the arm64 twin runs in the boot-smoke job below. This is what makes
+      # the image PR-testable at all — the release lane consumes the same
+      # Dockerfile and the same smoke script.
+      - name: Boot-smoke the Docker image (sqlite + volume)
+        working-directory: backend/services/stigmer-server
+        run: node scripts/smoke-docker-image.mjs
+
+      # The image against Postgres: without this, the first time the
+      # image ever met Postgres would be the compose gate (P5). Reuses the
+      # image the sqlite smoke just built and this job's service container,
+      # reached from the sibling container via the host gateway.
+      - name: Boot-smoke the Docker image (Postgres)
+        working-directory: backend/services/stigmer-server
+        run: |
+          node scripts/smoke-docker-image.mjs \
+            --image=stigmer-server:smoke-local \
+            --database-url=postgres://postgres:postgres@host.docker.internal:5432/postgres
+
       - name: Run the vitest suite
         env:
           TEST_DATABASE_URL: postgres://postgres:postgres@127.0.0.1:5432/postgres
@@ -216,3 +239,11 @@ jobs:
             sleep 1
           done
           node scripts/verify-slim-artifact.mjs
+
+      # The arm64 half of the Docker image's both-arch acceptance (DD-014,
+      # Phase-2 P4): the tree bundled above IS linux-arm64 on this native
+      # runner, so the container smoke here is the exact platform proof —
+      # no QEMU, no emulation blind spots (this job's founding posture).
+      - name: Boot-smoke the Docker image (sqlite + volume, native arm64)
+        working-directory: backend/services/stigmer-server
+        run: node scripts/smoke-docker-image.mjs

--- a/.github/workflows/release.npm-libs.yaml
+++ b/.github/workflows/release.npm-libs.yaml
@@ -343,6 +343,40 @@ jobs:
           done
           node scripts/verify-slim-artifact.mjs
 
+      # ── The Docker image's input (DD-014, Phase-2 P4) ──
+      # The amd64 tree is a byte copy of the tree the deep verify above
+      # just proved; the arm64 tree is the same bundle invocation
+      # retargeted (core-bridge's npm tarball carries every platform's
+      # prebuilds, so cross-building is exact — the pushed arm64 image is
+      # booted on a native arm64 runner before `latest` moves). Staged
+      # under the TARGETARCH names the Dockerfile's COPY expects and
+      # handed to publish-server-image as a workflow artifact: the image
+      # consumes the already-built slim artifact, never a rebuild of its
+      # own. The stamp env must ride along — the defines are baked at
+      # bundle time.
+      - name: Stage the per-arch image trees
+        working-directory: backend/services/stigmer-server
+        env:
+          STIGMER_SERVER_VERSION: ${{ needs.determine-version.outputs.version }}
+          STIGMER_GITHUB_CLIENT_ID: ${{ secrets.STIGMER_LOCAL_GITHUB_OAUTH_CLIENT_ID }}
+          STIGMER_GITHUB_CLIENT_SECRET: ${{ secrets.STIGMER_LOCAL_GITHUB_OAUTH_CLIENT_SECRET }}
+        run: |
+          cp -R dist-slim dist-slim-amd64
+          node scripts/bundle-slim.mjs --platform=linux-arm64
+          cp -R dist-slim dist-slim-arm64
+
+      # Before the npm publish so a failed upload leaves the version
+      # unpublished and the whole run safely re-runnable.
+      - name: Upload the per-arch image trees
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-slim-image-trees
+          path: |
+            backend/services/stigmer-server/dist-slim-amd64
+            backend/services/stigmer-server/dist-slim-arm64
+          retention-days: 3
+          if-no-files-found: error
+
       - name: Publish slim packages to npm
         working-directory: backend/services/stigmer-server
         env:
@@ -356,3 +390,154 @@ jobs:
             (cd "$pkg" && npm publish --access public --tag "$NPM_TAG")
           done
           cd dist-slim-pkgs/server-slim && npm publish --access public --tag "$NPM_TAG"
+
+  # ══ The official server Docker image (DD-014, Phase-2 P4) ══
+  # Push → prove → promote: the version tag is pushed first, both-arch
+  # NATIVE boot smokes run against the PUSHED bytes, and only then does
+  # `latest` move (the release.sandbox-cloud :prod blessing pattern applied
+  # to the public tag). `latest` is only ever an image that has booted on
+  # each platform it claims.
+  publish-server-image:
+    needs: [determine-version, publish-server-slim]
+    runs-on: ubuntu-latest
+    # A healthy build is a few minutes — the Dockerfile is COPY-only, so
+    # nothing executes under QEMU. Cap the job so a stalled buildx/QEMU
+    # step fails fast (the release.mcp-server ~1h hang on v3.1.11).
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download the per-arch image trees
+        uses: actions/download-artifact@v4
+        with:
+          name: server-slim-image-trees
+          path: backend/services/stigmer-server
+
+      # QEMU only assembles the foreign-arch layers (no RUN under
+      # emulation); registered explicitly rather than relying on
+      # preinstalled binfmt (release.mcp-server precedent).
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # No gha build cache: a COPY-only build gains nothing from it, and
+      # `cache-to type=gha` has hung the export for up to an hour
+      # (release.mcp-server, v3.1.11). Only the version tag is pushed
+      # here — `latest` waits for the smoke jobs below.
+      - name: Build and push the image (version tag only)
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --file backend/services/stigmer-server/Dockerfile \
+            --build-arg IMAGE_VERSION="v${VERSION}" \
+            --build-arg IMAGE_REVISION="${{ github.sha }}" \
+            --tag "ghcr.io/${{ github.repository_owner }}/stigmer-server:v${VERSION}" \
+            --push \
+            backend/services/stigmer-server
+
+      # New GHCR packages default to private; this image is the OSS
+      # self-host artifact. Idempotent, so it rides every release. The
+      # first push above came from this repo's workflow, which auto-links
+      # the package to stigmer/stigmer — keeping GITHUB_TOKEN write access
+      # (the linkage whose absence broke the mirror packages).
+      - name: Ensure GHCR package is public
+        continue-on-error: true
+        run: |
+          gh api \
+            -X PUT \
+            /orgs/${{ github.repository_owner }}/packages/container/stigmer-server/visibility \
+            -f visibility=public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Native smokes of the PUSHED tag — the same script PR CI and local dev
+  # run (scripts/smoke-docker-image.mjs): docker health, Connect-JSON
+  # health SERVING, console lane, CRUD round-trip, restart persistence,
+  # clean SIGTERM. No QEMU: each arch proves itself on its own runner.
+  smoke-server-image-amd64:
+    needs: [determine-version, publish-server-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Boot-smoke the pushed image (native amd64)
+        run: |
+          node backend/services/stigmer-server/scripts/smoke-docker-image.mjs \
+            --image="ghcr.io/${{ github.repository_owner }}/stigmer-server:v${{ needs.determine-version.outputs.version }}"
+
+  smoke-server-image-arm64:
+    needs: [determine-version, publish-server-image]
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Boot-smoke the pushed image (native arm64)
+        run: |
+          node backend/services/stigmer-server/scripts/smoke-docker-image.mjs \
+            --image="ghcr.io/${{ github.repository_owner }}/stigmer-server:v${{ needs.determine-version.outputs.version }}"
+
+  promote-server-image-latest:
+    needs: [determine-version, smoke-server-image-amd64, smoke-server-image-arm64]
+    # Stable only: a prerelease (any '-') never becomes `latest` — the npm
+    # `next`-tag logic applied to the image channel (DD-014: latest on
+    # stable). imagetools create re-points the manifest list without
+    # rebuilding, so `latest` is bit-identical to the smoked version tag.
+    if: ${{ !contains(needs.determine-version.outputs.version, '-') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      packages: write
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote latest to the smoked version tag
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "ghcr.io/${{ github.repository_owner }}/stigmer-server:latest" \
+            "ghcr.io/${{ github.repository_owner }}/stigmer-server:v${VERSION}"

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ bin/
 dist/
 dist-slim/
 dist-slim-pkgs/
+# Per-arch trees the Docker image build stages (scripts/smoke-docker-image.mjs).
+dist-slim-amd64/
+dist-slim-arm64/
 
 # Desktop embedded-runner staging: a symlink in dev (setup-runner-dev.sh),
 # the staged slim artifact in packaged builds (stage-runner-slim.sh).

--- a/Makefile
+++ b/Makefile
@@ -527,6 +527,14 @@ smoke-cli-cutover: build-runner build-server build-web ## Run the CLI E2E smoke:
 	@cd $(SERVER_DIR) && node scripts/bundle-slim.mjs
 	node scripts/smoke-cli-cutover.mjs
 
+# The bundle targets linux for THIS machine's arch (the docker daemon's
+# native platform), not the host OS — the smoke builds a linux container.
+.PHONY: smoke-docker-image
+smoke-docker-image: build-server build-web ## Build the server Docker image from a fresh slim bundle and boot-smoke it (DD-014; needs Docker)
+	@command -v docker >/dev/null 2>&1 || { echo "error: docker not found — the image smoke needs a Docker daemon"; exit 1; }
+	@cd $(SERVER_DIR) && node scripts/bundle-slim.mjs --platform=linux-$$(node -e "process.stdout.write(process.arch==='x64'?'x64':'arm64')")
+	@cd $(SERVER_DIR) && node scripts/smoke-docker-image.mjs
+
 .PHONY: test-conformance-cloud
 test-conformance-cloud: build-ts-stubs ## Run gRPC conformance CRUD suite against the Java cloud service (hermetic; needs Docker, `fga`, `temporal`, and the fat JAR)
 	@command -v go >/dev/null 2>&1 || { echo "error: go not found — the harness builds the cloud environment launcher"; exit 1; }

--- a/backend/services/stigmer-server/.dockerignore
+++ b/backend/services/stigmer-server/.dockerignore
@@ -1,0 +1,7 @@
+# Whitelist: the image consumes ONLY the staged per-arch slim trees.
+# Everything else in this directory (node_modules, src, dist, the npm
+# package staging) would bloat the build context by hundreds of MB and
+# invalidate layer caching on every source edit.
+*
+!dist-slim-amd64
+!dist-slim-arm64

--- a/backend/services/stigmer-server/Dockerfile
+++ b/backend/services/stigmer-server/Dockerfile
@@ -1,0 +1,94 @@
+# =============================================================================
+# The official stigmer-server image (DD-014, Phase-2 P4)
+# =============================================================================
+# Packages the SAME @stigmer/server-slim artifact the CLI acquires at
+# `stigmer up` — one artifact, every channel (console included, DD-012).
+# The image executes NO build steps: the per-arch dist-slim tree is built
+# and verified OUTSIDE docker (scripts/bundle-slim.mjs --platform=...,
+# release-stamped in the release lane), then copied in. That keeps the
+# multi-arch build hermetic — the QEMU leg of a buildx run assembles
+# layers without executing emulated code — and keeps this file from
+# becoming a second packaging path.
+#
+# Build (the smoke script and CI stage the tree; by hand):
+#   node scripts/bundle-slim.mjs --platform=linux-arm64   # or linux-x64
+#   mv dist-slim dist-slim-arm64                          # or dist-slim-amd64
+#   docker build -t stigmer-server backend/services/stigmer-server
+#
+# Run (laptop tier — sqlite, one volume):
+#   docker run -d -p 7234:7234 -p 7235:7235 -v stigmer-data:/data \
+#     ghcr.io/stigmer/stigmer-server:latest
+#
+# node:22-slim, not alpine/distroless: the Temporal core-bridge prebuilds
+# are gnu-triple (glibc) binaries, and 22 is the engines floor (DD-014;
+# the #24 Ruling-3 amendment).
+FROM node:22-slim
+
+# TARGETARCH (amd64|arm64) is populated by BuildKit per platform leg; the
+# staged trees are named after it so ONE buildx invocation covers both
+# platforms. A missing tree for the requested arch fails the COPY loudly.
+ARG TARGETARCH
+
+# The source label is load-bearing, not decorative: together with the
+# first push coming from a repo workflow, it links the GHCR package to
+# stigmer/stigmer so the repo's GITHUB_TOKEN keeps write access — the
+# linkage whose absence broke the mirror-image packages (permission_denied
+# on every upstream tag move).
+ARG IMAGE_VERSION=dev
+ARG IMAGE_REVISION=unknown
+LABEL org.opencontainers.image.source="https://github.com/stigmer/stigmer" \
+      org.opencontainers.image.title="stigmer-server" \
+      org.opencontainers.image.description="Stigmer control plane: unified gRPC/Connect/REST port with the bundled web console" \
+      org.opencontainers.image.licenses="Apache-2.0" \
+      org.opencontainers.image.version="${IMAGE_VERSION}" \
+      org.opencontainers.image.revision="${IMAGE_REVISION}"
+
+# HOME=/data is the persistence design, not a convenience: every stateful
+# default derives from the home directory — DB_PATH (~/.stigmer/stigmer.db),
+# STORAGE_PATH, ARTIFACT_LOCAL_BASE_PATH, AND the auto-generated encryption/
+# runner-token key files (src/encryption/key-manager.ts writes
+# ~/.stigmer/*.key; a key outside the volume would be lost on container
+# recreate, making every enc:v1: value in the database permanently
+# undecryptable). Pointing HOME at the volume puts ALL of it — including
+# keys — under one mount, with the exact on-disk layout of a bare-metal
+# ~/.stigmer: /data/.stigmer is byte-portable to and from `stigmer up`.
+#
+# ARTIFACT_HTTP_HOST=0.0.0.0 (DD-013): the artifact file server defaults
+# to loopback, which is unreachable through the container boundary even
+# with -p; the container network namespace is the isolation here.
+ENV HOME=/data \
+    ARTIFACT_HTTP_HOST=0.0.0.0
+
+# /data must exist owned by the runtime user before VOLUME freezes it:
+# named volumes initialize from the image and inherit this ownership.
+# (Bind mounts keep host ownership — the docker run docs cover chown.)
+RUN mkdir -p /data && chown node:node /data
+
+WORKDIR /app
+COPY --chown=node:node dist-slim-${TARGETARCH}/ /app/
+
+# Non-root: the server needs nothing root can do. node:22-slim ships the
+# node user (uid 1000).
+USER node
+
+# Keeps state out of the container's writable layer even when the operator
+# forgets -v (an anonymous volume outlives the layer and shows up in
+# `docker volume ls` instead of vanishing silently).
+VOLUME /data
+
+# 7234: the unified port — gRPC, gRPC-Web, Connect, REST, and the console
+# (lane 4). 7235: the artifact file server (GRPC_PORT+1, local storage).
+EXPOSE 7234 7235
+
+# Probes the REAL health service over the Connect JSON lane (the transport
+# pins this shape in src/transport/__tests__/server.test.ts): overall ""
+# flips SERVING only after wiring completes, so "healthy" means serving,
+# not merely bound. Reads GRPC_PORT so a port override keeps the probe
+# honest. start-period covers the boot-time search-index rebuild on large
+# adopted databases.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD node -e "const p=process.env.GRPC_PORT||'7234';fetch('http://127.0.0.1:'+p+'/grpc.health.v1.Health/Check',{method:'POST',headers:{'content-type':'application/json'},body:'{}'}).then(r=>r.ok?r.json():Promise.reject(new Error('http '+r.status))).then(b=>process.exit(b.status==='SERVING'?0:1)).catch(()=>process.exit(1))"
+
+# Exec form: node is PID 1 and receives docker stop's SIGTERM directly
+# (verify-slim-artifact pins the clean SIGTERM lifecycle).
+CMD ["node", "main.js"]

--- a/backend/services/stigmer-server/README.md
+++ b/backend/services/stigmer-server/README.md
@@ -23,6 +23,21 @@ register, and nothing diverges silently. The conformance suite
 (`test/conformance/`, targets `local` and `local-execution`) is the gate for
 every change that lands here.
 
+## Docker image
+
+The official image `ghcr.io/stigmer/stigmer-server` packages the same `@stigmer/server-slim` artifact the CLI acquires — unified port, bundled web console, sqlite by default — for linux/amd64 and linux/arm64. `stigmer up` remains the front door for laptops; the image is the alternative when you want the server contained or on a machine without the CLI:
+
+```bash
+docker run -d --name stigmer-server \
+  -p 7234:7234 -p 7235:7235 \
+  -v stigmer-data:/data \
+  ghcr.io/stigmer/stigmer-server:latest
+```
+
+The console is on `http://localhost:7234`, the API on the same port (gRPC, gRPC-Web, Connect, REST), and artifact downloads on 7235. `/data` holds ALL state — the database, skill storage, artifacts, and the auto-generated encryption keys — in the exact layout of a bare-metal `~/.stigmer`, so the volume is the complete backup and is portable to and from a `stigmer up` install. Losing the volume loses the encryption keys with it, which makes every encrypted value in a copied database unrecoverable — treat the volume as the unit of backup. With a bind mount instead of a named volume, `chown 1000` the host directory first (the server runs as the non-root `node` user). Set `DATABASE_URL` to run against Postgres instead of sqlite; point `TEMPORAL_HOST_PORT` at a reachable Temporal for the execution engine (the server serves without one — executions wait until it connects; the docker-compose stack that wires all of this arrives with the self-host tier).
+
+Tags: one per release (`vX.Y.Z`); `latest` moves only to stable releases, and only after the pushed image has boot-smoked on native runners of both architectures (`release.npm-libs.yaml`). Local build + smoke: `make smoke-docker-image`.
+
 ## Development
 
 Standalone package (own lockfile, not an npm workspace — the runner's model):

--- a/backend/services/stigmer-server/scripts/smoke-docker-image.mjs
+++ b/backend/services/stigmer-server/scripts/smoke-docker-image.mjs
@@ -1,0 +1,291 @@
+#!/usr/bin/env node
+
+/**
+ * Boot-smokes the official server Docker image (DD-014, Phase-2 P4) — the
+ * ONE smoke, shared by three consumers so their proofs cannot drift:
+ *
+ *   - local dev:        make smoke-docker-image
+ *   - PR CI:            ci.stigmer-server.yaml (both native arches; the
+ *                       amd64 job runs a second pass with DATABASE_URL —
+ *                       the image must not meet Postgres for the first
+ *                       time at the compose gate)
+ *   - the release lane: release.npm-libs.yaml smoke jobs run the PUSHED
+ *                       tag on native runners before `latest` is promoted
+ *
+ * What one pass proves, in order:
+ *   1. the container reaches Docker `healthy` — this executes the
+ *      Dockerfile's HEALTHCHECK line, which no other test touches;
+ *   2. the real health service answers SERVING over the Connect JSON lane
+ *      (wiring-complete, not merely port-bound);
+ *   3. the console is served: /config.json honors its contract
+ *      (authMode disabled, apiUrl derived from the request Host) and /
+ *      answers HTML — DD-012's restoration must survive packaging;
+ *   4. a CRUD round-trip (Organization create → get) through the Connect
+ *      JSON lane;
+ *   5. state survives `docker restart` — the /data volume story is
+ *      proven, not claimed (under DATABASE_URL the same probe proves the
+ *      Postgres path instead);
+ *   6. `docker stop` (SIGTERM) exits 0 — the clean-shutdown lifecycle.
+ *
+ * Usage:
+ *   node scripts/smoke-docker-image.mjs [--image=TAG] [--database-url=URL]
+ *
+ *   Without --image: stages dist-slim/ (built by bundle-slim.mjs for THIS
+ *   machine's arch) into dist-slim-<arch>/ and builds a local image first.
+ *   With --image: smokes the given tag as-is (the release lane's mode).
+ *
+ *   --database-url runs the container against Postgres. The URL is
+ *   resolved INSIDE the container: reach a host-published Postgres via
+ *   host.docker.internal (the script adds the host-gateway mapping).
+ *
+ * Plain node + docker CLI, no dependencies — runnable everywhere CI is.
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import { cpSync, existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const serverRoot = fileURLToPath(new URL("..", import.meta.url));
+
+const BOOT_TIMEOUT_MS = 90_000;
+// docker stop's grace must outlast the server's own drain (verify-slim
+// allows 20s) — a SIGKILL here would pass silently as a dirty shutdown.
+const STOP_GRACE_SECONDS = 30;
+
+function parseArgs() {
+  let image = "";
+  let databaseUrl = "";
+  for (const arg of process.argv.slice(2)) {
+    let m;
+    if ((m = arg.match(/^--image=(.+)$/)) !== null) image = m[1];
+    else if ((m = arg.match(/^--database-url=(.+)$/)) !== null) databaseUrl = m[1];
+    else fail(`unknown argument: ${arg}`);
+  }
+  return { image, databaseUrl };
+}
+
+function fail(message) {
+  console.error(`smoke-docker-image: ${message}`);
+  process.exit(1);
+}
+
+function log(step) {
+  console.log(`smoke-docker-image: ${step}`);
+}
+
+function docker(args, options = {}) {
+  return execFileSync("docker", args, { encoding: "utf8", ...options }).trim();
+}
+
+/** node's arch names map straight onto docker's TARGETARCH for our two. */
+function dockerArch() {
+  const arch = process.arch;
+  if (arch === "x64") return "amd64";
+  if (arch === "arm64") return "arm64";
+  fail(`unsupported host arch "${arch}" — the image ships amd64 + arm64 only`);
+}
+
+function buildLocalImage() {
+  const distSlim = join(serverRoot, "dist-slim");
+  if (!existsSync(join(distSlim, "main.js"))) {
+    fail(
+      "dist-slim/main.js not found — build it first:\n" +
+        "  npm run build && node scripts/bundle-slim.mjs",
+    );
+  }
+  const arch = dockerArch();
+  const staged = join(serverRoot, `dist-slim-${arch}`);
+  log(`staging dist-slim/ -> dist-slim-${arch}/ (the Dockerfile's TARGETARCH contract)`);
+  rmSync(staged, { recursive: true, force: true });
+  cpSync(distSlim, staged, { recursive: true });
+  const tag = "stigmer-server:smoke-local";
+  log(`docker build ${tag}`);
+  execFileSync("docker", ["build", "--tag", tag, serverRoot], {
+    stdio: "inherit",
+  });
+  return tag;
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function pollUntil(label, timeoutMs, probe) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "";
+  while (Date.now() < deadline) {
+    try {
+      const result = await probe();
+      if (result !== undefined && result !== false) return result;
+      lastError = "probe returned falsy";
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(1000);
+  }
+  throw new Error(`timed out waiting for ${label} (${timeoutMs}ms): ${lastError}`);
+}
+
+/** Unary Connect-JSON call — the same lane a curl user gets. */
+async function connectJson(baseUrl, procedure, body) {
+  const response = await fetch(`${baseUrl}/${procedure}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${procedure} -> HTTP ${response.status}: ${text.slice(0, 300)}`);
+  }
+  return JSON.parse(text);
+}
+
+async function main() {
+  const { image: imageArg, databaseUrl } = parseArgs();
+  const image = imageArg !== "" ? imageArg : buildLocalImage();
+
+  const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const container = `stigmer-server-smoke-${suffix}`;
+  const volume = `stigmer-server-smoke-data-${suffix}`;
+
+  const runArgs = [
+    "run",
+    "--detach",
+    "--name",
+    container,
+    // Ephemeral host ports on loopback: parallel-safe on shared CI hosts.
+    "-p",
+    "127.0.0.1::7234",
+    "-v",
+    `${volume}:/data`,
+  ];
+  if (databaseUrl !== "") {
+    // host-gateway resolves host.docker.internal on Linux runners too, so
+    // one URL shape reaches a host-published Postgres from every CI host.
+    runArgs.push("--add-host=host.docker.internal:host-gateway");
+    runArgs.push("-e", `DATABASE_URL=${databaseUrl}`);
+  }
+  runArgs.push(image);
+
+  let failed = false;
+  try {
+    log(`docker run ${image} (${databaseUrl !== "" ? "postgres" : "sqlite"} mode)`);
+    docker(runArgs);
+
+    const hostPort = docker(["port", container, "7234/tcp"])
+      .split("\n")[0]
+      .split(":")
+      .pop();
+    const baseUrl = `http://127.0.0.1:${hostPort}`;
+    log(`unified port published at ${baseUrl}`);
+
+    // 1. Docker-level health: proves the HEALTHCHECK instruction itself.
+    log("waiting for the container to report healthy...");
+    await pollUntil("docker health=healthy", BOOT_TIMEOUT_MS, () => {
+      const state = docker([
+        "inspect",
+        "--format",
+        "{{.State.Status}} {{if .State.Health}}{{.State.Health.Status}}{{end}}",
+        container,
+      ]);
+      if (!state.startsWith("running")) {
+        throw new Error(`container is not running: ${state}`);
+      }
+      return state.endsWith(" healthy");
+    });
+
+    // 2. The health service over Connect JSON, from the host's side.
+    const health = await connectJson(baseUrl, "grpc.health.v1.Health/Check", {});
+    if (health.status !== "SERVING") {
+      throw new Error(`health service answered ${JSON.stringify(health)} — want SERVING`);
+    }
+    log("health service: SERVING");
+
+    // 3. The console lane (DD-012): the /config.json contract and a real page.
+    const config = await (await fetch(`${baseUrl}/config.json`)).json();
+    if (config.authMode !== "disabled") {
+      throw new Error(`/config.json authMode=${config.authMode} — want disabled`);
+    }
+    if (config.apiUrl !== baseUrl) {
+      throw new Error(`/config.json apiUrl=${config.apiUrl} — want ${baseUrl} (Host-derived)`);
+    }
+    const index = await fetch(`${baseUrl}/`);
+    const indexType = index.headers.get("content-type") ?? "";
+    if (index.status !== 200 || !indexType.includes("text/html")) {
+      throw new Error(`console / -> ${index.status} ${indexType} — want 200 text/html`);
+    }
+    log("console lane: /config.json contract + / html both answer");
+
+    // 4. CRUD through the same lane a curl user gets.
+    const orgName = `smoke-org-${suffix}`;
+    const created = await connectJson(
+      baseUrl,
+      "ai.stigmer.tenancy.organization.v1.OrganizationCommandController/create",
+      { apiVersion: "tenancy.stigmer.ai/v1", kind: "Organization", metadata: { name: orgName } },
+    );
+    const orgId = created.metadata?.id;
+    if (orgId === undefined || orgId === "") {
+      throw new Error(`organization create returned no id: ${JSON.stringify(created)}`);
+    }
+    const fetched = await connectJson(
+      baseUrl,
+      "ai.stigmer.tenancy.organization.v1.OrganizationQueryController/get",
+      { value: orgId },
+    );
+    if (fetched.metadata?.name !== orgName) {
+      throw new Error(`organization get returned ${fetched.metadata?.name} — want ${orgName}`);
+    }
+    log(`CRUD round-trip: organization '${orgId}' created and fetched`);
+
+    // 5. Persistence across a restart: the volume (or Postgres) must carry
+    // the row into the next container lifecycle.
+    log("restarting the container...");
+    docker(["restart", "--time", String(STOP_GRACE_SECONDS), container]);
+    const restartedPort = docker(["port", container, "7234/tcp"])
+      .split("\n")[0]
+      .split(":")
+      .pop();
+    const restartedBase = `http://127.0.0.1:${restartedPort}`;
+    await pollUntil("health=SERVING after restart", BOOT_TIMEOUT_MS, async () => {
+      const check = await connectJson(restartedBase, "grpc.health.v1.Health/Check", {});
+      return check.status === "SERVING";
+    });
+    const survived = await connectJson(
+      restartedBase,
+      "ai.stigmer.tenancy.organization.v1.OrganizationQueryController/get",
+      { value: orgId },
+    );
+    if (survived.metadata?.name !== orgName) {
+      throw new Error(`organization did not survive the restart: ${JSON.stringify(survived)}`);
+    }
+    log("persistence: the organization survived a container restart");
+
+    // 6. Clean shutdown: SIGTERM in, exit code 0 out.
+    log("stopping (SIGTERM)...");
+    docker(["stop", "--time", String(STOP_GRACE_SECONDS), container]);
+    const exitCode = docker(["inspect", "--format", "{{.State.ExitCode}}", container]);
+    if (exitCode !== "0") {
+      throw new Error(`container exited ${exitCode} on SIGTERM — want 0`);
+    }
+    log("clean shutdown: exit 0");
+    log("PASS");
+  } catch (error) {
+    failed = true;
+    console.error(
+      `smoke-docker-image: FAIL — ${error instanceof Error ? error.message : String(error)}`,
+    );
+    console.error("--- docker logs (last 200 lines) ---");
+    const logs = spawnSync("docker", ["logs", "--tail", "200", container], {
+      encoding: "utf8",
+    });
+    console.error(logs.stdout ?? "");
+    console.error(logs.stderr ?? "");
+  } finally {
+    spawnSync("docker", ["rm", "--force", container]);
+    spawnSync("docker", ["volume", "rm", "--force", volume]);
+  }
+  process.exit(failed ? 1 : 0);
+}
+
+await main();

--- a/backend/services/stigmer-server/src/boot/__tests__/config.test.ts
+++ b/backend/services/stigmer-server/src/boot/__tests__/config.test.ts
@@ -51,6 +51,23 @@ describe("loadConfig", () => {
     expect(loadConfig({ LOG_LEVEL: "" }).logLevel).toBe("info");
   });
 
+  // DD-013 / Phase-2 P4: the loopback default is the retired Go server's
+  // posture and must survive any future refactor — a changed default would
+  // silently expose every bare-metal install's artifact lane.
+  it("defaults the artifact file server host to loopback", () => {
+    expect(loadConfig({}).artifactHttpHost).toBe("127.0.0.1");
+  });
+
+  it("reads an explicit ARTIFACT_HTTP_HOST (the container override)", () => {
+    expect(
+      loadConfig({ ARTIFACT_HTTP_HOST: "0.0.0.0" }).artifactHttpHost,
+    ).toBe("0.0.0.0");
+    // Empty string is absent, per the Go getEnvString leniency.
+    expect(loadConfig({ ARTIFACT_HTTP_HOST: "" }).artifactHttpHost).toBe(
+      "127.0.0.1",
+    );
+  });
+
   it("disables the model-registry refresh only for the literal 'off'", () => {
     expect(
       loadConfig({ STIGMER_MODEL_REGISTRY_REFRESH: "off" })

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -739,7 +739,10 @@ export async function composeServer(
       if (artifactFileServer !== undefined) {
         await warnOnLegacyArtifactLayout(config.artifactLocalBasePath, logger);
         try {
-          await artifactFileServer.listen(config.artifactHttpPort);
+          await artifactFileServer.listen(
+            config.artifactHttpPort,
+            config.artifactHttpHost,
+          );
         } catch (error) {
           logger.error("Artifact HTTP file server failed", {
             error: error instanceof Error ? error.message : String(error),

--- a/backend/services/stigmer-server/src/boot/config.ts
+++ b/backend/services/stigmer-server/src/boot/config.ts
@@ -82,6 +82,16 @@ export interface ServerConfig {
    * grpcPort+1). Only bound when artifact storage is local.
    */
   readonly artifactHttpPort: number;
+  /**
+   * The artifact file server's bind host (ARTIFACT_HTTP_HOST, DD-013;
+   * shipped with the Docker image, Phase-2 P4). Defaults to 127.0.0.1 —
+   * the retired Go server's posture, byte-identical for every bare-metal
+   * install: download URLs are minted for the local machine. Containers
+   * set 0.0.0.0 (the official image does, with its rationale) because a
+   * loopback bind is unreachable through the container boundary even
+   * with the port published.
+   */
+  readonly artifactHttpHost: string;
   /** Cloudflare R2 settings (S3-compatible; validated when type is "r2"). */
   readonly r2Bucket: string;
   readonly r2Endpoint: string;
@@ -162,6 +172,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
   const grpcPort = envInt(env, "GRPC_PORT", DEFAULT_GRPC_PORT);
   // Go: ARTIFACT_HTTP_PORT defaults to the gRPC port + 1.
   const artifactHttpPort = envInt(env, "ARTIFACT_HTTP_PORT", grpcPort + 1);
+  const artifactHttpHost = envString(env, "ARTIFACT_HTTP_HOST", "127.0.0.1");
   const artifactStorageType = envString(env, "ARTIFACT_STORAGE_TYPE", "local");
   const r2 = {
     r2Bucket: envString(env, "R2_BUCKET", ""),
@@ -179,6 +190,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
   return {
     grpcPort,
     artifactHttpPort,
+    artifactHttpHost,
     ...r2,
     temporalHostPort: envString(env, "TEMPORAL_HOST_PORT", "localhost:7233"),
     temporalNamespace: envString(env, "TEMPORAL_NAMESPACE", "default"),

--- a/backend/services/stigmer-server/src/domain/artifact/__tests__/file-server-host.test.ts
+++ b/backend/services/stigmer-server/src/domain/artifact/__tests__/file-server-host.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Pins the artifact file server's bind-host contract (ARTIFACT_HTTP_HOST,
+ * DD-013; shipped with the Docker image, Phase-2 P4): the listener binds
+ * exactly the host the composition root passes. Loopback — the default —
+ * must stay unreachable through non-loopback interfaces (the retired Go
+ * server's posture), and the container override (0.0.0.0) must serve the
+ * same bytes. The serving behavior itself (traversal guard, disposition,
+ * 404 copy) is pinned by artifact.test.ts through the composed server;
+ * this file pins only what that test cannot: WHERE the listener binds.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createLogger } from "../../../boot/logger.js";
+import { createArtifactFileServer } from "../file-server.js";
+import type { ArtifactFileServer } from "../file-server.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+let dir: string;
+let server: ArtifactFileServer | undefined;
+
+afterEach(async () => {
+  await server?.shutdown();
+  server = undefined;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function newServer(): ArtifactFileServer {
+  dir = mkdtempSync(path.join(tmpdir(), "artifact-file-server-host-"));
+  writeFileSync(path.join(dir, "probe.txt"), "probe-bytes\n");
+  server = createArtifactFileServer({ basePath: dir, logger: silentLogger });
+  return server;
+}
+
+describe("artifact file server bind host", () => {
+  it("serves on the loopback default", async () => {
+    const port = await newServer().listen(0, "127.0.0.1");
+    const response = await fetch(`http://127.0.0.1:${port}/probe.txt`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("probe-bytes\n");
+  });
+
+  it("serves through the wildcard host override (the container posture)", async () => {
+    const port = await newServer().listen(0, "0.0.0.0");
+    // Wildcard-bound listeners answer on loopback too — the reachable
+    // proof that the override took effect without needing a second NIC.
+    const response = await fetch(`http://127.0.0.1:${port}/probe.txt`);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("probe-bytes\n");
+  });
+});

--- a/backend/services/stigmer-server/src/domain/artifact/file-server.ts
+++ b/backend/services/stigmer-server/src/domain/artifact/file-server.ts
@@ -38,8 +38,15 @@ export interface ArtifactFileServerOptions {
 }
 
 export interface ArtifactFileServer {
-  /** Binds 127.0.0.1:<port> (an explicit port 0 picks ephemeral for tests). */
-  listen(port: number): Promise<number>;
+  /**
+   * Binds <host>:<port> (an explicit port 0 picks ephemeral for tests).
+   * The host is the composition root's call: 127.0.0.1 everywhere by
+   * default (ARTIFACT_HTTP_HOST, DD-013) — download URLs are minted for
+   * the local machine — and 0.0.0.0 only inside the official container
+   * image, where the loopback bind would strand the lane behind the
+   * container boundary (Phase-2 P4).
+   */
+  listen(port: number, host: string): Promise<number>;
   shutdown(): Promise<void>;
 }
 
@@ -53,12 +60,15 @@ export function createArtifactFileServer(
   });
 
   return {
-    listen(port: number): Promise<number> {
+    listen(port: number, host: string): Promise<number> {
       return new Promise((resolve, reject) => {
         server.once("error", reject);
-        // Loopback-only, as Go binds "127.0.0.1:<port>": download URLs are
-        // minted for the local machine, never a network interface.
-        server.listen(port, "127.0.0.1", () => {
+        // Loopback by DEFAULT, as Go bound "127.0.0.1:<port>": download
+        // URLs are minted for the local machine, never a network
+        // interface. The host became configurable (ARTIFACT_HTTP_HOST,
+        // DD-013) for containers, where 127.0.0.1 is unreachable from
+        // outside; the default preserves Go's posture byte-for-byte.
+        server.listen(port, host, () => {
           server.removeListener("error", reject);
           const address = server.address();
           const boundPort =


### PR DESCRIPTION
## Summary

The official server image: `ghcr.io/stigmer/stigmer-server`, linux/amd64 + linux/arm64, on `node:22-slim`, packaging the same release-stamped `@stigmer/server-slim` artifact the CLI acquires — console included (DD-012), sqlite by default, `DATABASE_URL` flips to Postgres with zero image changes. Phase-2 P4 of the self-hosting program (DD-014; parent project `20260822.01`, sub-project `20260826.07`).

## Context

DD-014 ratified a multi-arch server image from day one, published to GHCR in the release train, with boot smokes on both arches and a documented laptop `docker run` path. P2 (Postgres driver, #899) and P3 (console serving, #898) landed the image's contents; this entry packages them. Three plan-gate rulings (owner, 2026-08-26): the DD-013 `ARTIFACT_HTTP_HOST` seam ships here with its first consumer; image name `ghcr.io/stigmer/stigmer-server` with v-prefixed tags and `latest` on stable only; the Dockerfile COPYs the release-stamped per-arch `dist-slim` tree rather than npm-installing inside the build.

## Changes

- **`backend/services/stigmer-server/Dockerfile`** (+ `.dockerignore`): COPY-only per `TARGETARCH` (nothing executes under QEMU), non-root `node` user, `VOLUME /data`, `HEALTHCHECK` probing the real gRPC health service over the Connect JSON lane, exec-form CMD (clean SIGTERM), OCI labels (the `source` label + first-push-from-workflow auto-links the GHCR package to the repo — the linkage whose absence caused the mirror-packages `permission_denied` class).
- **`scripts/smoke-docker-image.mjs`** + `make smoke-docker-image`: ONE smoke for local dev, PR CI, and the release lane — docker `healthy` (exercises the HEALTHCHECK line itself), Connect-JSON health `SERVING`, console `/config.json` contract + `/` HTML, Organization create/get CRUD, restart persistence (the volume story proven), SIGTERM exit 0. `--image` smokes a pushed tag; `--database-url` runs Postgres mode via the host gateway.
- **`ci.stigmer-server.yaml`**: both existing jobs gain native image smokes (amd64 + arm64, no QEMU in CI); the amd64 job adds a Postgres pass against its existing service container — the image must not meet Postgres for the first time at the P5 compose gate.
- **`release.npm-libs.yaml`**: `publish-server-slim` stages per-arch trees (amd64 = byte copy of the deep-verified tree) and uploads them before the npm publish; new jobs `publish-server-image` (buildx both platforms, version tag only, visibility flip, job-scoped `packages: write`, 25-min cap, no gha cache — the `release.mcp-server` hardening), `smoke-server-image-{amd64,arm64}` (native smokes of the PUSHED tag), `promote-server-image-latest` (`imagetools create`, stable only). **`latest` is only ever an image that has booted on both arches** — the `release.sandbox-cloud` `:prod` blessing pattern applied to the public tag.
- **The DD-013 seam**: `ARTIFACT_HTTP_HOST` (default `127.0.0.1` — the retired Go server's posture, byte-identical for bare metal; the image sets `0.0.0.0` because a loopback bind is unreachable through the container boundary). `config.ts` + `file-server.ts` `listen(port, host)` + `compose.ts`; 4 new tests pin the default and the override.
- **README**: the laptop `docker run` section — documented, not promoted over `stigmer up` (DD-014 point 3); volume-as-backup and bind-mount ownership wrinkles stated; the P6 guide consolidates later.

## Implementation notes

- **`HOME=/data` (execution-time design decision, disclosed for the record)**: the plan drafted explicit `DB_PATH`/`STORAGE_PATH`/`ARTIFACT_LOCAL_BASE_PATH` envs; execution found that incomplete — the key ladder (`src/encryption/key-manager.ts`) auto-generates encryption/runner-token keys into `~/.stigmer/*.key`, which inside the container is `/home/node`, OFF the volume: a recreated container would lose the keys and render every `enc:v1:` value permanently undecryptable. `HOME=/data` puts ALL stateful defaults — db, storage, artifacts, AND keys — under one mount, with the exact bare-metal `~/.stigmer` layout (`/data/.stigmer/...` is byte-portable to and from a `stigmer up` install).
- **COPY vs npm-install** (gate ruling 3): the npm-install pattern (`release.mcp-server`) cannot be exercised in PR CI (unpublished versions) and inherits the registry-settle polling; both npm packages and image descend from the one `bundle-slim.mjs` invocation with the same stamped env, so "no second packaging path" holds in substance.
- Health flips SERVING with no Temporal reachable (engine availability is modeled in the agentexecution domain, never in gRPC health) — the image smoke needs no Temporal sidecar; the plan's verification point closed positively.

## Breaking changes

None. The artifact file server's default bind is unchanged (`127.0.0.1`); the seam is wire-invisible unless `ARTIFACT_HTTP_HOST` is explicitly set.

## Test plan

All on Node 22.23.2 (the 23.4 FTS5/webpack traps per register):
- Typecheck clean; server unit suite **1818/1818** (baseline 1814 + 4 new tests), `TEST_DATABASE_URL` against an isolated `postgres:16-alpine`.
- Conformance `local` **492/1-skipped** and `local-postgres` **492/1-skipped** — both baseline-exact.
- Local image smoke: sqlite + volume mode **PASS**, Postgres mode **PASS** (all six stages each, arm64 native).
- actionlint on both workflows: zero findings in the new jobs/steps.
- The execution rosters and the amd64 image smokes ride this PR's CI; the release-lane jobs are exercised by the next `v*` tag.

## Risks

- The release-lane image jobs cannot run before a real tag; mitigations: the PR CI smokes run the same Dockerfile + same smoke script, and `latest` cannot move unless both post-push native smokes pass. Rollback: revert this PR — nothing else consumes the new jobs or the seam.
- First GHCR push creates the package; the visibility flip is `continue-on-error` and idempotent (re-runs cover a transient failure).

## Checklist

- [x] Docs updated (server README `docker run` section)
- [x] Tests added/updated (config + file-server bind pins; the shared smoke script)
- [x] Backward compatible (loopback default preserved byte-for-byte)

Made with [Cursor](https://cursor.com)