### PR TITLE
docs(guides): add the self-hosting guide — compose quickstart, backup, upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Resource definitions are portable across both modes. The CLI talks to the same g
 
 - [Getting Started (Cloud)](https://stigmer.ai/docs/getting-started/quickstart) — Create your first agent in 5 minutes
 - [Getting Started (Local)](https://stigmer.ai/docs/getting-started/local) — Run agents on your machine
+- [Self-hosting](https://stigmer.ai/docs/guides/self-hosting/docker-compose) — Run the full stack on your own machine with Docker Compose
 - [CLI Reference](https://stigmer.ai/docs/cli) — Commands, flags, and examples
 - [SDK Reference](https://stigmer.ai/docs/sdk) — Go, TypeScript, Python, Java, React, and Ink
 - [Core Concepts](https://stigmer.ai/docs/concepts/what-is-stigmer) — Agents, Skills, Workflows, and how they fit together

--- a/docs/_inventory/classification.yaml
+++ b/docs/_inventory/classification.yaml
@@ -675,6 +675,27 @@ pages:
       pricing and spend-reduction mechanics that belong nearer the billing
       guides; the concept survives, the operational halves move out.
 
+  guides/self-hosting/docker-compose:
+    fate: keep
+    diataxis: how-to
+    teaches:
+      Run the complete stack (server, Postgres, Temporal, runner) on your own
+      machine with Docker Compose, bootstrap it with the CLI, and run a first
+      Agent — with the no-auth trust model stated up front.
+    medium: diagram
+    why:
+      The four-service topology and which volume holds what state is
+      structure; the compose file's inline comments can't orient a reader the
+      way one flowchart does.
+
+  guides/self-hosting/operations:
+    fate: keep
+    diataxis: how-to
+    teaches:
+      What a complete backup of a self-hosted stack is (three volumes plus
+      .env), how to restore one, and the version-pin upgrade path.
+    medium: none
+
   # ── CLI ────────────────────────────────────────────────────────────────
   cli:
     fate: keep

--- a/docs/guides/self-hosting/docker-compose.mdx
+++ b/docs/guides/self-hosting/docker-compose.mdx
@@ -1,0 +1,210 @@
+---
+title: Self-host with Docker Compose
+description:
+  Run the complete Stigmer stack — server, Postgres, Temporal, and runner — on
+  your own machine with Docker Compose.
+---
+
+The Stigmer repository ships a Docker Compose file that runs the complete
+platform on a machine you control: the server (API and web console), Postgres, a
+real Temporal server, and the runner that executes your Agents and Workflows.
+All state lives in Docker volumes on your machine.
+
+<Callout type="warn">
+  **Know the limitations before you start.** A self-hosted server has **no
+  authentication** — it's a single-operator trust domain. Anyone who can reach
+  the port has full control, so keep the stack on localhost or a private network
+  you trust, and never expose it to the internet. stdio MCP Servers spawn
+  **inside the runner container**: they can reach that container's filesystem
+  and network, not your host's.
+</Callout>
+
+Both amd64 and arm64 are supported — every release is smoke-tested on both
+architectures before its images publish.
+
+## What's in the stack
+
+Four services. The server and the runner share one artifact volume — file
+sharing is the contract between them, not HTTP.
+
+```mermaid
+flowchart LR
+    subgraph stack [Docker Compose stack]
+        server["stigmer-server<br/>API + console :7234<br/>artifacts :7235"]
+        runner["stigmer-runner<br/>executes Agents + Workflows"]
+        temporal["temporal<br/>execution coordination"]
+        postgres["postgres<br/>one instance, three databases"]
+    end
+    you["You: browser, CLI, SDKs"] --> server
+    server --> temporal
+    runner --> temporal
+    server --> postgres
+    temporal --> postgres
+    server -. "shared artifacts volume" .- runner
+```
+
+Durable state lives in three volumes — `postgres-data`, `artifacts`, and
+`server-data` — plus your `.env` file. See
+[Back up and upgrade your stack](/docs/guides/self-hosting/operations) for the
+complete backup story.
+
+<Steps>
+<Step>
+
+## Get the stack
+
+Clone the repository. The compose file and its `.env` template live at the root.
+
+```bash
+git clone https://github.com/stigmer/stigmer.git
+cd stigmer
+```
+
+**Prerequisites**: Docker with the Compose plugin, and free host ports 7234
+and 7235. If the laptop stack is running on this machine, stop it first with
+`stigmer down` — it uses the same ports.
+
+</Step>
+<Step>
+
+## Configure your secrets
+
+Copy the template and fill in the three required secrets:
+
+```bash
+cp .env.example .env
+```
+
+The stack refuses to boot until all three exist — that's deliberate. Keys that
+materialize implicitly make the backup story invisible exactly where you need it
+explicit.
+
+```bash
+# Postgres superuser password (internal to the stack)
+openssl rand -hex 24
+
+# STIGMER_ENCRYPTION_KEY — encrypts secret values at rest
+openssl rand -base64 32
+
+# STIGMER_RUNNER_TOKEN_KEY — signs the runner's execution-scoped tokens
+openssl rand -base64 32
+```
+
+Paste each value into its line in `.env`. To run Agents, also set
+`ANTHROPIC_API_KEY` in `.env` now — without it the stack still serves the
+console, the API, and LLM-free Workflow executions, but Agent runs fail at the
+LLM call.
+
+<Callout type="info">
+  Back up `.env` like a key file. Losing the two `STIGMER_*` keys strands every
+  encrypted value in the database.
+</Callout>
+
+</Step>
+<Step>
+
+## Start the stack
+
+```bash
+docker compose up -d
+```
+
+The first boot pulls four images and sets up Temporal's databases, so give it a
+few minutes. The command returns once the server is healthy and the runner has
+started; confirm with `docker compose ps` — every service shows `Up`, with
+`postgres`, `temporal`, and `stigmer-server` also reporting `(healthy)`.
+
+Open the web console at [http://localhost:7234](http://localhost:7234). The
+artifact file server answers on port 7235 — download links the platform mints
+point there.
+
+</Step>
+<Step>
+
+## Bootstrap with the CLI
+
+Install the Stigmer CLI on the host if you don't have it:
+
+<Tabs items={["Homebrew", "Shell script", "npm"]}>
+  <Tab value="Homebrew">```bash brew install stigmer/tap/stigmer ```</Tab>
+  <Tab value="Shell script">
+    ```bash curl -fsSL https://stigmer.ai/install.sh | sh ```
+  </Tab>
+  <Tab value="npm">```bash npm install -g @stigmer/cli ```</Tab>
+</Tabs>
+
+The CLI's local backend points at `localhost:7234` by default — exactly where
+the stack serves. If you've used Stigmer Cloud from this machine, switch back
+first with `stigmer config backend set local`.
+
+Apply the system Seedpack. It creates the default `stigmer` Organization and the
+built-in Agents, Skills, and Workflows — the same bootstrap `stigmer up`
+performs on the laptop tier:
+
+```bash
+stigmer seedpack apply
+```
+
+</Step>
+<Step>
+
+## Run your first Agent
+
+Create a file called `agent.yaml`:
+
+```yaml
+apiVersion: agentic.stigmer.ai/v1
+kind: Agent
+metadata:
+  name: my-first-agent
+spec:
+  instructions: |
+    You are a helpful assistant. Answer questions clearly
+    and concisely. When you don't know something, say so.
+```
+
+Apply it and run it:
+
+```bash
+stigmer apply -f agent.yaml
+stigmer run my-first-agent -m "What can you help me with?"
+```
+
+The Agent responds in your terminal. The run traveled from the CLI to the
+server, through Temporal, and executed inside the runner container — your whole
+stack, end to end.
+
+</Step>
+</Steps>
+
+## Connect from another machine
+
+Point any CLI at the stack by setting the server address:
+
+```bash
+export STIGMER_SERVER_ADDRESS=<stack-host>:7234
+```
+
+Two things to know before you do:
+
+- **There is no authentication.** Every machine that can reach the port has full
+  control. Treat network reachability as the access boundary.
+- Artifact download links are minted for the stack host by default
+  (`http://localhost:7235`). To serve them to other machines, change the
+  `x-artifact-serve-url` anchor in `docker-compose.yml` to an address they can
+  reach.
+
+## Next step
+
+Your stack is running, which means it now holds state worth protecting. Learn
+what a complete backup is and how upgrades work.
+
+<Cards>
+  <Card
+    title="Back up and upgrade your stack"
+    href="/docs/guides/self-hosting/operations"
+  >
+    The complete backup story — three volumes plus your `.env` — and the
+    version-pin upgrade path.
+  </Card>
+</Cards>

--- a/docs/guides/self-hosting/meta.json
+++ b/docs/guides/self-hosting/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Self-hosting",
+  "pages": ["docker-compose", "operations"]
+}

--- a/docs/guides/self-hosting/operations.mdx
+++ b/docs/guides/self-hosting/operations.mdx
@@ -1,0 +1,99 @@
+---
+title: Back up and upgrade your stack
+description:
+  What a complete backup of a self-hosted Stigmer stack is, how to restore one,
+  and how to move between released versions.
+---
+
+This guide assumes a running stack from
+[Self-host with Docker Compose](/docs/guides/self-hosting/docker-compose).
+
+## What a complete backup is
+
+The complete durable state of the stack is four things:
+
+| What                   | Holds                                                            |
+| ---------------------- | ---------------------------------------------------------------- |
+| `postgres-data` volume | Every resource, execution record, and Temporal's own state       |
+| `artifacts` volume     | Artifact files produced by executions                            |
+| `server-data` volume   | The Skill content store and other server-side file state         |
+| Your `.env` file       | The encryption keys that unlock encrypted values in the database |
+
+<Callout type="error">
+  The `.env` file is part of the backup, not just configuration. Losing
+  `STIGMER_ENCRYPTION_KEY` strands every encrypted value — Environment
+  variables, OAuth tokens — in the database with no recovery path. Store it like
+  a key file.
+</Callout>
+
+The fourth volume, `runner-data`, is lifecycle state, not backup state: it holds
+in-flight Session checkpoints and Agent working directories so paused runs
+survive a container restart. Losing it abandons in-flight runs but loses no
+durable data.
+
+## Back up
+
+Stop the stack first so Postgres isn't writing while you copy, then archive each
+volume:
+
+```bash
+docker compose down
+
+for v in postgres-data artifacts server-data; do
+  docker run --rm \
+    -v "stigmer_${v}:/source:ro" \
+    -v "$PWD/backup:/backup" \
+    alpine tar czf "/backup/${v}.tgz" -C /source .
+done
+
+cp .env backup/
+
+docker compose up -d
+```
+
+Docker Compose prefixes the volume names — `stigmer_` when you run from the
+cloned `stigmer` directory. Check yours with `docker volume ls`.
+
+## Restore
+
+On a fresh machine: clone the repository, put the backed-up `.env` at the root —
+the same keys, not new ones — then seed the volumes before first boot:
+
+```bash
+for v in postgres-data artifacts server-data; do
+  docker volume create "stigmer_${v}"
+  docker run --rm \
+    -v "stigmer_${v}:/target" \
+    -v "$PWD/backup:/backup:ro" \
+    alpine tar xzf "/backup/${v}.tgz" -C /target
+done
+
+docker compose up -d
+```
+
+## Upgrade
+
+The compose file pins a released version and the two Stigmer images always move
+together. To upgrade, set the version in `.env`:
+
+```bash
+# .env
+STIGMER_VERSION=v3.14.0
+```
+
+Then pull and restart:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+The server migrates its database schema forward automatically on boot. Because
+migrations only run forward, take a [backup](#back-up) before upgrading —
+rolling back to an older version against an already-migrated database isn't
+supported. Restore the pre-upgrade backup instead.
+
+Releases are published on the
+[GitHub releases page](https://github.com/stigmer/stigmer/releases). The default
+pin in `docker-compose.yml` is managed by the release pipeline, so pulling the
+latest repository state also moves you forward.

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -38,6 +38,7 @@
     "concepts/identity",
     "guides/authentication",
     "concepts/billing",
+    "guides/self-hosting",
     "sdk",
     "cli"
   ]


### PR DESCRIPTION
## Summary

The self-host guide (Phase-2 P6, the last Phase-2 entry): a new `docs/guides/self-hosting/` section documenting the docker-compose stack P5 shipped — quickstart from a clean clone, the `.env` key story, backup/restore/upgrade, and CLI connectivity — with the no-auth trust model stated up front, impossible to miss.

## Context

The compose stack (#905) is merged, CI-gated, and release-verified on both architectures at `v3.13.0`, but had zero user-facing documentation: no docs page, no nav entry, no README mention. Everything a self-hoster needs lived only in inline comments in `docker-compose.yml` and `.env.example`.

## Changes

- `docs/guides/self-hosting/docker-compose.mdx` (how-to): limitations callout first (no auth / single-operator trust domain; stdio MCP Servers spawn inside the runner container; amd64+arm64 both release-verified), the four-service topology with a Mermaid diagram, clean clone → `.env` keys with `openssl` one-liners → `docker compose up -d` → console, CLI bootstrap (`stigmer seedpack apply`) → first Agent run, and the `STIGMER_SERVER_ADDRESS` remote-machine path with its two caveats.
- `docs/guides/self-hosting/operations.mdx` (how-to): the complete backup story (three volumes + `.env`; `runner-data` is lifecycle state), concrete backup/restore commands, and the `STIGMER_VERSION` upgrade path with the forward-only-migrations rollback caveat.
- `docs/guides/self-hosting/meta.json` + nav entry in `docs/meta.json` under Platform; two entries in `docs/_inventory/classification.yaml` (both how-to; quickstart `medium: diagram` — topology is structure).
- `README.md`: one line in the Documentation links list (Q12 quiet-ship holds — no announcement, no tier marketing).

## Test plan

- Doc-verbatim validation against the PUBLISHED `v3.13.0` images from a clean clone (with `STIGMER_VERSION=v3.13.0` in `.env` — the default pin re-points via #910): stack healthy in ~70s; console `/` 200 HTML + `/config.json` contract; artifact listener 404 proof-of-life on 7235; `stigmer config backend status` → `local / localhost:7234`; `stigmer seedpack apply` bootstrapped the `stigmer` org + system resources (Skill pushes exercised the transfer lane through the compose topology); the quickstart's `agent.yaml` applied; `stigmer run` traveled CLI → server → Temporal → runner and failed exactly at the documented boundary (`Anthropic API key not found` — no key on the validation machine; the release lane's both-arch published-tag compose smokes prove the end-to-end execution path). Found and filed #911 during validation (CLI doesn't exit after a terminal FAILED agent run — product bug, not a docs defect; the docs' key-first path avoids it).
- Docs gates locally: Prettier clean, Vale 0 errors and 0 warnings on the new pages, `make check-docs-inventory` (202 pages OK), `make check-docs-yaml` (the `agent.yaml` manifest contract-validated), `make build-site` (217 static pages exported).

## Risks

- The quickstart's default-pin path assumes #910 (compose pin → `v3.13.0`) merges; until then a clean clone needs `STIGMER_VERSION=v3.13.0` in `.env`. Merge #910 first (or together).

## Checklist

- [x] Docs updated
- [x] Classification inventory updated in the same commit
- [x] Backward compatible (docs-only)

Made with [Cursor](https://cursor.com)