### PR TITLE
chore(release): pin the compose stack to v3.13.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,4 +46,4 @@ STIGMER_RUNNER_TOKEN_KEY=
 
 # Run a specific released stack version (both images move together; the
 # default pin in docker-compose.yml is managed by the release lane).
-#STIGMER_VERSION=v3.12.9
+#STIGMER_VERSION=v3.13.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       retries: 30
 
   stigmer-server:
-    image: ghcr.io/stigmer/stigmer-server:${STIGMER_VERSION:-v3.12.9}
+    image: ghcr.io/stigmer/stigmer-server:${STIGMER_VERSION:-v3.13.0}
     restart: unless-stopped
     depends_on:
       postgres:
@@ -140,7 +140,7 @@ services:
     # runner's depends_on gates on it.
 
   stigmer-runner:
-    image: ghcr.io/stigmer/stigmer-runner:${STIGMER_VERSION:-v3.12.9}
+    image: ghcr.io/stigmer/stigmer-runner:${STIGMER_VERSION:-v3.13.0}
     restart: unless-stopped
     depends_on:
       stigmer-server:


### PR DESCRIPTION
## Summary

- Automated release follow-up for `v3.13.0` (opened manually this once: the release lane's `bump-compose-pins` job pushed this branch but `gh pr create` was refused — "GitHub Actions is not permitted to create or approve pull requests". The org setting "Allow GitHub Actions to create and approve pull requests" needs enabling for the automation to finish on its own at future tags; run: https://github.com/stigmer/stigmer/actions/runs/33070181525).
- Re-points the `STIGMER_VERSION` default pin in `docker-compose.yml` and `.env.example` to `v3.13.0` — the first version whose `ghcr.io/stigmer/stigmer-server` and `ghcr.io/stigmer/stigmer-runner` images actually exist. Both images passed the published-tag compose smokes on native amd64 AND arm64 before `latest` promoted (same run, all smoke jobs green).

## Test plan

- [x] Release-lane published-tag compose smokes, both architectures (the gate that produced this pin)
- [ ] PR CI `ci.compose-stack` (build-from-source smoke)

Made with [Cursor](https://cursor.com)