### PR TITLE
feat(repo): ship the self-host docker compose stack (DD-013, Phase-2 P5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,49 @@
+# Stigmer self-host compose stack — environment template.
+#
+#   cp .env.example .env
+#
+# then fill in the three REQUIRED values below. `docker compose up` fails
+# loudly until they exist — that is deliberate (DD-013): keys that
+# materialize implicitly make the backup and rotation story invisible
+# exactly where a self-hoster needs it explicit.
+#
+# BACKUP STORY — the complete durable state of this stack is:
+#   the postgres-data volume + the artifacts volume + the server-data
+#   volume + THIS FILE. Losing the two STIGMER_* keys below strands every
+#   encrypted value in the database, so back this file up like a key file.
+
+# ── Required ────────────────────────────────────────────────────────────────
+
+# Postgres superuser password (the stack's internal database; not exposed
+# on the host). Any strong secret:
+#   openssl rand -hex 24
+POSTGRES_PASSWORD=
+
+# Encrypts secret values at rest (environment variables, OAuth tokens).
+# Base64-encoded 32 bytes — generate with:
+#   openssl rand -base64 32
+STIGMER_ENCRYPTION_KEY=
+
+# Signs the execution-scoped tokens the runner authenticates with.
+# Base64-encoded 32 bytes — generate with:
+#   openssl rand -base64 32
+STIGMER_RUNNER_TOKEN_KEY=
+
+# ── Optional ────────────────────────────────────────────────────────────────
+
+# LLM provider key for agent executions (Anthropic is the provider local
+# execution supports). Without it the stack still serves the console, the
+# API, and LLM-free workflow executions; agent runs will fail at the LLM
+# call.
+#ANTHROPIC_API_KEY=
+
+# Cursor API key, only for agents on the Cursor harness.
+#CURSOR_API_KEY=
+
+# Operator identity, stamped into audit slots on resources you create.
+#STIGMER_OPERATOR_EMAIL=you@example.com
+#STIGMER_OPERATOR_NAME=Your Name
+
+# Run a specific released stack version (both images move together; the
+# default pin in docker-compose.yml is managed by the release lane).
+#STIGMER_VERSION=v3.12.9

--- a/.github/workflows/ci.compose-stack.yaml
+++ b/.github/workflows/ci.compose-stack.yaml
@@ -1,0 +1,78 @@
+# =============================================================================
+# Compose Stack — the self-host phase gate (DD-013, Phase-2 P5)
+# =============================================================================
+# Proves `docker compose up` from a clean clone: server + one Postgres +
+# real Temporal + containerized runner, up to ONE END-TO-END workflow run
+# through the runner (LLM-free, zero provider secrets — the gate ruling Q-C).
+#
+# Both images build FROM SOURCE via docker-compose.dev.yml (the gate ruling
+# Q-A): the committed docker-compose.yml pins published version tags for
+# users, but a PR must prove the real topology without waiting for a
+# release. The published-tag path is re-proven by the release lane
+# (release.npm-libs.yaml), which runs the SAME scripts/smoke-compose.mjs
+# against the pushed images on native amd64 + arm64 runners.
+#
+# Path filter: the compose surface only. Server/runner SOURCE changes are
+# gated by ci.stigmer-server / ci.runner (+ the conformance lanes); this
+# workflow guards the topology, the images' packaging seams, and the smoke
+# itself.
+# =============================================================================
+
+name: ci.compose-stack
+
+on:
+  pull_request:
+    paths:
+      - "docker-compose.yml"
+      - "docker-compose.dev.yml"
+      - ".env.example"
+      - "scripts/smoke-compose.mjs"
+      - "backend/services/runner/Dockerfile.sandbox"
+      - "backend/services/stigmer-server/Dockerfile"
+      - "Makefile"
+      - ".github/workflows/ci.compose-stack.yaml"
+  push:
+    branches: [main]
+    paths:
+      - "docker-compose.yml"
+      - "docker-compose.dev.yml"
+      - ".env.example"
+      - "scripts/smoke-compose.mjs"
+      - "backend/services/runner/Dockerfile.sandbox"
+      - "backend/services/stigmer-server/Dockerfile"
+      - "Makefile"
+      - ".github/workflows/ci.compose-stack.yaml"
+  workflow_dispatch:
+
+concurrency:
+  group: compose-stack-${{ github.head_ref || github.ref }}
+  # PR pushes cancel superseded runs; main pushes queue instead, so every
+  # merge gets a completed, attributable run (stigmer/stigmer#725).
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+permissions:
+  contents: read
+
+jobs:
+  compose-gate:
+    name: Compose Gate (build-from-source)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install npm workspace dependencies
+        run: npm ci
+
+      # make smoke-compose = build-server (stubs + deps + compile) +
+      # build-web (the console export bundle-slim stages, DD-012) +
+      # bundle-slim + scripts/smoke-compose.mjs --build. One entry point,
+      # identical to what a contributor runs locally.
+      - name: Build the stack from source and run the gate smoke
+        run: make smoke-compose

--- a/.github/workflows/release.npm-libs.yaml
+++ b/.github/workflows/release.npm-libs.yaml
@@ -541,3 +541,238 @@ jobs:
           docker buildx imagetools create \
             --tag "ghcr.io/${{ github.repository_owner }}/stigmer-server:latest" \
             "ghcr.io/${{ github.repository_owner }}/stigmer-server:v${VERSION}"
+
+  # ══ The compose-runner image (DD-013/DD-014, Phase-2 P5) ══
+  # The self-host stack's runner: Dockerfile.sandbox's `compose-runner`
+  # stage (the cloud sandbox stage + the stigmer CLI the OSS-shape MCP
+  # attachments spawn). Published as ghcr.io/stigmer/stigmer-runner with
+  # the server image's tag policy: push the version tag → prove it with
+  # the FULL compose smoke on both native arches → promote `latest` and
+  # bump the committed compose pin.
+  #
+  # Unlike the server image (COPY-only, QEMU-safe), this build compiles
+  # the runner and npm-installs the CLI in RUN steps — so each arch builds
+  # NATIVELY on its own runner (per-arch tags), and a manifest job merges
+  # them. Needs `publish`: the CLI installs from the npm registry at this
+  # release's version.
+  publish-runner-image-amd64:
+    needs: [determine-version, publish]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (native amd64, per-arch tag)
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --target compose-runner \
+            --build-arg STIGMER_CLI_VERSION="${VERSION}" \
+            --file backend/services/runner/Dockerfile.sandbox \
+            --tag "ghcr.io/${{ github.repository_owner }}/stigmer-runner:v${VERSION}-amd64" \
+            --push \
+            .
+
+  publish-runner-image-arm64:
+    needs: [determine-version, publish]
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (native arm64, per-arch tag)
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --target compose-runner \
+            --build-arg STIGMER_CLI_VERSION="${VERSION}" \
+            --file backend/services/runner/Dockerfile.sandbox \
+            --tag "ghcr.io/${{ github.repository_owner }}/stigmer-runner:v${VERSION}-arm64" \
+            --push \
+            .
+
+  publish-runner-image:
+    needs: [determine-version, publish-runner-image-amd64, publish-runner-image-arm64]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      packages: write
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Merge the per-arch tags into the version manifest
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "ghcr.io/${{ github.repository_owner }}/stigmer-runner:v${VERSION}" \
+            "ghcr.io/${{ github.repository_owner }}/stigmer-runner:v${VERSION}-amd64" \
+            "ghcr.io/${{ github.repository_owner }}/stigmer-runner:v${VERSION}-arm64"
+
+      - name: Ensure GHCR package is public
+        continue-on-error: true
+        run: |
+          gh api \
+            -X PUT \
+            /orgs/${{ github.repository_owner }}/packages/container/stigmer-runner/visibility \
+            -f visibility=public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # The published-tag re-verification the P5 gate ruled (Q-A): the SAME
+  # scripts/smoke-compose.mjs that gates PRs (there: build-from-source)
+  # runs the full stack — Postgres, Temporal, server, runner — from the
+  # images just pushed, up to one end-to-end workflow run, natively per
+  # arch. `stigmer-runner:latest` and the compose pin only move after
+  # the stack these tags name has actually run somewhere.
+  smoke-compose-amd64:
+    needs: [determine-version, publish-server-image, publish-runner-image]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compose smoke against the pushed tags (native amd64)
+        run: |
+          node scripts/smoke-compose.mjs --published \
+            --version="v${{ needs.determine-version.outputs.version }}"
+
+  smoke-compose-arm64:
+    needs: [determine-version, publish-server-image, publish-runner-image]
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compose smoke against the pushed tags (native arm64)
+        run: |
+          node scripts/smoke-compose.mjs --published \
+            --version="v${{ needs.determine-version.outputs.version }}"
+
+  promote-runner-image-latest:
+    needs: [determine-version, smoke-compose-amd64, smoke-compose-arm64]
+    # Stable only — same channel policy as the server image, with a
+    # stronger proof: `latest` moves only after the full compose stack ran
+    # end-to-end on both arches from the pushed tags.
+    if: ${{ !contains(needs.determine-version.outputs.version, '-') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      packages: write
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Promote latest to the smoked version tag
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+        run: |
+          docker buildx imagetools create \
+            --tag "ghcr.io/${{ github.repository_owner }}/stigmer-runner:latest" \
+            "ghcr.io/${{ github.repository_owner }}/stigmer-runner:v${VERSION}"
+
+  # The compose pin is release-lane-managed (P5 gate ruling Q-A): after
+  # both published-tag compose smokes pass on a stable release, open a PR
+  # re-pointing docker-compose.yml's STIGMER_VERSION default (and the
+  # .env.example doc line) at this version. A PR, not a push: main stays
+  # protected and the bump is reviewable. Requires the org setting
+  # "Allow GitHub Actions to create and approve pull requests"; if the
+  # job fails on that, flip the setting — do not hand-edit the pin.
+  bump-compose-pins:
+    needs: [determine-version, smoke-compose-amd64, smoke-compose-arm64]
+    if: ${{ !contains(needs.determine-version.outputs.version, '-') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Re-point the compose pins and open the bump PR
+        env:
+          VERSION: ${{ needs.determine-version.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          sed -i -E "s/STIGMER_VERSION:-v[0-9A-Za-z.+-]+/STIGMER_VERSION:-v${VERSION}/g" docker-compose.yml
+          sed -i -E "s/^#STIGMER_VERSION=.*/#STIGMER_VERSION=v${VERSION}/" .env.example
+          if git diff --quiet; then
+            echo "pins already at v${VERSION} — nothing to bump"
+            exit 0
+          fi
+          BRANCH="release/compose-pin-v${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -am "chore(release): pin the compose stack to v${VERSION}"
+          git push -u origin "$BRANCH"
+          gh pr create \
+            --title "chore(release): pin the compose stack to v${VERSION}" \
+            --body "Automated by release.npm-libs.yaml after both published-tag compose smokes passed (amd64 + arm64). Re-points the \`STIGMER_VERSION\` default in docker-compose.yml (and the .env.example doc line) at the release both images were proven under."

--- a/.github/workflows/release.sandbox-cloud.yaml
+++ b/.github/workflows/release.sandbox-cloud.yaml
@@ -99,10 +99,17 @@ jobs:
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "Building: latest + main-$SHORT_SHA"
 
+      # --target sandbox: the Dockerfile's final stage is the self-host
+      # compose runner (sandbox + stigmer CLI, published separately as
+      # ghcr.io/stigmer/stigmer-runner by release.npm-libs.yaml); this lane
+      # ships the CLOUD sandbox stage, byte-identical to before the stage
+      # split. amd64 stays this lane's platform — the cloud fleet is amd64;
+      # the multi-arch proof lives on the compose-runner lane.
       - name: Build and push sandbox image
         run: |
           docker buildx build \
             --platform linux/amd64 \
+            --target sandbox \
             --file backend/services/runner/Dockerfile.sandbox \
             --tag ghcr.io/${{ github.repository_owner }}/runner:latest \
             --tag ghcr.io/${{ github.repository_owner }}/runner:main-${{ steps.tags.outputs.short_sha }} \

--- a/Makefile
+++ b/Makefile
@@ -535,6 +535,17 @@ smoke-docker-image: build-server build-web ## Build the server Docker image from
 	@cd $(SERVER_DIR) && node scripts/bundle-slim.mjs --platform=linux-$$(node -e "process.stdout.write(process.arch==='x64'?'x64':'arm64')")
 	@cd $(SERVER_DIR) && node scripts/smoke-docker-image.mjs
 
+# The compose gate (DD-013, Phase-2 P5): build both images from source and
+# prove the full self-host stack — server + Postgres + Temporal + runner —
+# up to one end-to-end workflow run. The same script the PR gate
+# (ci.compose-stack.yaml) and the release lane run. Fixed ports 7234/7235:
+# stop any running `stigmer up` first.
+.PHONY: smoke-compose
+smoke-compose: build-server build-web ## Build the compose stack from source and run the clean-clone gate smoke (DD-013; needs Docker)
+	@command -v docker >/dev/null 2>&1 || { echo "error: docker not found — the compose smoke needs a Docker daemon"; exit 1; }
+	@cd $(SERVER_DIR) && node scripts/bundle-slim.mjs --platform=linux-$$(node -e "process.stdout.write(process.arch==='x64'?'x64':'arm64')")
+	node scripts/smoke-compose.mjs --build
+
 .PHONY: test-conformance-cloud
 test-conformance-cloud: build-ts-stubs ## Run gRPC conformance CRUD suite against the Java cloud service (hermetic; needs Docker, `fga`, `temporal`, and the fat JAR)
 	@command -v go >/dev/null 2>&1 || { echo "error: go not found — the harness builds the cloud environment launcher"; exit 1; }

--- a/backend/services/runner/Dockerfile.sandbox
+++ b/backend/services/runner/Dockerfile.sandbox
@@ -1,10 +1,26 @@
-# Cloud Sandbox — Unified TypeScript Runner
-# Sandbox image for cloud-mode execution. Published to GHCR.
+# Unified TypeScript Runner — Sandbox + Compose Images
 #
 # Build context: Repository root
 # Build command: docker build -f backend/services/runner/Dockerfile.sandbox .
 #
-# This image provides:
+# TWO published images derive from one stage chain (DD-014: the compose
+# runner derives from the sandbox image; no second runner image is invented):
+#
+#   builder        — compiles the runner + its file:-linked @stigmer libs
+#   sandbox        — the CLOUD sandbox image (release.sandbox-cloud builds
+#                    `--target sandbox`; stigmer-service launches sandboxes
+#                    from it). The runner process is started by the control
+#                    plane (the Kubernetes provisioner sets the pod command),
+#                    so CMD stays /bin/bash and an ad-hoc `docker run` lands
+#                    in a shell.
+#   compose-runner — the SELF-HOST compose stack's runner (the default,
+#                    last stage; docker-compose.yml consumes it as
+#                    ghcr.io/stigmer/stigmer-runner). Compose is this
+#                    image's control plane, so the runner launch command is
+#                    baked in, and the stigmer CLI rides along for the
+#                    OSS-shape MCP attachments (see the stage comment).
+#
+# The image provides:
 #   1. Unified Temporal worker (Node.js) handling all execution types:
 #      ExecuteDeepAgent, ExecuteCursor, ExecuteServerlessWorkflow
 #   2. Language runtimes for agent shell work: Node.js 22 LTS, Python (uv), Go
@@ -13,13 +29,13 @@
 # Stdio MCP servers do NOT run on cloud runners (stdio is local-runner-only;
 # see shared/mcp-transport-guard.ts), so no MCP package caches are pre-warmed.
 # The runtimes stay because agents legitimately shell out to node/python/go
-# in their workspaces.
+# in their workspaces. The compose runner runs MODE=local, where stdio MCP
+# IS allowed — its subprocesses spawn inside this container.
 #
-# The runner process is started by the control plane (the Kubernetes
-# provisioner sets the pod command to launch the runner) — CMD stays
-# /bin/bash so an ad-hoc `docker run` lands in a shell.
-#
-# Platform: linux/amd64 only (Temporal native bindings are arch-specific)
+# Platforms: linux/amd64 + linux/arm64. The historical amd64-only claim
+# (arch-specific Temporal native bindings) was re-verified stale at Phase-2
+# P5: @temporalio/core-bridge ships linux-arm64 prebuilds and loads cleanly;
+# the only arch-named asset here is the yq download, parameterized below.
 
 # ---------- Build Proto Stubs + Runner ----------
 FROM node:22-slim AS builder
@@ -76,8 +92,14 @@ RUN npm prune --omit=dev --legacy-peer-deps && \
       fi; \
     done
 
-# ---------- Runtime ----------
-FROM debian:bookworm-slim
+# ---------- Runtime (the cloud sandbox image) ----------
+FROM debian:bookworm-slim AS sandbox
+
+# TARGETARCH (amd64|arm64) is populated by BuildKit per platform leg —
+# needed by the yq download below, which is the only arch-named asset in
+# this stage (node/go/uv all resolve their arch via multi-arch images or
+# installer detection).
+ARG TARGETARCH
 
 # --- Node.js 22 LTS (copied from official image, not Debian's v18) ---
 COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node
@@ -109,7 +131,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
     mv /root/.local/bin/uvx /usr/local/bin/uvx
 
 # --- yq (YAML processor) ---
-RUN curl -fsSL https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 \
+RUN curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${TARGETARCH}" \
         -o /usr/local/bin/yq && \
     chmod +x /usr/local/bin/yq
 
@@ -121,3 +143,39 @@ COPY --from=builder /build/backend/services/runner/package.json /runner/package.
 WORKDIR /workspace
 
 CMD ["/bin/bash"]
+
+# ---------- Compose runner (the self-host stack's runner) ----------
+# The sandbox stage plus the stigmer CLI. Why the CLI: in the OSS/local
+# shape (no STIGMER_MCP_BRIDGE_ENDPOINT) the runner synthesizes the memory
+# and channel MCP attachments as a spawned `stigmer mcp-server` stdio child
+# (shared/memory-attachment.ts, shared/channel-attachment.ts). On a laptop
+# the CLI is on PATH by definition; in a container it must be baked in, or
+# every memory-enabled session fails at spawn (ENOENT). The npm registry is
+# the CLI's canonical distribution channel — these are the same bytes a
+# laptop's global install resolves. The release lane pins the in-train
+# version; dev/CI source builds default to the latest published CLI.
+FROM sandbox AS compose-runner
+
+ARG STIGMER_CLI_VERSION=latest
+RUN npm install -g "@stigmer/cli@${STIGMER_CLI_VERSION}"
+
+# State home. The runner keeps session state — HITL/pause checkpoints
+# (sessions/<id>/checkpoints.db), the HITL gate dir — under $HOME/.stigmer
+# (shared/workspace/platform-dir.ts). /data mirrors the server image's
+# HOME=/data posture so compose can pin ONE volume mount point per
+# container; without it, in-flight paused sessions die with the container.
+#
+# The artifact path is pre-created uid/gid 1000 — the SERVER image's
+# non-root `node` user. Compose mounts one shared artifacts volume into
+# both containers at this path, and docker initializes a named volume from
+# whichever container mounts it FIRST: if that is this (root-running)
+# image and the path were root-owned, the non-root server could never
+# write an artifact. Pinning 1000 here makes initialization order
+# irrelevant; the runner itself runs as root and reads regardless.
+RUN mkdir -p /data/.stigmer/data/artifacts && chown -R 1000:1000 /data/.stigmer/data/artifacts
+ENV HOME=/data
+
+# Compose is this image's control plane (the sandbox header's contract),
+# so the launch command is baked here rather than repeated in every
+# compose file. dist/main.js is the runner package's published bin entry.
+CMD ["node", "/runner/dist/main.js"]

--- a/backend/services/stigmer-server/Dockerfile
+++ b/backend/services/stigmer-server/Dockerfile
@@ -62,7 +62,16 @@ ENV HOME=/data \
 # /data must exist owned by the runtime user before VOLUME freezes it:
 # named volumes initialize from the image and inherit this ownership.
 # (Bind mounts keep host ownership — the docker run docs cover chown.)
-RUN mkdir -p /data && chown node:node /data
+#
+# The artifact path is pre-created for the compose stack (DD-013): compose
+# mounts a SHARED named volume at this exact path (the runner reads what
+# the server writes). A nested mountpoint that does not pre-exist would be
+# created root-owned by the docker daemon INSIDE the outer /data volume —
+# and this non-root server would then fail its boot mkdirs with EACCES.
+# Pre-created node-owned, both the intermediate dirs and the volume's
+# initialized content stay writable. Harmless outside compose: the boot
+# mkdir -p of the same default path becomes a no-op.
+RUN mkdir -p /data/.stigmer/data/artifacts && chown -R node:node /data
 
 WORKDIR /app
 COPY --chown=node:node dist-slim-${TARGETARCH}/ /app/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,36 @@
+# Build-from-source override for the compose stack (contributors + CI).
+#
+#   make smoke-compose            # the full gate: build, up, probe, teardown
+#
+# or by hand — the server image COPYs a prebuilt slim tree, so stage it first:
+#
+#   make build-server build-web
+#   cd backend/services/stigmer-server && node scripts/bundle-slim.mjs && cd -
+#   node scripts/smoke-compose.mjs --build --keep
+#
+# (smoke-compose.mjs stages dist-slim into the dist-slim-<arch>/ directory
+# the Dockerfile's TARGETARCH COPY expects, then runs `docker compose build`
+# with both files. The runner image builds straight from the repo tree.)
+#
+# The published-image pins in docker-compose.yml stay the user contract;
+# this file exists so every PR can prove the real topology without waiting
+# for a release (the P5 gate ruling Q-A).
+
+services:
+  stigmer-server:
+    image: stigmer-server:compose-dev
+    build:
+      context: ./backend/services/stigmer-server
+    pull_policy: never
+
+  stigmer-runner:
+    image: stigmer-runner:compose-dev
+    build:
+      context: .
+      dockerfile: backend/services/runner/Dockerfile.sandbox
+      target: compose-runner
+      args:
+        # Source builds take the latest published CLI (the CLI is
+        # npm-distributed; the release lane pins the in-train version).
+        STIGMER_CLI_VERSION: ${STIGMER_CLI_VERSION:-latest}
+    pull_policy: never

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,186 @@
+# Stigmer self-host compose stack (Phase-2 P5; design record: DD-013/DD-014).
+#
+#   cp .env.example .env   # fill in the three required values (see the file)
+#   docker compose up -d
+#   open http://localhost:7234
+#
+# Topology — four services, one Postgres instance:
+#   postgres        one instance, three databases: `stigmer` (the app, created
+#                   by POSTGRES_DB), plus `temporal` + `temporal_visibility`
+#                   (created by Temporal's auto-setup). One container, one
+#                   volume, one backup story.
+#   temporal        a real Temporal server (temporalio/auto-setup), NOT the
+#                   CLI's dev-server binary.
+#   stigmer-server  the control plane + web console + artifact file server.
+#   stigmer-runner  the execution worker (agents + workflows). stdio MCP
+#                   servers spawn INSIDE this container — they can reach this
+#                   container's filesystem and network, not your host's.
+#
+# Image pins: the STIGMER_VERSION default below is managed by the release
+# lane (release.npm-libs.yaml bumps it via PR after both published images
+# pass the compose smoke on both architectures). Override in .env to run a
+# different released version.
+#
+# The env blocks below set every load-bearing variable EXPLICITLY, even
+# where the image default would coincide — two independent defaults
+# agreeing by luck is not a contract (the client-apps/cli daemon's
+# components.ts discipline, applied to compose).
+
+# The ONE runner task queue: the server dispatches to it and the runner
+# polls it, both from this anchor, so the two can never drift.
+x-runner-task-queue: &runner-task-queue "stigmer_runner"
+
+# The artifact root. The server WRITES artifacts here and the runner READS
+# them from the same named volume (stigmer/stigmer#285's local pattern,
+# ported: filesystem sharing is the contract, not HTTP). The path is the
+# daemon's ~/.stigmer/data/artifacts layout under the containers' HOME=/data.
+x-artifacts-path: &artifacts-path "/data/.stigmer/data/artifacts"
+
+# Where artifact download URLs point. These URLs are minted for HOST-side
+# consumers (your browser, the CLI), so they use the host-published port —
+# NOT the in-network address. Serving this stack to other machines? Change
+# this to an address they can reach.
+x-artifact-serve-url: &artifact-serve-url "http://localhost:7235"
+
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?missing — copy .env.example to .env and fill it in}
+      # The app database. Temporal's auto-setup creates its own two
+      # (`temporal`, `temporal_visibility`) on this same instance at first
+      # boot.
+      POSTGRES_DB: stigmer
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  temporal:
+    image: temporalio/auto-setup:1.28.0
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DB: postgres12
+      DB_PORT: "5432"
+      POSTGRES_USER: postgres
+      POSTGRES_PWD: ${POSTGRES_PASSWORD:?missing — copy .env.example to .env and fill it in}
+      POSTGRES_SEEDS: postgres
+    # Ready means "the default namespace is registered", NOT "the frontend
+    # answers": auto-setup registers the namespace a few seconds AFTER the
+    # frontend starts serving, and a server that connects in that window
+    # fails its Temporal worker creation without a later retry (the health
+    # monitor watches connection health, which is green — issue #904,
+    # stigmer-server src/temporal/manager.ts). Encoding real readiness
+    # here makes first boot deterministic. $$ is compose-escaping for a
+    # literal $; the CLI must dial the container IP because the frontend
+    # binds it, not loopback.
+    healthcheck:
+      test: ["CMD-SHELL", "temporal operator namespace describe -n default --address $$(hostname -i):7233"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  stigmer-server:
+    image: ghcr.io/stigmer/stigmer-server:${STIGMER_VERSION:-v3.12.9}
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      # service_healthy = the default namespace exists (see the temporal
+      # service): the server's worker creation needs the namespace, and its
+      # health monitor does not re-run it on a healthy connection.
+      temporal:
+        condition: service_healthy
+    ports:
+      # 7234: the unified port — gRPC, Connect, the web console.
+      # 7235: the artifact file server (downloads); a separate listener by
+      #       design, bound 0.0.0.0 inside the container (the image sets
+      #       ARTIFACT_HTTP_HOST; the laptop tier keeps its loopback default).
+      - "7234:7234"
+      - "7235:7235"
+    environment:
+      GRPC_PORT: "7234"
+      # Non-empty DATABASE_URL selects the Postgres driver (DD-010); the
+      # image's sqlite path is the single-container `docker run` tier.
+      DATABASE_URL: postgres://postgres:${POSTGRES_PASSWORD:?missing — copy .env.example to .env and fill it in}@postgres:5432/stigmer
+      TEMPORAL_HOST_PORT: temporal:7233
+      TEMPORAL_NAMESPACE: default
+      TEMPORAL_AGENT_EXECUTION_RUNNER_TASK_QUEUE: *runner-task-queue
+      TEMPORAL_WORKFLOW_EXECUTION_RUNNER_TASK_QUEUE: *runner-task-queue
+      ARTIFACT_STORAGE_TYPE: local
+      ARTIFACT_LOCAL_BASE_PATH: *artifacts-path
+      ARTIFACT_LOCAL_SERVE_URL: *artifact-serve-url
+      # Skill push/download capability URLs are host-consumed too (the CLI
+      # and SDKs); same reasoning as the artifact serve URL.
+      SKILL_TRANSFER_BASE_URL: "http://localhost:7234"
+      # Explicit keys, loud fail (DD-013): the server would otherwise
+      # auto-generate keys into the volume, making the backup/rotation
+      # story invisible exactly where self-hosters need it explicit.
+      STIGMER_ENCRYPTION_KEY: ${STIGMER_ENCRYPTION_KEY:?missing — copy .env.example to .env and fill it in}
+      STIGMER_RUNNER_TOKEN_KEY: ${STIGMER_RUNNER_TOKEN_KEY:?missing — copy .env.example to .env and fill it in}
+      # Optional operator identity for audit attribution (see .env.example).
+      STIGMER_OPERATOR_EMAIL: ${STIGMER_OPERATOR_EMAIL:-}
+      STIGMER_OPERATOR_NAME: ${STIGMER_OPERATOR_NAME:-}
+    volumes:
+      # Server state beyond Postgres: the skill content store
+      # (~/.stigmer/storage) and anything else under the image's HOME=/data.
+      - server-data:/data
+      # The shared artifact root — the same named volume the runner mounts.
+      - type: volume
+        source: artifacts
+        target: *artifacts-path
+    # Healthcheck comes from the image (Connect-JSON health probe); the
+    # runner's depends_on gates on it.
+
+  stigmer-runner:
+    image: ghcr.io/stigmer/stigmer-runner:${STIGMER_VERSION:-v3.12.9}
+    restart: unless-stopped
+    depends_on:
+      stigmer-server:
+        condition: service_healthy
+      temporal:
+        condition: service_healthy
+    environment:
+      # local mode: stdio MCP servers are allowed (they spawn inside this
+      # container — see the header) and the LangGraph checkpointer uses its
+      # durable sqlite saver under HOME.
+      MODE: local
+      STIGMER_BACKEND_ENDPOINT: http://stigmer-server:7234
+      TEMPORAL_SERVICE_ADDRESS: temporal:7233
+      TEMPORAL_NAMESPACE: default
+      STIGMER_TASK_QUEUE: *runner-task-queue
+      # The daemon's ~/.stigmer/data/workspace layout under HOME=/data —
+      # agent workspaces live on the runner-data volume with the session
+      # state.
+      WORKSPACE_ROOT_DIR: /data/.stigmer/data/workspace
+      ARTIFACT_STORAGE_TYPE: local
+      LOCAL_ARTIFACT_PATH: *artifacts-path
+      LOCAL_ARTIFACT_SERVE_URL: *artifact-serve-url
+      # LLM provider keys (optional at boot; agent executions need one —
+      # see .env.example). Workflow executions without agent tasks run
+      # key-free.
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      CURSOR_API_KEY: ${CURSOR_API_KEY:-}
+    volumes:
+      # Runner state (HITL/pause checkpoints, session dirs, workspaces)
+      # lives under HOME=/data — on a volume so in-flight paused sessions
+      # survive container recreation, the durability the laptop tier gets
+      # from the user's own disk. Lifecycle state, not backup state: the
+      # complete backup is postgres-data + artifacts + server-data + .env.
+      - runner-data:/data
+      - type: volume
+        source: artifacts
+        target: *artifacts-path
+
+volumes:
+  postgres-data:
+  server-data:
+  runner-data:
+  artifacts:

--- a/scripts/smoke-compose.mjs
+++ b/scripts/smoke-compose.mjs
@@ -1,0 +1,368 @@
+#!/usr/bin/env node
+
+/**
+ * The compose-stack gate smoke (DD-013, Phase-2 P5) — the ONE smoke,
+ * shared by three consumers so their proofs cannot drift:
+ *
+ *   - local dev:        make smoke-compose            (build-from-source)
+ *   - PR CI:            ci.compose-stack.yaml         (build-from-source)
+ *   - the release lane: release.npm-libs.yaml runs it against the PUSHED
+ *                       image tags on native amd64 AND arm64 runners
+ *                       before `latest` moves and the compose pin bumps
+ *
+ * What one pass proves, in order:
+ *   1. `docker compose up` from this clean tree reaches a healthy server
+ *      (the image HEALTHCHECK via compose depends_on, then the real
+ *      health service answering SERVING over Connect JSON);
+ *   2. the console is served on the unified port (/config.json contract +
+ *      / answers HTML) — DD-012 must survive the compose topology;
+ *   3. the artifact file server is published and answering on 7235 (the
+ *      0.0.0.0 bind + port publish — a 404 from it IS the proof of life);
+ *   4. one END-TO-END RUN: a deterministic `set_vars` workflow execution
+ *      travels server → Temporal → runner → COMPLETED, with zero LLM
+ *      keys (the gate ruling Q-C; the ci.conformance-execution precedent).
+ *      This is the line the phase gate draws: the runner container
+ *      polled the queue and executed real work;
+ *   5. clean teardown (`docker compose down --volumes`).
+ *
+ * Usage:
+ *   node scripts/smoke-compose.mjs --build
+ *       Builds both images from source via docker-compose.dev.yml. The
+ *       server image COPYs a prebuilt slim tree: run `make build-server
+ *       build-web` and `node backend/services/stigmer-server/scripts/
+ *       bundle-slim.mjs` first (make smoke-compose does all of it).
+ *
+ *   node scripts/smoke-compose.mjs --published --version=vX.Y.Z
+ *       Pulls the published ghcr.io images at that tag (the release
+ *       lane's mode; requires the tags to exist).
+ *
+ *   --keep    leave the stack running (skip teardown) for debugging.
+ *
+ * The stack publishes fixed host ports 7234/7235 (the product contract),
+ * so this smoke refuses to start if they are occupied — stop any running
+ * `stigmer up` or compose stack first. Keys are generated fresh per run
+ * into a temp env file; a developer's real .env is never read.
+ *
+ * Plain node + docker CLI, no dependencies — runnable everywhere CI is.
+ */
+import { execFileSync, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { cpSync, existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { connect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("..", import.meta.url));
+const serverRoot = join(repoRoot, "backend", "services", "stigmer-server");
+
+const SERVER_PORT = 7234;
+const ARTIFACT_PORT = 7235;
+// First boot pulls/starts four containers, runs Temporal schema setup, and
+// waits for the server's start-period; generous on shared CI hosts.
+const SERVER_HEALTHY_TIMEOUT_MS = 240_000;
+// The end-to-end run additionally needs the runner's worker to connect
+// (it restarts until Temporal answers) and the first task-queue poll.
+const RUN_COMPLETED_TIMEOUT_MS = 240_000;
+
+function parseArgs() {
+  let mode = "";
+  let version = "";
+  let keep = false;
+  for (const arg of process.argv.slice(2)) {
+    let m;
+    if (arg === "--build") mode = "build";
+    else if (arg === "--published") mode = mode === "" ? "published" : mode;
+    else if ((m = arg.match(/^--version=(.+)$/)) !== null) version = m[1];
+    else if (arg === "--keep") keep = true;
+    else fail(`unknown argument: ${arg}`);
+  }
+  if (mode === "") fail("pass exactly one of --build or --published");
+  if (mode === "published" && version === "") {
+    fail("--published requires --version=vX.Y.Z (the pushed image tag)");
+  }
+  return { mode, version, keep };
+}
+
+function fail(message) {
+  console.error(`smoke-compose: ${message}`);
+  process.exit(1);
+}
+
+function log(step) {
+  console.log(`smoke-compose: ${step}`);
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function pollUntil(label, timeoutMs, probe) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = "";
+  while (Date.now() < deadline) {
+    try {
+      const result = await probe();
+      if (result !== undefined && result !== false) return result;
+      lastError = "probe returned falsy";
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(2000);
+  }
+  throw new Error(`timed out waiting for ${label} (${timeoutMs}ms): ${lastError}`);
+}
+
+/** Unary Connect-JSON call — the same lane a curl user gets. */
+async function connectJson(procedure, body) {
+  const response = await fetch(`http://127.0.0.1:${SERVER_PORT}/${procedure}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`${procedure} -> HTTP ${response.status}: ${text.slice(0, 300)}`);
+  }
+  return JSON.parse(text);
+}
+
+/** Fails when the port is already taken — a stigmer stack is running. */
+function assertPortFree(port) {
+  return new Promise((resolve, reject) => {
+    const socket = connect({ host: "127.0.0.1", port, timeout: 1500 });
+    socket.once("connect", () => {
+      socket.destroy();
+      reject(new Error(
+        `port ${port} is already in use — stop the running stigmer stack ` +
+        `(stigmer down / docker compose down) before the smoke`,
+      ));
+    });
+    socket.once("error", () => resolve(undefined)); // refused = free
+    socket.once("timeout", () => {
+      socket.destroy();
+      resolve(undefined);
+    });
+  });
+}
+
+/**
+ * The dev server image build COPYs dist-slim-<arch>/; stage it from the
+ * dist-slim tree bundle-slim.mjs produced for THIS machine (the
+ * smoke-docker-image.mjs staging contract).
+ */
+function stageServerTree() {
+  const distSlim = join(serverRoot, "dist-slim");
+  if (!existsSync(join(distSlim, "main.js"))) {
+    fail(
+      "dist-slim/main.js not found — build it first:\n" +
+        "  make build-server build-web && " +
+        "cd backend/services/stigmer-server && node scripts/bundle-slim.mjs",
+    );
+  }
+  const arch = process.arch === "x64" ? "amd64" : process.arch === "arm64" ? "arm64" : "";
+  if (arch === "") fail(`unsupported host arch "${process.arch}"`);
+  const staged = join(serverRoot, `dist-slim-${arch}`);
+  log(`staging dist-slim/ -> dist-slim-${arch}/`);
+  rmSync(staged, { recursive: true, force: true });
+  cpSync(distSlim, staged, { recursive: true });
+}
+
+async function main() {
+  const { mode, version, keep } = parseArgs();
+
+  await assertPortFree(SERVER_PORT);
+  await assertPortFree(ARTIFACT_PORT);
+
+  // Fresh keys per run into an isolated env file: the smoke never reads a
+  // developer's real .env, and two runs never share state.
+  const workDir = mkdtempSync(join(tmpdir(), "stigmer-compose-smoke-"));
+  const envFile = join(workDir, "smoke.env");
+  const envLines = [
+    `POSTGRES_PASSWORD=${randomBytes(24).toString("hex")}`,
+    `STIGMER_ENCRYPTION_KEY=${randomBytes(32).toString("base64")}`,
+    `STIGMER_RUNNER_TOKEN_KEY=${randomBytes(32).toString("base64")}`,
+  ];
+  if (version !== "") envLines.push(`STIGMER_VERSION=${version}`);
+  writeFileSync(envFile, envLines.join("\n") + "\n");
+
+  const project = `stigmer-smoke-${Date.now()}`;
+  const composeArgs = [
+    "compose",
+    "-p",
+    project,
+    "--env-file",
+    envFile,
+    "-f",
+    join(repoRoot, "docker-compose.yml"),
+  ];
+  if (mode === "build") {
+    composeArgs.push("-f", join(repoRoot, "docker-compose.dev.yml"));
+  }
+
+  const compose = (args, options = {}) =>
+    execFileSync("docker", [...composeArgs, ...args], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      ...options,
+    });
+
+  let failed = false;
+  try {
+    if (mode === "build") {
+      stageServerTree();
+      log("docker compose build (server + runner from source)");
+      compose(["build"], { stdio: "inherit" });
+    } else {
+      log(`pulling published images at ${version}`);
+      compose(["pull", "--quiet", "stigmer-server", "stigmer-runner"], { stdio: "inherit" });
+    }
+
+    log("docker compose up -d");
+    compose(["up", "-d"], { stdio: "inherit" });
+
+    // 1. The server healthy — through compose depends_on this also proves
+    // Postgres answered pg_isready and the image HEALTHCHECK went green.
+    log("waiting for the server health service (SERVING)...");
+    await pollUntil("health SERVING", SERVER_HEALTHY_TIMEOUT_MS, async () => {
+      const health = await connectJson("grpc.health.v1.Health/Check", {});
+      return health.status === "SERVING";
+    });
+    log("health service: SERVING");
+
+    // 2. The console lane (DD-012) through the compose topology.
+    const config = await (await fetch(`http://127.0.0.1:${SERVER_PORT}/config.json`)).json();
+    if (config.authMode !== "disabled") {
+      throw new Error(`/config.json authMode=${config.authMode} — want disabled`);
+    }
+    if (config.apiUrl !== `http://127.0.0.1:${SERVER_PORT}`) {
+      throw new Error(`/config.json apiUrl=${config.apiUrl} — want the Host-derived origin`);
+    }
+    const index = await fetch(`http://127.0.0.1:${SERVER_PORT}/`);
+    const indexType = index.headers.get("content-type") ?? "";
+    if (index.status !== 200 || !indexType.includes("text/html")) {
+      throw new Error(`console / -> ${index.status} ${indexType} — want 200 text/html`);
+    }
+    log("console lane: /config.json contract + / html both answer");
+
+    // 3. The artifact file server on its published port: a 404 from the
+    // listener proves the 0.0.0.0 bind and the port publish; content
+    // round-trips ride the artifact conformance suites, not this smoke.
+    const artifactProbe = await fetch(
+      `http://127.0.0.1:${ARTIFACT_PORT}/smoke-nonexistent-key`,
+    );
+    if (artifactProbe.status !== 404) {
+      throw new Error(`artifact server probe -> HTTP ${artifactProbe.status} — want 404`);
+    }
+    log("artifact file server: answering on the published port");
+
+    // 4. The end-to-end run — the phase gate's line. A single set_vars
+    // task: sub-second, hermetic, no LLM/MCP/keys (the conformance
+    // suite's canonical execution fixture), but it only completes if the
+    // runner container connected to Temporal and polled the queue.
+    const suffix = `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+    const org = await connectJson(
+      "ai.stigmer.tenancy.organization.v1.OrganizationCommandController/create",
+      {
+        apiVersion: "tenancy.stigmer.ai/v1",
+        kind: "Organization",
+        metadata: { name: `smoke-org-${suffix}` },
+      },
+    );
+    const orgId = org.metadata?.id;
+    if (!orgId) throw new Error(`organization create returned no id: ${JSON.stringify(org)}`);
+
+    const workflow = await connectJson(
+      "ai.stigmer.agentic.workflow.v1.WorkflowCommandController/create",
+      {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Workflow",
+        metadata: { name: `smoke-wf-${suffix}`, org: orgId },
+        spec: {
+          description: "compose smoke fixture",
+          document: {
+            dsl: "1.0.0",
+            namespace: orgId,
+            name: `smoke-wf-${suffix}`,
+            version: "1.0.0",
+          },
+          tasks: [
+            {
+              name: "setVars",
+              kind: "set_vars",
+              taskConfig: { variables: { greeting: "hello" } },
+              export: { as: "${ . }" },
+            },
+          ],
+        },
+      },
+    );
+    const workflowId = workflow.metadata?.id;
+    if (!workflowId) throw new Error(`workflow create returned no id: ${JSON.stringify(workflow)}`);
+    log(`workflow ${workflowId} created`);
+
+    const execution = await connectJson(
+      "ai.stigmer.agentic.workflowexecution.v1.WorkflowExecutionCommandController/create",
+      {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "WorkflowExecution",
+        metadata: { name: `smoke-wfx-${suffix}`, org: orgId },
+        spec: { workflowId },
+      },
+    );
+    const executionId = execution.metadata?.id;
+    if (!executionId) throw new Error(`execution create returned no id: ${JSON.stringify(execution)}`);
+    log(`execution ${executionId} created — awaiting COMPLETED...`);
+
+    const TERMINAL_FAILURES = new Set([
+      "EXECUTION_FAILED",
+      "EXECUTION_CANCELLED",
+      "EXECUTION_TERMINATED",
+    ]);
+    await pollUntil("execution EXECUTION_COMPLETED", RUN_COMPLETED_TIMEOUT_MS, async () => {
+      const current = await connectJson(
+        "ai.stigmer.agentic.workflowexecution.v1.WorkflowExecutionQueryController/get",
+        { value: executionId },
+      );
+      const phase = current.status?.phase ?? "EXECUTION_PHASE_UNSPECIFIED";
+      if (TERMINAL_FAILURES.has(phase)) {
+        // Terminal-and-wrong: surface immediately with the server's own error.
+        throw new Error(
+          `execution reached ${phase}: ${JSON.stringify(current.status?.error ?? {})}`,
+        );
+      }
+      return phase === "EXECUTION_COMPLETED";
+    });
+    log(`end-to-end run: execution ${executionId} COMPLETED through the runner`);
+
+    log("PASS");
+  } catch (error) {
+    failed = true;
+    console.error(
+      `smoke-compose: FAIL — ${error instanceof Error ? error.message : String(error)}`,
+    );
+    console.error("--- docker compose ps ---");
+    console.error(spawnSync("docker", [...composeArgs, "ps"], { encoding: "utf8" }).stdout ?? "");
+    console.error("--- docker compose logs (last 120 lines/service) ---");
+    const logs = spawnSync(
+      "docker",
+      [...composeArgs, "logs", "--tail", "120"],
+      { encoding: "utf8" },
+    );
+    console.error(logs.stdout ?? "");
+    console.error(logs.stderr ?? "");
+  } finally {
+    if (keep && !failed) {
+      log(`--keep: stack left running (project ${project}; env file ${envFile})`);
+    } else {
+      spawnSync("docker", [...composeArgs, "down", "--volumes", "--remove-orphans"], {
+        stdio: "inherit",
+      });
+      rmSync(workDir, { recursive: true, force: true });
+    }
+  }
+  process.exit(failed ? 1 : 0);
+}
+
+await main();


### PR DESCRIPTION
## Summary

The Phase-2 P5 phase gate: `docker compose up` works from a clean clone — stigmer-server + one Postgres + real Temporal + a containerized runner — proven end-to-end by ONE smoke script shared by local dev (`make smoke-compose`), PR CI (`ci.compose-stack.yaml`, build-from-source), and the release lane (published-tag smokes on native amd64 + arm64 before `latest` moves and the compose pin bumps).

Design record: parent DD-013 (topology, artifacts, keys) + DD-014 (images); all six sub-project plan-gate rulings (Q-A..Q-F) landed as recommended and are executed here.

## Changes

- **`docker-compose.yml`** (root): `postgres:16` (one instance; `POSTGRES_DB=stigmer`, Temporal auto-setup creates `temporal` + `temporal_visibility`), `temporalio/auto-setup:1.28.0` with a **namespace-readiness healthcheck**, the published `ghcr.io/stigmer/stigmer-server` image, and the new `ghcr.io/stigmer/stigmer-runner` compose-runner image. Shared `artifacts` named volume mounted into server AND runner at the daemon's exact layout (#285's pattern ported); YAML anchors pin the runner task queue and serve-URL once; every load-bearing env var is explicit (the `components.ts` discipline).
- **`.env.example`**: three required values (`POSTGRES_PASSWORD`, `STIGMER_ENCRYPTION_KEY`, `STIGMER_RUNNER_TOKEN_KEY`) with generator one-liners; `${VAR:?}` loud-fail per DD-013; optional LLM keys + operator identity; the backup story documented in-file.
- **`docker-compose.dev.yml`**: build-from-source override (server from staged dist-slim; runner from `Dockerfile.sandbox --target compose-runner`).
- **`backend/services/runner/Dockerfile.sandbox`**: runtime stage named `sandbox` (the cloud lane now builds `--target sandbox` — byte-identical output); new final `compose-runner` stage = sandbox + the npm-published stigmer CLI (the runner's memory/channel MCP attachments spawn `stigmer mcp-server`; without the CLI every memory-enabled session fails at spawn) + `HOME=/data` + the baked runner launch command; `yq_linux_${TARGETARCH}` fix — **the amd64-only header claim was re-verified stale** (DD-014's named task): the image builds natively on linux/arm64 and `@temporalio/core-bridge` loads its native binding.
- **`backend/services/stigmer-server/Dockerfile`**: pre-creates the artifact path node-owned — a nested named-volume mountpoint that doesn't pre-exist is created root-owned by the docker daemon inside the outer `/data` volume, and the non-root server then fails its boot mkdirs with EACCES (found by the smoke, first run).
- **`release.npm-libs.yaml`**: `publish-runner-image-{amd64,arm64}` (native per-arch builds — this Dockerfile has real RUN steps, so no QEMU builds, unlike the COPY-only server image) → manifest merge → `smoke-compose-{amd64,arm64}` against the pushed tags → `promote-runner-image-latest` (stable only) → **`bump-compose-pins`** (stable only; automated PR re-pointing the `STIGMER_VERSION` default).
- **`release.sandbox-cloud.yaml`**: `--target sandbox` pin (cloud image bytes unchanged).
- **`ci.compose-stack.yaml` + `make smoke-compose` + `scripts/smoke-compose.mjs`**: the gate. One pass proves: server healthy → console `/config.json` contract + HTML → artifact file server answering on published 7235 → a deterministic `set_vars` workflow execution COMPLETED through the runner (zero LLM keys, the ci.conformance-execution precedent) → clean teardown.

## Implementation notes / disclosures (the register)

- **Issue #904 filed (owner-ruled)**: the server's TemporalManager never retries worker creation when the initial attempt fails over a healthy connection (fresh real-Temporal namespace race — auto-setup registers `default` AFTER the frontend serves). The compose stack closes it at the topology level with the namespace-readiness healthcheck; the manager fix lands as its own reviewed change.
- **Temporal database count**: measured one instance / THREE databases (`stigmer`, `temporal`, `temporal_visibility`) vs DD-013's "two databases" letter — owner-ratified as within the decision's substance (one INSTANCE); DD-013 carries a dated amendment note.
- **Durable state is wider than DD-013's two-volume line**: `postgres-data` + `artifacts` + `server-data` (the skill content store under the image's HOME=/data) + `.env`; the `runner-data` volume (Q-F ruling) is lifecycle state for in-flight HITL/pause sessions, not backup state. Documented in `.env.example`.
- **Volume-ownership mechanics**: the shared artifacts path is pre-created uid-1000 in BOTH images so the named volume initializes server-writable regardless of which container mounts it first.
- **The committed image pins activate at the next release**: `ghcr.io/stigmer/stigmer-server` has no published tag yet (P4's lane first fires on the next `v*` tag) and `ghcr.io/stigmer/stigmer-runner` is introduced by THIS PR's release-lane changes. Until that release, the dev override is the working path (and is what CI proves per the Q-A ruling); `bump-compose-pins` then keeps the pins truthful. The new release-lane jobs first execute for real on that tag (the P4 precedent).
- The gate CI's paths filter scopes to the compose surface (compose files, both Dockerfiles, the smoke, Makefile, the workflow) — server/runner source changes remain gated by their own lanes; the release lane re-proves the full stack each release.
- stdio MCP servers run INSIDE the runner container (documented in the compose header + `.env.example`); `MODE=local` keeps them allowed per `mcp-transport-guard.ts`.
- Workspaces and runner session state live on `runner-data`; workspace content is not part of the backup story (DD-013's posture).

## Test plan

- `make smoke-compose` (native linux/arm64, Docker Desktop): **PASS** — full pipeline: source-built images → `docker compose up -d` → health SERVING → console lane → artifact listener → `set_vars` execution `EXECUTION_COMPLETED` through the runner → clean teardown (101s total).
- The smoke's first two runs caught and fixed real defects (the EACCES nested-volume ownership failure; the #904 namespace race) — the gate does its job.
- arm64 probes: `Dockerfile.sandbox --target compose-runner` builds natively in 59s; in-container `@temporalio/core-bridge` loads, `go1.25.10 linux/arm64`, `yq v4.53.6`, `uvx aarch64` all answer.
- `docker compose config` valid (base + dev overlay); actionlint clean on the new/edited workflows (all remaining findings pre-existing); `node --check` clean on the smoke.
- No TS source changed — conformance rosters are not in this PR's blast radius; `ci.stigmer-server` runs regardless (the server Dockerfile is in its paths) and re-proves both image smokes.

## Risks

- The release-lane jobs (runner image chain, published-tag smokes, pin bump) first run on the next `v*` tag; the bump job additionally needs the org setting "Allow GitHub Actions to create and approve pull requests" (it fails visibly if off).
- Rollback: revert the commit — no data formats, no wire behavior, no source-code changes ship here; the cloud sandbox lane's output is byte-identical under `--target sandbox`.

## Checklist

- [x] Backward compatible (cloud sandbox image bytes unchanged; laptop tier untouched)
- [x] Tests: the gate smoke + CI workflow ship with the feature
- [ ] Self-host docs (P6 `sp.self-host-docs`, next in sequence)

Made with [Cursor](https://cursor.com)