### PR TITLE
feat(backend/stigmer-server): add the extension registry, exports map, and server edition seam

### DIFF
--- a/.github/workflows/ci.stigmer-server.yaml
+++ b/.github/workflows/ci.stigmer-server.yaml
@@ -38,6 +38,7 @@ on:
       - "apis/stubs/ts/**"
       - "client-apps/web/nginx.conf"
       - "scripts/verify-static-export-routes.mjs"
+      - "test/extension-consumer/**"
       - "Makefile"
       - ".github/workflows/ci.stigmer-server.yaml"
   push:
@@ -47,6 +48,7 @@ on:
       - "apis/stubs/ts/**"
       - "client-apps/web/nginx.conf"
       - "scripts/verify-static-export-routes.mjs"
+      - "test/extension-consumer/**"
       - "Makefile"
       - ".github/workflows/ci.stigmer-server.yaml"
 
@@ -114,6 +116,17 @@ jobs:
       - name: Build and boot-check the compiled dist
         working-directory: backend/services/stigmer-server
         run: npm run build && npm run verify:dist
+
+      # The exports-map compile proof (DD-005, sub-project 20260826.09/O1):
+      # a standalone consumer typechecks a fake extension against the
+      # @stigmer/server library contract ALONE — a missing export fails
+      # here, at PR time, instead of at the cloud composition's pin bump.
+      # Runs after the dist build above because the exports map points into
+      # dist. Standalone install, the same per-service pattern as the
+      # server itself.
+      - name: Compile-proof the exports map (test/extension-consumer)
+        working-directory: test/extension-consumer
+        run: npm ci --no-audit --no-fund && npm run typecheck
 
       - name: Bundle and boot-check the slim artifact
         working-directory: backend/services/stigmer-server

--- a/Makefile
+++ b/Makefile
@@ -375,6 +375,15 @@ test-server: build-ts-stubs $(SERVER_DIR)/node_modules ## Run the TypeScript ser
 	@echo "testing  $(SERVER_DIR)"
 	@cd $(SERVER_DIR) && npm test
 
+# The consumer compiles a fake extension against the @stigmer/server
+# exports map ALONE (DD-005): a missing export is a tsc failure here, not
+# a review miss. Standalone package with a file: link — the exact posture
+# the commit-pin consumer (the cloud composition) occupies.
+.PHONY: test-extension-consumer
+test-extension-consumer: build-server ## Compile-proof the @stigmer/server library contract via test/extension-consumer
+	@echo "compile-proof  test/extension-consumer (the exports-map contract)"
+	@cd test/extension-consumer && npm ci --no-audit --no-fund && npm run typecheck
+
 # ─── Integration Test ─────────────────────────
 # Integration test logic lives in each suite's Makefile under test/.
 # These are thin delegates that pass through env vars.

--- a/backend/services/stigmer-server/package.json
+++ b/backend/services/stigmer-server/package.json
@@ -5,6 +5,13 @@
   "license": "Apache-2.0",
   "type": "module",
   "private": true,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "engines": {
     "node": ">=22.13.0 <23 || >=24"
   },

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -14,10 +14,18 @@
  * flips SERVING only when wiring is complete, and the port binds AFTER
  * that — the CLI's serverGate TCP probe treats port-bind as readiness.
  * Shutdown is the reverse (grpc lib Stop): NOT_SERVING first, then drain.
+ *
+ * Extensions (DD-006, sub-project 20260826.09/O1): the optional
+ * `extensions` units resolve FIRST — a bad registry aborts boot before any
+ * stage has side effects — and their contributions ride the existing
+ * stages (services in the one routes closure, workers on the manager's
+ * factory list, the edition into the platform controller). With no
+ * extensions composed, every stage below behaves byte-identically to
+ * before the parameter existed; the conformance rosters pin that.
  */
 import path from "node:path";
 
-import type { ConnectRouter } from "@connectrpc/connect";
+import type { ConnectRouter, Transport } from "@connectrpc/connect";
 
 import { HealthCheckResponse_ServingStatus as ServingStatus } from "@stigmer/protos/grpc/health/v1/health_pb";
 
@@ -80,6 +88,8 @@ import { RunnerAuthService } from "../runnerauth/runnerauth.js";
 import { PostgresStore } from "../store/postgres/store.js";
 import { SqliteStore } from "../store/sqlite/store.js";
 import type { Store } from "../store/interface.js";
+import { resolveExtensions } from "../extensions/registry.js";
+import type { ServerExtension } from "../extensions/registry.js";
 import { registerWorkflowServices } from "../domain/workflow/controller.js";
 import {
   bundledModelRegistryDocument,
@@ -134,6 +144,15 @@ export interface ComposedServer {
    * production writers.
    */
   workflowExecutionStreamBroker: WorkflowExecutionStreamBroker;
+  /**
+   * The in-process router transport — the same routes and interceptor
+   * chain as the serving router (DD-002's bufconn shape). Exposed because
+   * it is the one lane that reaches EVERY registered service, extension
+   * services included (blueprint 20260826.02/03 §8): compositions build
+   * clients to their extension services over it, and the O1 extension
+   * suite proves both-router visibility through it.
+   */
+  inProcessTransport: Transport;
   /** Completes wiring, flips SERVING, binds the port; returns the bound port. */
   start(): Promise<number>;
   /** NOT_SERVING first, stop background work, drain connections. */
@@ -143,6 +162,12 @@ export interface ComposedServer {
 export interface ComposeOptions {
   config: ServerConfig;
   logger: Logger;
+  /**
+   * Named extension units composed into this server (DD-006). Omitted or
+   * empty means plain OSS — byte-identical wire behavior, pinned by the
+   * conformance rosters.
+   */
+  extensions?: ReadonlyArray<ServerExtension>;
   /** Test seam forwarded to the model-registry upstream fetch. */
   fetchImpl?: typeof fetch;
   /** Test seam: bind an ephemeral port instead of config.grpcPort. */
@@ -154,6 +179,17 @@ export async function composeServer(
   options: ComposeOptions,
 ): Promise<ComposedServer> {
   const { config, logger } = options;
+
+  // Stage: extensions — resolves and validates BEFORE any stage has side
+  // effects (DD-006 §2b: a bad registry is a loud boot throw, never a
+  // partially-wired server). The empty set resolves to explicit defaults
+  // and logs nothing, keeping today's boot output stable.
+  const extensions = resolveExtensions(options.extensions);
+  if (extensions.unitNames.length > 0) {
+    logger.info("extension units composed", {
+      units: extensions.unitNames.join(", "),
+    });
+  }
 
   // Stage: storage — the driver selection seam (DD-010): DATABASE_URL
   // present → Postgres (async connect + advisory-locked migrations), else
@@ -313,6 +349,9 @@ export async function composeServer(
         runStarter: scheduleRunStarter,
         logger,
       }),
+      // Extension workers append after the OSS set — their own queues,
+      // the Java worker-per-queue split as precedent (blueprint §8).
+      ...extensions.workers,
     ],
   });
   // The provider IS the injection mechanism (no Go-style creator
@@ -668,10 +707,19 @@ export async function composeServer(
       temporalHostPort: config.temporalHostPort,
       temporalNamespace: config.temporalNamespace,
       runnerAuthService,
+      edition: extensions.edition,
       logger,
     });
+    // Extension services register after the whole OSS set, inside the ONE
+    // routes closure — so the serving router AND the in-process transport
+    // see them by construction (blueprint §2a; DD-002's parity doctrine
+    // extends to extension services unchanged).
+    for (const registerExtensionServices of extensions.services) {
+      registerExtensionServices(router);
+    }
   };
-  inProcess = createInProcessClients(routes, logger);
+  const inProcessWiring = createInProcessClients(routes, logger);
+  inProcess = inProcessWiring.clients;
 
   const server = createUnifiedPortServer({
     logger,
@@ -690,6 +738,7 @@ export async function composeServer(
     runnerAuthService,
     agentExecutionStreamBroker,
     workflowExecutionStreamBroker,
+    inProcessTransport: inProcessWiring.transport,
 
     async start(): Promise<number> {
       // Temporal boot is NON-fatal end to end (Go server.go): a failed

--- a/backend/services/stigmer-server/src/boot/inprocess.ts
+++ b/backend/services/stigmer-server/src/boot/inprocess.ts
@@ -15,7 +15,7 @@
  * supplies the client objects those providers close over.
  */
 import { createClient, createRouterTransport } from "@connectrpc/connect";
-import type { ConnectRouter } from "@connectrpc/connect";
+import type { ConnectRouter, Transport } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 
 import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
@@ -132,6 +132,20 @@ export interface InProcessClients {
 }
 
 /**
+ * The in-process wiring: the narrow typed clients above PLUS the transport
+ * they ride. The transport is exposed because it is the one lane that can
+ * reach EVERY service the routes closure registers — extension services
+ * included (blueprint 20260826.02/03 §8) — which the fixed client set
+ * above cannot know about; it doubles as the extension test suite's
+ * both-router visibility proof (O1) and stays behavior-identical to the
+ * clients' own calls (same routes, same interceptor chain).
+ */
+export interface InProcessWiring {
+  readonly clients: InProcessClients;
+  readonly transport: Transport;
+}
+
+/**
  * Builds the in-process clients over a router transport that registers the
  * SAME routes and runs the SAME interceptor chain as the serving router —
  * validation parity is the point, exactly Go's bufconn shape.
@@ -139,7 +153,7 @@ export interface InProcessClients {
 export function createInProcessClients(
   routes: (router: ConnectRouter) => void,
   logger: Logger,
-): InProcessClients {
+): InProcessWiring {
   const transport = createRouterTransport(routes, {
     router: { interceptors: buildInterceptorChain(logger) },
   });
@@ -182,7 +196,7 @@ export function createInProcessClients(
   const mcpServerCommand = createClient(McpServerCommandController, transport);
   const skillCommand = createClient(SkillCommandController, transport);
 
-  return {
+  const clients: InProcessClients = {
     // Go's ApplyAsSystem is the Apply RPC with no extra identity attached:
     // the audit actor comes from the process-global operator identity
     // (installed once by main.ts, #400), so a plain apply IS the
@@ -322,4 +336,6 @@ export function createInProcessClients(
       },
     },
   };
+
+  return { clients, transport };
 }

--- a/backend/services/stigmer-server/src/domain/platform/__tests__/platform.test.ts
+++ b/backend/services/stigmer-server/src/domain/platform/__tests__/platform.test.ts
@@ -168,6 +168,7 @@ describe("platform domain (keyless runner-token service)", () => {
         temporalHostPort: "localhost:7233",
         temporalNamespace: "default",
         runnerAuthService: RunnerAuthService.create(undefined),
+        edition: ServerEdition.oss,
         logger: silentLogger,
       });
     });

--- a/backend/services/stigmer-server/src/domain/platform/controller.ts
+++ b/backend/services/stigmer-server/src/domain/platform/controller.ts
@@ -55,6 +55,12 @@ export interface PlatformControllerDeps {
    * keyless instance is the modeled disabled state.)
    */
   readonly runnerAuthService: RunnerAuthService;
+  /**
+   * The served edition, composition-derived (DD-006; blueprint §11 item
+   * 11): the extension registry declares it and defaults to oss, so the
+   * cloud composition answers `cloud` without forking this controller.
+   */
+  readonly edition: ServerEdition;
   readonly logger: Logger;
 }
 
@@ -64,16 +70,16 @@ export function registerPlatformServices(
   deps: PlatformControllerDeps,
 ): void {
   router.service(PlatformQueryController, {
-    getServerInfo: () => getServerInfo(),
+    getServerInfo: () => getServerInfo(deps),
     getRunnerBootstrapConfig: () => getRunnerBootstrapConfig(deps),
     getRunnerScopedToken: (input) => getRunnerScopedToken(deps, input),
   });
 }
 
 /** Go GetServerInfo: the server edition and build version. */
-function getServerInfo(): GetServerInfoOutput {
+function getServerInfo(deps: PlatformControllerDeps): GetServerInfoOutput {
   return create(GetServerInfoOutputSchema, {
-    edition: ServerEdition.oss,
+    edition: deps.edition,
     version: SERVER_VERSION,
   });
 }

--- a/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Pins the composed extension surface end to end (sub-project
+ * 20260826.09/O1, DD-006 §2a): a fake extension unit registering a
+ * cloud-family service the OSS server never serves
+ * (BillingQueryController) is visible through BOTH routers — the bound
+ * port and the in-process transport — with the full interceptor chain
+ * running on each lane (the SP-B parity doctrine extended to extension
+ * services), and the registry-declared edition answers on getServerInfo.
+ *
+ * The empty-set arm — no extensions composed, wire behavior byte-identical
+ * to before the parameter existed — is pinned where it belongs: the
+ * platform domain suite (edition oss) and the four conformance rosters.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { createClient } from "@connectrpc/connect";
+import type { Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { BillingQueryController } from "@stigmer/protos/ai/stigmer/billing/v1/query_pb";
+import { BillingAccountSchema } from "@stigmer/protos/ai/stigmer/billing/v1/billing_account_pb";
+import {
+  PlatformQueryController,
+  ServerEdition,
+} from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+
+import { loadConfig } from "../../boot/config.js";
+import { composeServer } from "../../boot/compose.js";
+import type { ComposedServer } from "../../boot/compose.js";
+import { createLogger } from "../../boot/logger.js";
+import type { ServerExtension } from "../registry.js";
+
+const BILLING_PROCEDURE =
+  "/ai.stigmer.billing.v1.BillingQueryController/getBillingAccount";
+
+describe("extension composition (composed server)", () => {
+  let server: ComposedServer;
+  let dir: string;
+  let portTransport: Transport;
+  // Captured NDJSON log lines — the interceptor-chain proof reads them.
+  const logLines: string[] = [];
+
+  const fakeBillingExtension: ServerExtension = {
+    name: "fake-billing",
+    edition: ServerEdition.cloud,
+    services: [
+      (router): void => {
+        // Partial implementation is deliberate: the fake pins service
+        // VISIBILITY and chain traversal, not the billing contract
+        // (that is C5's job, years of entries away).
+        router.service(BillingQueryController, {
+          getBillingAccount: (input) =>
+            create(BillingAccountSchema, { orgId: input.orgId }),
+        });
+      },
+    ],
+  };
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "extension-composition-test-"));
+    server = await composeServer({
+      config: loadConfig({
+        STIGMER_MODEL_REGISTRY_REFRESH: "off",
+        DB_PATH: path.join(dir, "stigmer.db"),
+        ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      }),
+      logger: createLogger({
+        level: "info",
+        pretty: false,
+        write: (line) => logLines.push(line),
+      }),
+      extensions: [fakeBillingExtension],
+      portOverride: 0,
+      host: "127.0.0.1",
+    });
+    const port = await server.start();
+    portTransport = createGrpcTransport({ baseUrl: `http://127.0.0.1:${port}` });
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("serves the extension service on the bound port, through the interceptor chain", async () => {
+    const before = logLines.length;
+    const client = createClient(BillingQueryController, portTransport);
+    const account = await client.getBillingAccount({ orgId: "org-serving" });
+    expect(account.orgId).toBe("org-serving");
+
+    // The logging interceptor (chain position 2) records every completed
+    // RPC — its line for the billing procedure proves the extension
+    // service traversed the SAME chain OSS services do.
+    const completed = logLines
+      .slice(before)
+      .filter(
+        (line) =>
+          line.includes("rpc completed") && line.includes(BILLING_PROCEDURE),
+      );
+    expect(completed.length).toBe(1);
+  });
+
+  it("serves the extension service on the in-process transport, through the same chain", async () => {
+    const before = logLines.length;
+    const client = createClient(
+      BillingQueryController,
+      server.inProcessTransport,
+    );
+    const account = await client.getBillingAccount({ orgId: "org-inprocess" });
+    expect(account.orgId).toBe("org-inprocess");
+
+    const completed = logLines
+      .slice(before)
+      .filter(
+        (line) =>
+          line.includes("rpc completed") && line.includes(BILLING_PROCEDURE),
+      );
+    expect(completed.length).toBe(1);
+  });
+
+  it("answers the registry-declared edition on getServerInfo", async () => {
+    const client = createClient(PlatformQueryController, portTransport);
+    const info = await client.getServerInfo({});
+    expect(info.edition).toBe(ServerEdition.cloud);
+  });
+
+  it("logs the composed unit names at boot", () => {
+    const bootLine = logLines.find((line) =>
+      line.includes("extension units composed"),
+    );
+    expect(bootLine).toBeDefined();
+    expect(bootLine).toContain("fake-billing");
+  });
+});

--- a/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Pins the extension registry's merge semantics and the DD-006 §2b
+ * loud-fail contract (sub-project 20260826.09/O1): explicit empty
+ * defaults, unit-order concatenation for list points, single-declaration
+ * enforcement for authorizer and edition, unique unit names, and the
+ * unknown-gate-slot boot throw. The composed-server behavior (services on
+ * both routers, edition on the wire) is pinned by
+ * extension-composition.test.ts; empty-set wire byte-identity is pinned by
+ * the conformance rosters.
+ */
+import { describe, expect, it } from "vitest";
+
+import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+import type { DescMessage } from "@bufbuild/protobuf";
+
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { WorkerFactory } from "../../temporal/manager.js";
+import type { Authorizer } from "../authorizer.js";
+import type { GateSlotName } from "../gate-slots.js";
+import type { IdentityVerifier } from "../identity.js";
+import { resolveExtensions } from "../registry.js";
+import type { ServerExtension } from "../registry.js";
+
+const allowAll: Authorizer = {
+  authorize: () => Promise.resolve({ kind: "allow" }),
+};
+
+const denyAll: Authorizer = {
+  authorize: () => Promise.resolve({ kind: "deny", reason: "unit test" }),
+};
+
+function verifier(name: string): IdentityVerifier {
+  return { name, verify: () => Promise.resolve(null) };
+}
+
+// Never invoked — the factory's identity is what the merge tests assert.
+const workerFactory: WorkerFactory = () =>
+  Promise.reject(new Error("unit-test worker factory — never started"));
+
+describe("resolveExtensions — defaults", () => {
+  it("resolves the omitted set to explicit empty defaults, edition oss", () => {
+    const resolved = resolveExtensions();
+    expect(resolved.unitNames).toEqual([]);
+    expect(resolved.edition).toBe(ServerEdition.oss);
+    expect(resolved.authorizer).toBeUndefined();
+    expect(resolved.identityVerifiers).toEqual([]);
+    expect(resolved.gateSteps.size).toBe(0);
+    expect(resolved.statusObservers).toEqual([]);
+    expect(resolved.responseDecorators).toEqual([]);
+    expect(resolved.services).toEqual([]);
+    expect(resolved.workers).toEqual([]);
+  });
+
+  it("resolves the empty list identically to the omitted set", () => {
+    expect(resolveExtensions([])).toEqual(resolveExtensions());
+  });
+});
+
+describe("resolveExtensions — merge semantics", () => {
+  it("concatenates list points in unit order and keeps declared singletons", () => {
+    const registerA = (): void => {};
+    const registerB = (): void => {};
+    const observerA = (): void => {};
+    const decoratorB = (): void => {};
+    const resolved = resolveExtensions([
+      {
+        name: "alpha",
+        identityVerifiers: [verifier("a1"), verifier("a2")],
+        services: [registerA],
+        statusTransitionHooks: { observers: [observerA] },
+      },
+      {
+        name: "beta",
+        edition: ServerEdition.cloud,
+        authorizer: allowAll,
+        identityVerifiers: [verifier("b1")],
+        services: [registerB],
+        workers: [workerFactory],
+        statusTransitionHooks: { responseDecorators: [decoratorB] },
+      },
+    ]);
+    expect(resolved.unitNames).toEqual(["alpha", "beta"]);
+    expect(resolved.edition).toBe(ServerEdition.cloud);
+    expect(resolved.authorizer).toBe(allowAll);
+    expect(resolved.identityVerifiers.map((v) => v.name)).toEqual([
+      "a1",
+      "a2",
+      "b1",
+    ]);
+    expect(resolved.services).toEqual([registerA, registerB]);
+    expect(resolved.workers).toEqual([workerFactory]);
+    expect(resolved.statusObservers).toEqual([observerA]);
+    expect(resolved.responseDecorators).toEqual([decoratorB]);
+  });
+});
+
+describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
+  it("throws on an empty unit name", () => {
+    expect(() => resolveExtensions([{ name: "" }])).toThrowError(
+      /empty name/,
+    );
+  });
+
+  it("throws on a duplicate unit name, naming it", () => {
+    expect(() =>
+      resolveExtensions([{ name: "billing" }, { name: "billing" }]),
+    ).toThrowError(/duplicate extension name 'billing'/);
+  });
+
+  it("throws on a second Authorizer, naming both units", () => {
+    expect(() =>
+      resolveExtensions([
+        { name: "first-authz", authorizer: allowAll },
+        { name: "second-authz", authorizer: denyAll },
+      ]),
+    ).toThrowError(
+      /extension 'second-authz' registers an Authorizer, but 'first-authz' already did/,
+    );
+  });
+
+  it("throws on a second edition declaration, naming both units", () => {
+    expect(() =>
+      resolveExtensions([
+        { name: "first-edition", edition: ServerEdition.cloud },
+        { name: "second-edition", edition: ServerEdition.oss },
+      ]),
+    ).toThrowError(
+      /extension 'second-edition' declares the server edition, but 'first-edition' already did/,
+    );
+  });
+
+  it("throws on a declared-but-unspecified edition", () => {
+    expect(() =>
+      resolveExtensions([
+        { name: "vague", edition: ServerEdition.server_edition_unspecified },
+      ]),
+    ).toThrowError(/edition 'server_edition_unspecified'/);
+  });
+
+  it("throws on a registration into an unknown gate slot, naming the slot", () => {
+    const step: PipelineStep<DescMessage> = {
+      name: "UnitTestGate",
+      execute: () => {},
+    };
+    // GateSlotName is the empty union until O4 declares the ratified
+    // slots, so no registration typechecks — the cast exercises the
+    // runtime arm of the two-layer contract (a JS consumer, or a
+    // composition built against a pin where a slot has moved, must throw
+    // at boot, never no-op).
+    const gateSteps = new Map([
+      ["agent-execution-create:pre-side-effect-gate", [step]],
+    ]) as unknown as ReadonlyMap<
+      GateSlotName,
+      ReadonlyArray<PipelineStep<DescMessage>>
+    >;
+    const unit: ServerExtension = { name: "early-gate", gateSteps };
+    expect(() => resolveExtensions([unit])).toThrowError(
+      /extension 'early-gate' registered gate steps into unknown slot 'agent-execution-create:pre-side-effect-gate'.*none in this build/,
+    );
+  });
+});

--- a/backend/services/stigmer-server/src/extensions/authorizer.ts
+++ b/backend/services/stigmer-server/src/extensions/authorizer.ts
@@ -1,0 +1,50 @@
+/**
+ * The Authorizer extension point — the one authorization decision seam of
+ * the convergence blueprint (20260826.02 blueprint/03 §5, DD-007), carried
+ * by the extension registry from O1 (20260826.09) and CONSUMED by O2,
+ * which splices the shared Authorize step at position 1 of every chain and
+ * installs the OSS permissive single-team default.
+ *
+ * The interface is transcribed verbatim from the ratified design. The
+ * `unavailable` arm is deliberate: the Java StepResult distinguishes
+ * denial from evaluation error so an authorization-backend outage surfaces
+ * as an INTERNAL fault, never a silent lockout dressed as
+ * PERMISSION_DENIED. An interface without that distinction would be wrong
+ * on day one — the deny/unavailable mapping is wire contract (deny →
+ * PERMISSION_DENIED; unavailable → INTERNAL), unit-tested both arms when
+ * O2 lands the step.
+ */
+import type { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import type { CallerIdentity } from "./identity.js";
+
+/**
+ * One authorization check: may `caller` exercise `permission` on the named
+ * resource? Permission names are the shared IamPermission enum verbatim —
+ * in the cloud they are the FGA relation vocabulary.
+ */
+export interface AuthzCheck {
+  readonly permission: IamPermission;
+  readonly resourceKind: ApiResourceKind;
+  readonly resourceId: string;
+}
+
+/** The three-arm decision (blueprint §5a — deny and unavailable are distinct). */
+export type AuthzDecision =
+  | { readonly kind: "allow" }
+  /** A genuine denial — maps to PERMISSION_DENIED on the wire. */
+  | { readonly kind: "deny"; readonly reason: string }
+  /** An evaluation failure — maps to INTERNAL on the wire, never a denial. */
+  | { readonly kind: "unavailable"; readonly cause: Error };
+
+/**
+ * The pure decision interface. Exactly ONE implementation is composed per
+ * server (the resolver enforces it): OSS's permissive single-team default
+ * (O2) or an extension's (the cloud registers OpenFGA). Write concerns —
+ * tuple seeding on create — are NOT authorization checks; they ride the
+ * post-persist gate slots (blueprint §5b item 4).
+ */
+export interface Authorizer {
+  authorize(caller: CallerIdentity, check: AuthzCheck): Promise<AuthzDecision>;
+}

--- a/backend/services/stigmer-server/src/extensions/drivers.ts
+++ b/backend/services/stigmer-server/src/extensions/drivers.ts
@@ -1,0 +1,19 @@
+/**
+ * The drivers extension point — infrastructure substitution seams of the
+ * convergence blueprint (20260826.02 blueprint/03 §6, DD-006 §2a). The
+ * point exists from O1 (20260826.09) so the registry carries all seven
+ * ratified point types; the registrable KINDS join with their extraction
+ * entries, each adding a field here as an owner-visible surface change:
+ *
+ *   - model-catalog provider (§6a) and artifact-storage driver
+ *     registration + runner-credential provider (§6b/§6c) — O5
+ *   - sandbox provisioners (§6d) — O6
+ *
+ * Empty deliberately, not provisionally: those interfaces are extractions
+ * from verified read surfaces, and guessing their shapes here would hand
+ * O5/O6 churn instead of a seam (the ruled ratified-types scope decision,
+ * this sub-project's T01 record).
+ */
+
+/** The driver contributions of one extension unit. No kinds exist yet. */
+export interface ExtensionDrivers {}

--- a/backend/services/stigmer-server/src/extensions/gate-slots.ts
+++ b/backend/services/stigmer-server/src/extensions/gate-slots.ts
@@ -1,0 +1,35 @@
+/**
+ * Named gate slots — the pipeline injection mechanism of the convergence
+ * blueprint (20260826.02 blueprint/03 §3, DD-006 §2). A slot is a point in
+ * a shared per-RPC chain where the builder splices extension-registered
+ * gate steps: zero steps in OSS, the cloud's gates in the cloud
+ * composition. Slot names are PROTECTED VOCABULARY (never renamed,
+ * byte-stable), scoped `<chain-name>:<position>`.
+ *
+ * O1 (20260826.09) ships the mechanism; O4 declares the six ratified slots
+ * at their Java-verified semantic positions and adds each name to BOTH
+ * layers below. Until then no slot exists, so every registration is the
+ * §2b unknown-slot boot throw — proven by the extension test suite.
+ *
+ * Two enforcement layers, deliberately redundant:
+ *   - GateSlotName (compile time): the union of declared slot literals.
+ *     Empty today, so a TS consumer cannot even express a registration.
+ *   - DECLARED_GATE_SLOTS (boot time): the load-bearing §2b contract. A JS
+ *     consumer, or a composition built against a pin where a slot has
+ *     since moved, must throw loudly at boot — never no-op silently.
+ */
+
+/**
+ * The declared slot-name union. Grows only with owner-visible slot
+ * additions (a slot table change in the blueprint's successor docs — O4
+ * declares the first six). `never` is the honest empty union: no slot
+ * exists, so no registration typechecks.
+ */
+export type GateSlotName = never;
+
+/**
+ * The boot-time declared-slot set — resolveExtensions validates every
+ * registration against it. Kept in lockstep with GateSlotName by hand;
+ * the extension suite pins the correspondence once slots exist.
+ */
+export const DECLARED_GATE_SLOTS: ReadonlySet<string> = new Set<string>();

--- a/backend/services/stigmer-server/src/extensions/identity.ts
+++ b/backend/services/stigmer-server/src/extensions/identity.ts
@@ -1,0 +1,56 @@
+/**
+ * Identity extension-point types — the verifier-chain contract of the
+ * convergence blueprint (20260826.02 blueprint/03 §4, DD-007), carried by
+ * the extension registry from O1 (20260826.09) and CONSUMED by O2, which
+ * turns the pass-through auth interceptor into the ordered verifier chain.
+ *
+ * The shapes are transcribed from the ratified design, not invented here:
+ * a verifier either CLAIMS a token (verifying it fully, throwing on
+ * signature/expiry/audience failure) or PASSES (returns null → next
+ * verifier) — the TS rendering of the Java ProviderManager chain. The
+ * product is one typed value, CallerIdentity, threaded explicitly through
+ * HandlerContext.values (never ambient state — the every-dependency-
+ * explicit doctrine).
+ */
+
+/**
+ * The caller-class discriminant. OSS knows user / machine / runner; the
+ * cloud composition extends the vocabulary (guest / channel / schedule)
+ * without an OSS enum change — hence the open string arm. `string & {}`
+ * keeps literal autocomplete while admitting extension values (a plain
+ * `string` would erase the known classes from the type surface).
+ */
+export type CallerClass = "user" | "machine" | "runner" | (string & {});
+
+/**
+ * The authenticated caller, produced by the verifier chain and read by the
+ * Authorizer and the audit-actor seam. Org membership is DELIBERATELY not
+ * carried (blueprint §4b): it is authorization data, resolved by the
+ * Authorizer per check, never cached on the identity.
+ */
+export interface CallerIdentity {
+  /** The principal the Authorizer sees (e.g. an identity-account id). */
+  readonly identityId: string;
+  readonly callerClass: CallerClass;
+  /** The issuer that vouched for the token (empty for local postures). */
+  readonly issuer: string;
+  /** The raw presented token, carried for downstream propagation. */
+  readonly rawToken: string;
+}
+
+/**
+ * One entry in the ordered token-verifier chain (claim-or-pass semantics,
+ * blueprint §4a). Order is composition order: OSS entries first, extension
+ * entries after, in extension-unit order.
+ */
+export interface IdentityVerifier {
+  /** Names the verifier in boot logs and auth failures (e.g. 'oidc'). */
+  readonly name: string;
+  /**
+   * Claims the token (returns the identity), passes (returns null so the
+   * next verifier runs), or throws — a verifier that RECOGNIZES a token
+   * but cannot verify it must throw, never pass (a pass would let a forged
+   * token fall through to a laxer verifier).
+   */
+  verify(token: string): Promise<CallerIdentity | null>;
+}

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -1,0 +1,225 @@
+/**
+ * The extension registry — the ONE extension surface of the convergence
+ * program (20260826.02 blueprint/03 §2, DD-006; built by sub-project
+ * 20260826.09 / O1). `composeServer` gains an optional `extensions` list
+ * of named contribution units; this module merges them into the resolved
+ * registry the composition stages consume. With no units, OSS behaves
+ * byte-identically to today — every point resolves to an explicit empty
+ * default, never a nullable surprise (the composition doctrine).
+ *
+ * Why a LIST of named units and not one flat object: the cloud composes
+ * MANY extension packages (billing, IAM lifecycle, channel delivery, the
+ * FGA authorizer, drivers — blueprint §10), each contributing its piece.
+ * Units give the §2b collision rules something real to enforce — a second
+ * Authorizer is representable and therefore rejectable — and every boot
+ * error names its offending unit(s). Single-instance points share one
+ * uniform merge rule (at most one declaring unit; a second throws naming
+ * both); list points concatenate in unit order.
+ *
+ * Loud-fail discipline (DD-006 §2b): resolution runs FIRST in
+ * composeServer, before any stage has side effects. Registering into a
+ * gate slot that does not exist, duplicating a unit name, or doubling a
+ * single-instance point is a boot throw. Nothing degrades silently.
+ *
+ * Consumption map (each point's consumer entry): services + workers +
+ * edition are consumed here in O1; identity verifiers + authorizer land
+ * with O2; gate steps + status hooks with O4; driver kinds with O5/O6.
+ */
+import type { DescMessage } from "@bufbuild/protobuf";
+import type { ConnectRouter } from "@connectrpc/connect";
+
+import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+
+import type { PipelineStep } from "../pipeline/pipeline.js";
+import type { WorkerFactory } from "../temporal/manager.js";
+import type { Authorizer } from "./authorizer.js";
+import type { ExtensionDrivers } from "./drivers.js";
+import { DECLARED_GATE_SLOTS } from "./gate-slots.js";
+import type { GateSlotName } from "./gate-slots.js";
+import type { IdentityVerifier } from "./identity.js";
+import type {
+  AgentExecutionResponseDecorator,
+  AgentExecutionStatusHooks,
+  AgentExecutionStatusObserver,
+} from "./status-hooks.js";
+
+/**
+ * Registers one or more ConnectRPC services on a router. Runs inside the
+ * ONE `routes` closure, so both the serving router and the in-process
+ * transport see the services automatically (blueprint §2a — a missed
+ * in-process wiring silently skipping extension services on cross-domain
+ * calls is exactly the bug this placement makes impossible).
+ */
+export type ExtensionServiceRegistration = (router: ConnectRouter) => void;
+
+/**
+ * One named extension unit — a package's whole contribution to the server
+ * composition. All fields but `name` are optional; an omitted field is
+ * the point's empty state.
+ */
+export interface ServerExtension {
+  /**
+   * Unique across the composed set; names the unit in boot logs and every
+   * registration error (`extension 'billing' …`).
+   */
+  readonly name: string;
+  /**
+   * The served edition (single-declaration point). Exactly one unit may
+   * declare it; undeclared compositions serve ServerEdition.oss. The
+   * cloud composition's first-party unit declares `cloud` — the D4
+   * addendum on blueprint §11 item 11.
+   */
+  readonly edition?: ServerEdition;
+  /** The authorization decision seam (single-instance point; consumed by O2). */
+  readonly authorizer?: Authorizer;
+  /** Ordered verifier-chain entries, appended in unit order (consumed by O2). */
+  readonly identityVerifiers?: ReadonlyArray<IdentityVerifier>;
+  /**
+   * Gate-step registrations per declared slot (consumed by O4). Every key
+   * must name a declared slot — an unknown slot is a boot throw, the §2b
+   * contract that keeps a composition and its pinned server honest.
+   */
+  readonly gateSteps?: ReadonlyMap<
+    GateSlotName,
+    ReadonlyArray<PipelineStep<DescMessage>>
+  >;
+  /** Agent-execution status observers/decorators (consumed by O4). */
+  readonly statusTransitionHooks?: AgentExecutionStatusHooks;
+  /** Driver substitutions (no kinds registrable yet — see drivers.ts). */
+  readonly drivers?: ExtensionDrivers;
+  /** Service registrations, appended to the routes closure after the OSS set. */
+  readonly services?: ReadonlyArray<ExtensionServiceRegistration>;
+  /** Temporal worker factories, appended to the manager's OSS factory list. */
+  readonly workers?: ReadonlyArray<WorkerFactory>;
+}
+
+/**
+ * The merged registry the composition stages consume. Every point is
+ * present with its explicit empty/default state — consumers never test
+ * for undefined, they iterate or read.
+ */
+export interface ResolvedExtensions {
+  /** Composed unit names, in order (boot-log material). */
+  readonly unitNames: ReadonlyArray<string>;
+  /** Defaults to ServerEdition.oss when no unit declares one. */
+  readonly edition: ServerEdition;
+  /**
+   * The single composed Authorizer, or undefined when none is registered —
+   * O2's consumption site installs the OSS permissive single-team default
+   * for the undefined arm (the default lives with the consumer that
+   * defines its semantics, not with this data holder).
+   */
+  readonly authorizer: Authorizer | undefined;
+  readonly identityVerifiers: ReadonlyArray<IdentityVerifier>;
+  /** Slot name → steps, validated against DECLARED_GATE_SLOTS. */
+  readonly gateSteps: ReadonlyMap<
+    string,
+    ReadonlyArray<PipelineStep<DescMessage>>
+  >;
+  readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
+  readonly responseDecorators: ReadonlyArray<AgentExecutionResponseDecorator>;
+  readonly drivers: ExtensionDrivers;
+  readonly services: ReadonlyArray<ExtensionServiceRegistration>;
+  readonly workers: ReadonlyArray<WorkerFactory>;
+}
+
+/**
+ * Merges the composed units, enforcing the §2b loud-fail rules. Runs
+ * before any composition stage — a throw here aborts boot with zero side
+ * effects. Plain Errors, not ConnectErrors: these are boot faults, the
+ * same class as the composition root's wiring throws.
+ */
+export function resolveExtensions(
+  units: ReadonlyArray<ServerExtension> = [],
+): ResolvedExtensions {
+  const unitNames: string[] = [];
+  const identityVerifiers: IdentityVerifier[] = [];
+  const gateSteps = new Map<string, ReadonlyArray<PipelineStep<DescMessage>>>();
+  const statusObservers: AgentExecutionStatusObserver[] = [];
+  const responseDecorators: AgentExecutionResponseDecorator[] = [];
+  const services: ExtensionServiceRegistration[] = [];
+  const workers: WorkerFactory[] = [];
+
+  let edition: ServerEdition | undefined;
+  let editionDeclaredBy: string | undefined;
+  let authorizer: Authorizer | undefined;
+  let authorizerDeclaredBy: string | undefined;
+
+  for (const unit of units) {
+    if (unit.name === "") {
+      throw new Error(
+        "extension unit with an empty name — every extension must be named (names carry every registration error and boot log)",
+      );
+    }
+    if (unitNames.includes(unit.name)) {
+      throw new Error(
+        `duplicate extension name '${unit.name}' — extension names must be unique across the composed set`,
+      );
+    }
+    unitNames.push(unit.name);
+
+    if (unit.edition !== undefined) {
+      if (unit.edition === ServerEdition.server_edition_unspecified) {
+        throw new Error(
+          `extension '${unit.name}' declares edition 'server_edition_unspecified' — declare a concrete edition or omit the field`,
+        );
+      }
+      if (editionDeclaredBy !== undefined) {
+        throw new Error(
+          `extension '${unit.name}' declares the server edition, but '${editionDeclaredBy}' already did — exactly one extension may declare the edition`,
+        );
+      }
+      edition = unit.edition;
+      editionDeclaredBy = unit.name;
+    }
+
+    if (unit.authorizer !== undefined) {
+      if (authorizerDeclaredBy !== undefined) {
+        throw new Error(
+          `extension '${unit.name}' registers an Authorizer, but '${authorizerDeclaredBy}' already did — exactly one Authorizer may be composed`,
+        );
+      }
+      authorizer = unit.authorizer;
+      authorizerDeclaredBy = unit.name;
+    }
+
+    if (unit.gateSteps !== undefined) {
+      for (const [slot, steps] of unit.gateSteps) {
+        if (!DECLARED_GATE_SLOTS.has(slot)) {
+          const declared =
+            DECLARED_GATE_SLOTS.size > 0
+              ? [...DECLARED_GATE_SLOTS].sort().join("', '")
+              : "";
+          throw new Error(
+            `extension '${unit.name}' registered gate steps into unknown slot '${slot}' — declared slots: ${
+              declared === "" ? "(none in this build)" : `'${declared}'`
+            }`,
+          );
+        }
+        const existing = gateSteps.get(slot) ?? [];
+        gateSteps.set(slot, [...existing, ...steps]);
+      }
+    }
+
+    identityVerifiers.push(...(unit.identityVerifiers ?? []));
+    statusObservers.push(...(unit.statusTransitionHooks?.observers ?? []));
+    responseDecorators.push(
+      ...(unit.statusTransitionHooks?.responseDecorators ?? []),
+    );
+    services.push(...(unit.services ?? []));
+    workers.push(...(unit.workers ?? []));
+  }
+
+  return {
+    unitNames,
+    edition: edition ?? ServerEdition.oss,
+    authorizer,
+    identityVerifiers,
+    gateSteps,
+    statusObservers,
+    responseDecorators,
+    drivers: {},
+    services,
+    workers,
+  };
+}

--- a/backend/services/stigmer-server/src/extensions/status-hooks.ts
+++ b/backend/services/stigmer-server/src/extensions/status-hooks.ts
@@ -1,0 +1,55 @@
+/**
+ * Status-transition hook types — the execution-lifecycle seam of the
+ * convergence blueprint (20260826.02 blueprint/03 §7, DD-006 §3), carried
+ * by the extension registry from O1 (20260826.09) and CONSUMED by O4 at
+ * the updateStatus chokepoint (src/domain/agentexecution/update-status.ts,
+ * the single merge point every status transition funnels through).
+ *
+ * The ratified contract, verbatim: observers fire synchronously after the
+ * store write and MAY NOT mutate the execution; decorators may contribute
+ * only response fields the OSS reply schema already carries (the
+ * control-signal field exists on the shared proto); StreamBroker.broadcast
+ * stays last. The workflow `stigmer/agent-execution/invoke` stays
+ * byte-identical — no extension activities inside it (the rejected
+ * alternative in DD-006).
+ *
+ * Scope note (ratified census finding): this hook family spans the
+ * agent-execution family ONLY. Workflowexecution is unmetered in the cloud
+ * edition, and no hook is built ahead of need there.
+ */
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { UpdateStatusResponse } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+
+/** One observed phase transition, delivered post-merge (blueprint §7). */
+export interface AgentExecutionStatusTransition {
+  /** The merged, persisted execution snapshot. Observers may not mutate it. */
+  readonly execution: AgentExecution;
+  readonly oldPhase: ExecutionPhase;
+  readonly newPhase: ExecutionPhase;
+}
+
+/**
+ * Fires synchronously after the merge persists. A throwing observer is an
+ * extension bug logged by the chokepoint, never a failed transition — the
+ * cloud's expiry sweep remains the reconciliation backstop it already is.
+ */
+export type AgentExecutionStatusObserver = (
+  transition: AgentExecutionStatusTransition,
+) => void | Promise<void>;
+
+/**
+ * Runs after the merge, before the reply; may set only fields the shared
+ * reply schema carries. Decorator failure degrades the contributed fields
+ * to their defaults (the verified non-fatal posture), never the RPC.
+ */
+export type AgentExecutionResponseDecorator = (
+  execution: AgentExecution,
+  response: UpdateStatusResponse,
+) => void | Promise<void>;
+
+/** The hook bundle one extension unit contributes (both lists optional). */
+export interface AgentExecutionStatusHooks {
+  readonly observers?: ReadonlyArray<AgentExecutionStatusObserver>;
+  readonly responseDecorators?: ReadonlyArray<AgentExecutionResponseDecorator>;
+}

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -1,0 +1,83 @@
+/**
+ * The @stigmer/server library contract (DD-005, sub-project 20260826.09).
+ *
+ * This file IS the blessed surface: the package.json exports map resolves
+ * the bare package name here and nowhere else, so everything a commit-pin
+ * consumer (the cloud composition) may import appears below — and nothing
+ * else does. Deep imports into dist/ internals are unsupported; anything a
+ * consumer needs that is not exported is a seam request to OSS, never a
+ * reach-around. Additions to this file are owner-visible surface changes,
+ * extended only through gates (the DD-005 review property: a surface
+ * change is a one-file diff).
+ *
+ * The surface is exactly what the ratified architecture names (blueprint
+ * 20260826.02/03 §1) and the parameter types those entries force:
+ *   - the compose entry and config loading (composeServer + its options'
+ *     required types: ServerConfig via loadConfig, Logger via createLogger)
+ *   - the extension-point types (§2 — the whole src/extensions contract)
+ *   - the pipeline primitives extensions build gates from (PipelineStep,
+ *     RequestContext, the semantic error helpers, and the typed store
+ *     not-found errors the ratified store-fault mapping keys on)
+ *   - the driver interfaces (Store, ArtifactStorage; §6's new interfaces
+ *     join with their extraction entries O5/O6)
+ *   - the worker factory types extension workers implement (§8)
+ *
+ * The package stays private and unpublished: this is the library contract
+ * for the commit-pinned consumer, not a public package (DD-005).
+ */
+
+// The compose entry and config loading.
+export { composeServer } from "./boot/compose.js";
+export type { ComposeOptions, ComposedServer } from "./boot/compose.js";
+export { loadConfig } from "./boot/config.js";
+export type { ServerConfig } from "./boot/config.js";
+export { createLogger } from "./boot/logger.js";
+export type { LogFields, Logger, LoggerOptions, LogLevel } from "./boot/logger.js";
+
+// The extension-point types (DD-006 — the seven-point registry).
+export type {
+  ExtensionServiceRegistration,
+  ResolvedExtensions,
+  ServerExtension,
+} from "./extensions/registry.js";
+export type {
+  CallerClass,
+  CallerIdentity,
+  IdentityVerifier,
+} from "./extensions/identity.js";
+export type {
+  Authorizer,
+  AuthzCheck,
+  AuthzDecision,
+} from "./extensions/authorizer.js";
+export type { GateSlotName } from "./extensions/gate-slots.js";
+export type {
+  AgentExecutionResponseDecorator,
+  AgentExecutionStatusHooks,
+  AgentExecutionStatusObserver,
+  AgentExecutionStatusTransition,
+} from "./extensions/status-hooks.js";
+export type { ExtensionDrivers } from "./extensions/drivers.js";
+
+// The pipeline primitives extensions build gate steps from.
+export type { PipelineStep } from "./pipeline/pipeline.js";
+export { RequestContext } from "./pipeline/request-context.js";
+export {
+  abortedError,
+  alreadyExistsError,
+  failedPreconditionError,
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+  unavailableError,
+} from "./pipeline/errors.js";
+
+// The driver interfaces and the store-fault classes the ratified mapping
+// keys on (typed not-found → NotFound; anything else rethrows as an
+// infrastructure fault — the guidelines' instanceof idiom).
+export type { Store } from "./store/interface.js";
+export { AuditNotFoundError, ResourceNotFoundError } from "./store/interface.js";
+export type { ArtifactStorage } from "./artifactstorage/artifact-storage.js";
+
+// The worker factory types extension workers implement (§8).
+export type { WorkerFactory, WorkerFactoryDeps } from "./temporal/manager.js";

--- a/test/extension-consumer/package-lock.json
+++ b/test/extension-consumer/package-lock.json
@@ -1,0 +1,130 @@
+{
+  "name": "@stigmer/extension-consumer",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@stigmer/extension-consumer",
+      "version": "0.0.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "2.12.0",
+        "@connectrpc/connect": "^2.0.0",
+        "@stigmer/protos": "file:../../apis/stubs/ts",
+        "@stigmer/server": "file:../../backend/services/stigmer-server"
+      },
+      "devDependencies": {
+        "@types/node": "22.20.1",
+        "typescript": "^5.7.0"
+      }
+    },
+    "../../apis/stubs/ts": {
+      "name": "@stigmer/protos",
+      "version": "0.0.0-dev",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "2.12.0"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "../../backend/services/stigmer-server": {
+      "name": "@stigmer/server",
+      "version": "0.0.0-dev",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "3.1116.0",
+        "@aws-sdk/s3-request-presigner": "3.1116.0",
+        "@bufbuild/protobuf": "2.12.0",
+        "@bufbuild/protovalidate": "^1.1.1",
+        "@connectrpc/connect": "^2.0.0",
+        "@connectrpc/connect-node": "^2.0.0",
+        "@stigmer/protos": "file:../../../apis/stubs/ts",
+        "@stigmer/temporal-codecs": "file:../../libs/ts/temporal-codecs",
+        "@stigmer/zip-structure": "file:../../libs/ts/zip-structure",
+        "@temporalio/activity": "1.16.2",
+        "@temporalio/client": "1.16.2",
+        "@temporalio/common": "1.16.2",
+        "@temporalio/proto": "1.16.2",
+        "@temporalio/worker": "1.16.2",
+        "@temporalio/workflow": "1.16.2",
+        "fflate": "^0.8.3",
+        "js-yaml": "^4.3.1",
+        "pg": "8.23.0",
+        "ulidx": "2.4.1"
+      },
+      "devDependencies": {
+        "@connectrpc/connect-web": "^2.0.0",
+        "@temporalio/testing": "1.16.2",
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "22.20.1",
+        "@types/pg": "8.23.1",
+        "esbuild": "^0.28.0",
+        "tsx": "^4.21.0",
+        "typescript": "^5.7.0",
+        "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=22.13.0 <23 || >=24"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
+      "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.2.tgz",
+      "integrity": "sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^2.7.0"
+      }
+    },
+    "node_modules/@stigmer/protos": {
+      "resolved": "../../apis/stubs/ts",
+      "link": true
+    },
+    "node_modules/@stigmer/server": {
+      "resolved": "../../backend/services/stigmer-server",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/test/extension-consumer/package.json
+++ b/test/extension-consumer/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@stigmer/extension-consumer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Compile-proof consumer of the @stigmer/server library contract: a fake extension that typechecks against the exports map alone (DD-005). Deliberately NOT a root-workspace member — it file:-links the server exactly the way the commit-pin consumer (the cloud composition) will.",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": "2.12.0",
+    "@connectrpc/connect": "^2.0.0",
+    "@stigmer/protos": "file:../../apis/stubs/ts",
+    "@stigmer/server": "file:../../backend/services/stigmer-server"
+  },
+  "devDependencies": {
+    "@types/node": "22.20.1",
+    "typescript": "^5.7.0"
+  }
+}

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -1,0 +1,154 @@
+/**
+ * The compile-proof fake extension (sub-project 20260826.09/O1, DD-005).
+ *
+ * This module typechecks a consumer-shaped composition against the
+ * @stigmer/server exports map ALONE — every server import below is the
+ * bare package name, resolved through the exports map to dist. If a needed
+ * type or function is missing from the blessed surface, THIS file fails to
+ * compile: the exports map's completeness is enforced by tsc, not by
+ * review memory. Deep imports are deliberately absent; a consumer need
+ * that cannot be expressed here is a seam request to OSS.
+ *
+ * It exercises every extension point a consumer can touch today: the
+ * seven-point unit shape (services, workers, edition, authorizer,
+ * verifiers, status hooks; gate slots are compile-closed until O4 declares
+ * the ratified names), a gate-step body built from the pipeline
+ * primitives, the store-fault idiom, and the compose entry itself. It is
+ * never executed — the runtime behavior is pinned by the server's own
+ * extension suite; execution here would need real infrastructure for no
+ * additional proof.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { DescMessage } from "@bufbuild/protobuf";
+import type { ConnectRouter } from "@connectrpc/connect";
+
+import { BillingAccountSchema } from "@stigmer/protos/ai/stigmer/billing/v1/billing_account_pb";
+import { BillingQueryController } from "@stigmer/protos/ai/stigmer/billing/v1/query_pb";
+import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+
+import {
+  composeServer,
+  createLogger,
+  loadConfig,
+  notFoundError,
+  ResourceNotFoundError,
+} from "@stigmer/server";
+import type {
+  AgentExecutionResponseDecorator,
+  AgentExecutionStatusObserver,
+  ArtifactStorage,
+  Authorizer,
+  CallerIdentity,
+  ComposedServer,
+  IdentityVerifier,
+  PipelineStep,
+  ServerExtension,
+  Store,
+  WorkerFactory,
+} from "@stigmer/server";
+
+/** A permissive Authorizer in the consumer's own code (the O2 shape). */
+const authorizer: Authorizer = {
+  authorize: (caller: CallerIdentity) =>
+    Promise.resolve(
+      caller.callerClass === "user"
+        ? { kind: "allow" as const }
+        : { kind: "deny" as const, reason: "machine callers are refused here" },
+    ),
+};
+
+/** A claim-or-pass verifier (the O2 chain-entry shape). */
+const verifier: IdentityVerifier = {
+  name: "consumer-fake",
+  verify: (token) =>
+    Promise.resolve(
+      token.startsWith("fake_")
+        ? {
+            identityId: "ida_consumer",
+            callerClass: "user",
+            issuer: "https://issuer.invalid",
+            rawToken: token,
+          }
+        : null,
+    ),
+};
+
+/**
+ * A gate-step body built from the exported pipeline primitives — the shape
+ * every cloud gate (billing preflight, capacity, tier validation) takes
+ * once O4 opens the slots. The store-fault idiom rides along: a typed
+ * not-found maps to NotFound, anything else rethrows.
+ */
+export function consumerGateStep(): PipelineStep<DescMessage> {
+  return {
+    name: "ConsumerFakeGate",
+    execute: () => {
+      const missing = false as boolean;
+      if (missing) {
+        throw notFoundError("billing account", "org-fake");
+      }
+    },
+  };
+}
+
+/** The typed store not-found classes are importable for the instanceof idiom. */
+export function isStoreNotFound(error: unknown): boolean {
+  return error instanceof ResourceNotFoundError;
+}
+
+const statusObserver: AgentExecutionStatusObserver = (transition) => {
+  void transition.execution.metadata?.id;
+  void transition.newPhase;
+};
+
+const responseDecorator: AgentExecutionResponseDecorator = (
+  execution,
+  response,
+) => {
+  void execution.metadata?.id;
+  // The control-signal field the §7 decorator contract names — it already
+  // exists on the shared reply schema.
+  void response.signal;
+};
+
+const workerFactory: WorkerFactory = () =>
+  Promise.reject(new Error("compile-proof worker — never started"));
+
+const registerBillingService = (router: ConnectRouter): void => {
+  router.service(BillingQueryController, {
+    getBillingAccount: (input) =>
+      create(BillingAccountSchema, { orgId: input.orgId }),
+  });
+};
+
+/** The whole unit — every point a consumer can populate today. */
+export const fakeExtension: ServerExtension = {
+  name: "consumer-fake",
+  edition: ServerEdition.cloud,
+  authorizer,
+  identityVerifiers: [verifier],
+  statusTransitionHooks: {
+    observers: [statusObserver],
+    responseDecorators: [responseDecorator],
+  },
+  services: [registerBillingService],
+  workers: [workerFactory],
+};
+
+/** The thin composition program's exact shape (blueprint §2a). */
+export async function composeFakeCloud(): Promise<ComposedServer> {
+  return composeServer({
+    config: loadConfig(),
+    logger: createLogger({ level: "info", pretty: false }),
+    extensions: [fakeExtension],
+  });
+}
+
+/**
+ * The exported driver interfaces are consumable in extension signatures —
+ * the shape O5's registrations will take.
+ */
+export interface ConsumerDriverBundle {
+  readonly store: Store;
+  readonly artifactStorage: ArtifactStorage;
+}

--- a/test/extension-consumer/tsconfig.json
+++ b/test/extension-consumer/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
The OSS extension seam foundation of the cloud convergence program — entry **O1** of the approved breakdown (stigmer-cloud `_projects/2026-08/20260826.02.cloud-ts-convergence-and-java-retirement/blueprint/04-subproject-breakdown.md`, Gate 4; binding designs DD-005 + DD-006). `composeServer` gains an optional, typed extension registry; `@stigmer/server` gains its first exports map (the DD-005 library contract); the served edition becomes composition-derived.

## Context
The cloud control plane converges onto this server as a library-plus-extensions composition. O1 builds the seam the whole program hangs on: the one registry every later entry (identity/authorizer O2, gate slots + status hooks O4, driver seams O5, sandbox provisioner O6, and the cloud composition C1) registers through — with OSS behavior byte-identical when no extension is composed.

## Changes
- **`src/extensions/`** — the seven-point registry (DD-006 §2a): gate steps, status-transition hooks, authorizer, identity verifiers, drivers, services, workers, plus the registry-declared edition. `resolveExtensions` merges named units with the §2b loud-fail rules: duplicate unit name, second `Authorizer`, second edition declaration, and unknown-gate-slot registrations are boot throws naming the offending unit(s). Authorizer/verifier/hook types are transcribed verbatim from the ratified blueprint (§4b, §5a, §7); the drivers point ships with zero registrable kinds (each kind joins with its extraction entry).
- **`composeServer`** — resolves extensions FIRST (zero side effects on a bad registry); extension services register at the end of the ONE `routes` closure so both the serving router and the in-process transport see them by construction; extension worker factories append to `TemporalManager`'s list; the edition threads into the platform controller.
- **`ComposedServer.inProcessTransport`** — one new documented seam (blueprint §8): the lane that reaches every registered service, extension services included; also the both-router test proof.
- **Exports map** — one curated entry: `src/index.ts` IS the DD-005 blessed surface (compose entry + config loading, extension-point types, pipeline primitives + error helpers + typed store-fault classes, `Store`/`ArtifactStorage`, worker factory types). Package stays `private: true`.
- **`test/extension-consumer`** — standalone compile proof: a fake extension that typechecks against the exports map ALONE through a `file:` link (the exact posture the commit-pin cloud consumer occupies). Wired as `make test-extension-consumer` and into `ci.stigmer-server.yaml` after the dist build.
- **`getServerInfo`** — answers the registry-declared edition, defaulting to `ServerEdition.oss` (byte-identical when undeclared).

## Implementation notes
- **Named extension units (owner-flagged refinement)**: the `extensions` parameter is a LIST of named units merged by a loud-fail resolver, not one flat object — DD-006 §2b's "second Authorizer is a boot throw" is unrepresentable on a flat object, and the blueprint's §10 topology composes many extension packages. Single-instance points share one uniform merge rule (at most one declaring unit; a second throws naming both).
- Gate slots have two enforcement layers: the `GateSlotName` type union (empty until O4 declares the six ratified slots) and the runtime `DECLARED_GATE_SLOTS` set — the runtime check is the load-bearing contract for JS consumers and pin drift.
- The fake-extension suite registers `BillingQueryController` (a cloud-family service OSS never serves) and proves both-router visibility WITH the interceptor chain running on each lane (asserted via the logging interceptor's records).

## Breaking changes
- None on the wire. `createInProcessClients` now returns `{ clients, transport }` (internal boot seam; both call sites updated).

## Test plan
- Fake-extension suites: 13 tests (merge semantics, every loud-fail throw, both-router visibility + chain traversal, edition override, boot log).
- Full server gate: `npm run typecheck` clean; vitest 132 files / 1776 tests passed; `verify:dist` boots clean with the exports map in place.
- Compile proof: `test/extension-consumer` `tsc --noEmit` green against the built dist.
- **Empty-set byte-identity (the acceptance instrument): all four conformance rosters green unchanged** — `local` 492 passed, `local-postgres` 492 passed, `local-execution` 160 passed, `local-postgres-execution` 160 passed (pre-existing skips only).

## Risks
- The exports map changes module resolution for the package name only; verified no consumer imports `@stigmer/server` as a module today (the CLI spawns `dist/main.js` by path; `bundle-slim.mjs` synthesizes the slim manifest field-by-field).
- Rollback: revert the single commit; no schema, wire, or workflow changes.

## Checklist
- [x] Tests added/updated
- [x] Backward compatible (empty-set byte-identity proven by the conformance rosters)
- [x] Docs: project records updated in stigmer-cloud (T01 plan/review, next-task worktree block)

Made with [Cursor](https://cursor.com)