### PR TITLE
feat(test/conformance): enable the mcpserver suites on the cloud lanes and harden the cloud instrument

### DIFF
--- a/backend/services/runner/src/activities/call-agent.ts
+++ b/backend/services/runner/src/activities/call-agent.ts
@@ -22,7 +22,7 @@
 import { randomUUID } from "node:crypto";
 import { Context, CompleteAsyncError } from "@temporalio/activity";
 import { StigmerClient } from "../client/stigmer-client.js";
-import { loadConfig } from "../config.js";
+import { loadConfig, type Config } from "../config.js";
 import { resolveObjectPlaceholders } from "../workflow-engine/resolve.js";
 import type { AgentCallConfig } from "../workflow-engine/types.js";
 import { startHeartbeat } from "../shared/heartbeat.js";
@@ -49,6 +49,7 @@ export async function callAgentAction(
   config: AgentCallConfig,
   runtimeEnv: Record<string, unknown>,
   parentWorkflowId: string,
+  appConfig: Config = loadConfig(),
 ): Promise<void> {
   const taskToken = Context.current().info.taskToken;
 
@@ -81,10 +82,19 @@ export async function callAgentAction(
     );
   }
 
-  const appConfig = loadConfig();
   const client = new StigmerClient({
     endpoint: appConfig.stigmerBackendEndpoint,
     token: appConfig.stigmerToken,
+    tokenRef: appConfig.stigmerTokenRef,
+    // The child-execution create must authenticate as the RUNNER, not the
+    // user: it stamps the workflow lineage labels, which cloud's
+    // reserved-label guard and environment composer accept only from
+    // runner-class callers. The client's credential-selection table routes
+    // exactly that create to this credential; null (OSS/local, no mint)
+    // falls through to the control-plane token unchanged. The refs live only
+    // on the runner's INJECTED Config (loadConfig() rebuilds from env and
+    // never carries them), which is why the factory passes it in.
+    runnerTokenRef: appConfig.stigmerRunnerTokenRef,
   });
 
   const agentRef = parseAgentReference(resolved.agent, orgId);
@@ -382,7 +392,7 @@ function resolveExecutionTarget(target?: number): ExecutionTarget {
   return ExecutionTarget.UNSPECIFIED;
 }
 
-export function createCallAgentActivities() {
+export function createCallAgentActivities(appConfig: Config) {
   return {
     CallAgent: async (
       config: AgentCallConfig,
@@ -391,7 +401,7 @@ export function createCallAgentActivities() {
     ): Promise<void> => {
       const hb = startHeartbeat(15_000, () => ({ phase: "creating_agent_execution" }));
       try {
-        return await callAgentAction(config, runtimeEnv, parentWorkflowId);
+        return await callAgentAction(config, runtimeEnv, parentWorkflowId, appConfig);
       } finally {
         hb.stop();
       }

--- a/backend/services/runner/src/client/stigmer-client.ts
+++ b/backend/services/runner/src/client/stigmer-client.ts
@@ -234,7 +234,10 @@ export class StigmerClient {
         //    scoped-token exchange itself requires the embedded_runner
         //    bootstrap credential (a desktop runner's control-plane token is
         //    the user's own Auth0 token, which the server correctly treats as
-        //    a browsing user).
+        //    a browsing user); and the workflow child-execution create stamps
+        //    the platform's workflow lineage labels, which cloud's
+        //    reserved-label guard and environment composer accept only from
+        //    runner-class callers — a user-token create is rejected outright.
         //
         // 3. Everything else uses the control-plane token. Falls through
         //    unchanged when no runner token exists (OSS/local, where the
@@ -246,7 +249,9 @@ export class StigmerClient {
           const usesRunnerCredential =
             req.service.typeName === ExecutionContextQueryController.typeName ||
             (req.service.typeName === PlatformQueryController.typeName &&
-              req.method.name === PlatformQueryController.method.getRunnerScopedToken.name);
+              req.method.name === PlatformQueryController.method.getRunnerScopedToken.name) ||
+            (req.service.typeName === AgentExecutionCommandController.typeName &&
+              req.method.name === AgentExecutionCommandController.method.create.name);
           const token =
             (usesRunnerCredential ? this.runnerTokenRef?.current : null)
             ?? this.tokenRef?.current

--- a/backend/services/runner/src/runner-manager.ts
+++ b/backend/services/runner/src/runner-manager.ts
@@ -789,7 +789,7 @@ async function createAllActivities(config: Config): Promise<WorkerActivities> {
     ...createCallGrpcActivities(),
     ...createCallFunctionActivities(),
     ...createCallLlmActivities(),
-    ...createCallAgentActivities(),
+    ...createCallAgentActivities(config),
     ...createCallAgentStatusActivities(),
     ...createRunCommandActivities(),
     ...createHydrateWorkflowActivities(config),

--- a/backend/services/runner/src/runner.ts
+++ b/backend/services/runner/src/runner.ts
@@ -524,7 +524,7 @@ async function createAllActivities(config: Config): Promise<WorkerActivities> {
     ...createCallGrpcActivities(),
     ...createCallFunctionActivities(),
     ...createCallLlmActivities(),
-    ...createCallAgentActivities(),
+    ...createCallAgentActivities(config),
     ...createCallAgentStatusActivities(),
     ...createRunCommandActivities(),
     ...createHydrateWorkflowActivities(config),

--- a/test/conformance/src/harness/cloud-env.ts
+++ b/test/conformance/src/harness/cloud-env.ts
@@ -25,6 +25,7 @@ import { PlatformClientCommandController } from "@stigmer/protos/ai/stigmer/iam/
 import { PlatformClientTokenController } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/token_pb";
 import { createTransport, makeClients } from "./clients";
 import { awaitGrpcReady } from "./grpc-ready";
+import { CONFORMANCE_OAUTH_REDIRECT_URI } from "./server-process";
 import { uniqueName } from "../support/naming";
 
 // Contract between global-setup-cloud.ts (writer) and CloudTarget (reader).
@@ -115,6 +116,15 @@ export async function spawnCloudEnvironment(): Promise<CloudEnvironment> {
     // .test-output/ like the integration tests' own runs.
     cwd: LAUNCHER_MODULE_DIR,
     stdio: ["ignore", "pipe", "inherit"],
+    env: {
+      ...process.env,
+      // The launcher passes this through to the Java service (an explicit
+      // ServiceConfig field, never ambient inheritance). The suite's own
+      // constant is the single source of truth: the mcpserver OAuth suites
+      // assert this exact value inside DCR requests and authorize URLs, so
+      // a second definition anywhere would drift.
+      STIGMER_OAUTH_REDIRECT_URI: CONFORMANCE_OAUTH_REDIRECT_URI,
+    },
   });
 
   const readyLine = await waitForReadyLine(child);

--- a/test/conformance/src/suites-execution/mcpserver-connect.conformance.test.ts
+++ b/test/conformance/src/suites-execution/mcpserver-connect.conformance.test.ts
@@ -444,17 +444,21 @@ describe("McpServer connect conformance — grant health boundaries", () => {
       org,
     });
 
-    // PINNED CURRENT BEHAVIOR, arguably a bug: completeOAuthConnect records
-    // the refresh-token ENV VAR NAME on the grant unconditionally (the
-    // `_REFRESH_TOKEN` naming convention), and evaluateHealth keys
-    // "refreshable" off that name being non-empty — so a grant whose vendor
-    // never issued a refresh token still reports TOKEN_EXPIRED_REFRESHABLE,
-    // and the TOKEN_EXPIRED health state is unreachable through this flow.
-    // Filed as stigmer/stigmer#863 — when fixed (both editions), flip this
-    // pin to TOKEN_EXPIRED.
+    // TWO-ARMED implementation-lag pin (stigmer/stigmer#863; the multiTenant
+    // flag is only the edition discriminant here, not a tenancy semantic):
+    //  - OSS arm — PINNED CURRENT BEHAVIOR, arguably a bug: completeOAuthConnect
+    //    records the refresh-token ENV VAR NAME on the grant unconditionally
+    //    (the `_REFRESH_TOKEN` naming convention), and evaluateHealth keys
+    //    "refreshable" off that name being non-empty — so a grant whose vendor
+    //    never issued a refresh token still reports TOKEN_EXPIRED_REFRESHABLE,
+    //    and TOKEN_EXPIRED is unreachable through this flow.
+    //  - Cloud arm — already answers the correct TOKEN_EXPIRED.
+    // When #863 is fixed in OSS, collapse both arms to TOKEN_EXPIRED.
     expect(status.connected).toBe(true);
     expect(status.connectionHealth).toBe(
-      OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED_REFRESHABLE,
+      target.capabilities.multiTenant
+        ? OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED
+        : OAuthConnectionHealth.OAUTH_CONNECTION_HEALTH_TOKEN_EXPIRED_REFRESHABLE,
     );
   });
 });
@@ -738,21 +742,43 @@ describe("McpServer connect conformance — refresh-on-connect pre-flight", () =
     const exchangesBeforeConnect = mockAs.capturedTokenRequests().length;
     scriptClassifierVerdict(true);
 
+    // TWO-ARMED implementation-lag pin (stigmer/stigmer#863; multiTenant is
+    // only the edition discriminant, not a tenancy semantic):
+    //  - Cloud arm — refuses honestly: an expired grant with no refresh token
+    //    answers FailedPrecondition with the re-authenticate copy, before any
+    //    connect run starts. This is the behavior #863's fix converges on.
+    //  - OSS arm — PINNED CURRENT BEHAVIOR: with no refresh token stored, the
+    //    pre-flight's managed-env read fails and the refresh is SKIPPED
+    //    silently — connect proceeds with the expired token rather than
+    //    refusing (the refusal copy is unreachable through the wire: it fires
+    //    only when the managed env returns an EMPTY refresh token, which
+    //    completeOAuthConnect never writes). The stale token only fails
+    //    later, at the target server — which the echo fixture, needing no
+    //    auth, never does. The silent skip hides an expired, unrefreshable
+    //    grant.
+    // When #863 is fixed in OSS, collapse both arms to the cloud arm.
+    if (target.capabilities.multiTenant) {
+      const err = await expectGrpcCode(
+        () => clients.mcpServerCommand.connect({ mcpServerId: server.metadata!.id, org }),
+        Code.FailedPrecondition,
+        "connect with an expired, unrefreshable grant",
+      );
+      expect(err.rawMessage).toBe(
+        `Access token for MCP server '${server.metadata!.id}' has expired and no refresh ` +
+          "token is available. Please re-authenticate via OAuth Connect",
+      );
+      expect(
+        mockAs.capturedTokenRequests().length,
+        "no refresh attempt must reach the vendor",
+      ).toBe(exchangesBeforeConnect);
+      return;
+    }
+
     const connected = await clients.mcpServerCommand.connect({
       mcpServerId: server.metadata!.id,
       org,
     });
 
-    // PINNED CURRENT BEHAVIOR: with no refresh token stored, the pre-flight's
-    // managed-env read fails and the refresh is SKIPPED silently — connect
-    // proceeds with the expired token rather than refusing with the
-    // "no refresh token is available" re-authenticate error (that copy is
-    // unreachable through the wire: it fires only when the managed env
-    // returns an EMPTY refresh token, which completeOAuthConnect never
-    // writes). The stale token only fails later, at the target server —
-    // which the echo fixture, needing no auth, never does. Filed as
-    // stigmer/stigmer#863: the silent skip hides an expired, unrefreshable
-    // grant.
     expect(connected.status?.connectStatus?.phase).toBe(ConnectPhase.succeeded);
     expect(mockAs.capturedTokenRequests().length, "no refresh attempt must reach the vendor").toBe(
       exchangesBeforeConnect,

--- a/test/conformance/src/suites-execution/workflowexecution.conformance.test.ts
+++ b/test/conformance/src/suites-execution/workflowexecution.conformance.test.ts
@@ -208,7 +208,13 @@ describe("WorkflowExecution conformance — queries", () => {
       "getEventLog empty execution_id",
     ));
 
-  it("getEventLog of an unknown execution returns an empty page (not NotFound)", async () => {
+  it("getEventLog of an unknown execution returns an empty page (not NotFound)", async (ctx) => {
+    // Single-user-posture arm: the multi-tenant edition's authorization
+    // fails closed on a fabricated id (PermissionDenied, no existence leak)
+    // before the handler runs — the wave-2 fabricated-id class, disclosed in
+    // the parity register. Only the single-user editions reach the
+    // empty-page contract.
+    if (target.capabilities.multiTenant) return ctx.skip();
     // Unlike get/subscribe, getEventLog does not 404 — it returns no events.
     const log = await clients.workflowExecutionQuery.getEventLog({ executionId: "wex_doesnotexist" });
     expect(log.events).toHaveLength(0);

--- a/test/conformance/src/suites/mcpserver-oauth.conformance.test.ts
+++ b/test/conformance/src/suites/mcpserver-oauth.conformance.test.ts
@@ -478,8 +478,22 @@ describe("McpServer OAuth conformance — grant-free reads", () => {
   });
 
   it("disconnectOAuth is idempotent: no grant answers disconnected=false, not an error", async () => {
+    // The probe targets a REAL owned server (the wave-2 real-owned-resource
+    // convention): on the multi-tenant edition a fabricated id fails closed
+    // in authorization (PermissionDenied, no existence leak) before the
+    // handler runs, so only an owned server reaches the shared idempotence
+    // contract on both editions — which is also the stronger assertion: a
+    // real grant-free server, not a nonexistent one.
     const { org } = await target.provisionTenancy();
-    const out = await clients.mcpServerCommand.disconnectOAuth({ resourceId: "mcp_nogrant", org });
+    const server = await createOAuthMcpServer({
+      org,
+      name: uniqueName("nogrant-disconnect"),
+      discoveryUrl: mockAs.origin(),
+    });
+    const out = await clients.mcpServerCommand.disconnectOAuth({
+      resourceId: server.metadata!.id,
+      org,
+    });
     expect(out.disconnected).toBe(false);
   });
 });

--- a/test/conformance/src/suites/session.conformance.test.ts
+++ b/test/conformance/src/suites/session.conformance.test.ts
@@ -26,6 +26,7 @@ import { assertResourceParity } from "../contract/parity";
 import type { ConformanceClients } from "../harness/clients";
 import { FixtureTracker } from "../harness/fixtures";
 import { makeAgent } from "../support/agents";
+import { makeSlackAgentChannel } from "../support/agentchannels";
 import { uniqueName } from "../support/naming";
 import { SESSION_API_VERSION, SESSION_KIND, makeSession, makeSessionSpec } from "../support/sessions";
 import { createTarget, type TargetProfile } from "../targets";
@@ -305,28 +306,41 @@ describe("Session conformance — queries", () => {
     ));
 
   it("listByChannel answers an empty list for a channel with no sessions — ordinary sessions never leak into a channel view", async () => {
-    // Channel sessions are created by the cloud channel runtime, which stamps
-    // the stigmer.ai/channel-id label at create time. The OSS runtime has no
-    // channel broker, so nothing ever stamps it there — the empty answer IS
-    // the OSS contract. Creating an ordinary session first makes this a real
-    // filter assertion rather than a vacuous empty-store read: a broken
-    // filter that returned unlabeled sessions would fail here.
+    // The probe targets a REAL owned channel (the conversation-lane
+    // convention, wave-2): on cloud a fabricated channel id fails closed in
+    // the channel can_view gate (PermissionDenied, no existence leak —
+    // DD-012) before the filter ever runs, so only an owned channel reaches
+    // the shared truthful-emptiness contract on both editions. Channel
+    // sessions are created by the cloud channel runtime, which stamps the
+    // stigmer.ai/channel-id label at create time; the OSS runtime has no
+    // channel broker, so nothing ever stamps it there. Creating an ordinary
+    // session first makes this a real filter assertion rather than a vacuous
+    // empty-store read: a broken filter that returned unlabeled sessions
+    // would fail here.
     const { org } = await target.provisionTenancy();
-    const agentInstanceId = await provisionAgentInstance(org);
-    await createSession(org, uniqueName("session"), agentInstanceId);
+    const agent = await clients.agentCommand.create(makeAgent({ org, name: uniqueName("agent") }));
+    fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
+    const channel = await clients.agentChannelCommand.create(
+      makeSlackAgentChannel(org, uniqueName("channel"), agent.metadata!.slug),
+    );
+    fixtures.defer(() => clients.agentChannelCommand.delete({ value: channel.metadata!.id }));
+    await createSession(org, uniqueName("session"), agent.status!.defaultInstanceId);
 
-    const listed = await clients.sessionQuery.listByChannel({ channelId: uniqueName("ach") });
+    const listed = await clients.sessionQuery.listByChannel({ channelId: channel.metadata!.id });
 
     expect(listed.entries).toHaveLength(0);
   });
 
   it("listByChannel returns exactly the sessions stamped with the channel's label", async () => {
     // The positive arm: the filter must key on the stigmer.ai/channel-id
-    // label, not on emptiness. The label is a server-stamped reserved key an
-    // ordinary caller cannot forge on cloud (GuardReservedLabelsStep), so the
-    // channel-originated session is seeded through the privileged scope
-    // (stigmer#547) — the activity suite's runtime-origin seeding pattern.
-    // Deployed endpoints carry no operator credential by design and skip.
+    // label, not on emptiness. The channel is a REAL owned resource (the
+    // wave-2 conversation-lane convention — cloud's DD-012 can_view gate
+    // passes only for channels the caller can open), and the label is a
+    // server-stamped reserved key an ordinary caller cannot forge on cloud
+    // (GuardReservedLabelsStep), so the channel-originated session is seeded
+    // through the privileged scope (stigmer#547) — the activity suite's
+    // runtime-origin seeding pattern. Deployed endpoints carry no operator
+    // credential by design and skip.
     if (target.provisionPrivilegedScope === undefined) return;
     const scope = await target.provisionPrivilegedScope();
 
@@ -336,7 +350,10 @@ describe("Session conformance — queries", () => {
         makeAgent({ org, name: uniqueName("agent") }),
       );
       const agentInstanceId = agent.status!.defaultInstanceId;
-      const channelId = uniqueName("ach");
+      const channel = await scope.clients.agentChannelCommand.create(
+        makeSlackAgentChannel(org, uniqueName("channel"), agent.metadata!.slug),
+      );
+      const channelId = channel.metadata!.id;
 
       const channelSession = await scope.clients.sessionCommand.create(
         makeSession({
@@ -357,6 +374,7 @@ describe("Session conformance — queries", () => {
         channelSession.metadata?.id,
       ]);
 
+      await scope.clients.agentChannelCommand.delete({ value: channel.metadata!.id });
       await scope.clients.agentCommand.delete({ value: agent.metadata!.id });
     } finally {
       await scope.cleanup();

--- a/test/conformance/vitest.cloud-execution.config.ts
+++ b/test/conformance/vitest.cloud-execution.config.ts
@@ -15,6 +15,10 @@
 // - open-computer-use is EXCLUDED: a local-only developer gate (macOS
 //   accessibility + STIGMER_DESKTOP_TESTS opt-in) that can never run in the
 //   headless CI this config exists for.
+// - mcpserver-connect runs here like every other Class B suite: the cloud
+//   global setup passes STIGMER_OAUTH_REDIRECT_URI through the hermetic
+//   launcher to the JAR (the 20260824.05 owner-gated follow-up, closed by
+//   sub-project 20260826.08).
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -23,12 +27,6 @@ export default defineConfig({
     exclude: [
       "src/suites-execution/schedule-firing.conformance.test.ts",
       "src/suites-execution/open-computer-use.conformance.test.ts",
-      // EXCLUDED for the same reason as mcpserver-oauth in
-      // vitest.cloud.config.ts: its OAuth handshake setup needs
-      // STIGMER_OAUTH_REDIRECT_URI on the service, which the hermetic
-      // launcher does not yet pass to the JAR. Cloud enablement is an
-      // owner-gated follow-up (CW-1 wrap-up, sub-project 20260824.05).
-      "src/suites-execution/mcpserver-connect.conformance.test.ts",
     ],
     globalSetup: ["./src/harness/global-setup-cloud-execution.ts"],
     env: {

--- a/test/conformance/vitest.cloud.config.ts
+++ b/test/conformance/vitest.cloud.config.ts
@@ -21,20 +21,15 @@ export default defineConfig({
     // tick), so it is the first Class B behavior assertable against cloud —
     // the full runner-backed Class B suites live in the cloud-execution run
     // (vitest.cloud-execution.config.ts).
+    // mcpserver-oauth runs here like every other Class A suite: the cloud
+    // global setup passes STIGMER_OAUTH_REDIRECT_URI through the hermetic
+    // launcher to the JAR (the 20260824.05 owner-gated follow-up, closed by
+    // sub-project 20260826.08 — the Java unset-redirect refusal copy was
+    // byte-aligned to the shared message in the same change).
     include: [
       "src/suites/**/*.conformance.test.ts",
       "src/suites-execution/schedule-firing.conformance.test.ts",
     ],
-    // mcpserver-oauth is EXCLUDED (deliberately, the mcp.conformance
-    // convention): the OAuth initiate lanes need STIGMER_OAUTH_REDIRECT_URI
-    // on the service, which the hermetic launcher does not yet pass to the
-    // JAR — and the Java edition's refusal copy is already known to diverge
-    // (its unset-redirect message names the `stigmer.oauth.redirect-uri`
-    // property where the Go edition names the env var). Enabling this suite
-    // here is an owner-gated follow-up: wire the env var through the
-    // launcher, run hermetically, and two-arm the divergent copy from that
-    // evidence (CW-1 wrap-up, sub-project 20260824.05).
-    exclude: ["src/suites/mcpserver-oauth.conformance.test.ts"],
     globalSetup: ["./src/harness/global-setup-cloud.ts"],
     env: {
       CONFORMANCE_TARGET: "cloud",
@@ -43,7 +38,7 @@ export default defineConfig({
     // organization suite's count/pagination baselines would race across
     // concurrently running files.
     fileParallelism: false,
-    // Cloud RPCs traverse real auth + Mongo + FGA; give each test headroom
+    // Cloud RPCs traverse real auth + Postgres + FGA; give each test headroom
     // over the local budget.
     testTimeout: 30_000,
     // Covers the per-file readiness probe against the shared environment.

--- a/test/integration/cmd/conformance-cloudenv/main.go
+++ b/test/integration/cmd/conformance-cloudenv/main.go
@@ -110,6 +110,12 @@ func run(logger *slog.Logger) error {
 		VaultToken:      h.OpenBao.RootToken,
 		LogDir:          h.LogDir(),
 		Security:        harness.SecurityModeTest,
+		// The conformance global setup (cloud-env.ts) sets this on the
+		// launcher's environment from the suite's own redirect-URI constant —
+		// the single source of truth the OAuth suites assert against. Passed
+		// through explicitly (never via ambient environment inheritance) so
+		// the service's OAuth posture is visible right here.
+		OAuthRedirectURI: os.Getenv("STIGMER_OAUTH_REDIRECT_URI"),
 	}, logger)
 	if err != nil {
 		return fmt.Errorf("start stigmer-service: %w", err)

--- a/test/integration/harness/service.go
+++ b/test/integration/harness/service.go
@@ -131,6 +131,15 @@ type ServiceConfig struct {
 	// stall on a live HTTP call.
 	WhatsAppGraphBaseURL string
 
+	// OAuthRedirectURI is the frontend callback URL for MCP OAuth Connect
+	// flows (STIGMER_OAUTH_REDIRECT_URI → stigmer.oauth.redirect-uri). The
+	// conformance suites' mock authorization server never redirects, so the
+	// URL is never fetched — but initiateOAuthConnect refuses without it,
+	// which kept the mcpserver OAuth suites off the cloud targets until the
+	// launcher passed it through. When empty, OAuth Connect is unavailable
+	// (the production default).
+	OAuthRedirectURI string
+
 	// LogDir is the directory for the service log file.
 	// If empty, a temporary directory is used.
 	LogDir string
@@ -570,6 +579,12 @@ func buildServiceEnv(cfg ServiceConfig) []string {
 	if cfg.WhatsAppGraphBaseURL != "" {
 		env = append(env,
 			fmt.Sprintf("STIGMER_CHANNELS_WHATSAPP_GRAPH_API_BASE_URL=%s", cfg.WhatsAppGraphBaseURL),
+		)
+	}
+
+	if cfg.OAuthRedirectURI != "" {
+		env = append(env,
+			fmt.Sprintf("STIGMER_OAUTH_REDIRECT_URI=%s", cfg.OAuthRedirectURI),
 		)
 	}
 


### PR DESCRIPTION
## Summary
Stigmer-side half of H1 `sp.conformance-cloud-instrument-hardening` (convergence program entry H1): the hermetic launcher passes `STIGMER_OAUTH_REDIRECT_URI` to the service JAR, both mcpserver suites join the cloud lanes, the suite arms that assumed single-user posture now probe real owned resources, and the runner's workflow child-execution create authenticates with the runner credential. With the companion stigmer-cloud PR (stigmer/stigmer-cloud#541), the nightly cloud lane is green end-to-end.

## Context
The nightly `ci.conformance-cloud` lane had been red since 2026-08-19 (#807). Beyond the recorded reds, the `mcpserver-oauth`/`mcpserver-connect` exclusions were an owner-gated follow-up from sub-project 20260824.05 with a pre-specified enable path — wiring the redirect-URI env through the launcher. Pre-spawn verification also corrected the record: the second launcher-caused exclusion was `mcpserver-connect`, not `open-computer-use` (which keeps its own macOS-developer-gate exclusion).

## Changes
- **Launcher wiring** (explicit at every hop, TS constant as single source of truth): `cloud-env.ts` sets `STIGMER_OAUTH_REDIRECT_URI` on the launcher's spawn env from `CONFORMANCE_OAUTH_REDIRECT_URI`; `conformance-cloudenv` reads it into a documented `ServiceConfig.OAuthRedirectURI` field; `buildServiceEnv` appends it to the JAR env.
- **Config**: `mcpserver-oauth` exclusion removed from `vitest.cloud.config.ts`; `mcpserver-connect` exclusion removed from `vitest.cloud-execution.config.ts`; stale Mongo comment fixed (Postgres since 2026-07).
- **Suite reworks** (each owner-ruled at the sub-project gate):
  - session listByChannel probes a REAL owned channel — cloud's DD-012 channel gate fails closed on fabricated ids, so only an owned channel reaches the shared filter contract on both editions (overturns the recorded "Java-side fix" classification).
  - getEventLog unknown-id skips on `multiTenant` targets (the file's own single-user-posture precedent).
  - disconnectOAuth idempotence probes a real never-connected server.
  - The oss#863 family is two-armed per edition (grant health; expired-unrefreshable connect pre-flight); both arms collapse to the cloud behavior when #863 is fixed in OSS.
- **Runner fix** (production bug, not test-only): `call-agent` created child executions with the user's control-plane token because it rebuilt config via `loadConfig()`, which never carries the adopted token refs. The factory now passes the injected `Config`, and `StigmerClient`'s credential-selection table routes the agent-execution create to the runner credential (the stigmer-cloud#507 lane). OSS/local unchanged — a null ref falls through to the control-plane token.

## Test plan
- Hermetic cloud Class A: 28 files / 461 passed / 0 failed.
- Hermetic cloud execution: 17 files / 155 passed / 0 failed (child-approval round-trip green).
- Local regression: `local` 492 passed, `local-execution` 160 passed (Node 22.22.1 per `.nvmrc`).
- `go build`/`go vet`/gofmt clean; `tsc --noEmit` introduces no new errors vs main.

## Merge order
**stigmer/stigmer-cloud#541 merges FIRST** — this PR's own `ci.conformance-cloud` lanes build the service JAR from stigmer-cloud main and go green only after the Java fixes land there.

## Risks
- The runner credential routing row affects only the agent-execution create and only when a minted runner token exists; rollback is a revert.

Closes #807

Made with [Cursor](https://cursor.com)