### PR TITLE
ci(python-sdk): install Node before the TS-driven SDK codegen

### DIFF
--- a/.github/workflows/release.python-sdk.yaml
+++ b/.github/workflows/release.python-sdk.yaml
@@ -87,10 +87,14 @@ jobs:
           pip install build
           python -m build
 
+      # skip-existing keeps release re-runs idempotent: recovering a partial
+      # release via workflow_dispatch re-runs this job, and PyPI rejects
+      # duplicate uploads of an already-published version (oss#908).
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: apis/stubs/python/stigmer/dist/
+          skip-existing: true
 
   publish-sdk:
     needs: [determine-version, publish-protos]
@@ -104,10 +108,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      # The client generator runs from TypeScript source via the repo-pinned
+      # tsx (never bare npx — oss#531), so the root npm install must exist
+      # before the codegen step.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          go-version: '1.25'
+          node-version-file: ".nvmrc"
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -137,7 +148,9 @@ jobs:
           pip install build
           python -m build
 
+      # skip-existing for the same re-run idempotency as publish-protos.
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: sdk/python/dist/
+          skip-existing: true


### PR DESCRIPTION
## Summary

- `release.python-sdk`'s `publish-sdk` job failed on the `v3.13.0` tag at `make -C sdk/python codegen` with `tsx not found` ([run](https://github.com/stigmer/stigmer/actions/runs/33070181423)): the client generator runs from TypeScript source via the repo-pinned tsx since #895, but the job still carried the retired Go generator's `setup-go` and never installed Node. Replaced with `setup-node` (`.nvmrc`, npm cache) + `npm ci` — the exact #901 pattern that fixed `ci.java-sdk` and `release.maven`; this lane was the one it missed.
- Added `skip-existing: true` to both PyPI publish steps so release re-runs are idempotent: recovering v3.13.0 goes through `workflow_dispatch`, which re-runs `publish-protos`, and `stigmer-protos==3.13.0` is already on PyPI (that job has Node and succeeded on the tag run) — a duplicate upload would otherwise fail the recovery.

Closes #908

## Test plan

- [x] actionlint on the workflow (only pre-existing SC2086 info in the untouched determine-version script)
- [ ] Post-merge: dispatch `release.python-sdk` with version `3.13.0` — `publish-protos` should skip the existing upload, `publish-sdk` should generate and publish `stigmer==3.13.0`

Made with [Cursor](https://cursor.com)