### PR TITLE
feat(backend/stigmer-server): extract the O5 driver seams (catalog, artifact storage, runner credentials)

### DIFF
--- a/backend/services/stigmer-server/src/artifactstorage/__tests__/artifact-storage.test.ts
+++ b/backend/services/stigmer-server/src/artifactstorage/__tests__/artifact-storage.test.ts
@@ -4,18 +4,27 @@
  * contained dot-segment keys allowed), the #285 no-implicit-segment
  * layout contract, the local signed-URL shape, and the
  * Content-Disposition builder. Adds the factory's r2/unknown refusals
- * (Go's are boot asserted; here they're the disclosed deferral).
+ * (Go's are boot asserted; here they're the disclosed deferral), and the
+ * O5 widened surface: size, the typed not-found, presigned-PUT over the
+ * skill-transfer-lane mechanism, and registered-driver factory selection.
  */
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { Readable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
+import { UPLOADS_SEGMENT } from "../../domain/skill/constants.js";
+import { UploadSlots } from "../../domain/skill/transfer/slots.js";
+import { uploadUrl } from "../../domain/skill/transfer/handler.js";
+import { SKILL_ARTIFACTS_PATH_PREFIX } from "../../transport/constants.js";
 import {
+  ArtifactStorageNotFoundError,
   LocalArtifactStorage,
   contentDispositionAttachment,
   newArtifactStorage,
 } from "../artifact-storage.js";
+import type { ArtifactStorage } from "../artifact-storage.js";
 
 // Keys that, once cleaned, resolve outside the artifact root — the
 // containment guard must refuse every one of them.
@@ -154,6 +163,92 @@ describe("LocalArtifactStorage", () => {
     await expect(storage.health()).resolves.toBeUndefined();
     expect(existsSync(path.join(base, ".health_check"))).toBe(false);
   });
+
+  describe("O5 widened surface", () => {
+    it("size stats the stored byte count without loading", async () => {
+      await storage.upload("attachments/01S/f.bin", Buffer.from("12345"), "");
+      expect(await storage.size("attachments/01S/f.bin")).toBe(5);
+    });
+
+    it("download and size answer the typed not-found with the historical copy", async () => {
+      for (const op of [
+        () => storage.download("attachments/absent.bin"),
+        () => storage.size("attachments/absent.bin"),
+      ]) {
+        const error = await op().catch((e: unknown) => e);
+        expect(error).toBeInstanceOf(ArtifactStorageNotFoundError);
+        expect((error as Error).message).toBe(
+          "artifact not found: attachments/absent.bin",
+        );
+      }
+    });
+
+    it("presignPut without a wired lane is the explicit not-configured throw, never a silent no-op", async () => {
+      await expect(storage.presignPut(16, 60_000)).rejects.toThrow(
+        "local presigned uploads not configured",
+      );
+    });
+  });
+});
+
+// The local presigned-PUT arm over the REAL skill-transfer-lane slot
+// mechanism (§6b, the Q1 ruling: one upload surface, no new lane) — the
+// adapter below mirrors boot/compose.ts's wiring exactly.
+describe("LocalArtifactStorage presignPut over the transfer-lane slots", () => {
+  const BASE_URL = "http://localhost:8080";
+  let root: string;
+  let slots: UploadSlots;
+  let driver: ArtifactStorage;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), "artifact-presign-"));
+    slots = new UploadSlots(
+      path.join(root, "skills-staging"),
+      60_000,
+      1024 * 1024,
+    );
+    driver = new LocalArtifactStorage(root, "", {
+      mint: (declaredSizeBytes) => slots.mint(declaredSizeBytes),
+      uploadUrl: (ref) => uploadUrl(BASE_URL, ref),
+      stagedKey: (ref) => `skills-staging/${slots.stagedFileName(ref)}`,
+    });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("mint → PUT (lane receive) → download(stagingKey) round-trips the bytes", async () => {
+    const bytes = Buffer.from("staged artifact bytes");
+    const upload = await driver.presignPut(bytes.length, 999_999_999);
+
+    // The URL is the lane's wire shape and the ref is its last segment —
+    // exactly how the lane handler dispatches a PUT.
+    expect(
+      upload.url.startsWith(
+        `${BASE_URL}${SKILL_ARTIFACTS_PATH_PREFIX}${UPLOADS_SEGMENT}`,
+      ),
+    ).toBe(true);
+    // The lane's slot TTL governs, not the caller's larger ask.
+    expect(upload.ttlMs).toBe(60_000);
+
+    const ref = upload.url.slice(upload.url.lastIndexOf("/") + 1);
+    await slots.receive(ref, Readable.from(bytes));
+
+    expect(Buffer.from(await driver.download(upload.stagingKey))).toEqual(
+      bytes,
+    );
+    expect(await driver.size(upload.stagingKey)).toBe(bytes.length);
+  });
+
+  it("the staged key never resolves outside the driver root", async () => {
+    const upload = await driver.presignPut(4, 60_000);
+    expect(upload.stagingKey.startsWith("skills-staging/")).toBe(true);
+    // Unreceived slot: the key is honest about absence.
+    await expect(driver.download(upload.stagingKey)).rejects.toThrow(
+      ArtifactStorageNotFoundError,
+    );
+  });
 });
 
 const NO_R2 = {
@@ -192,6 +287,46 @@ describe("newArtifactStorage factory", () => {
     expect(() =>
       newArtifactStorage({ type: "s3", localBasePath: "", localServeUrl: "", ...NO_R2 }),
     ).toThrow("unknown storage type: s3 (must be 'local' or 'r2')");
+  });
+
+  it("selects a registered driver by name — and only constructs the selected one (O5)", () => {
+    let constructed = 0;
+    let neverConstructed = 0;
+    const fake = { health: () => Promise.resolve() } as unknown as ReturnType<
+      typeof newArtifactStorage
+    >;
+    const registered = new Map([
+      [
+        "cloud-r2",
+        () => {
+          constructed += 1;
+          return fake;
+        },
+      ],
+      [
+        "unused",
+        () => {
+          neverConstructed += 1;
+          return fake;
+        },
+      ],
+    ]);
+    const s = newArtifactStorage(
+      { type: "cloud-r2", localBasePath: "", localServeUrl: "", ...NO_R2 },
+      registered,
+    );
+    expect(s).toBe(fake);
+    expect(constructed).toBe(1);
+    expect(neverConstructed, "unselected drivers must construct nothing").toBe(0);
+  });
+
+  it("unknown type names the registered drivers in its refusal (O5)", () => {
+    expect(() =>
+      newArtifactStorage(
+        { type: "s3", localBasePath: "", localServeUrl: "", ...NO_R2 },
+        new Map([["cloud-r2", () => ({}) as never]]),
+      ),
+    ).toThrow("unknown storage type: s3 (must be 'local' or 'r2' or 'cloud-r2')");
   });
 });
 

--- a/backend/services/stigmer-server/src/artifactstorage/__tests__/r2-storage.test.ts
+++ b/backend/services/stigmer-server/src/artifactstorage/__tests__/r2-storage.test.ts
@@ -3,11 +3,19 @@
  * pure local SigV4 computation; no call leaves the host). The Go tree
  * ships r2_storage.go untested; these pins are what the port adds:
  * required-config copy, the 7-day presign clamp, the signed
- * Content-Disposition, and the not-found mapping.
+ * Content-Disposition, the not-found mapping, and the O5 widened surface
+ * (typed not-found on download/size, presigned-PUT under the pinned
+ * staging prefix with the signed Content-Length).
  */
 import { describe, expect, it } from "vitest";
 
-import { R2ArtifactStorage, R2_MAX_EXPIRATION_MS, isNotFoundError } from "../r2-storage.js";
+import { ArtifactStorageNotFoundError } from "../artifact-storage.js";
+import {
+  R2ArtifactStorage,
+  R2_MAX_EXPIRATION_MS,
+  R2_STAGING_PREFIX,
+  isNotFoundError,
+} from "../r2-storage.js";
 
 const VALID = {
   bucket: "stigmer-artifacts",
@@ -52,6 +60,62 @@ describe("R2ArtifactStorage presigned URLs", () => {
     // Signed as a response-content-disposition override, mirroring Go.
     expect(url).toContain("response-content-disposition=");
     expect(decodeURIComponent(url)).toContain('attachment; filename="report.txt"');
+  });
+});
+
+describe("R2ArtifactStorage O5 widened surface", () => {
+  it("presignPut mints under the pinned staging prefix, clamps the TTL, and signs the declared size", async () => {
+    const storage = new R2ArtifactStorage(VALID);
+    const upload = await storage.presignPut(1234, R2_MAX_EXPIRATION_MS * 5);
+
+    expect(upload.stagingKey.startsWith(R2_STAGING_PREFIX)).toBe(true);
+    expect(upload.ttlMs).toBe(R2_MAX_EXPIRATION_MS);
+    expect(
+      upload.url.startsWith(
+        `${VALID.endpoint}/${VALID.bucket}/${upload.stagingKey}?`,
+      ),
+    ).toBe(true);
+    expect(upload.url).toContain("X-Amz-Expires=604800");
+    // Content-Length rides the signature: a body of a different size
+    // fails the check — R2's arm of the exact-size contract.
+    expect(upload.url.toLowerCase()).toContain("content-length");
+  });
+
+  it("two mints never share a staging key (the URL is the credential)", async () => {
+    const storage = new R2ArtifactStorage(VALID);
+    const a = await storage.presignPut(1, 60_000);
+    const b = await storage.presignPut(1, 60_000);
+    expect(a.stagingKey).not.toBe(b.stagingKey);
+  });
+
+  it("download and size map the SDK's not-found onto the typed class; real faults stay wrapped", async () => {
+    const notFound = Object.assign(new Error("no such key"), {
+      name: "NoSuchKey",
+    });
+    const refused = new Error("connection refused");
+    let nextError: Error = notFound;
+    const failingClient = {
+      send: () => Promise.reject(nextError),
+    };
+    const storage = new R2ArtifactStorage(VALID, {
+      client: failingClient as never,
+      presign: () => Promise.resolve("unused"),
+    });
+
+    await expect(storage.download("k")).rejects.toThrow(
+      ArtifactStorageNotFoundError,
+    );
+    await expect(storage.size("k")).rejects.toThrow(
+      ArtifactStorageNotFoundError,
+    );
+
+    nextError = refused;
+    await expect(storage.download("k")).rejects.toThrow(
+      "r2 download failed: connection refused",
+    );
+    await expect(storage.size("k")).rejects.toThrow(
+      "r2 head failed: connection refused",
+    );
   });
 });
 

--- a/backend/services/stigmer-server/src/artifactstorage/artifact-storage.ts
+++ b/backend/services/stigmer-server/src/artifactstorage/artifact-storage.ts
@@ -14,6 +14,14 @@
  * The R2 backend (S3-compatible, AWS SDK) lives in r2-storage.ts — it
  * arrived with the artifact domain (#13) per the ratified deferral, closing
  * the temporary ARTIFACT_STORAGE_TYPE=r2 boot-fail divergence #17 shipped.
+ *
+ * Since O5 (20260827.02, blueprint 03 §6b) this is the ONE blob-driver
+ * seam of the convergence program: it gained the presigned-PUT capability,
+ * `size`, a typed not-found error, and registry-driven driver registration
+ * (extensions/drivers.ts). Domain semantics — content-addressed keys,
+ * staging lanes, write-once postures — deliberately live ABOVE this
+ * interface in their owning domains: the driver stores blobs; the domain
+ * owns keys and lanes.
  */
 import { mkdirSync } from "node:fs";
 import {
@@ -33,11 +41,52 @@ import { R2ArtifactStorage } from "./r2-storage.js";
  * artifact file server (#13) reads it to set Content-Disposition. */
 export const LOCAL_DOWNLOAD_QUERY_PARAM = "download";
 
+/**
+ * A storage key that addresses no stored blob. Consumers that must map
+ * "missing" onto their own domain vocabulary (skill's ArtifactNotFoundError,
+ * a NotFound wire code) branch on this class per the ratified store-fault
+ * instanceof idiom; every OTHER driver failure is an infrastructure fault
+ * to rethrow or wrap, never a not-found.
+ */
+export class ArtifactStorageNotFoundError extends Error {
+  constructor(key: string) {
+    // The local backend's historical copy, kept verbatim — this class adds
+    // a type to the existing message, not a new message.
+    super(`artifact not found: ${key}`);
+    this.name = "ArtifactStorageNotFoundError";
+  }
+}
+
+/**
+ * A staged upload minted by presignPut: the URL receives the bytes, the
+ * stagingKey reads them back through the same driver. Staged blobs are
+ * short-lived by contract — the local lane sweeps them on TTL expiry and
+ * boot; R2 deployments configure a bucket lifecycle rule on the staging
+ * prefix (the §6b driver-side sweep expectation).
+ */
+export interface PresignedUpload {
+  /** Accepts one HTTP PUT of exactly the declared byte count. */
+  readonly url: string;
+  /** Driver key where the staged bytes land, readable via download(). */
+  readonly stagingKey: string;
+  /** The TTL actually granted, after per-driver clamping. */
+  readonly ttlMs: number;
+}
+
 export interface ArtifactStorage {
   /** Stores artifact data under the key. */
   upload(key: string, data: Uint8Array, contentType: string): Promise<void>;
-  /** Retrieves artifact data by key. */
+  /**
+   * Retrieves artifact data by key; a key addressing no stored blob
+   * throws ArtifactStorageNotFoundError.
+   */
   download(key: string): Promise<Uint8Array>;
+  /**
+   * The stored blob's byte size without loading its content (local stat /
+   * R2 HeadObject); a key addressing no stored blob throws
+   * ArtifactStorageNotFoundError.
+   */
+  size(key: string): Promise<number>;
   /**
    * A time-limited download URL. downloadFilename, when non-empty, bakes
    * a browser-download disposition into the URL (browsers ignore the HTML
@@ -48,12 +97,55 @@ export interface ArtifactStorage {
     expiresInMs: number,
     downloadFilename: string,
   ): Promise<string>;
+  /**
+   * A time-limited upload URL for a staging-prefixed blob of exactly
+   * declaredSizeBytes (§6b). Per-driver semantics differ DELIBERATELY and
+   * are contract, not accident: the local backend rides the skill transfer
+   * lane's URL-as-credential slot mechanism (single-use, exact-size
+   * enforced by the lane, TTL clamped to the lane's slot TTL) and answers
+   * only on instances with a staged-upload lane wired — unwired instances
+   * throw the explicit not-configured error, never a silent no-op. The R2
+   * backend presigns a PUT (repeatable within its TTL, size enforced by
+   * the signed Content-Length header, TTL clamped to the 7-day R2
+   * maximum).
+   */
+  presignPut(declaredSizeBytes: number, ttlMs: number): Promise<PresignedUpload>;
   /** Removes the artifact; missing is not an error. */
   delete(key: string): Promise<void>;
   /** Whether an artifact with the key exists. */
   exists(key: string): Promise<boolean>;
   /** Storage connectivity/writability probe (boot health check). */
   health(): Promise<void>;
+}
+
+/**
+ * Constructs a registered driver. Lazy DELIBERATELY (the WorkerFactory
+ * precedent): driver constructors may have side effects — the local
+ * backend mkdirs its root — and a composition must not pay them for
+ * drivers its config never selects. Extensions close over their own
+ * configuration; the factory takes nothing.
+ */
+export type ArtifactStorageDriverFactory = () => ArtifactStorage;
+
+/**
+ * The staged-upload mechanism a LocalArtifactStorage instance rides for
+ * presignPut — the seam the composition root adapts the skill transfer
+ * lane's UploadSlots + URL renderer into (Q1 ruling, 20260827.02 T01: one
+ * upload surface, no new lane). Declared HERE, not imported from the skill
+ * domain: the §6b layering runs domain-over-driver, so the driver states
+ * the shape it needs and stays ignorant of who provides it.
+ */
+export interface StagedUploadLane {
+  /** Reserves a single-use upload slot; returns its reference + TTL. */
+  mint(declaredSizeBytes: number): { ref: string; ttlMs: number };
+  /** The externally-reachable PUT URL for a minted reference. */
+  uploadUrl(ref: string): string;
+  /**
+   * The driver key where the reference's staged bytes land — MUST resolve
+   * inside the driver instance's root, or download(stagingKey) could
+   * never read what the lane received.
+   */
+  stagedKey(ref: string): string;
 }
 
 export interface ArtifactStorageConfig {
@@ -69,9 +161,22 @@ export interface ArtifactStorageConfig {
   readonly r2Region: string;
 }
 
-/** Factory mirroring Go NewArtifactStorage. */
+/**
+ * The built-in driver names. Registered drivers may not shadow them —
+ * resolveExtensions enforces that at boot (a shadowed built-in would be
+ * silently unreachable, the §2b loud-fail rules forbid exactly that).
+ */
+export const BUILT_IN_STORAGE_TYPES = ["local", "r2"] as const;
+
+/**
+ * Factory mirroring Go NewArtifactStorage, opened to registered drivers
+ * with O5 (§6b): built-ins first, then the composition's registered driver
+ * map — the cloud substitutes its per-domain R2 drivers without this
+ * switch ever growing a case.
+ */
 export function newArtifactStorage(
   config: ArtifactStorageConfig,
+  registeredDrivers: ReadonlyMap<string, ArtifactStorageDriverFactory> = new Map(),
 ): ArtifactStorage {
   const storageType = config.type === "" ? "local" : config.type;
   switch (storageType) {
@@ -88,10 +193,16 @@ export function newArtifactStorage(
         secretAccessKey: config.r2SecretAccessKey,
         region: config.r2Region,
       });
-    default:
-      throw new Error(
-        `unknown storage type: ${storageType} (must be 'local' or 'r2')`,
-      );
+    default: {
+      const registered = registeredDrivers.get(storageType);
+      if (registered !== undefined) {
+        return registered();
+      }
+      const known = [...BUILT_IN_STORAGE_TYPES, ...registeredDrivers.keys()]
+        .map((name) => `'${name}'`)
+        .join(" or ");
+      throw new Error(`unknown storage type: ${storageType} (must be ${known})`);
+    }
   }
 }
 
@@ -99,6 +210,14 @@ export class LocalArtifactStorage implements ArtifactStorage {
   constructor(
     private readonly basePath: string,
     private readonly serveUrl: string,
+    /**
+     * The staged-upload mechanism backing presignPut — optional because
+     * only instances whose root the lane stages into can serve it (the
+     * skill store instance today); presignPut on an unwired instance is
+     * the explicit not-configured throw, mirroring getSignedUrl's
+     * serve-URL posture.
+     */
+    private readonly stagedUploadLane?: StagedUploadLane,
   ) {
     // Ensure the artifact root exists (Go NewLocalStorage MkdirAll).
     mkdirSync(this.root(), { recursive: true });
@@ -121,10 +240,42 @@ export class LocalArtifactStorage implements ArtifactStorage {
       return await readFile(filePath);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-        throw new Error(`artifact not found: ${key}`);
+        throw new ArtifactStorageNotFoundError(key);
       }
       throw error;
     }
+  }
+
+  async size(key: string): Promise<number> {
+    const filePath = this.resolveWithinRoot(key);
+    try {
+      return (await stat(filePath)).size;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        throw new ArtifactStorageNotFoundError(key);
+      }
+      throw error;
+    }
+  }
+
+  async presignPut(
+    declaredSizeBytes: number,
+    _ttlMs: number,
+  ): Promise<PresignedUpload> {
+    if (this.stagedUploadLane === undefined) {
+      throw new Error(
+        "local presigned uploads not configured - no staged-upload lane is wired to this store instance",
+      );
+    }
+    // The lane's slot TTL governs, not the caller's ask — the slot
+    // registry sweeps on ITS clock, and a URL outliving its slot would be
+    // a credential for nothing.
+    const { ref, ttlMs } = this.stagedUploadLane.mint(declaredSizeBytes);
+    return {
+      url: this.stagedUploadLane.uploadUrl(ref),
+      stagingKey: this.stagedUploadLane.stagedKey(ref),
+      ttlMs,
+    };
   }
 
   async getSignedUrl(

--- a/backend/services/stigmer-server/src/artifactstorage/r2-storage.ts
+++ b/backend/services/stigmer-server/src/artifactstorage/r2-storage.ts
@@ -9,6 +9,8 @@
  * that have logic: config validation copy, the 7-day presign clamp, the
  * signed Content-Disposition, and the not-found mapping.
  */
+import { randomBytes } from "node:crypto";
+
 import {
   DeleteObjectCommand,
   GetObjectCommand,
@@ -19,11 +21,21 @@ import {
 } from "@aws-sdk/client-s3";
 import { getSignedUrl as presignGetObject } from "@aws-sdk/s3-request-presigner";
 
-import type { ArtifactStorage } from "./artifact-storage.js";
-import { contentDispositionAttachment } from "./artifact-storage.js";
+import type { ArtifactStorage, PresignedUpload } from "./artifact-storage.js";
+import {
+  ArtifactStorageNotFoundError,
+  contentDispositionAttachment,
+} from "./artifact-storage.js";
 
 /** Go: "R2 has a maximum expiration of 7 days" — presigns clamp here. */
 export const R2_MAX_EXPIRATION_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Key prefix for presignPut staging blobs (§6b). Pinned as the surface a
+ * deployment's bucket lifecycle rule targets: the driver mints under it,
+ * operations sweeps it — changing it orphans staged blobs from the sweep.
+ */
+export const R2_STAGING_PREFIX = "staging/";
 
 /**
  * Go get_content/get_download_url wrap their storage calls in a 30s
@@ -114,9 +126,58 @@ export class R2ArtifactStorage implements ArtifactStorage {
       }
       body = await result.Body.transformToByteArray();
     } catch (error) {
+      // The typed not-found arm (O5): consumers mapping "missing" onto
+      // domain vocabulary branch on the class; every other failure stays
+      // the wrapped infrastructure fault it always was. Only the log-line
+      // text of the missing-object arm changes — every production caller
+      // wraps download faults in a sanitized Internal before the wire.
+      if (isNotFoundError(error)) {
+        throw new ArtifactStorageNotFoundError(key);
+      }
       throw new Error(`r2 download failed: ${errorText(error)}`, { cause: error });
     }
     return body;
+  }
+
+  async size(key: string): Promise<number> {
+    try {
+      const result = await this.client.send(
+        new HeadObjectCommand({ Bucket: this.bucket, Key: key }),
+      );
+      return Number(result.ContentLength ?? 0);
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        throw new ArtifactStorageNotFoundError(key);
+      }
+      throw new Error(`r2 head failed: ${errorText(error)}`, { cause: error });
+    }
+  }
+
+  async presignPut(
+    declaredSizeBytes: number,
+    ttlMs: number,
+  ): Promise<PresignedUpload> {
+    const clampedMs = Math.min(ttlMs, R2_MAX_EXPIRATION_MS);
+    // Random staging key: the URL is the credential (unguessable), and the
+    // prefix is the contract surface a bucket lifecycle rule sweeps (§6b —
+    // staged uploads the domain never committed must not accrete forever).
+    const stagingKey = `${R2_STAGING_PREFIX}${randomBytes(16).toString("hex")}`;
+    const command = new PutObjectCommand({
+      Bucket: this.bucket,
+      Key: stagingKey,
+      // Signed into the URL: a PUT whose body disagrees with the declared
+      // size fails the signature check — R2's arm of the exact-size
+      // contract the local lane enforces by counting bytes.
+      ContentLength: declaredSizeBytes,
+    });
+    try {
+      const url = await this.presign(this.client, command, {
+        expiresIn: Math.floor(clampedMs / 1000),
+      });
+      return { url, stagingKey, ttlMs: clampedMs };
+    } catch (error) {
+      throw new Error(`r2 presign failed: ${errorText(error)}`, { cause: error });
+    }
   }
 
   async getSignedUrl(

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -23,6 +23,7 @@
  * extensions composed, every stage below behaves byte-identically to
  * before the parameter existed; the conformance rosters pin that.
  */
+import { mkdirSync } from "node:fs";
 import path from "node:path";
 
 import type { ConnectRouter, Transport } from "@connectrpc/connect";
@@ -32,7 +33,11 @@ import { HealthCheckResponse_ServingStatus as ServingStatus } from "@stigmer/pro
 import { registerAgentServices } from "../domain/agent/controller.js";
 import { newConfigFromEnv } from "../domain/agentexecution/temporal/config.js";
 import { registerAgentExecutionServices } from "../domain/agentexecution/controller.js";
-import { newArtifactStorage } from "../artifactstorage/artifact-storage.js";
+import {
+  LocalArtifactStorage,
+  newArtifactStorage,
+} from "../artifactstorage/artifact-storage.js";
+import type { ArtifactStorage } from "../artifactstorage/artifact-storage.js";
 import { StreamBroker } from "../domain/agentexecution/stream-broker.js";
 import { newExecutionEngineStateProvider } from "../temporal/agentexecution/engine-client.js";
 import { newMcpServerEngineStateProvider } from "../temporal/mcpserver/engine-client.js";
@@ -73,8 +78,11 @@ import { registerProjectServices } from "../domain/project/controller.js";
 import { registerSessionServices } from "../domain/session/controller.js";
 import { registerSkillServices } from "../domain/skill/controller.js";
 import { DEFAULT_SLOT_TTL_MS, MAX_ZIP_SIZE } from "../domain/skill/constants.js";
-import { LocalFileStorage as SkillLocalFileStorage } from "../domain/skill/storage/artifact-storage.js";
-import { newSkillTransferLane } from "../domain/skill/transfer/handler.js";
+import { newSkillArtifactStorage } from "../domain/skill/storage/artifact-storage.js";
+import {
+  newSkillTransferLane,
+  uploadUrl as skillUploadUrl,
+} from "../domain/skill/transfer/handler.js";
 import { UploadSlots } from "../domain/skill/transfer/slots.js";
 import { SecretService } from "../encryption/encryption.js";
 import { registerActivityServices } from "../query/activity/controller.js";
@@ -84,6 +92,7 @@ import { SearchHandler } from "../query/search/handler.js";
 import { SqliteSearchQueryStore } from "../query/search/query-store.js";
 import { newSearchableResourceRegistry } from "../query/search/registry.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
+import { newExecutionScopedRunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
 import { RunnerAuthService } from "../runnerauth/runnerauth.js";
 import { PostgresStore } from "../store/postgres/store.js";
 import { SqliteStore } from "../store/sqlite/store.js";
@@ -95,6 +104,7 @@ import {
   bundledModelRegistryDocument,
   bundledTaskKindRegistryDocument,
 } from "../domain/workflow/registry/bundled.js";
+import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
 import { ModelRegistryStore } from "../domain/workflow/registry/model-registry-store.js";
 import { InProcessValidator } from "../domain/workflow/validation/validator.js";
 import { registerWorkflowInstanceServices } from "../domain/workflowinstance/controller.js";
@@ -237,6 +247,14 @@ export async function composeServer(
     secretService = SecretService.create(undefined);
   }
   const runnerAuthService = RunnerAuthService.fromEnv();
+  // The runner-credential seam (§6c, O5): the composed provider, or the
+  // OSS execution-scoped default over the service above. The concrete
+  // service is constructed and exposed UNCONDITIONALLY either way — its
+  // boot-fatal key posture is the ratified cross-domain invariant, and the
+  // boot/EC-decrypt tests mint against the server's own key through it.
+  const runnerCredentials =
+    extensions.drivers.runnerCredentialProvider ??
+    newExecutionScopedRunnerCredentialProvider(runnerAuthService);
 
   // Stage: temporal (#18). Construction is sync and connection-free —
   // initialConnect/startWorkers/startHealthMonitor run in start(), all
@@ -256,25 +274,36 @@ export async function composeServer(
   // consumer, so it lives here with the temporal stage.
   const workflowExecutionTemporalConfig = newWorkflowExecutionConfigFromEnv();
   const healthState = new HealthState();
-  // The model-registry store is DOMAIN-owned (workflow-family DD-A,
-  // restoring Go's ownership): workflow validation and the transport's
-  // registry lane read this one store, so the pickers and validation can
-  // never drift (DD-004). The composition root owns its refresh lifecycle.
-  const modelRegistryStore = new ModelRegistryStore({
-    bundledDocument: bundledModelRegistryDocument(),
-    upstreamOrigin: config.modelRegistryUpstream,
-    refreshEnabled: config.modelRegistryRefreshEnabled,
-    logger,
-    fetchImpl: options.fetchImpl,
-  });
+  // The model catalog (DD-008, O5): ONE provider instance feeds workflow
+  // validation, the pin checks, and the transport's registry lane, so the
+  // pickers and validation can never drift (DD-004) — on either arm. With
+  // no extension provider composed, the OSS domain-owned ModelRegistryStore
+  // (workflow-family DD-A, restoring Go's ownership) is constructed and
+  // this root owns its refresh lifecycle; with one composed, the OSS store
+  // and its hourly upstream refresh are never built — a substituted
+  // composition must not keep fetching registry data nobody reads.
+  let modelCatalog: ModelCatalogProvider;
+  let ossModelRegistryStore: ModelRegistryStore | undefined;
+  if (extensions.drivers.modelCatalogProvider !== undefined) {
+    modelCatalog = extensions.drivers.modelCatalogProvider;
+  } else {
+    ossModelRegistryStore = new ModelRegistryStore({
+      bundledDocument: bundledModelRegistryDocument(),
+      upstreamOrigin: config.modelRegistryUpstream,
+      refreshEnabled: config.modelRegistryRefreshEnabled,
+      logger,
+      fetchImpl: options.fetchImpl,
+    });
+    modelCatalog = ossModelRegistryStore;
+  }
   const registryLanes = createRegistryLanes({
     taskKindRegistryDocument: bundledTaskKindRegistryDocument(),
-    modelRegistryStore,
+    modelRegistryStore: modelCatalog,
   });
-  // The Layer-2 workflow validator reads the domain-owned registry store
+  // The Layer-2 workflow validator reads the composed catalog provider
   // per validation call, keeping validation and the served pickers in
   // lockstep (DD-004).
-  const workflowValidator = new InProcessValidator(modelRegistryStore, logger);
+  const workflowValidator = new InProcessValidator(modelCatalog, logger);
   // ONE broker spans both routers AND the Temporal worker's activities:
   // the worker's status persists broadcast through the same fabric, so
   // recovery/fallback updates reach externally-connected subscribe
@@ -375,17 +404,21 @@ export async function composeServer(
   // The artifact blob store (Go server.go 349: shared by agentexecution
   // attachments, the artifact domain (#13), and skill push (#8)). The r2
   // arm landed with #13; the health probe runs in start(), matching Go's
-  // boot check.
-  const artifactStorage = newArtifactStorage({
-    type: config.artifactStorageType,
-    localBasePath: config.artifactLocalBasePath,
-    localServeUrl: config.artifactLocalServeUrl,
-    r2Bucket: config.r2Bucket,
-    r2Endpoint: config.r2Endpoint,
-    r2AccessKeyId: config.r2AccessKeyId,
-    r2SecretAccessKey: config.r2SecretAccessKey,
-    r2Region: config.r2Region,
-  });
+  // boot check. Since O5 the factory consults the composition's registered
+  // drivers for non-built-in types (§6b).
+  const artifactStorage = newArtifactStorage(
+    {
+      type: config.artifactStorageType,
+      localBasePath: config.artifactLocalBasePath,
+      localServeUrl: config.artifactLocalServeUrl,
+      r2Bucket: config.r2Bucket,
+      r2Endpoint: config.r2Endpoint,
+      r2AccessKeyId: config.r2AccessKeyId,
+      r2SecretAccessKey: config.r2SecretAccessKey,
+      r2Region: config.r2Region,
+    },
+    extensions.drivers.artifactStorageDrivers,
+  );
   // The artifact download lane: a SECOND loopback listener on
   // ARTIFACT_HTTP_PORT, local storage only (Go server.go 849–870) —
   // deliberately not a unified-port lane. Lifecycle rides start()/
@@ -404,12 +437,61 @@ export async function composeServer(
   // the lane is ALWAYS configured (Go wires it unconditionally too): the
   // FailedPrecondition lane-absent arms exist for construction-order
   // safety, and the capability matrix pins skillArtifactTransferLane=true.
-  const skillArtifactStorage = new SkillLocalFileStorage(config.storagePath);
+  //
+  // Since O5 the store is the skill-domain port over a PER-DOMAIN blob
+  // driver (§6b, Q2/Q2b rulings): skill keeps its own root and its own
+  // backend knob (SKILL_ARTIFACT_STORAGE_TYPE), so an r2-configured
+  // deployment changes nothing for skill artifacts until it opts in
+  // explicitly, and the Go-written skills/ directory keeps serving in
+  // place on the default arm.
   const skillUploadSlots = new UploadSlots(
     path.join(config.storagePath, "skills-staging"),
     DEFAULT_SLOT_TTL_MS,
     MAX_ZIP_SIZE,
   );
+  const skillStorageDriver = ((): ArtifactStorage => {
+    const skillType =
+      config.skillArtifactStorageType === ""
+        ? "local"
+        : config.skillArtifactStorageType;
+    if (skillType === "local") {
+      // Go layout invariant: {storagePath}/skills exists from boot with
+      // 0755 (the retired LocalFileStorage constructor's mkdir; the
+      // generic driver only creates directories on demand).
+      mkdirSync(path.join(config.storagePath, "skills"), {
+        recursive: true,
+        mode: 0o755,
+      });
+      // The local presigned-PUT arm rides the skill transfer lane's slot
+      // mechanism (§6b Q1 ruling: one upload surface, no new lane). The
+      // slots stage inside THIS driver's root, so a minted stagingKey
+      // reads back through the same instance; the empty serve URL is the
+      // honest state — skill downloads ride the transfer lane, never
+      // getSignedUrl.
+      return new LocalArtifactStorage(config.storagePath, "", {
+        mint: (declaredSizeBytes) => skillUploadSlots.mint(declaredSizeBytes),
+        uploadUrl: (ref) => skillUploadUrl(config.skillTransferBaseUrl, ref),
+        stagedKey: (ref) =>
+          `skills-staging/${skillUploadSlots.stagedFileName(ref)}`,
+      });
+    }
+    // Non-local skill backends share the artifact store's R2 settings for
+    // the built-in arm and the composition's registered drivers beyond it.
+    return newArtifactStorage(
+      {
+        type: skillType,
+        localBasePath: config.storagePath,
+        localServeUrl: "",
+        r2Bucket: config.r2Bucket,
+        r2Endpoint: config.r2Endpoint,
+        r2AccessKeyId: config.r2AccessKeyId,
+        r2SecretAccessKey: config.r2SecretAccessKey,
+        r2Region: config.r2Region,
+      },
+      extensions.drivers.artifactStorageDrivers,
+    );
+  })();
+  const skillArtifactStorage = newSkillArtifactStorage(skillStorageDriver);
   const skillTransferLane = newSkillTransferLane(
     skillUploadSlots,
     skillArtifactStorage,
@@ -524,7 +606,7 @@ export async function composeServer(
       store,
       logger,
       secretService,
-      runnerAuthService,
+      runnerAuthService: runnerCredentials,
     });
     registerAgentServices(router, {
       store,
@@ -554,7 +636,7 @@ export async function composeServer(
       // The SAME domain-owned registry instance the workflow validator
       // and the registry lanes read — the channel model-pin rule
       // (stigmer/stigmer#774) can never drift from the served pickers.
-      modelRegistry: modelRegistryStore,
+      modelRegistry: modelCatalog,
     });
     registerChannelMessageServices(router);
     registerChannelConversationServices(router);
@@ -567,7 +649,7 @@ export async function composeServer(
     registerScheduleServices(router, {
       store,
       logger,
-      modelRegistry: modelRegistryStore,
+      modelRegistry: modelCatalog,
       clock: () => scheduleSyncer,
       runner: () => scheduleRunStarter,
     });
@@ -577,7 +659,7 @@ export async function composeServer(
       logger,
       broker: agentExecutionStreamBroker,
       engineState: executionEngineState,
-      modelRegistry: modelRegistryStore,
+      modelRegistry: modelCatalog,
       artifactStorage,
       agentLoader: () => requireInProcess().executionAgentLoader,
       agentInstanceCreator: () =>
@@ -654,7 +736,7 @@ export async function composeServer(
           delete: (input) =>
             requireInProcess().connectExecutionContextClient.delete(input),
         },
-        runnerAuth: runnerAuthService,
+        runnerAuth: runnerCredentials,
         managedEnv: managedEnvService,
         // The SAME grant-store instance agentexecution's session-time
         // token injection reads (Go server.go:732-735 shares it too).
@@ -706,7 +788,7 @@ export async function composeServer(
     registerPlatformServices(router, {
       temporalHostPort: config.temporalHostPort,
       temporalNamespace: config.temporalNamespace,
-      runnerAuthService,
+      runnerAuthService: runnerCredentials,
       edition: extensions.edition,
       logger,
     });
@@ -776,7 +858,9 @@ export async function composeServer(
       // Wiring complete → SERVING → background refresh → bind. The port
       // must be the LAST observable effect (serverGate contract).
       healthState.setOverall(ServingStatus.SERVING);
-      modelRegistryStore.startRefresh();
+      // Undefined when an extension provider substituted the catalog —
+      // that implementation owns its own freshness.
+      ossModelRegistryStore?.startRefresh();
       const port = await server.listen(
         options.portOverride ?? config.grpcPort,
         options.host,
@@ -803,7 +887,7 @@ export async function composeServer(
 
     async shutdown(): Promise<void> {
       healthState.setOverall(ServingStatus.NOT_SERVING);
-      modelRegistryStore.stopRefresh();
+      ossModelRegistryStore?.stopRefresh();
       await artifactFileServer?.shutdown();
       // The reconciler stops before the manager: a pass mid-flight may
       // still call through the manager's client, and nothing may fire

--- a/backend/services/stigmer-server/src/boot/config.ts
+++ b/backend/services/stigmer-server/src/boot/config.ts
@@ -123,6 +123,17 @@ export interface ServerConfig {
    */
   readonly storagePath: string;
   /**
+   * Skill artifact storage backend (SKILL_ARTIFACT_STORAGE_TYPE) — the
+   * per-domain opt-in of §6b/O5, deliberately SEPARATE from
+   * ARTIFACT_STORAGE_TYPE: skill artifacts stay on the local storagePath
+   * root (the Go-written-directory serving invariant) regardless of the
+   * generic artifact store's backend, until a deployment opts skill in
+   * here explicitly. "" or "local" is today's local arm; "r2" shares the
+   * artifact store's R2 settings; any other name selects a
+   * composition-registered driver.
+   */
+  readonly skillArtifactStorageType: string;
+  /**
    * Externally-reachable base of the skill artifact transfer lane's
    * capability URLs (#675). Defaults to the server's own port on
    * localhost; SKILL_TRANSFER_BASE_URL overrides when the server is
@@ -181,10 +192,17 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
     r2SecretAccessKey: envString(env, "R2_SECRET_ACCESS_KEY", ""),
     r2Region: envString(env, "R2_REGION", "auto"),
   };
+  const skillArtifactStorageType = envString(
+    env,
+    "SKILL_ARTIFACT_STORAGE_TYPE",
+    "",
+  );
   // Go validateR2Config: boot-fatal on incomplete r2 configuration — a
   // second deliberate exception to the lenient-loader posture (a server
   // that silently ignored half an R2 config would write blobs nowhere).
-  if (artifactStorageType === "r2") {
+  // Skill's per-domain knob (O5) shares the settings, so its r2 arm gets
+  // the same completeness gate.
+  if (artifactStorageType === "r2" || skillArtifactStorageType === "r2") {
     validateR2Config(r2);
   }
   return {
@@ -219,6 +237,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
     dbPath: envString(env, "DB_PATH", defaultDbPath()),
     databaseUrl: envString(env, "DATABASE_URL", ""),
     storagePath: envString(env, "STORAGE_PATH", defaultStoragePath()),
+    skillArtifactStorageType,
     skillTransferBaseUrl: envString(
       env,
       "SKILL_TRANSFER_BASE_URL",

--- a/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
@@ -73,7 +73,7 @@ import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
 import type { Store } from "../../store/interface.js";
-import type { ModelRegistryStore } from "../workflow/registry/model-registry-store.js";
+import type { ModelCatalogProvider } from "../workflow/registry/model-catalog-provider.js";
 import { INSTALL_UNAVAILABLE_MESSAGE } from "./constants.js";
 import {
   newInitInstallStateStep,
@@ -84,7 +84,7 @@ import {
 export interface AgentChannelControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
-  readonly modelRegistry: ModelRegistryStore;
+  readonly modelRegistry: ModelCatalogProvider;
 }
 
 /** Registers both agentchannel resource services on the router. */

--- a/backend/services/stigmer-server/src/domain/agentchannel/steps.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/steps.ts
@@ -34,7 +34,7 @@ import { findResourceBySlug } from "../../pipeline/steps/helpers.js";
 import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
 import type { Store } from "../../store/interface.js";
 import { unknownModelPinRefusal } from "../workflow/registry/pin-validation.js";
-import type { ModelRegistryStore } from "../workflow/registry/model-registry-store.js";
+import type { ModelCatalogProvider } from "../workflow/registry/model-catalog-provider.js";
 import {
   AGENT_REF_SLUG_REQUIRED_MESSAGE,
   APP_REF_FROZEN_WHILE_INSTALLED_MESSAGE,
@@ -55,12 +55,12 @@ type AgentChannelDesc = typeof AgentChannelSchema;
  * channel serves. Validated against EVERY registry harness section (the
  * "" harness mode) because this edition stores channel specs without a
  * serving runtime (the DD-015 divergence posture). Go reads a
- * package-level registry; the TS registry is the domain-owned
- * ModelRegistryStore (workflow-family DD-A), passed explicitly. Shared by
- * create (ResolveChannelDefaults) and update (ValidateChannelUpdate).
+ * package-level registry; here the composed ModelCatalogProvider (DD-008,
+ * workflow-family DD-A) is passed explicitly. Shared by create
+ * (ResolveChannelDefaults) and update (ValidateChannelUpdate).
  */
 function validateChannelModelPin(
-  registry: ModelRegistryStore,
+  registry: ModelCatalogProvider,
   spec: AgentChannelSpec | undefined,
 ): void {
   const reason = unknownModelPinRefusal(
@@ -96,7 +96,7 @@ function validateChannelModelPin(
  */
 export function newResolveChannelDefaultsStep(
   store: Store,
-  registry: ModelRegistryStore,
+  registry: ModelCatalogProvider,
 ): PipelineStep<AgentChannelDesc> {
   return {
     name: "ResolveChannelDefaults",
@@ -216,7 +216,7 @@ export function providerFieldName(spec: AgentChannelSpec | undefined): string {
  * generic BuildUpdateState preserves them wholesale.
  */
 export function newValidateChannelUpdateStep(
-  registry: ModelRegistryStore,
+  registry: ModelCatalogProvider,
 ): PipelineStep<AgentChannelDesc> {
   return {
     name: "ValidateChannelUpdate",

--- a/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
@@ -58,7 +58,7 @@ import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import type { Store } from "../../store/interface.js";
 
 import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
-import type { ModelRegistryStore } from "../workflow/registry/model-registry-store.js";
+import type { ModelCatalogProvider } from "../workflow/registry/model-catalog-provider.js";
 
 import {
   getArtifactContent,
@@ -141,7 +141,7 @@ export interface AgentExecutionControllerDeps {
    * instance, DD-004) — the #357/#772 tier and thinking-mode validators
    * read it at create.
    */
-  readonly modelRegistry: ModelRegistryStore;
+  readonly modelRegistry: ModelCatalogProvider;
   /** The shared artifact blob store (attachments + artifact reads). */
   readonly artifactStorage: ArtifactStorage;
   /**

--- a/backend/services/stigmer-server/src/domain/agentexecution/validate-service-tier.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/validate-service-tier.ts
@@ -27,13 +27,11 @@ import { ServiceTier } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v
 
 import { invalidArgumentError } from "../../pipeline/errors.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
-import {
-  FAST_VARIANT_KEY,
-  type ModelRegistryStore,
-} from "../workflow/registry/model-registry-store.js";
+import type { ModelCatalogProvider } from "../workflow/registry/model-catalog-provider.js";
+import { FAST_VARIANT_KEY } from "../workflow/registry/model-registry-store.js";
 
 export function newValidateServiceTierStep(
-  registry: ModelRegistryStore,
+  registry: ModelCatalogProvider,
 ): PipelineStep<typeof AgentExecutionSchema> {
   return {
     name: "ValidateServiceTier",
@@ -69,7 +67,7 @@ export function newValidateServiceTierStep(
  * sorted (the store keeps the list sorted), empty when the registry
  * prices none.
  */
-function fastCapableSuffix(registry: ModelRegistryStore): string {
+function fastCapableSuffix(registry: ModelCatalogProvider): string {
   const capable = registry.canonicalModelsWithVariant(FAST_VARIANT_KEY);
   if (capable.length === 0) {
     return "";

--- a/backend/services/stigmer-server/src/domain/agentexecution/validate-thinking-mode.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/validate-thinking-mode.ts
@@ -30,14 +30,12 @@ import { ThinkingMode } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/
 
 import { invalidArgumentError } from "../../pipeline/errors.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
-import {
-  THINKING_CAPABILITY_KEY,
-  type ModelRegistryStore,
-} from "../workflow/registry/model-registry-store.js";
+import type { ModelCatalogProvider } from "../workflow/registry/model-catalog-provider.js";
+import { THINKING_CAPABILITY_KEY } from "../workflow/registry/model-registry-store.js";
 import { HARNESS_NAME_CURSOR } from "../workflow/registry/pin-validation.js";
 
 export function newValidateThinkingModeStep(
-  registry: ModelRegistryStore,
+  registry: ModelCatalogProvider,
 ): PipelineStep<typeof AgentExecutionSchema> {
   return {
     name: "ValidateThinkingMode",
@@ -80,7 +78,7 @@ export function newValidateThinkingModeStep(
  * sorted (the store keeps the list sorted), empty when the registry
  * declares none.
  */
-function thinkingCapableSuffix(registry: ModelRegistryStore): string {
+function thinkingCapableSuffix(registry: ModelCatalogProvider): string {
   const capable = registry.canonicalModelsWithCapabilityForHarness(
     HARNESS_NAME_CURSOR,
     THINKING_CAPABILITY_KEY,

--- a/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
@@ -78,7 +78,7 @@ import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
-import type { RunnerAuthService } from "../../runnerauth/runnerauth.js";
+import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
 import type { Store } from "../../store/interface.js";
 import { redactExecutionContextSecrets } from "./redact.js";
 import { resolveValuesForCaller } from "./resolve-values-for-caller.js";
@@ -104,7 +104,7 @@ export interface ExecutionContextControllerDeps {
    * token, every read redacts — is the modeled "disabled" arm, the TS
    * shape of Go's nil-service check.
    */
-  readonly runnerAuthService: RunnerAuthService;
+  readonly runnerAuthService: RunnerCredentialProvider;
 }
 
 /** Registers both executioncontext services on the router (routes stage). */

--- a/backend/services/stigmer-server/src/domain/executioncontext/resolve-values-for-caller.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/resolve-values-for-caller.ts
@@ -47,14 +47,15 @@ import type { Logger } from "../../boot/logger.js";
 import { EncryptionDisabledError } from "../../encryption/encryption.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import { internalError } from "../../pipeline/errors.js";
-import type { RunnerAuthService } from "../../runnerauth/runnerauth.js";
+import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
+import { TOKEN_TYPE_EXECUTION_SCOPED } from "../../runnerauth/runnerauth.js";
 import { encryptionKeyMissingMessage } from "./constants.js";
 import { redactExecutionContextSecrets } from "./redact.js";
 
 export interface ResolveValuesDeps {
   readonly logger: Logger;
   readonly secretService: SecretService;
-  readonly runnerAuthService: RunnerAuthService;
+  readonly runnerAuthService: RunnerCredentialProvider;
 }
 
 /**
@@ -86,8 +87,10 @@ export function resolveValuesForCaller(
  * the caller falls closed to redaction — with the mismatch case
  * WARN-logged because a runner reading across executions indicates a bug,
  * while an absent header is just an ordinary user-shaped read. A keyless
- * RunnerAuthService rejects every token (verify throws), the TS shape of
- * Go's nil-service arm: without a key no token can be genuine.
+ * provider rejects every token (verify throws), the TS shape of Go's
+ * nil-service arm: without a key no token can be genuine. This lane
+ * accepts exactly the execution_scoped credential lane — the caller-side
+ * trust statement the provider contract requires.
  */
 function verifyRunnerToken(
   deps: ResolveValuesDeps,
@@ -101,7 +104,10 @@ function verifyRunnerToken(
 
   let tokenExecutionId: string;
   try {
-    tokenExecutionId = deps.runnerAuthService.verify(token);
+    tokenExecutionId = deps.runnerAuthService.verify(
+      TOKEN_TYPE_EXECUTION_SCOPED,
+      token,
+    );
   } catch {
     deps.logger.debug(
       "Presented runner token failed verification - redacting execution context secrets",

--- a/backend/services/stigmer-server/src/domain/mcpserver/__tests__/connect.test.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/__tests__/connect.test.ts
@@ -28,6 +28,7 @@ import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/execu
 
 import { createLogger } from "../../../boot/logger.js";
 import { SecretService } from "../../../encryption/encryption.js";
+import { newExecutionScopedRunnerCredentialProvider } from "../../../runnerauth/runner-credential-provider.js";
 import { RunnerAuthService } from "../../../runnerauth/runnerauth.js";
 import { SqliteStore } from "../../../store/sqlite/store.js";
 import {
@@ -155,7 +156,9 @@ function makeHarness(options: FakeEngineOptions = {}): Harness {
           return create(ExecutionContextSchema);
         },
       },
-      runnerAuth: RunnerAuthService.fromEnv(),
+      runnerAuth: newExecutionScopedRunnerCredentialProvider(
+        RunnerAuthService.fromEnv(),
+      ),
       // The REAL service over a client backed by nothing: the refresh
       // pre-flight arms that need it are exercised in the handshake
       // composed test; here every read throws, which the pre-flight

--- a/backend/services/stigmer-server/src/domain/mcpserver/connect.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/connect.ts
@@ -49,7 +49,8 @@ import {
   invalidArgumentError,
   unavailableError,
 } from "../../pipeline/errors.js";
-import type { RunnerAuthService } from "../../runnerauth/runnerauth.js";
+import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
+import { TOKEN_TYPE_EXECUTION_SCOPED } from "../../runnerauth/runnerauth.js";
 import type {
   OAuthGrantStore,
   PendingOAuthStateStore,
@@ -190,7 +191,7 @@ export interface McpServerConnectDeps {
   readonly engineState: McpServerEngineStateProvider;
   readonly environmentReader: ConnectEnvironmentReader;
   readonly executionContext: ConnectExecutionContextClient;
-  readonly runnerAuth: RunnerAuthService;
+  readonly runnerAuth: RunnerCredentialProvider;
   readonly managedEnv: ManagedEnvironmentService;
   readonly oauthGrants: OAuthGrantStore;
   readonly pendingOAuthStates: PendingOAuthStateStore;
@@ -391,9 +392,16 @@ export async function prepareConnect(
   // with declared credentials will refuse the redacted read with an
   // actionable error, and credential-less servers connect fine without
   // the token.
-  if (ecResourceId !== "" && deps.runnerAuth.isEnabled()) {
+  if (
+    ecResourceId !== "" &&
+    deps.runnerAuth.isEnabled(TOKEN_TYPE_EXECUTION_SCOPED)
+  ) {
     try {
-      const minted = deps.runnerAuth.mint(executionId, 0);
+      const minted = deps.runnerAuth.mint(
+        TOKEN_TYPE_EXECUTION_SCOPED,
+        executionId,
+        0,
+      );
       return {
         workflowInput: {
           ...workflowInput,

--- a/backend/services/stigmer-server/src/domain/platform/__tests__/platform.test.ts
+++ b/backend/services/stigmer-server/src/domain/platform/__tests__/platform.test.ts
@@ -36,6 +36,7 @@ import { loadConfig } from "../../../boot/config.js";
 import { composeServer } from "../../../boot/compose.js";
 import type { ComposedServer } from "../../../boot/compose.js";
 import { createLogger } from "../../../boot/logger.js";
+import { newExecutionScopedRunnerCredentialProvider } from "../../../runnerauth/runner-credential-provider.js";
 import { RunnerAuthService } from "../../../runnerauth/runnerauth.js";
 import { registerPlatformServices } from "../controller.js";
 
@@ -167,7 +168,9 @@ describe("platform domain (keyless runner-token service)", () => {
       registerPlatformServices(router, {
         temporalHostPort: "localhost:7233",
         temporalNamespace: "default",
-        runnerAuthService: RunnerAuthService.create(undefined),
+        runnerAuthService: newExecutionScopedRunnerCredentialProvider(
+          RunnerAuthService.create(undefined),
+        ),
         edition: ServerEdition.oss,
         logger: silentLogger,
       });

--- a/backend/services/stigmer-server/src/domain/platform/controller.ts
+++ b/backend/services/stigmer-server/src/domain/platform/controller.ts
@@ -35,7 +35,8 @@ import type {
 } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
 
 import type { Logger } from "../../boot/logger.js";
-import type { RunnerAuthService } from "../../runnerauth/runnerauth.js";
+import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
+import { TOKEN_TYPE_EXECUTION_SCOPED } from "../../runnerauth/runnerauth.js";
 import { SERVER_VERSION } from "./version.js";
 
 export interface PlatformControllerDeps {
@@ -54,7 +55,7 @@ export interface PlatformControllerDeps {
    * nil service in tests; the composition root here always wires one — a
    * keyless instance is the modeled disabled state.)
    */
-  readonly runnerAuthService: RunnerAuthService;
+  readonly runnerAuthService: RunnerCredentialProvider;
   /**
    * The served edition, composition-derived (DD-006; blueprint §11 item
    * 11): the extension registry declares it and defaults to oss, so the
@@ -147,12 +148,19 @@ function getRunnerScopedToken(
     }
   }
 
-  if (executionId === "" || !deps.runnerAuthService.isEnabled()) {
+  if (
+    executionId === "" ||
+    !deps.runnerAuthService.isEnabled(TOKEN_TYPE_EXECUTION_SCOPED)
+  ) {
     return create(GetRunnerScopedTokenOutputSchema);
   }
 
   try {
-    const minted = deps.runnerAuthService.mint(executionId, 0);
+    const minted = deps.runnerAuthService.mint(
+      TOKEN_TYPE_EXECUTION_SCOPED,
+      executionId,
+      0,
+    );
     return create(GetRunnerScopedTokenOutputSchema, {
       runnerScopedToken: minted.token,
       tokenType: "Bearer",

--- a/backend/services/stigmer-server/src/domain/schedule/controller.ts
+++ b/backend/services/stigmer-server/src/domain/schedule/controller.ts
@@ -78,7 +78,7 @@ import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
 import type { Store } from "../../store/interface.js";
-import type { ModelRegistryStore } from "../workflow/registry/model-registry-store.js";
+import type { ModelCatalogProvider } from "../workflow/registry/model-catalog-provider.js";
 import {
   newArmResumedScheduleStep,
   newArmScheduleStep,
@@ -107,7 +107,7 @@ import {
 export interface ScheduleControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
-  readonly modelRegistry: ModelRegistryStore;
+  readonly modelRegistry: ModelCatalogProvider;
   /**
    * The scheduling runtime (clock.ts), resolved at call time so the
    * compose root can wire it after the Temporal stage — Go's SetClock,

--- a/backend/services/stigmer-server/src/domain/schedule/steps.ts
+++ b/backend/services/stigmer-server/src/domain/schedule/steps.ts
@@ -29,12 +29,12 @@ import {
   harnessName,
   unknownModelPinRefusal,
 } from "../workflow/registry/pin-validation.js";
-import type { ModelRegistryStore } from "../workflow/registry/model-registry-store.js";
+import type { ModelCatalogProvider } from "../workflow/registry/model-catalog-provider.js";
 import { validateScheduleCron, validateScheduleTimeZone } from "./cron.js";
 
 export interface ScheduleValidationDeps {
   readonly store: Store;
-  readonly modelRegistry: ModelRegistryStore;
+  readonly modelRegistry: ModelCatalogProvider;
 }
 
 /**
@@ -167,7 +167,7 @@ export function validateScheduleWorkspace(spec: ScheduleSpec | undefined): void 
  *     must never break an existing schedule at its 3 AM fire).
  */
 export function validateScheduleModelPinning(
-  modelRegistry: ModelRegistryStore,
+  modelRegistry: ModelCatalogProvider,
   spec: ScheduleSpec | undefined,
 ): void {
   const presence = scheduleModelPinningRefusal(spec);

--- a/backend/services/stigmer-server/src/domain/skill/__tests__/artifact-storage.test.ts
+++ b/backend/services/stigmer-server/src/domain/skill/__tests__/artifact-storage.test.ts
@@ -2,32 +2,43 @@
  * Pins the skill artifact store against Go's artifact_storage_test.go:
  * path layout ({root}/skills/{hash}.zip — cutover inherits Go-written
  * directories), permissions, traversal-guarded reads, and the dedupe
- * surface (exists/getStorageKey).
+ * surface (exists/getStorageKey). Since O5 the store is the domain port
+ * over the local blob driver — the assertions are UNCHANGED from the
+ * pre-reconciliation class on purpose: they are the byte-identity proof.
  */
-import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { ArtifactNotFoundError, LocalFileStorage } from "../storage/artifact-storage.js";
+import { LocalArtifactStorage } from "../../../artifactstorage/artifact-storage.js";
+import {
+  ArtifactNotFoundError,
+  newSkillArtifactStorage,
+} from "../storage/artifact-storage.js";
+import type { SkillArtifactStorage } from "../storage/artifact-storage.js";
 
 const HASH = "a".repeat(64);
 const DATA = new TextEncoder().encode("zip bytes");
 
 let dir: string;
-let storage: LocalFileStorage;
+let storage: SkillArtifactStorage;
 
 beforeEach(() => {
   dir = mkdtempSync(path.join(tmpdir(), "skill-artifact-test-"));
-  storage = new LocalFileStorage(dir);
+  // Mirrors the compose local arm (boot/compose.ts): skills/ boot-created
+  // 0755 (the Go layout invariant), the driver rooted at the storage path,
+  // the port owning keys and the not-found vocabulary.
+  mkdirSync(path.join(dir, "skills"), { recursive: true, mode: 0o755 });
+  storage = newSkillArtifactStorage(new LocalArtifactStorage(dir, ""));
 });
 
 afterEach(() => {
   rmSync(dir, { recursive: true, force: true });
 });
 
-describe("LocalFileStorage", () => {
+describe("skill artifact store over the local driver", () => {
   it("stores under skills/{hash}.zip — a LITERAL forward-slash key on every platform — and round-trips the bytes", async () => {
     const key = await storage.store(HASH, DATA);
     expect(key).toBe(`skills/${HASH}.zip`);

--- a/backend/services/stigmer-server/src/domain/skill/storage/artifact-storage.ts
+++ b/backend/services/stigmer-server/src/domain/skill/storage/artifact-storage.ts
@@ -7,11 +7,20 @@
  * the interface: historical versions stay downloadable through the storage
  * keys listVersions exposes.
  *
+ * Since O5 (20260827.02, blueprint 03 §6b) this is a DOMAIN PORT layered
+ * over the one ArtifactStorage blob driver (the Q2 gate ruling): the
+ * driver stores blobs; this module owns the keys, the write-once posture,
+ * and the not-found vocabulary. The compose root hands it a PER-DOMAIN
+ * driver instance rooted at storagePath (the Q2b ruling) — skill artifacts
+ * never silently follow the generic artifact store's backend selection.
+ *
  * Proven by __tests__/artifact-storage.test.ts and the skill conformance
  * suite's getArtifact/round-trip tests.
  */
-import fs from "node:fs";
 import path from "node:path";
+
+import type { ArtifactStorage } from "../../../artifactstorage/artifact-storage.js";
+import { ArtifactStorageNotFoundError } from "../../../artifactstorage/artifact-storage.js";
 
 /**
  * Storage abstraction for skill artifacts (Go ArtifactStorage). The
@@ -43,111 +52,88 @@ export class ArtifactNotFoundError extends Error {
   }
 }
 
-/** Filesystem implementation (Go LocalFileStorage). */
-export class LocalFileStorage implements SkillArtifactStorage {
-  private readonly storagePath: string;
+/** Skill artifacts are zip archives; the driver stores the honest type. */
+const SKILL_ARTIFACT_CONTENT_TYPE = "application/zip";
 
-  /** Creates the backend and ensures {storagePath}/skills exists (0755). */
-  constructor(storagePath: string) {
-    this.storagePath = storagePath;
-    fs.mkdirSync(path.join(storagePath, "skills"), {
-      recursive: true,
-      mode: 0o755,
-    });
-  }
+/**
+ * The skill store over a blob driver. Object-literal factory rather than a
+ * class: all state is the captured driver, and the seam-adapter shape
+ * matches runner-credential-provider.ts (the O5 house style for ports).
+ */
+export function newSkillArtifactStorage(
+  driver: ArtifactStorage,
+): SkillArtifactStorage {
+  return {
+    /**
+     * "skills/<hash>.zip" — the relative key format shared with cloud R2.
+     * Deliberately a LITERAL forward-slash join, not path.join: the key is
+     * a wire-visible identifier (status.artifact_storage_key, download
+     * URLs, the lane's "skills/" prefix check), and Windows support
+     * arrives only through this server (#24) — path.join would mint
+     * backslash keys there that the download lane could never serve.
+     */
+    getStorageKey(hash: string): string {
+      return `skills/${hash}.zip`;
+    },
 
-  /** Writes with 0600 (owner-only) — artifacts are not world-readable. */
-  async store(hash: string, data: Uint8Array): Promise<string> {
-    const storageKey = this.getStorageKey(hash);
-    const filePath = path.join(this.storagePath, storageKey);
-    await fs.promises.mkdir(path.dirname(filePath), {
-      recursive: true,
-      mode: 0o755,
-    });
-    await fs.promises.writeFile(filePath, data, { mode: 0o600 });
-    return storageKey;
-  }
+    async store(hash: string, data: Uint8Array): Promise<string> {
+      const storageKey = this.getStorageKey(hash);
+      await driver.upload(storageKey, data, SKILL_ARTIFACT_CONTENT_TYPE);
+      return storageKey;
+    },
 
-  async get(storageKey: string): Promise<Uint8Array> {
-    const filePath = this.resolveWithinRoot(storageKey);
-    if (filePath === undefined) {
-      throw new ArtifactNotFoundError(storageKey);
-    }
-    try {
-      return await fs.promises.readFile(filePath);
-    } catch (error) {
-      if (isNotFound(error)) {
+    async get(storageKey: string): Promise<Uint8Array> {
+      if (keyEscapesStore(storageKey)) {
         throw new ArtifactNotFoundError(storageKey);
       }
-      throw new Error(
-        `failed to read artifact: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  }
-
-  async exists(hash: string): Promise<boolean> {
-    const filePath = path.join(this.storagePath, this.getStorageKey(hash));
-    try {
-      await fs.promises.stat(filePath);
-      return true;
-    } catch (error) {
-      if (isNotFound(error)) {
-        return false;
+      try {
+        return await driver.download(storageKey);
+      } catch (error) {
+        if (error instanceof ArtifactStorageNotFoundError) {
+          throw new ArtifactNotFoundError(storageKey);
+        }
+        throw new Error(
+          `failed to read artifact: ${error instanceof Error ? error.message : String(error)}`,
+        );
       }
-      throw error;
-    }
-  }
+    },
 
-  /**
-   * "skills/<hash>.zip" — the relative key format shared with cloud R2.
-   * Deliberately a LITERAL forward-slash join, not path.join: the key is
-   * a wire-visible identifier (status.artifact_storage_key, download
-   * URLs, the lane's "skills/" prefix check), and Windows support arrives
-   * only through this server (#24) — path.join would mint backslash keys
-   * there that the download lane could never serve. Filesystem access
-   * re-joins the key per-OS (store/get/size).
-   */
-  getStorageKey(hash: string): string {
-    return `skills/${hash}.zip`;
-  }
+    async exists(hash: string): Promise<boolean> {
+      return driver.exists(this.getStorageKey(hash));
+    },
 
-  async size(storageKey: string): Promise<number> {
-    const filePath = this.resolveWithinRoot(storageKey);
-    if (filePath === undefined) {
-      throw new ArtifactNotFoundError(storageKey);
-    }
-    try {
-      const info = await fs.promises.stat(filePath);
-      return info.size;
-    } catch (error) {
-      if (isNotFound(error)) {
+    async size(storageKey: string): Promise<number> {
+      if (keyEscapesStore(storageKey)) {
         throw new ArtifactNotFoundError(storageKey);
       }
-      throw new Error(
-        `failed to stat artifact: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  }
-
-  /**
-   * Joins a client-supplied storage key to the root and confirms the
-   * resolved path stays inside it (Go resolveWithinRoot) — traversal keys
-   * ("../../etc/passwd") address nothing inside the store.
-   */
-  private resolveWithinRoot(storageKey: string): string | undefined {
-    const root = path.resolve(this.storagePath);
-    const filePath = path.resolve(root, storageKey);
-    if (filePath !== root && !filePath.startsWith(root + path.sep)) {
-      return undefined;
-    }
-    return filePath;
-  }
+      try {
+        return await driver.size(storageKey);
+      } catch (error) {
+        if (error instanceof ArtifactStorageNotFoundError) {
+          throw new ArtifactNotFoundError(storageKey);
+        }
+        throw new Error(
+          `failed to stat artifact: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    },
+  };
 }
 
-function isNotFound(error: unknown): boolean {
+/**
+ * The domain's own traversal guard (Go resolveWithinRoot, kept HERE per
+ * "the domain owns keys"): a client-supplied storage key that resolves
+ * outside the store addresses nothing inside it, and must collapse to the
+ * same not-found as a missing file BEFORE the driver sees it — the
+ * driver's own containment refusal is a distinguishable error, and
+ * distinguishing them would tell a probing caller which escapes exist.
+ * Lexical, against a fixed virtual root, so the judgment is identical on
+ * every backend rather than an accident of the local driver's directory.
+ */
+function keyEscapesStore(storageKey: string): boolean {
+  const virtualRoot = path.resolve(path.sep, "skill-store");
+  const resolved = path.resolve(virtualRoot, storageKey);
   return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as NodeJS.ErrnoException).code === "ENOENT"
+    resolved !== virtualRoot && !resolved.startsWith(virtualRoot + path.sep)
   );
 }

--- a/backend/services/stigmer-server/src/domain/skill/transfer/slots.ts
+++ b/backend/services/stigmer-server/src/domain/skill/transfer/slots.ts
@@ -210,11 +210,22 @@ export class UploadSlots {
   }
 
   /**
+   * The staging file name for a reference. Public since O5: the local
+   * driver's presigned-PUT arm maps refs onto driver staging keys
+   * (boot/compose.ts), and that mapping must come from HERE — a
+   * re-declared "<ref>.zip" in the composition would drift from stagePath
+   * with nothing to catch it.
+   */
+  stagedFileName(ref: string): string {
+    return `${ref}.zip`;
+  }
+
+  /**
    * Maps a reference to its staging file. refs are server-generated hex
    * (never client-supplied paths), so simple joining is safe.
    */
   private stagePath(ref: string): string {
-    return path.join(this.stagingDir, `${ref}.zip`);
+    return path.join(this.stagingDir, this.stagedFileName(ref));
   }
 }
 

--- a/backend/services/stigmer-server/src/domain/workflow/registry/model-catalog-provider.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/registry/model-catalog-provider.ts
@@ -1,0 +1,134 @@
+/**
+ * The model-catalog provider seam — DD-008 (convergence program
+ * 20260826.02, blueprint/03 §6a), extracted with O5 (20260827.02).
+ *
+ * ONE interface covers catalog data AND pin-policy source: the registry
+ * document, model/harness validity, pricing-variant and capability
+ * queries, canonical-model listing. A split seam was rejected by the
+ * ratified DD-008 ruling — separating the priced catalog from the pin
+ * policy lets them drift apart, recreating exactly the selectable-vs-billed
+ * drift the one-store design exists to prevent.
+ *
+ * Two disciplines are CONTRACT here, not folklore:
+ *
+ *   1. Reads are PER CALL. Implementations may cache internally (they own
+ *      invalidation), but consumers never build boot-time indexes over
+ *      this provider. The named counterexample is the cloud Java
+ *      ModelValidationHelper's @PostConstruct index, which captured the
+ *      stage-1 embedded registry before the DB baseline loaded and served
+ *      stale validity for the process's whole life.
+ *   2. Validation logic stays OSS and edition-neutral. The did-you-mean
+ *      pin machinery (pin-validation.ts) and every refusal message CONSUME
+ *      this provider; an edition substitutes the data source only, never
+ *      the judgment. Refusal copy is conformance-visible shared contract.
+ *
+ * The OSS implementation is ModelRegistryStore (bundled snapshot + hourly
+ * upstream refresh), unchanged; its refresh lifecycle is deliberately NOT
+ * part of this contract — refresh is how ONE implementation keeps itself
+ * current, owned by the composition root that constructs it. Extensions
+ * substitute an implementation through the drivers registry point
+ * (extensions/drivers.ts); with none composed, behavior is byte-identical
+ * to the pre-extraction store.
+ */
+
+/**
+ * Read surface of the model catalog. All answers reflect the
+ * implementation's CURRENT document — callers re-ask per request and never
+ * memoize across requests (discipline 1 above).
+ */
+export interface ModelCatalogProvider {
+  /** The served registry document bytes; always complete and valid. */
+  document(): string;
+
+  /**
+   * Whether a model reference (canonical id or provider api id) is
+   * executable on the given harness.
+   */
+  isValidModel(harness: string, model: string): boolean;
+
+  /** Whether the catalog knows any models for a harness. */
+  hasHarness(harness: string): boolean;
+
+  /**
+   * Whether the catalog loaded at all — validation degrades to a no-op
+   * rather than rejecting everything when it did not.
+   */
+  hasAnyModels(): boolean;
+
+  /**
+   * Whether a model reference is executable on AT LEAST ONE harness. The
+   * existence check for surfaces with no serving harness in this edition
+   * (agent channels): a pin no section knows is certainly a typo, while a
+   * pin valid anywhere may be right where the spec actually serves.
+   */
+  isValidModelOnAnyHarness(model: string): boolean;
+
+  /**
+   * The sorted, deduplicated canonical model ids across every harness
+   * section — the did-you-mean candidate pool for the any-harness
+   * existence check. Callers must not mutate the result.
+   */
+  canonicalModelsAcrossHarnesses(): string[];
+
+  /**
+   * The sorted canonical model ids for a harness (deterministic
+   * did-you-mean suggestions — canonical ids are the documented form, so
+   * suggestions never surface provider api ids). Callers must not mutate.
+   */
+  canonicalModels(harness: string): string[];
+
+  /**
+   * Whether a model reference prices the given variant key under ANY
+   * harness — the capability check for ExecutionConfig.service_tier at
+   * execution create (oss#357), deliberately harness-free (it never
+   * resolves the session).
+   */
+  hasPricingVariant(model: string, variant: string): boolean;
+
+  /**
+   * Whether a model reference prices the given variant key under the given
+   * harness. The workflow validators use this form — the task config names
+   * its harness, so a fast variant priced only under another harness must
+   * not validate (it would execute as a silent no-op).
+   */
+  hasPricingVariantForHarness(
+    harness: string,
+    model: string,
+    variant: string,
+  ): boolean;
+
+  /**
+   * The sorted canonical model ids that price the given variant key under
+   * any harness, for actionable refusal messages. Callers must not mutate.
+   */
+  canonicalModelsWithVariant(variant: string): string[];
+
+  /**
+   * The sorted canonical model ids that price the given variant key under
+   * the given harness. Callers must not mutate.
+   */
+  canonicalModelsWithVariantForHarness(
+    harness: string,
+    variant: string,
+  ): string[];
+
+  /**
+   * Whether a model reference declares the given capability key (e.g.
+   * "thinking") true under the given harness. Capability flags are
+   * harness-scoped facts, so there is no any-harness form (oss#772).
+   */
+  hasCapabilityForHarness(
+    harness: string,
+    model: string,
+    capability: string,
+  ): boolean;
+
+  /**
+   * The sorted canonical model ids that declare the given capability key
+   * under the given harness, for actionable refusal messages.
+   */
+  canonicalModelsWithCapabilityForHarness(
+    harness: string,
+    capability: string,
+  ): string[];
+}

--- a/backend/services/stigmer-server/src/domain/workflow/registry/model-registry-store.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/registry/model-registry-store.ts
@@ -19,8 +19,13 @@
  * Failure logging matches Go (:454-476): the FIRST consecutive refresh
  * failure logs at warn, repeats at debug until a success resets the flag —
  * an offline laptop must not fill its log with hourly warnings.
+ *
+ * Since O5 (20260827.02) this class is the OSS implementation of the
+ * ModelCatalogProvider seam (DD-008) — consumers hold the interface; the
+ * refresh lifecycle below stays composition-owned, outside the contract.
  */
 import type { Logger } from "../../../boot/logger.js";
+import type { ModelCatalogProvider } from "./model-catalog-provider.js";
 
 /** Upstream refresh cadence (Go modelRegistryRefreshInterval, :34). */
 export const MODEL_REGISTRY_REFRESH_INTERVAL_MS = 60 * 60 * 1000;
@@ -98,7 +103,7 @@ interface RegistryIndexes {
   sortedModelsByCapabilityHarness: Map<string, Map<string, string[]>>;
 }
 
-export class ModelRegistryStore {
+export class ModelRegistryStore implements ModelCatalogProvider {
   private currentDocument: string;
   private indexes: RegistryIndexes;
   private refreshTimer: NodeJS.Timeout | undefined;

--- a/backend/services/stigmer-server/src/domain/workflow/registry/pin-validation.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/registry/pin-validation.ts
@@ -13,7 +13,7 @@
  */
 import { Harness } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
 
-import type { ModelRegistryStore } from "./model-registry-store.js";
+import type { ModelCatalogProvider } from "./model-catalog-provider.js";
 
 /**
  * Harness section names as the registry document spells them. Exported so
@@ -67,7 +67,7 @@ export function harnessName(h: Harness): string {
  * Returns the refusal copy, or "" when the pin is valid (or unverifiable).
  */
 export function unknownModelPinRefusal(
-  store: ModelRegistryStore,
+  store: ModelCatalogProvider,
   fieldPath: string,
   harness: string,
   model: string,

--- a/backend/services/stigmer-server/src/domain/workflow/validation/model-validation.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/validation/model-validation.ts
@@ -2,12 +2,11 @@
  * Harness-aware model-reference validation — ports
  * pkg/domain/workflow/validation/model_validation.go.
  *
- * Model validity comes from the domain's ModelRegistryStore — the same
- * document the /v1/proxy/model-registry HTTP lane serves (the bundled
- * registry, upgraded by the background refresh when reachable). Reading the
- * store per validation call instead of a boot-time snapshot is what keeps
- * validation and the served pickers in lockstep: a model that appears in
- * every picker after a refresh must also validate (DD-004).
+ * Model validity comes from the composed ModelCatalogProvider (DD-008) —
+ * the same document the /v1/proxy/model-registry HTTP lane serves. Reading
+ * the provider per validation call instead of a boot-time snapshot is what
+ * keeps validation and the served pickers in lockstep: a model that appears
+ * in every picker after a refresh must also validate (DD-004).
  *
  * Harness names, suggestion machinery, and the write-time pin-existence
  * rule all live in the registry module (the shared validation authority) —
@@ -28,7 +27,7 @@ import {
   FAST_VARIANT_KEY,
   THINKING_CAPABILITY_KEY,
 } from "../registry/model-registry-store.js";
-import type { ModelRegistryStore } from "../registry/model-registry-store.js";
+import type { ModelCatalogProvider } from "../registry/model-catalog-provider.js";
 import {
   HARNESS_NAME_NATIVE,
   harnessName,
@@ -45,7 +44,7 @@ import {
  *   - eval: model (required) against the native harness
  */
 export function validateModelReferences(
-  models: ModelRegistryStore,
+  models: ModelCatalogProvider,
   spec: WorkflowSpec | undefined,
 ): string[] {
   if (spec === undefined || spec.tasks.length === 0) {
@@ -144,7 +143,7 @@ export function validateModelReferences(
  * function (strict unmarshaling refuses non-canonical enum values).
  */
 function validateAgentCallServiceTier(
-  models: ModelRegistryStore,
+  models: ModelCatalogProvider,
   taskName: string,
   harness: string,
   rc: RunConfig | undefined,
@@ -181,7 +180,7 @@ function validateAgentCallServiceTier(
  * function (strict unmarshaling refuses non-canonical enum values).
  */
 function validateAgentCallThinkingMode(
-  models: ModelRegistryStore,
+  models: ModelCatalogProvider,
   taskName: string,
   harness: string,
   rc: RunConfig | undefined,
@@ -212,7 +211,7 @@ function validateAgentCallThinkingMode(
  * empty when the registry declares none for that harness.
  */
 function thinkingCapableSuffix(
-  models: ModelRegistryStore,
+  models: ModelCatalogProvider,
   harness: string,
 ): string {
   const capable = models.canonicalModelsWithCapabilityForHarness(
@@ -230,7 +229,7 @@ function thinkingCapableSuffix(
  * empty when the registry prices none for that harness.
  */
 function fastCapableSuffix(
-  models: ModelRegistryStore,
+  models: ModelCatalogProvider,
   harness: string,
 ): string {
   const capable = models.canonicalModelsWithVariantForHarness(
@@ -244,7 +243,7 @@ function fastCapableSuffix(
 }
 
 function buildModelError(
-  models: ModelRegistryStore,
+  models: ModelCatalogProvider,
   taskName: string,
   kindLabel: string,
   model: string,

--- a/backend/services/stigmer-server/src/domain/workflow/validation/validator.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/validation/validator.ts
@@ -28,7 +28,7 @@ import type { ServerlessWorkflowValidation } from "@stigmer/protos/ai/stigmer/ag
 
 import type { Logger } from "../../../boot/logger.js";
 import { protoToYaml } from "../converter/converter.js";
-import type { ModelRegistryStore } from "../registry/model-registry-store.js";
+import type { ModelCatalogProvider } from "../registry/model-catalog-provider.js";
 import { checkBudgetWarnings } from "./budget-warnings.js";
 import {
   validateCrossTaskReferences,
@@ -42,7 +42,7 @@ import { validateTaskConfigConstraints } from "./task-config-constraints.js";
 
 export class InProcessValidator {
   constructor(
-    private readonly modelRegistry: ModelRegistryStore,
+    private readonly modelRegistry: ModelCatalogProvider,
     private readonly logger: Logger,
   ) {}
 

--- a/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
@@ -28,6 +28,7 @@ import {
   ServerEdition,
 } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
 
+import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
 import { loadConfig } from "../../boot/config.js";
 import { composeServer } from "../../boot/compose.js";
 import type { ComposedServer } from "../../boot/compose.js";
@@ -134,5 +135,119 @@ describe("extension composition (composed server)", () => {
     );
     expect(bootLine).toBeDefined();
     expect(bootLine).toContain("fake-billing");
+  });
+});
+
+/**
+ * The O5 driver-substitution arm: every consumption site routes through
+ * the composed drivers — the registry lane serves the substituted
+ * catalog's document, the platform exchange mints through the substituted
+ * credential provider, and the artifact factory selects the registered
+ * blob driver by its configured name.
+ */
+describe("extension composition (O5 driver substitution)", () => {
+  const FAKE_DOCUMENT = `{"models":[{"id":"fake/model","harness":"native"}]}`;
+  let server: ComposedServer;
+  let dir: string;
+  let port: number;
+  let blobDriverConstructed = 0;
+
+  const driverExtension: ServerExtension = {
+    name: "fake-drivers",
+    drivers: {
+      modelCatalogProvider: {
+        document: () => FAKE_DOCUMENT,
+        isValidModel: () => true,
+        hasHarness: () => true,
+        hasAnyModels: () => true,
+        isValidModelOnAnyHarness: () => true,
+        canonicalModelsAcrossHarnesses: () => ["fake/model"],
+        canonicalModels: () => ["fake/model"],
+        hasPricingVariant: () => true,
+        hasPricingVariantForHarness: () => true,
+        canonicalModelsWithVariant: () => ["fake/model"],
+        canonicalModelsWithVariantForHarness: () => ["fake/model"],
+        hasCapabilityForHarness: () => true,
+        canonicalModelsWithCapabilityForHarness: () => ["fake/model"],
+      },
+      runnerCredentialProvider: {
+        isEnabled: () => true,
+        mint: (lane, binding) => ({
+          token: `fake-${lane}-${binding}`,
+          ttlSeconds: 42,
+        }),
+        verify: (lane, token) => `${lane}:${token}`,
+      },
+      artifactStorageDrivers: new Map([
+        [
+          "fake-blob",
+          (): ArtifactStorage => {
+            blobDriverConstructed += 1;
+            const blobs = new Map<string, Uint8Array>();
+            return {
+              upload: (key, data) => {
+                blobs.set(key, data);
+                return Promise.resolve();
+              },
+              download: (key) =>
+                Promise.resolve(blobs.get(key) ?? new Uint8Array()),
+              size: (key) => Promise.resolve(blobs.get(key)?.length ?? 0),
+              presignPut: () =>
+                Promise.reject(new Error("not exercised here")),
+              getSignedUrl: () => Promise.resolve("https://blob.invalid"),
+              delete: () => Promise.resolve(),
+              exists: (key) => Promise.resolve(blobs.has(key)),
+              health: () => Promise.resolve(),
+            };
+          },
+        ],
+      ]),
+    },
+  };
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "driver-substitution-test-"));
+    server = await composeServer({
+      config: loadConfig({
+        STIGMER_MODEL_REGISTRY_REFRESH: "off",
+        DB_PATH: path.join(dir, "stigmer.db"),
+        STORAGE_PATH: path.join(dir, "storage"),
+        // The registered driver serves the GENERIC artifact store; the
+        // skill store stays on its default local arm (Q2b: per-domain).
+        ARTIFACT_STORAGE_TYPE: "fake-blob",
+        ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      }),
+      logger: createLogger({ level: "error", pretty: false, write: () => {} }),
+      extensions: [driverExtension],
+      portOverride: 0,
+      host: "127.0.0.1",
+    });
+    port = await server.start();
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("the registry lane serves the substituted catalog's document verbatim", async () => {
+    const response = await fetch(
+      `http://127.0.0.1:${port}/v1/proxy/model-registry`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe(FAKE_DOCUMENT);
+  });
+
+  it("the platform exchange mints through the substituted credential provider", async () => {
+    const client = createClient(PlatformQueryController, server.inProcessTransport);
+    const out = await client.getRunnerScopedToken({
+      scope: { case: "agentExecutionId", value: "aex_substituted" },
+    });
+    expect(out.runnerScopedToken).toBe("fake-execution_scoped-aex_substituted");
+    expect(out.expiresInSeconds).toBe(42);
+  });
+
+  it("the artifact factory constructed the registered blob driver exactly once", () => {
+    expect(blobDriverConstructed).toBe(1);
   });
 });

--- a/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
@@ -2,8 +2,10 @@
  * Pins the extension registry's merge semantics and the DD-006 §2b
  * loud-fail contract (sub-project 20260826.09/O1): explicit empty
  * defaults, unit-order concatenation for list points, single-declaration
- * enforcement for authorizer and edition, unique unit names, and the
- * unknown-gate-slot boot throw. The composed-server behavior (services on
+ * enforcement for authorizer and edition, unique unit names, the
+ * unknown-gate-slot boot throw, and the O5 driver points (single-instance
+ * providers, name-keyed storage-driver registration with duplicate and
+ * built-in-shadow throws). The composed-server behavior (services on
  * both routers, edition on the wire) is pinned by
  * extension-composition.test.ts; empty-set wire byte-identity is pinned by
  * the conformance rosters.
@@ -13,7 +15,10 @@ import { describe, expect, it } from "vitest";
 import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
 import type { DescMessage } from "@bufbuild/protobuf";
 
+import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
+import type { ModelCatalogProvider } from "../../domain/workflow/registry/model-catalog-provider.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
 import type { WorkerFactory } from "../../temporal/manager.js";
 import type { Authorizer } from "../authorizer.js";
 import type { GateSlotName } from "../gate-slots.js";
@@ -37,6 +42,41 @@ function verifier(name: string): IdentityVerifier {
 const workerFactory: WorkerFactory = () =>
   Promise.reject(new Error("unit-test worker factory — never started"));
 
+// Driver fakes: identity is all the merge tests assert; no method runs.
+function fakeCatalog(): ModelCatalogProvider {
+  return {
+    document: () => "{}",
+    isValidModel: () => false,
+    hasHarness: () => false,
+    hasAnyModels: () => false,
+    isValidModelOnAnyHarness: () => false,
+    canonicalModelsAcrossHarnesses: () => [],
+    canonicalModels: () => [],
+    hasPricingVariant: () => false,
+    hasPricingVariantForHarness: () => false,
+    canonicalModelsWithVariant: () => [],
+    canonicalModelsWithVariantForHarness: () => [],
+    hasCapabilityForHarness: () => false,
+    canonicalModelsWithCapabilityForHarness: () => [],
+  };
+}
+
+function fakeCredentials(): RunnerCredentialProvider {
+  return {
+    isEnabled: () => false,
+    mint: () => {
+      throw new Error("unit-test credential provider — never minted");
+    },
+    verify: () => {
+      throw new Error("unit-test credential provider — never verified");
+    },
+  };
+}
+
+const fakeStorageDriver = (): ArtifactStorage => {
+  throw new Error("unit-test storage driver factory — never constructed");
+};
+
 describe("resolveExtensions — defaults", () => {
   it("resolves the omitted set to explicit empty defaults, edition oss", () => {
     const resolved = resolveExtensions();
@@ -47,6 +87,9 @@ describe("resolveExtensions — defaults", () => {
     expect(resolved.gateSteps.size).toBe(0);
     expect(resolved.statusObservers).toEqual([]);
     expect(resolved.responseDecorators).toEqual([]);
+    expect(resolved.drivers.modelCatalogProvider).toBeUndefined();
+    expect(resolved.drivers.runnerCredentialProvider).toBeUndefined();
+    expect(resolved.drivers.artifactStorageDrivers.size).toBe(0);
     expect(resolved.services).toEqual([]);
     expect(resolved.workers).toEqual([]);
   });
@@ -91,6 +134,36 @@ describe("resolveExtensions — merge semantics", () => {
     expect(resolved.workers).toEqual([workerFactory]);
     expect(resolved.statusObservers).toEqual([observerA]);
     expect(resolved.responseDecorators).toEqual([decoratorB]);
+  });
+
+  it("merges the O5 driver points: singleton providers, name-keyed storage drivers across units", () => {
+    const catalog = fakeCatalog();
+    const credentials = fakeCredentials();
+    const resolved = resolveExtensions([
+      {
+        name: "catalog-unit",
+        drivers: {
+          modelCatalogProvider: catalog,
+          artifactStorageDrivers: new Map([["r2-skill", fakeStorageDriver]]),
+        },
+      },
+      {
+        name: "credential-unit",
+        drivers: {
+          runnerCredentialProvider: credentials,
+          artifactStorageDrivers: new Map([["r2-artifacts", fakeStorageDriver]]),
+        },
+      },
+    ]);
+    expect(resolved.drivers.modelCatalogProvider).toBe(catalog);
+    expect(resolved.drivers.runnerCredentialProvider).toBe(credentials);
+    expect([...resolved.drivers.artifactStorageDrivers.keys()].sort()).toEqual([
+      "r2-artifacts",
+      "r2-skill",
+    ]);
+    expect(resolved.drivers.artifactStorageDrivers.get("r2-skill")).toBe(
+      fakeStorageDriver,
+    );
   });
 });
 
@@ -157,5 +230,67 @@ describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
     expect(() => resolveExtensions([unit])).toThrowError(
       /extension 'early-gate' registered gate steps into unknown slot 'agent-execution-create:pre-side-effect-gate'.*none in this build/,
     );
+  });
+
+  it("throws on a second ModelCatalogProvider, naming both units", () => {
+    expect(() =>
+      resolveExtensions([
+        { name: "first-catalog", drivers: { modelCatalogProvider: fakeCatalog() } },
+        { name: "second-catalog", drivers: { modelCatalogProvider: fakeCatalog() } },
+      ]),
+    ).toThrowError(
+      /extension 'second-catalog' registers a ModelCatalogProvider, but 'first-catalog' already did/,
+    );
+  });
+
+  it("throws on a second RunnerCredentialProvider, naming both units", () => {
+    expect(() =>
+      resolveExtensions([
+        {
+          name: "first-cred",
+          drivers: { runnerCredentialProvider: fakeCredentials() },
+        },
+        {
+          name: "second-cred",
+          drivers: { runnerCredentialProvider: fakeCredentials() },
+        },
+      ]),
+    ).toThrowError(
+      /extension 'second-cred' registers a RunnerCredentialProvider, but 'first-cred' already did/,
+    );
+  });
+
+  it("throws on a duplicate storage-driver name across units, naming both", () => {
+    expect(() =>
+      resolveExtensions([
+        {
+          name: "first-blob",
+          drivers: { artifactStorageDrivers: new Map([["gcs", fakeStorageDriver]]) },
+        },
+        {
+          name: "second-blob",
+          drivers: { artifactStorageDrivers: new Map([["gcs", fakeStorageDriver]]) },
+        },
+      ]),
+    ).toThrowError(
+      /extension 'second-blob' registers artifact-storage driver 'gcs', but 'first-blob' already did/,
+    );
+  });
+
+  it("throws on a storage-driver name shadowing a built-in backend", () => {
+    for (const name of ["local", "r2"]) {
+      expect(() =>
+        resolveExtensions([
+          {
+            name: "shadowing",
+            drivers: { artifactStorageDrivers: new Map([[name, fakeStorageDriver]]) },
+          },
+        ]),
+      ).toThrowError(
+        new RegExp(
+          `extension 'shadowing' registers artifact-storage driver '${name}', which shadows a built-in backend`,
+        ),
+      );
+    }
   });
 });

--- a/backend/services/stigmer-server/src/extensions/drivers.ts
+++ b/backend/services/stigmer-server/src/extensions/drivers.ts
@@ -1,19 +1,50 @@
 /**
  * The drivers extension point — infrastructure substitution seams of the
  * convergence blueprint (20260826.02 blueprint/03 §6, DD-006 §2a). The
- * point exists from O1 (20260826.09) so the registry carries all seven
- * ratified point types; the registrable KINDS join with their extraction
- * entries, each adding a field here as an owner-visible surface change:
+ * point exists from O1 (20260826.09); the registrable KINDS join with
+ * their extraction entries, each adding a field here as an owner-visible
+ * surface change:
  *
  *   - model-catalog provider (§6a) and artifact-storage driver
- *     registration + runner-credential provider (§6b/§6c) — O5
+ *     registration + runner-credential provider (§6b/§6c) — landed, O5
+ *     (20260827.02)
  *   - sandbox provisioners (§6d) — O6
  *
- * Empty deliberately, not provisionally: those interfaces are extractions
- * from verified read surfaces, and guessing their shapes here would hand
- * O5/O6 churn instead of a seam (the ruled ratified-types scope decision,
- * this sub-project's T01 record).
+ * Merge rules (enforced by resolveExtensions, DD-006 §2b): the two
+ * provider kinds are single-instance points — a second declaring unit is
+ * a boot throw naming both units (the authorizer rule); artifact-storage
+ * drivers merge as a name-keyed map — a duplicated name, or a name
+ * shadowing a built-in backend, is a boot throw (the gateSteps rule: a
+ * registration the factory could never reach must fail loudly, not sit
+ * dark). OSS defaults install at the boot/compose.ts consumption sites,
+ * never here (the default-lives-with-the-consumer doctrine).
  */
+import type { ArtifactStorageDriverFactory } from "../artifactstorage/artifact-storage.js";
+import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
+import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
 
-/** The driver contributions of one extension unit. No kinds exist yet. */
-export interface ExtensionDrivers {}
+/** The driver contributions of one extension unit. */
+export interface ExtensionDrivers {
+  /**
+   * The model-catalog data source (DD-008; single-instance point). When
+   * composed, it replaces the OSS ModelRegistryStore everywhere — the
+   * OSS store and its upstream refresh are then never constructed.
+   */
+  readonly modelCatalogProvider?: ModelCatalogProvider;
+  /**
+   * The runner-credential mint/verify seam (§6c; single-instance point).
+   * When composed, it replaces the OSS execution-scoped HS256 default at
+   * every consumer (platform exchange, mcpserver connect, the
+   * executioncontext decrypt lane).
+   */
+  readonly runnerCredentialProvider?: RunnerCredentialProvider;
+  /**
+   * Blob-storage backends registrable by name (§6b), selectable through
+   * the ARTIFACT_STORAGE_TYPE / SKILL_ARTIFACT_STORAGE_TYPE config knobs.
+   * Factories, not instances — an unselected driver constructs nothing.
+   */
+  readonly artifactStorageDrivers?: ReadonlyMap<
+    string,
+    ArtifactStorageDriverFactory
+  >;
+}

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -23,14 +23,21 @@
  *
  * Consumption map (each point's consumer entry): services + workers +
  * edition are consumed here in O1; identity verifiers + authorizer land
- * with O2; gate steps + status hooks with O4; driver kinds with O5/O6.
+ * with O2; gate steps + status hooks with O4; the O5 driver kinds
+ * (catalog provider, artifact-storage registration, runner-credential
+ * provider) are consumed at their compose.ts construction sites; sandbox
+ * provisioners land with O6.
  */
 import type { DescMessage } from "@bufbuild/protobuf";
 import type { ConnectRouter } from "@connectrpc/connect";
 
 import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
 
+import type { ArtifactStorageDriverFactory } from "../artifactstorage/artifact-storage.js";
+import { BUILT_IN_STORAGE_TYPES } from "../artifactstorage/artifact-storage.js";
+import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
 import type { PipelineStep } from "../pipeline/pipeline.js";
+import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
 import type { WorkerFactory } from "../temporal/manager.js";
 import type { Authorizer } from "./authorizer.js";
 import type { ExtensionDrivers } from "./drivers.js";
@@ -85,7 +92,7 @@ export interface ServerExtension {
   >;
   /** Agent-execution status observers/decorators (consumed by O4). */
   readonly statusTransitionHooks?: AgentExecutionStatusHooks;
-  /** Driver substitutions (no kinds registrable yet — see drivers.ts). */
+  /** Driver substitutions (the O5 kinds — see drivers.ts). */
   readonly drivers?: ExtensionDrivers;
   /** Service registrations, appended to the routes closure after the OSS set. */
   readonly services?: ReadonlyArray<ExtensionServiceRegistration>;
@@ -118,9 +125,25 @@ export interface ResolvedExtensions {
   >;
   readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
   readonly responseDecorators: ReadonlyArray<AgentExecutionResponseDecorator>;
-  readonly drivers: ExtensionDrivers;
+  readonly drivers: ResolvedExtensionDrivers;
   readonly services: ReadonlyArray<ExtensionServiceRegistration>;
   readonly workers: ReadonlyArray<WorkerFactory>;
+}
+
+/**
+ * The merged driver points. The two providers follow the authorizer
+ * shape — undefined when no unit declares one, and the compose.ts
+ * consumption site installs the OSS default (the default lives with the
+ * consumer that defines its semantics, not with this data holder).
+ */
+export interface ResolvedExtensionDrivers {
+  readonly modelCatalogProvider: ModelCatalogProvider | undefined;
+  readonly runnerCredentialProvider: RunnerCredentialProvider | undefined;
+  /** Registered name → factory, validated against the built-in names. */
+  readonly artifactStorageDrivers: ReadonlyMap<
+    string,
+    ArtifactStorageDriverFactory
+  >;
 }
 
 /**
@@ -144,6 +167,15 @@ export function resolveExtensions(
   let editionDeclaredBy: string | undefined;
   let authorizer: Authorizer | undefined;
   let authorizerDeclaredBy: string | undefined;
+  let modelCatalogProvider: ModelCatalogProvider | undefined;
+  let catalogDeclaredBy: string | undefined;
+  let runnerCredentialProvider: RunnerCredentialProvider | undefined;
+  let credentialDeclaredBy: string | undefined;
+  const artifactStorageDrivers = new Map<
+    string,
+    ArtifactStorageDriverFactory
+  >();
+  const storageDriverDeclaredBy = new Map<string, string>();
 
   for (const unit of units) {
     if (unit.name === "") {
@@ -183,6 +215,44 @@ export function resolveExtensions(
       authorizerDeclaredBy = unit.name;
     }
 
+    if (unit.drivers?.modelCatalogProvider !== undefined) {
+      if (catalogDeclaredBy !== undefined) {
+        throw new Error(
+          `extension '${unit.name}' registers a ModelCatalogProvider, but '${catalogDeclaredBy}' already did — exactly one may be composed`,
+        );
+      }
+      modelCatalogProvider = unit.drivers.modelCatalogProvider;
+      catalogDeclaredBy = unit.name;
+    }
+
+    if (unit.drivers?.runnerCredentialProvider !== undefined) {
+      if (credentialDeclaredBy !== undefined) {
+        throw new Error(
+          `extension '${unit.name}' registers a RunnerCredentialProvider, but '${credentialDeclaredBy}' already did — exactly one may be composed`,
+        );
+      }
+      runnerCredentialProvider = unit.drivers.runnerCredentialProvider;
+      credentialDeclaredBy = unit.name;
+    }
+
+    if (unit.drivers?.artifactStorageDrivers !== undefined) {
+      for (const [name, factory] of unit.drivers.artifactStorageDrivers) {
+        if ((BUILT_IN_STORAGE_TYPES as ReadonlyArray<string>).includes(name)) {
+          throw new Error(
+            `extension '${unit.name}' registers artifact-storage driver '${name}', which shadows a built-in backend — built-in names are reserved`,
+          );
+        }
+        const declaredBy = storageDriverDeclaredBy.get(name);
+        if (declaredBy !== undefined) {
+          throw new Error(
+            `extension '${unit.name}' registers artifact-storage driver '${name}', but '${declaredBy}' already did — driver names must be unique across the composed set`,
+          );
+        }
+        artifactStorageDrivers.set(name, factory);
+        storageDriverDeclaredBy.set(name, unit.name);
+      }
+    }
+
     if (unit.gateSteps !== undefined) {
       for (const [slot, steps] of unit.gateSteps) {
         if (!DECLARED_GATE_SLOTS.has(slot)) {
@@ -218,7 +288,11 @@ export function resolveExtensions(
     gateSteps,
     statusObservers,
     responseDecorators,
-    drivers: {},
+    drivers: {
+      modelCatalogProvider,
+      runnerCredentialProvider,
+      artifactStorageDrivers,
+    },
     services,
     workers,
   };

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -18,8 +18,9 @@
  *   - the pipeline primitives extensions build gates from (PipelineStep,
  *     RequestContext, the semantic error helpers, and the typed store
  *     not-found errors the ratified store-fault mapping keys on)
- *   - the driver interfaces (Store, ArtifactStorage; §6's new interfaces
- *     join with their extraction entries O5/O6)
+ *   - the driver interfaces (Store, ArtifactStorage; O5 added §6a/§6b/§6c —
+ *     ModelCatalogProvider, the widened storage surface, and
+ *     RunnerCredentialProvider; §6d's sandbox provisioner joins with O6)
  *   - the worker factory types extension workers implement (§8)
  *
  * The package stays private and unpublished: this is the library contract
@@ -58,6 +59,7 @@ export type {
   AgentExecutionStatusTransition,
 } from "./extensions/status-hooks.js";
 export type { ExtensionDrivers } from "./extensions/drivers.js";
+export type { ResolvedExtensionDrivers } from "./extensions/registry.js";
 
 // The pipeline primitives extensions build gate steps from.
 export type { PipelineStep } from "./pipeline/pipeline.js";
@@ -77,7 +79,26 @@ export {
 // infrastructure fault — the guidelines' instanceof idiom).
 export type { Store } from "./store/interface.js";
 export { AuditNotFoundError, ResourceNotFoundError } from "./store/interface.js";
-export type { ArtifactStorage } from "./artifactstorage/artifact-storage.js";
+export type {
+  ArtifactStorage,
+  ArtifactStorageDriverFactory,
+  PresignedUpload,
+  StagedUploadLane,
+} from "./artifactstorage/artifact-storage.js";
+export { ArtifactStorageNotFoundError } from "./artifactstorage/artifact-storage.js";
+
+// The O5 driver seams (§6a/§6c): the model-catalog read surface with the
+// DD-008 disciplines in its contract, and the per-lane runner-credential
+// seam with its OSS lane constant (an extension's verify callers name the
+// lane they accept).
+export type { ModelCatalogProvider } from "./domain/workflow/registry/model-catalog-provider.js";
+export type { RunnerCredentialProvider } from "./runnerauth/runner-credential-provider.js";
+export type { MintedToken } from "./runnerauth/runnerauth.js";
+export {
+  InvalidTokenError,
+  MintingDisabledError,
+  TOKEN_TYPE_EXECUTION_SCOPED,
+} from "./runnerauth/runnerauth.js";
 
 // The worker factory types extension workers implement (§8).
 export type { WorkerFactory, WorkerFactoryDeps } from "./temporal/manager.js";

--- a/backend/services/stigmer-server/src/runnerauth/__tests__/runner-credential-provider.test.ts
+++ b/backend/services/stigmer-server/src/runnerauth/__tests__/runner-credential-provider.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Pins the OSS RunnerCredentialProvider default (O5, §6c) as behaviorally
+ * identical to direct RunnerAuthService use on the execution_scoped lane,
+ * and pins the per-arm posture for lanes OSS does not provide: verify
+ * fails CLOSED (InvalidTokenError — callers fall back to redaction), mint
+ * fails LOUD (a plain Error naming the lane — a composition bug, not a
+ * runtime condition), isEnabled answers the honest false.
+ */
+import { randomBytes } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { newExecutionScopedRunnerCredentialProvider } from "../runner-credential-provider.js";
+import {
+  DEFAULT_TTL_SECONDS,
+  InvalidTokenError,
+  MintingDisabledError,
+  RunnerAuthService,
+  TOKEN_TYPE_EXECUTION_SCOPED,
+} from "../runnerauth.js";
+
+const KEY = randomBytes(32);
+
+describe("execution-scoped provider over a keyed service", () => {
+  const service = RunnerAuthService.create(KEY);
+  const provider = newExecutionScopedRunnerCredentialProvider(service);
+
+  it("mints on the execution_scoped lane exactly as the service does", () => {
+    const minted = provider.mint(TOKEN_TYPE_EXECUTION_SCOPED, "aex_prov", 0);
+    expect(minted.ttlSeconds).toBe(DEFAULT_TTL_SECONDS);
+    // Cross-verification both ways: one key, one token dialect.
+    expect(service.verify(minted.token)).toBe("aex_prov");
+    expect(provider.verify(TOKEN_TYPE_EXECUTION_SCOPED, minted.token)).toBe(
+      "aex_prov",
+    );
+  });
+
+  it("isEnabled answers per lane: true for execution_scoped, false for anything else", () => {
+    expect(provider.isEnabled(TOKEN_TYPE_EXECUTION_SCOPED)).toBe(true);
+    expect(provider.isEnabled("session_scoped")).toBe(false);
+    expect(provider.isEnabled("")).toBe(false);
+  });
+
+  it("mint on an unprovided lane fails loud, naming the lane", () => {
+    expect(() => provider.mint("pool_claim", "aex_x", 0)).toThrowError(
+      /runner credential lane 'pool_claim' is not provided by this implementation \(provides 'execution_scoped'\)/,
+    );
+  });
+
+  it("verify on an unprovided lane fails closed to InvalidTokenError", () => {
+    const minted = provider.mint(TOKEN_TYPE_EXECUTION_SCOPED, "aex_prov", 0);
+    // Even a GENUINE token fails when the caller accepts a different
+    // lane — the caller's trust statement governs.
+    expect(() => provider.verify("session_scoped", minted.token)).toThrow(
+      InvalidTokenError,
+    );
+  });
+
+  it("verify failures on the provided lane collapse to the one InvalidTokenError", () => {
+    expect(() =>
+      provider.verify(TOKEN_TYPE_EXECUTION_SCOPED, "not-a-token"),
+    ).toThrow(InvalidTokenError);
+  });
+});
+
+describe("execution-scoped provider over a keyless service", () => {
+  const provider = newExecutionScopedRunnerCredentialProvider(
+    RunnerAuthService.create(undefined),
+  );
+
+  it("isEnabled is false even for the provided lane", () => {
+    expect(provider.isEnabled(TOKEN_TYPE_EXECUTION_SCOPED)).toBe(false);
+  });
+
+  it("mint throws MintingDisabledError — the not-minted response arm", () => {
+    expect(() =>
+      provider.mint(TOKEN_TYPE_EXECUTION_SCOPED, "aex_keyless", 0),
+    ).toThrow(MintingDisabledError);
+  });
+
+  it("verify rejects everything — without a key no token can be genuine", () => {
+    expect(() =>
+      provider.verify(TOKEN_TYPE_EXECUTION_SCOPED, "any-token"),
+    ).toThrow(InvalidTokenError);
+  });
+});

--- a/backend/services/stigmer-server/src/runnerauth/runner-credential-provider.ts
+++ b/backend/services/stigmer-server/src/runnerauth/runner-credential-provider.ts
@@ -1,0 +1,99 @@
+/**
+ * The runner-credential provider seam — convergence program 20260826.02,
+ * blueprint/03 §6c, extracted with O5 (20260827.02). Lives in
+ * src/runnerauth beside the OSS implementation it fronts.
+ *
+ * Mint and verify PER CREDENTIAL LANE, where a lane is an implementation's
+ * own token_type vocabulary: OSS defines exactly one
+ * (TOKEN_TYPE_EXECUTION_SCOPED, runnerauth.ts); the cloud edition's
+ * session/workflow/connect/pool lanes stay entirely on its side of the
+ * seam (C4). The lane parameter is an open string DELIBERATELY — this
+ * contract must neither import cloud vocabulary into OSS nor pretend OSS
+ * has lanes it does not (the Q4 gate ruling).
+ *
+ * Per-arm fail posture, pinned precisely because the approved docs
+ * abbreviate it two different ways ("fail-closed" / "fail-soft") and the
+ * real contract is BOTH, per arm:
+ *
+ *   - verify fails CLOSED: any failure — forged, expired, wrong lane, a
+ *     lane the implementation does not provide — throws InvalidTokenError,
+ *     and the caller's only correct reaction is to fall back to redaction
+ *     (the executioncontext decrypt lane's posture, oss#535).
+ *   - mint on a PROVIDED lane without a signing key throws
+ *     MintingDisabledError, which the platform exchange RPC maps to the
+ *     presence-based "not minted" response the runner handles — degraded,
+ *     not fatal. Minting on a lane the implementation does NOT provide is
+ *     a composition bug, not a runtime condition: it throws a plain Error
+ *     naming the lane (the loud-fail doctrine).
+ *
+ * The OSS default (newExecutionScopedRunnerCredentialProvider) adapts
+ * RunnerAuthService unchanged — same key ladder, same HS256 tokens, same
+ * boot-fatal key posture owned by the composition root. Extensions
+ * substitute an implementation through the drivers registry point
+ * (extensions/drivers.ts); with none composed, behavior is byte-identical
+ * to the direct-service wiring this seam replaced.
+ */
+import type { MintedToken } from "./runnerauth.js";
+import {
+  InvalidTokenError,
+  RunnerAuthService,
+  TOKEN_TYPE_EXECUTION_SCOPED,
+} from "./runnerauth.js";
+
+/**
+ * Mints and verifies runner credentials per lane. Implementations must be
+ * stateless-safe for concurrent use (they gate every ExecutionContext
+ * decrypt and every execution dispatch).
+ */
+export interface RunnerCredentialProvider {
+  /**
+   * Whether the implementation can currently mint for the lane — false
+   * for lanes it does not provide AND for provided lanes with no signing
+   * key. Callers that degrade on "cannot mint" (mcpserver connect) probe
+   * this instead of catching MintingDisabledError.
+   */
+  isEnabled(lane: string): boolean;
+  /**
+   * A credential on the given lane bound to `binding` (what the binding
+   * identifies is lane vocabulary — OSS's execution_scoped lane binds an
+   * execution id). ttlSeconds <= 0 selects the implementation default.
+   */
+  mint(lane: string, binding: string, ttlSeconds: number): MintedToken;
+  /**
+   * Verifies a credential against the ONE lane the caller accepts — the
+   * caller states its trust decision, the provider enforces it — and
+   * returns the binding. ANY failure throws InvalidTokenError.
+   */
+  verify(lane: string, token: string): string;
+}
+
+/**
+ * The OSS default: RunnerAuthService behind the provider contract,
+ * providing only the execution_scoped lane. A separate adapter rather
+ * than the service implementing the interface: the service's concrete
+ * lane-free signatures are a stable test surface (and the O2 sub-project
+ * edits runnerauth.ts in parallel — this file keeps O5 out of it).
+ */
+export function newExecutionScopedRunnerCredentialProvider(
+  service: RunnerAuthService,
+): RunnerCredentialProvider {
+  return {
+    isEnabled(lane: string): boolean {
+      return lane === TOKEN_TYPE_EXECUTION_SCOPED && service.isEnabled();
+    },
+    mint(lane: string, binding: string, ttlSeconds: number): MintedToken {
+      if (lane !== TOKEN_TYPE_EXECUTION_SCOPED) {
+        throw new Error(
+          `runner credential lane '${lane}' is not provided by this implementation (provides '${TOKEN_TYPE_EXECUTION_SCOPED}')`,
+        );
+      }
+      return service.mint(binding, ttlSeconds);
+    },
+    verify(lane: string, token: string): string {
+      if (lane !== TOKEN_TYPE_EXECUTION_SCOPED) {
+        throw new InvalidTokenError();
+      }
+      return service.verify(token);
+    },
+  };
+}

--- a/backend/services/stigmer-server/src/transport/registry/lanes.ts
+++ b/backend/services/stigmer-server/src/transport/registry/lanes.ts
@@ -19,7 +19,7 @@
  *   other   → 405 (with the allow-all header — the CORS wrap is
  *             unconditional in Go).
  */
-import type { ModelRegistryStore } from "../../domain/workflow/registry/model-registry-store.js";
+import type { ModelCatalogProvider } from "../../domain/workflow/registry/model-catalog-provider.js";
 import { applyRegistryCorsHeaders, handleRegistryPreflight } from "../cors.js";
 import type { LaneHandler } from "../lanes.js";
 
@@ -34,8 +34,8 @@ export interface RegistryLanes {
 export interface RegistryLanesOptions {
   /** The task-kind registry document (static per release). */
   taskKindRegistryDocument: string;
-  /** The domain-owned model-registry store the lane serves from. */
-  modelRegistryStore: ModelRegistryStore;
+  /** The composed model-catalog provider the lane serves from (DD-008). */
+  modelRegistryStore: ModelCatalogProvider;
 }
 
 export function createRegistryLanes(

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -11,12 +11,12 @@
  *
  * It exercises every extension point a consumer can touch today: the
  * seven-point unit shape (services, workers, edition, authorizer,
- * verifiers, status hooks; gate slots are compile-closed until O4 declares
- * the ratified names), a gate-step body built from the pipeline
- * primitives, the store-fault idiom, and the compose entry itself. It is
- * never executed — the runtime behavior is pinned by the server's own
- * extension suite; execution here would need real infrastructure for no
- * additional proof.
+ * verifiers, status hooks, the O5 driver kinds; gate slots are
+ * compile-closed until O4 declares the ratified names), a gate-step body
+ * built from the pipeline primitives, the store-fault idiom, and the
+ * compose entry itself. It is never executed — the runtime behavior is
+ * pinned by the server's own extension suite; execution here would need
+ * real infrastructure for no additional proof.
  */
 import { create } from "@bufbuild/protobuf";
 import type { DescMessage } from "@bufbuild/protobuf";
@@ -27,21 +27,30 @@ import { BillingQueryController } from "@stigmer/protos/ai/stigmer/billing/v1/qu
 import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
 
 import {
+  ArtifactStorageNotFoundError,
   composeServer,
   createLogger,
+  InvalidTokenError,
   loadConfig,
+  MintingDisabledError,
   notFoundError,
   ResourceNotFoundError,
+  TOKEN_TYPE_EXECUTION_SCOPED,
 } from "@stigmer/server";
 import type {
   AgentExecutionResponseDecorator,
   AgentExecutionStatusObserver,
   ArtifactStorage,
+  ArtifactStorageDriverFactory,
   Authorizer,
   CallerIdentity,
   ComposedServer,
   IdentityVerifier,
+  MintedToken,
+  ModelCatalogProvider,
   PipelineStep,
+  PresignedUpload,
+  RunnerCredentialProvider,
   ServerExtension,
   Store,
   WorkerFactory,
@@ -114,6 +123,67 @@ const responseDecorator: AgentExecutionResponseDecorator = (
 const workerFactory: WorkerFactory = () =>
   Promise.reject(new Error("compile-proof worker — never started"));
 
+/**
+ * A consumer-shaped model-catalog provider (the O5 §6a shape — the cloud's
+ * DB-resident baseline implements exactly this surface, read per call).
+ */
+const catalogProvider: ModelCatalogProvider = {
+  document: () => `{"models":[]}`,
+  isValidModel: () => false,
+  hasHarness: () => false,
+  hasAnyModels: () => false,
+  isValidModelOnAnyHarness: () => false,
+  canonicalModelsAcrossHarnesses: () => [],
+  canonicalModels: () => [],
+  hasPricingVariant: () => false,
+  hasPricingVariantForHarness: () => false,
+  canonicalModelsWithVariant: () => [],
+  canonicalModelsWithVariantForHarness: () => [],
+  hasCapabilityForHarness: () => false,
+  canonicalModelsWithCapabilityForHarness: () => [],
+};
+
+/**
+ * A consumer-shaped runner-credential provider (the O5 §6c shape). The
+ * per-arm fail posture is contract: verify failures collapse to
+ * InvalidTokenError (callers fall closed to redaction); a provided lane
+ * that cannot mint throws MintingDisabledError (mapped to the
+ * presence-based not-minted response).
+ */
+const credentialProvider: RunnerCredentialProvider = {
+  isEnabled: (lane) => lane === TOKEN_TYPE_EXECUTION_SCOPED,
+  mint: (lane, _binding, ttlSeconds): MintedToken => {
+    if (lane !== TOKEN_TYPE_EXECUTION_SCOPED) {
+      throw new MintingDisabledError();
+    }
+    return { token: "fake-token", ttlSeconds };
+  },
+  verify: (): string => {
+    throw new InvalidTokenError();
+  },
+};
+
+/**
+ * A consumer-registered blob driver (the O5 §6b registration shape) —
+ * lazy factory, typed not-found, the widened size/presignPut surface.
+ */
+const consumerBlobDriver: ArtifactStorageDriverFactory =
+  (): ArtifactStorage => ({
+    upload: () => Promise.resolve(),
+    download: (key) => Promise.reject(new ArtifactStorageNotFoundError(key)),
+    size: (key) => Promise.reject(new ArtifactStorageNotFoundError(key)),
+    presignPut: (declaredSizeBytes, ttlMs): Promise<PresignedUpload> =>
+      Promise.resolve({
+        url: `https://blob.invalid/put?size=${declaredSizeBytes}`,
+        stagingKey: "staging/fake",
+        ttlMs,
+      }),
+    getSignedUrl: () => Promise.resolve("https://blob.invalid/get"),
+    delete: () => Promise.resolve(),
+    exists: () => Promise.resolve(false),
+    health: () => Promise.resolve(),
+  });
+
 const registerBillingService = (router: ConnectRouter): void => {
   router.service(BillingQueryController, {
     getBillingAccount: (input) =>
@@ -131,6 +201,11 @@ export const fakeExtension: ServerExtension = {
     observers: [statusObserver],
     responseDecorators: [responseDecorator],
   },
+  drivers: {
+    modelCatalogProvider: catalogProvider,
+    runnerCredentialProvider: credentialProvider,
+    artifactStorageDrivers: new Map([["consumer-blob", consumerBlobDriver]]),
+  },
   services: [registerBillingService],
   workers: [workerFactory],
 };
@@ -146,9 +221,12 @@ export async function composeFakeCloud(): Promise<ComposedServer> {
 
 /**
  * The exported driver interfaces are consumable in extension signatures —
- * the shape O5's registrations will take.
+ * the O5 registrations above populate them; this bundle keeps the plain
+ * type positions covered too.
  */
 export interface ConsumerDriverBundle {
   readonly store: Store;
   readonly artifactStorage: ArtifactStorage;
+  readonly modelCatalog: ModelCatalogProvider;
+  readonly runnerCredentials: RunnerCredentialProvider;
 }


### PR DESCRIPTION
## Summary

Entry O5 of the cloud-TS-convergence program (20260826.02, blueprint 03 §6a/§6b/§6c): the three OSS driver seams are extracted, with byte-identical behavior when no extensions are composed. All four conformance rosters green unchanged — empty-set byte-identity is the regression instrument.

## Context

The convergence program replaces the cloud Java service with extension packages composed over this server. O1 (#906) shipped the extension registry with a deliberately hollow `ExtensionDrivers`; this PR fills its three ratified kinds so the cloud can substitute its catalog, blob storage, and runner-credential machinery without editing an OSS switch. All five gate questions were ruled at the sub-project's T01 gate (20260827.02 `tasks/T01_1_review.md`), plus two mid-planning rulings (driver `size()` and a typed not-found).

## Changes

- **Registry mechanics**: `ExtensionDrivers` gains `modelCatalogProvider` and `runnerCredentialProvider` (single-instance points, the authorizer merge rule) and `artifactStorageDrivers` (name-keyed factory map; duplicate names and built-in `local`/`r2` shadowing are boot throws). `resolveExtensions` merges them; defaults install at the compose consumption sites.
- **§6a — ModelCatalogProvider** (DD-008): extracted from `ModelRegistryStore`'s verified read surface with both disciplines written into the contract (reads per call — the Java `ModelValidationHelper` `@PostConstruct` trap is the named counterexample; validation stays OSS and edition-neutral). All consumers move to the interface; a substituted composition never constructs the OSS store or its hourly refresh.
- **§6b — ArtifactStorage widening**: one `presignPut` method (local: rides the existing skill-transfer-lane URL-as-credential slot mechanism, no new lane, wire shape untouched; R2: presigned PUT under the pinned `staging/` prefix, 7-day clamp, signed Content-Length), `size(key)`, a typed `ArtifactStorageNotFoundError` (message copy unchanged), and the factory opened to registered drivers.
- **§6b — skill reconciliation**: `SkillArtifactStorage` survives as a domain port over a per-domain driver instance rooted at `storagePath`. Byte-pinned `skills/<hash>.zip` keys, the `ArtifactNotFoundError` copy, the write-once no-delete posture, and the traversal-collapse anti-probing behavior are preserved exactly. New `SKILL_ARTIFACT_STORAGE_TYPE` knob (default: today's local arm) is the explicit per-domain opt-in.
- **§6c — RunnerCredentialProvider**: per-lane mint/verify with an open lane discriminant (OSS defines only `execution_scoped`). The OSS default adapts `RunnerAuthService` — which stays byte-untouched — in a new file; the three consumers (platform exchange, mcpserver connect, executioncontext decrypt lane) move to the provider. Per-arm fail posture pinned in the contract header: verify fails closed to redaction; mint-disabled maps to the presence-based not-minted response.
- **Exports map** (DD-005): the new interfaces join `src/index.ts`; the `test/extension-consumer` compile proof now registers all three driver kinds.

## Implementation notes

- The local `presignPut` result's `stagingKey` reads back through the same driver instance because the lane stages inside the skill driver's root — zero new machinery; `UploadSlots` gains only a public `stagedFileName` accessor so the compose mapping cannot drift from `stagePath`.
- The skill port pre-validates key containment lexically in domain code (the domain owns keys), preserving the collapse of traversal keys and missing files into one indistinguishable not-found.
- The R2 `download` not-found arm now throws the typed class; every production caller wraps download faults in a sanitized `Internal`, so the only observable change is a server-side log line on the R2 arm.

## Breaking changes

- None. Empty-set behavior is byte-identical; the four rosters pin it.

## Test plan

- `tsc --noEmit` clean; full unit suite: 1802 passed.
- Driver tests: local presigned-PUT round trip over a real `UploadSlots`, `size`, typed not-found on both backends, the not-configured throw, lazy registered-driver selection.
- Skill store tests re-pointed at the reconciled port with assertions unchanged (the byte-identity proof); registry loud-fail arms for all three new points; composed substitution test proves the registry lane serves a substituted catalog's document, the platform exchange mints through a substituted credential provider, and the factory constructs a registered blob driver exactly once.
- Conformance rosters, all green: `local` (492), `local-execution` (160), `local-postgres` (492), `local-postgres-execution` (160).

## Risks

- O2 (20260827.01) touches `boot/compose.ts` in parallel; whichever PR merges second absorbs a small, mechanical conflict (the ruled Q5 posture).

## Checklist

- [x] Tests added/updated
- [x] Backward compatible (empty-set byte-identity, roster-proven)

Made with [Cursor](https://cursor.com)