### PR TITLE
feat(backend/stigmer-server): thread caller identity and add the Authorize step to every chain (O2)

### DIFF
--- a/backend/services/stigmer-server/docs/authorization-coverage.md
+++ b/backend/services/stigmer-server/docs/authorization-coverage.md
@@ -1,0 +1,446 @@
+# Authorization Coverage Inventory
+
+This document is the ratified coverage inventory for the stigmer-server authorization surface (sub-project 20260827.01, identity-context-and-authorizer, ruling Q2). It classifies EVERY entry point the server exposes — every RPC method of every registered service, plus the non-RPC HTTP lanes — by its authorization posture: whether the shared `Authorize` pipeline step (`src/pipeline/steps/authorize.ts`) runs for it, what proto method annotation it carries, and what a direct handler does instead. It is a permanent acceptance artifact: the follow-up cloud sub-projects (C1/C2) inherit this map instead of discovering gaps against FGA. It MUST be updated whenever a method is added or removed, a handler changes between pipeline and direct form, or a `(ai.stigmer.commons.rpc.config)` / `is_public` / `is_skip_authorization` annotation changes.
+
+How to read the tables:
+
+- **Annotation** is what the method's proto declares: a `config` summary (`permission` on `resource_kind`, the `field_path` or literal `resource_id` the target is resolved from, and whether `error_msg` is set), `is_public` (50057), `is_skip_authorization` (50058), or `none` (no option at all — the apply RPCs and the gRPC health service).
+- **Handler** is what the server actually runs: `chain-with-Authorize` means the handler builds a `newPipeline(...)` whose FIRST `.addStep` is `newAuthorizeStep(<its own method descriptor>, authorizer)`; `direct: <posture>` means no pipeline is built and the Authorize step never runs for that method.
+- The two columns are independent facts. A method can carry a `config` annotation and still be a direct handler — for such methods the annotation is declared but not evaluated by the Authorize step today. Every such method is called out in the "annotated but direct" list before the notes section.
+- Authorize step semantics (verified in `src/pipeline/steps/authorize.ts`): the step returns immediately for the `internal` caller class, then for `is_public`, then for `is_skip_authorization`, then for methods with no `config` option; only a present `config` reaches the composed Authorizer. So even on chain methods, a skip/public annotation means the Authorizer is never consulted — the step's presence still gives C1/C2 the uniform interception point.
+
+Verification notes: every registration map in `src/boot/compose.ts`'s routes closure was cross-checked against its controller file and its proto service definition; every `newAuthorizeStep` call site was checked for descriptor/RPC agreement (all ten lifecycle RPCs pass their own descriptor through the shared `runLifecyclePipeline` builder; memory `confirm`/`reject` pass their own descriptors through the shared `runTransition` helper); a mechanical scan confirmed `newAuthorizeStep` is the first `.addStep` of every `newPipeline` in the server (zero exceptions).
+
+## Totals
+
+- Registered services: 27 (26 Stigmer services + the standard gRPC health service).
+- Registered RPC methods: 227.
+- Handler classes: 173 `chain-with-Authorize`, 54 `direct`.
+- Annotation classes: 136 `config`, 71 `is_skip_authorization`, 2 `is_public`, 18 `none` (15 apply RPCs + 3 health methods).
+- Config-annotated methods served by direct handlers (annotation declared, Authorize step not running): 30 — enumerated before the notes section.
+
+## 1. Health (`grpc.health.v1.Health`, `src/transport/health.ts`)
+
+The standard gRPC health protocol — an external proto with no Stigmer annotations.
+
+| Method | Annotation | Handler |
+|---|---|---|
+| check | none (external proto) | direct: pure in-memory health-state read |
+| list | none (external proto) | direct: pure in-memory health-state read |
+| watch | none (external proto) | direct: server-stream over in-memory health-state notifications |
+
+## 2. Organization (`src/domain/organization/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| OrganizationCommandController.apply | none | chain-with-Authorize |
+| OrganizationCommandController.create | is_skip_authorization | chain-with-Authorize |
+| OrganizationCommandController.update | config: can_edit on organization (field metadata.id), error_msg yes | chain-with-Authorize |
+| OrganizationCommandController.delete | config: can_delete on organization (field value), error_msg yes | chain-with-Authorize |
+| OrganizationQueryController.get | config: can_view on organization (field value), error_msg yes | chain-with-Authorize |
+| OrganizationQueryController.find | is_skip_authorization | chain-with-Authorize |
+| OrganizationQueryController.findMyOrganizations | is_skip_authorization | direct: full store list — single-team OSS posture, ALL organizations are "mine" (cloud filters by IAM policy instead) |
+
+Proto method NOT registered by this server: `OrganizationQueryController.getByExternalOrgId` (is_skip_authorization) — see the unregistered-methods list.
+
+## 3. Environment (`src/domain/environment/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| EnvironmentCommandController.apply | none | chain-with-Authorize |
+| EnvironmentCommandController.create | config: can_create_environment on organization (field metadata.org), error_msg yes | chain-with-Authorize |
+| EnvironmentCommandController.update | config: can_edit on environment (field metadata.id), error_msg yes | chain-with-Authorize |
+| EnvironmentCommandController.updateVisibility | config: can_edit on environment (field resource_id), error_msg yes | chain-with-Authorize |
+| EnvironmentCommandController.delete | config: can_edit on environment (field resource_id), error_msg yes | chain-with-Authorize |
+| EnvironmentCommandController.updateVariables | config: can_edit on environment (field environment_id), error_msg yes | chain-with-Authorize |
+| EnvironmentCommandController.removeVariables | config: can_edit on environment (field environment_id), error_msg yes | chain-with-Authorize |
+| EnvironmentQueryController.get | config: can_view on environment (field value), error_msg yes | chain-with-Authorize |
+| EnvironmentQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+| EnvironmentQueryController.getSecretValue | config: can_read_secrets on environment (field environment_id), error_msg yes | chain-with-Authorize |
+| EnvironmentQueryController.list | is_skip_authorization | chain-with-Authorize |
+
+## 4. OAuthApp (`src/domain/oauthapp/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| OAuthAppCommandController.apply | none | chain-with-Authorize |
+| OAuthAppCommandController.create | config: can_create_oauth_app on organization (field metadata.org), error_msg yes | chain-with-Authorize |
+| OAuthAppCommandController.update | config: can_edit on oauth_app (field metadata.id), error_msg yes | chain-with-Authorize |
+| OAuthAppCommandController.delete | config: can_delete on oauth_app (field resource_id), error_msg yes | chain-with-Authorize |
+| OAuthAppQueryController.get | config: can_view on oauth_app (field value), error_msg yes | chain-with-Authorize |
+| OAuthAppQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+| OAuthAppQueryController.listByOrg | config: can_view on organization (field org), error_msg yes | chain-with-Authorize |
+
+## 5. ExecutionContext (`src/domain/executioncontext/controller.ts`)
+
+All six RPCs are chains, and the proto deliberately marks every one `is_skip_authorization` with a real handler-level check instead (the proto's own header documents this): the read RPCs redact secret values by default, and getByExecutionId's domain step verifies an execution-scoped runner token — a matching scope-bound token gets decrypted values, everyone else gets the same response shape redacted, as a SUCCESS ("redaction-as-success": no error discloses the lane).
+
+| Method | Annotation | Handler |
+|---|---|---|
+| ExecutionContextCommandController.apply | none | chain-with-Authorize |
+| ExecutionContextCommandController.create | is_skip_authorization | chain-with-Authorize |
+| ExecutionContextCommandController.delete | is_skip_authorization | chain-with-Authorize |
+| ExecutionContextQueryController.get | is_skip_authorization | chain-with-Authorize (response redacted) |
+| ExecutionContextQueryController.getByReference | is_skip_authorization | chain-with-Authorize (response redacted) |
+| ExecutionContextQueryController.getByExecutionId | is_skip_authorization | chain-with-Authorize (runner-token verified in domain; redaction-as-success) |
+
+## 6. Agent (`src/domain/agent/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| AgentCommandController.apply | none | chain-with-Authorize |
+| AgentCommandController.create | config: can_create_agent on organization (field metadata.org), error_msg yes | chain-with-Authorize |
+| AgentCommandController.update | config: can_edit on agent (field metadata.id), error_msg yes | chain-with-Authorize |
+| AgentCommandController.updateVisibility | config: can_edit on agent (field resource_id), error_msg yes | chain-with-Authorize |
+| AgentCommandController.delete | config: can_delete on agent (field value), error_msg yes | chain-with-Authorize |
+| AgentQueryController.get | config: can_view on agent (field value), error_msg yes | chain-with-Authorize |
+| AgentQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+| AgentQueryController.getDefault | is_skip_authorization | chain-with-Authorize |
+
+## 7. AgentInstance (`src/domain/agentinstance/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| AgentInstanceCommandController.apply | none | chain-with-Authorize |
+| AgentInstanceCommandController.create | is_skip_authorization | chain-with-Authorize |
+| AgentInstanceCommandController.update | config: can_edit on agent_instance (field metadata.id), error_msg yes | chain-with-Authorize |
+| AgentInstanceCommandController.updateVisibility | config: can_edit on agent_instance (field resource_id), error_msg yes | chain-with-Authorize |
+| AgentInstanceCommandController.delete | config: can_delete on agent_instance (field value), error_msg yes | chain-with-Authorize |
+| AgentInstanceQueryController.get | config: can_view on agent_instance (field value), error_msg yes | chain-with-Authorize |
+| AgentInstanceQueryController.getByAgent | is_skip_authorization | chain-with-Authorize |
+| AgentInstanceQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+| AgentInstanceQueryController.list | is_skip_authorization | chain-with-Authorize |
+
+## 8. Session (`src/domain/session/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| SessionCommandController.apply | none | chain-with-Authorize |
+| SessionCommandController.create | config: can_create_session on organization (field metadata.org), error_msg yes | chain-with-Authorize |
+| SessionCommandController.update | config: can_edit on session (field metadata.id), error_msg yes | chain-with-Authorize |
+| SessionCommandController.updateSubject | config: can_edit on session (field id), error_msg yes | direct: field-level read-modify-write on the server (no pipeline by design — ports Go update_subject.go); annotated but Authorize does not run |
+| SessionCommandController.delete | config: can_delete on session (field value), error_msg yes | chain-with-Authorize |
+| SessionQueryController.get | config: can_view on session (field value), error_msg yes | chain-with-Authorize |
+| SessionQueryController.list | is_skip_authorization | chain-with-Authorize |
+| SessionQueryController.listByAgentInstance | is_skip_authorization | chain-with-Authorize |
+| SessionQueryController.listByChannel | is_skip_authorization | chain-with-Authorize |
+
+## 9. AgentShare (`src/domain/agentshare/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| AgentShareCommandController.apply | none | chain-with-Authorize |
+| AgentShareCommandController.create | is_skip_authorization | chain-with-Authorize |
+| AgentShareCommandController.update | config: can_edit on agent_share (field metadata.id), error_msg yes | chain-with-Authorize |
+| AgentShareCommandController.rotateShareLink | config: can_edit on agent_share (field resource_id), error_msg yes | chain-with-Authorize |
+| AgentShareCommandController.delete | config: can_delete on agent_share (field value), error_msg yes | chain-with-Authorize |
+| AgentShareQueryController.get | config: can_view on agent_share (field value), error_msg yes | chain-with-Authorize |
+| AgentShareQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+| AgentShareQueryController.getByAgent | is_skip_authorization | chain-with-Authorize |
+| AgentShareQueryController.list | is_skip_authorization | chain-with-Authorize |
+| AgentShareQueryController.getSharedProfile | is_public | chain-with-Authorize (the public share-link read; the step's is_public arm skips the Authorizer) |
+| AgentShareQueryController.getSharedProfileForMember | is_skip_authorization | chain-with-Authorize |
+
+## 10. AgentChannel (`src/domain/agentchannel/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| AgentChannelCommandController.apply | none | chain-with-Authorize |
+| AgentChannelCommandController.create | is_skip_authorization | chain-with-Authorize |
+| AgentChannelCommandController.update | config: can_edit on agent_channel (field metadata.id), error_msg yes | chain-with-Authorize |
+| AgentChannelCommandController.initiateInstall | config: can_edit on agent_channel (field resource_id), error_msg yes | direct: OSS stub — loads the channel (NOT_FOUND contract matches cloud), then refuses FAILED_PRECONDITION (install unavailable on this edition) |
+| AgentChannelCommandController.completeInstall | config: can_edit on agent_channel (field resource_id), error_msg yes | direct: OSS stub — same load-then-refuse FAILED_PRECONDITION |
+| AgentChannelCommandController.delete | config: can_delete on agent_channel (field value), error_msg yes | chain-with-Authorize |
+| AgentChannelQueryController.get | config: can_view on agent_channel (field value), error_msg yes | chain-with-Authorize |
+| AgentChannelQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+| AgentChannelQueryController.getByAgent | is_skip_authorization | chain-with-Authorize |
+| AgentChannelQueryController.list | is_skip_authorization | chain-with-Authorize |
+
+## 11. ChannelMessage (`src/domain/agentchannel/message.ts`)
+
+The proactive-messaging surface is a cloud capability; OSS serves edition stubs, all direct.
+
+| Method | Annotation | Handler |
+|---|---|---|
+| ChannelMessageCommandController.sendMessage | is_skip_authorization | direct: OSS stub — refuses FAILED_PRECONDITION (proactive messaging unavailable) |
+| ChannelMessageQueryController.listTemplates | is_skip_authorization | direct: OSS stub — refuses FAILED_PRECONDITION |
+| ChannelMessageQueryController.listMessagingChannels | is_skip_authorization | direct: returns an empty list |
+
+## 12. ChannelConversation (`src/domain/agentchannel/conversation.ts`)
+
+The conversation surface is a cloud capability; OSS serves edition stubs, all direct.
+
+| Method | Annotation | Handler |
+|---|---|---|
+| ChannelConversationQueryController.listConversations | is_skip_authorization | direct: returns an empty list |
+| ChannelConversationQueryController.getConversation | config: can_view on agent_channel (field agent_channel_id), error_msg yes | direct: OSS stub — answers NOT_FOUND unconditionally (no load-then-miss probing) |
+| ChannelConversationQueryController.getTimeline | config: can_view on agent_channel (field agent_channel_id), error_msg yes | direct: returns an empty timeline |
+| ChannelConversationQueryController.getMediaDownloadUrl | config: can_view on agent_channel (field agent_channel_id), error_msg yes | direct: OSS stub — byte-pinned uniform NOT_FOUND miss (a prober cannot learn which items exist) |
+| ChannelConversationCommandController.reply | config: can_participate on agent_channel (field agent_channel_id), error_msg yes | direct: OSS stub — refuses FAILED_PRECONDITION (participation unavailable) |
+| ChannelConversationCommandController.takeOver | config: can_participate on agent_channel (field agent_channel_id), error_msg yes | direct: OSS stub — refuses FAILED_PRECONDITION |
+| ChannelConversationCommandController.handBack | config: can_participate on agent_channel (field agent_channel_id), error_msg yes | direct: OSS stub — refuses FAILED_PRECONDITION |
+| ChannelConversationCommandController.clearAttention | config: can_participate on agent_channel (field agent_channel_id), error_msg yes | direct: OSS stub — refuses FAILED_PRECONDITION |
+| ChannelConversationCommandController.escalate | is_skip_authorization | direct: OSS stub — refuses FAILED_PRECONDITION |
+
+## 13. ChannelApp (`src/domain/channelapp/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| ChannelAppCommandController.apply | none | chain-with-Authorize |
+| ChannelAppCommandController.create | config: can_create_channel_app on organization (field metadata.org), error_msg yes | chain-with-Authorize |
+| ChannelAppCommandController.update | config: can_edit on channel_app (field metadata.id), error_msg yes | chain-with-Authorize |
+| ChannelAppCommandController.delete | config: can_delete on channel_app (field resource_id), error_msg yes | chain-with-Authorize |
+| ChannelAppQueryController.get | config: can_view on channel_app (field value), error_msg yes | chain-with-Authorize |
+| ChannelAppQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+| ChannelAppQueryController.listByOrg | config: can_view on organization (field org), error_msg yes | chain-with-Authorize |
+
+## 14. Schedule (`src/domain/schedule/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| ScheduleCommandController.apply | none | chain-with-Authorize |
+| ScheduleCommandController.create | is_skip_authorization | chain-with-Authorize |
+| ScheduleCommandController.update | config: can_edit on schedule (field metadata.id), error_msg yes | chain-with-Authorize |
+| ScheduleCommandController.delete | config: can_delete on schedule (field value), error_msg yes | chain-with-Authorize |
+| ScheduleCommandController.resume | config: can_edit on schedule (field value), error_msg yes | chain-with-Authorize |
+| ScheduleCommandController.trigger | config: can_edit on schedule (field value), error_msg yes | chain-with-Authorize |
+| ScheduleQueryController.get | config: can_view on schedule (field value), error_msg yes | chain-with-Authorize |
+| ScheduleQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+| ScheduleQueryController.getByAgent | is_skip_authorization | chain-with-Authorize |
+| ScheduleQueryController.list | is_skip_authorization | chain-with-Authorize |
+| ScheduleQueryController.listRuns | config: can_view on schedule (field schedule_id), error_msg yes | chain-with-Authorize |
+
+## 15. Memory (`src/domain/memory/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| MemoryCommandController.create | is_skip_authorization | chain-with-Authorize |
+| MemoryCommandController.update | config: can_edit on memory (field metadata.id), error_msg yes | chain-with-Authorize |
+| MemoryCommandController.delete | config: can_delete on memory (field value), error_msg yes | chain-with-Authorize |
+| MemoryCommandController.confirm | config: can_edit on memory (field value), error_msg yes | chain-with-Authorize (shared runTransition helper, own descriptor) |
+| MemoryCommandController.reject | config: can_edit on memory (field value), error_msg yes | chain-with-Authorize (shared runTransition helper, own descriptor) |
+| MemoryQueryController.get | config: can_view on memory (field value), error_msg yes | chain-with-Authorize |
+| MemoryQueryController.list | is_skip_authorization | chain-with-Authorize |
+
+## 16. AgentExecution (`src/domain/agentexecution/controller.ts` + lifecycle.ts, update-status.ts, submit-approval.ts, submit-file-decision.ts, usage.ts, artifacts.ts, subscribe.ts)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| AgentExecutionCommandController.create | is_skip_authorization | chain-with-Authorize |
+| AgentExecutionCommandController.update | config: can_edit on agent_execution (field metadata.id), error_msg yes | chain-with-Authorize |
+| AgentExecutionCommandController.updateStatus | config: can_edit on agent_execution (field execution_id), error_msg yes | chain-with-Authorize (update-status.ts) |
+| AgentExecutionCommandController.submitApproval | config: can_edit on agent_execution (field agent_execution_id), error_msg yes | chain-with-Authorize (submit-approval.ts) |
+| AgentExecutionCommandController.submitFileDecision | config: can_edit on agent_execution (field agent_execution_id), error_msg yes | chain-with-Authorize (submit-file-decision.ts) |
+| AgentExecutionCommandController.cancel | config: can_edit on agent_execution (field id), error_msg yes | chain-with-Authorize (lifecycle.ts, own descriptor) |
+| AgentExecutionCommandController.terminate | config: can_edit on agent_execution (field id), error_msg yes | chain-with-Authorize (lifecycle.ts, own descriptor) |
+| AgentExecutionCommandController.recover | config: can_edit on agent_execution (field id), error_msg yes | chain-with-Authorize (lifecycle.ts, own descriptor) |
+| AgentExecutionCommandController.pause | config: can_edit on agent_execution (field id), error_msg yes | chain-with-Authorize (lifecycle.ts, own descriptor) |
+| AgentExecutionCommandController.resume | config: can_edit on agent_execution (field id), error_msg yes | chain-with-Authorize (lifecycle.ts, own descriptor) |
+| AgentExecutionCommandController.uploadAttachment | is_skip_authorization | direct: blob-store write; the returned storage_key acts as the capability token for the later create |
+| AgentExecutionCommandController.delete | config: can_edit on agent_execution (field value), error_msg yes | chain-with-Authorize |
+| AgentExecutionQueryController.get | config: can_view on agent_execution (field value), error_msg yes | chain-with-Authorize |
+| AgentExecutionQueryController.list | is_skip_authorization | chain-with-Authorize |
+| AgentExecutionQueryController.listBySession | is_skip_authorization | chain-with-Authorize |
+| AgentExecutionQueryController.subscribe | config: can_view on agent_execution (field value), error_msg yes | direct: stream subscribe over broker (register-before-snapshot; server-stream generator cannot run inside the pipeline executor) |
+| AgentExecutionQueryController.getArtifactDownloadUrl | config: can_view on agent_execution (field execution_id), error_msg yes | direct: key-prefix / attachment-membership ownership check, then time-limited URL mint |
+| AgentExecutionQueryController.getArtifactContent | config: can_view on agent_execution (field execution_id), error_msg yes | direct: key-prefix ownership check, CAS-blob integrity check, truncated bytes in response |
+| AgentExecutionQueryController.getExecutionUsageReport | config: can_view on agent_execution (field execution_id), error_msg yes | chain-with-Authorize (usage.ts) |
+| AgentExecutionQueryController.getSessionUsageReport | config: can_view on session (field session_id), error_msg yes | chain-with-Authorize (usage.ts) |
+| AgentExecutionQueryController.getAgentUsageReport | config: can_view on organization (field org_id), error_msg yes | chain-with-Authorize (usage.ts) |
+| AgentExecutionQueryController.getOrgUsageReport | config: can_view on organization (field org_id), error_msg yes | chain-with-Authorize (usage.ts) |
+| AgentExecutionQueryController.getExecutionSummary | is_skip_authorization | direct: full-scan store aggregate for the dashboard (a direct handler in Go as well) |
+
+## 17. Workflow (`src/domain/workflow/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| WorkflowCommandController.apply | none | chain-with-Authorize |
+| WorkflowCommandController.create | config: can_create_workflow on organization (field metadata.org), error_msg yes | chain-with-Authorize |
+| WorkflowCommandController.update | config: can_edit on workflow (field metadata.id), error_msg yes | chain-with-Authorize |
+| WorkflowCommandController.updateVisibility | config: can_edit on workflow (field resource_id), error_msg yes | chain-with-Authorize |
+| WorkflowCommandController.delete | config: can_delete on workflow (field value), error_msg yes | chain-with-Authorize |
+| WorkflowCommandController.validateSpec | config: can_create_workflow on organization (field metadata.org), error_msg yes | direct: validation-only, nothing persisted (Layer-2 validator over the domain-owned registry store) |
+| WorkflowCommandController.tagVersion | config: can_edit on workflow (field workflow_id), error_msg yes | chain-with-Authorize |
+| WorkflowQueryController.get | config: can_view on workflow (field value), error_msg yes | chain-with-Authorize |
+| WorkflowQueryController.getByReference | is_skip_authorization | direct: branching slug/org read (Go's own direct-handler note) |
+| WorkflowQueryController.listVersions | is_skip_authorization | chain-with-Authorize |
+| WorkflowQueryController.getVersion | config: can_view on workflow (field workflow_id), error_msg yes | direct: live-then-audit version read |
+
+## 18. WorkflowInstance (`src/domain/workflowinstance/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| WorkflowInstanceCommandController.apply | none | chain-with-Authorize |
+| WorkflowInstanceCommandController.create | is_skip_authorization | chain-with-Authorize |
+| WorkflowInstanceCommandController.update | config: can_edit on workflow_instance (field metadata.id), error_msg yes | chain-with-Authorize |
+| WorkflowInstanceCommandController.updateVisibility | config: can_edit on workflow_instance (field resource_id), error_msg yes | chain-with-Authorize |
+| WorkflowInstanceCommandController.updateExecutionVisibility | config: can_grant_access on workflow_instance (field resource_id), error_msg yes | chain-with-Authorize |
+| WorkflowInstanceCommandController.delete | config: can_delete on workflow_instance (field value), error_msg yes | chain-with-Authorize |
+| WorkflowInstanceQueryController.get | config: can_view on workflow_instance (field value), error_msg yes | chain-with-Authorize |
+| WorkflowInstanceQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+| WorkflowInstanceQueryController.getByWorkflow | is_skip_authorization | chain-with-Authorize |
+
+## 19. WorkflowExecution (`src/domain/workflowexecution/controller.ts` + lifecycle.ts, update-status.ts, submit-approval.ts, submit-file-decision.ts, submit-workflow-task-approval.ts, send-signal.ts, queries.ts, subscribe.ts, subscribe-events.ts, get-event-log.ts, get-execution-summary.ts, list-pending-approvals.ts)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| WorkflowExecutionCommandController.create | is_skip_authorization | chain-with-Authorize |
+| WorkflowExecutionCommandController.update | config: can_edit on workflow_execution (field metadata.id), error_msg yes | chain-with-Authorize |
+| WorkflowExecutionCommandController.updateStatus | config: can_edit on workflow_execution (field execution_id), error_msg yes | chain-with-Authorize (update-status.ts) |
+| WorkflowExecutionCommandController.submitApproval | config: can_edit on workflow_execution (field execution_id), error_msg yes | chain-with-Authorize (submit-approval.ts) |
+| WorkflowExecutionCommandController.submitFileDecision | config: can_edit on workflow_execution (field execution_id), error_msg yes | chain-with-Authorize (submit-file-decision.ts) |
+| WorkflowExecutionCommandController.submitWorkflowTaskApproval | config: can_edit on workflow_execution (field execution_id), error_msg yes | chain-with-Authorize (submit-workflow-task-approval.ts) |
+| WorkflowExecutionCommandController.delete | config: can_edit on workflow_execution (field value), error_msg yes | chain-with-Authorize |
+| WorkflowExecutionCommandController.sendSignal | config: can_edit on workflow_execution (field execution_id), error_msg yes | chain-with-Authorize (send-signal.ts) |
+| WorkflowExecutionCommandController.cancel | config: can_edit on workflow_execution (field id), error_msg yes | chain-with-Authorize (lifecycle.ts, own descriptor) |
+| WorkflowExecutionCommandController.terminate | config: can_edit on workflow_execution (field id), error_msg yes | chain-with-Authorize (lifecycle.ts, own descriptor) |
+| WorkflowExecutionCommandController.recover | config: can_edit on workflow_execution (field id), error_msg yes | chain-with-Authorize (lifecycle.ts, own descriptor) |
+| WorkflowExecutionCommandController.pause | config: can_edit on workflow_execution (field id), error_msg yes | chain-with-Authorize (lifecycle.ts, own descriptor) |
+| WorkflowExecutionCommandController.resume | config: can_edit on workflow_execution (field id), error_msg yes | chain-with-Authorize (lifecycle.ts, own descriptor) |
+| WorkflowExecutionQueryController.get | config: can_view on workflow_execution (field value), error_msg yes | chain-with-Authorize |
+| WorkflowExecutionQueryController.list | is_skip_authorization | direct: full-scan store read (malformed rows skipped) |
+| WorkflowExecutionQueryController.listByWorkflow | is_skip_authorization | direct: full-scan store read filtered by workflow |
+| WorkflowExecutionQueryController.subscribe | config: can_view on workflow_execution (field execution_id), error_msg yes | direct: stream subscribe over broker |
+| WorkflowExecutionQueryController.getEventLog | config: can_view on workflow_execution (field execution_id), error_msg yes | direct: cursor-paginated read over the event side table (no existence check by contract) |
+| WorkflowExecutionQueryController.subscribeEvents | config: can_view on workflow_execution (field execution_id), error_msg yes | direct: event-log replay + poll stream (existence-checked NotFound before streaming) |
+| WorkflowExecutionQueryController.getExecutionSummary | is_skip_authorization | direct: full-scan store aggregate for the dashboard |
+| WorkflowExecutionQueryController.listPendingApprovals | is_skip_authorization | direct: scan of IN_PROGRESS executions for waiting-approval tasks |
+
+## 20. McpServer (`src/domain/mcpserver/controller.ts` + connect.ts, start-connect.ts, initiate-oauth-connect.ts, complete-oauth-connect.ts, disconnect-oauth.ts, get-oauth-grant-status.ts)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| McpServerCommandController.apply | none | chain-with-Authorize |
+| McpServerCommandController.create | is_skip_authorization | chain-with-Authorize |
+| McpServerCommandController.update | config: can_edit on mcp_server (field metadata.id), error_msg yes | chain-with-Authorize |
+| McpServerCommandController.updateVisibility | config: can_edit on mcp_server (field resource_id), error_msg yes | chain-with-Authorize |
+| McpServerCommandController.delete | config: can_delete on mcp_server (field resource_id), error_msg yes | chain-with-Authorize |
+| McpServerCommandController.connect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: blocking connect flow over the engine seam (ephemeral ExecutionContext, decrypt-lane token mint, runner workflow start) |
+| McpServerCommandController.startConnect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: async connect lane over the engine seam |
+| McpServerCommandController.initiateOAuthConnect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: OAuth authorize-URL mint (refuses FAILED_PRECONDITION without a configured redirect URI) |
+| McpServerCommandController.completeOAuthConnect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: OAuth code exchange + grant persistence |
+| McpServerCommandController.disconnectOAuth | config: can_connect on mcp_server (field resource_id), error_msg yes | direct: grant teardown |
+| McpServerCommandController.setOrgOAuthApp | config: can_create_oauth_app on organization (field org), error_msg yes | direct: OSS stub — throws Unimplemented (org OAuth-app overrides are cloud-only) |
+| McpServerCommandController.deleteOrgOAuthApp | config: can_create_oauth_app on organization (field org), error_msg yes | direct: OSS stub — throws Unimplemented |
+| McpServerQueryController.get | config: can_view on mcp_server (field value), error_msg yes | chain-with-Authorize |
+| McpServerQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+| McpServerQueryController.getOAuthGrantStatus | config: can_view on mcp_server (field resource_id), error_msg yes | direct: grant-store read |
+| McpServerQueryController.getOrgOAuthApp | config: can_view on mcp_server (field resource_id), error_msg yes | direct: OSS stub — throws Unimplemented |
+
+## 21. Skill (`src/domain/skill/controller.ts` + push.ts)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| SkillCommandController.push | config: can_create_skill on organization (field org), error_msg yes | chain-with-Authorize |
+| SkillCommandController.createArtifactUploadUrl | config: can_create_skill on organization (field org), error_msg yes | chain-with-Authorize |
+| SkillCommandController.pushFromExecutionArtifact | config: can_create_skill on organization (field org), error_msg yes | chain-with-Authorize BY DELEGATION: the handler validates the storage-key ownership prefix directly, downloads the execution artifact, then calls the shared push pipeline WITH ITS OWN method descriptor (the runLifecyclePipeline pattern — the pipeline's authorizing descriptor is a caller-supplied parameter), so this method's own annotation is the one evaluated. |
+| SkillCommandController.updateVisibility | config: can_edit on skill (field resource_id), error_msg yes | chain-with-Authorize |
+| SkillCommandController.delete | config: can_delete on skill (field value), error_msg yes | chain-with-Authorize |
+| SkillQueryController.get | config: can_view on skill (field value), error_msg yes | chain-with-Authorize |
+| SkillQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+| SkillQueryController.getArtifact | is_skip_authorization | chain-with-Authorize |
+| SkillQueryController.getArtifactDownloadUrl | is_skip_authorization | chain-with-Authorize |
+| SkillQueryController.listVersions | is_skip_authorization | chain-with-Authorize |
+
+## 22. Artifact (`src/domain/artifact/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| ArtifactCommandController.create | is_skip_authorization | direct: content-addressed blob write + metadata row persist |
+| ArtifactCommandController.delete | config: can_edit on artifact (field value), error_msg yes | direct: soft delete — storage_state transition, never a row removal |
+| ArtifactQueryController.get | config: can_view on artifact (field value), error_msg yes | chain-with-Authorize |
+| ArtifactQueryController.listByExecution | is_skip_authorization | chain-with-Authorize |
+| ArtifactQueryController.getDownloadUrl | config: can_view on artifact (field value), error_msg yes | direct: time-limited URL mint against the blob store |
+| ArtifactQueryController.getContent | config: can_view on artifact (field artifact_id), error_msg yes | direct: truncated bytes in the response (512KB default cap) |
+
+## 23. Project (`src/domain/project/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| ProjectCommandController.apply | none | chain-with-Authorize |
+| ProjectCommandController.create | config: can_create_project on organization (field metadata.org), error_msg yes | chain-with-Authorize |
+| ProjectCommandController.update | config: can_edit on project (field metadata.id), error_msg yes | chain-with-Authorize |
+| ProjectCommandController.delete | config: can_delete on project (field value), error_msg yes | chain-with-Authorize |
+| ProjectQueryController.get | config: can_view on project (field value), error_msg yes | chain-with-Authorize |
+| ProjectQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
+
+## 24. Search (`src/query/search/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| SearchService.search | is_skip_authorization | direct: CQRS read over the search query store (cross-aggregate; carries no api_resource_kind option) |
+
+## 25. Activity (`src/query/activity/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| ActivityQueryController.listRecentActivity | is_skip_authorization | direct: CQRS recents read over listResources (the request's org merely narrows the result) |
+
+## 26. GitHub (`src/domain/github/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| GitHubService.getOAuthAuthorizeUrl | is_skip_authorization | direct: stateless OAuth broker — authorize-URL mint from config, nothing persisted |
+| GitHubService.exchangeOAuthCode | is_skip_authorization | direct: stateless OAuth broker — code-for-token exchange, token returned to the caller, never stored |
+
+## 27. Platform (`src/domain/platform/controller.ts`)
+
+| Method | Annotation | Handler |
+|---|---|---|
+| PlatformQueryController.getServerInfo | is_public | direct: static edition + version read |
+| PlatformQueryController.getRunnerBootstrapConfig | is_skip_authorization | direct: publishes the Temporal coordinates for embedded runners (token fields deliberately empty on OSS) |
+| PlatformQueryController.getRunnerScopedToken | is_skip_authorization | direct: mints the execution-scoped runner token for the ExecutionContext decrypt lane; fail-soft (empty id, keyless service, or mint error answer the not-minted shape). On OSS there is no caller credential to verify — the token is the lane discriminator, not a trust boundary (DD-004). |
+
+## Config-annotated methods served by direct handlers
+
+These 30 methods declare a `(ai.stigmer.commons.rpc.config)` annotation but run no pipeline, so the Authorize step never evaluates them on this server. C1/C2 must decide per method whether the cloud edition enforces the annotation in its own handler (several already do — the cloud conversation/install handlers are real) or whether the method needs to move onto a chain.
+
+- Session: updateSubject
+- AgentChannel: initiateInstall, completeInstall
+- ChannelConversation: getConversation, getTimeline, getMediaDownloadUrl, reply, takeOver, handBack, clearAttention
+- AgentExecution: subscribe, getArtifactDownloadUrl, getArtifactContent
+- Workflow: validateSpec, getVersion
+- WorkflowExecution: subscribe, getEventLog, subscribeEvents
+- McpServer: connect, startConnect, initiateOAuthConnect, completeOAuthConnect, disconnectOAuth, setOrgOAuthApp, deleteOrgOAuthApp, getOAuthGrantStatus, getOrgOAuthApp
+- Artifact: delete, getDownloadUrl, getContent
+
+## Descriptor mismatches found
+
+- `SkillCommandController.pushFromExecutionArtifact` delegates into the shared push pipeline. This WAS a descriptor mismatch (the delegated pipeline hardcoded `method.push`); the inventory pass caught it and the pipeline now takes the authorizing descriptor from its caller, so each of the two RPCs authorizes under its own annotation. Recorded here because the trap shape — shared pipeline, hardcoded descriptor — is the one thing a future delegating handler must not reintroduce.
+
+No other mismatch exists: every other `newAuthorizeStep` call site passes the descriptor of the RPC it serves, including all ten lifecycle RPCs (shared builder, per-method descriptor) and memory confirm/reject (shared transition helper, per-method descriptor).
+
+## Unregistered proto methods and services
+
+- `OrganizationQueryController.getByExternalOrgId` (is_skip_authorization) exists in the proto but is not in the server's registration map — the only partially-registered service.
+- `TaskKindRegistryQueryController.getTaskKindRegistry` is a proto service the server never registers as an RPC; the task-kind registry is served over the HTTP registry lane instead (below).
+- Entire proto service families exist under `apis/ai/stigmer/` that this server does not register at all — they are cloud-edition surfaces: Billing (command + query), CursorAccount (command + query), ProviderStanding (query), and the IAM family: ApiKey, IamPolicy, IdentityAccount, IdentityProvider, Invitation, PlatformClient (command + query each, plus PlatformClientTokenController with the two `is_public` mint RPCs). Their annotations (including the `resource_id = "stigmer"` platform-operator checks and the config-without-resource_kind IamPolicy arms) are already declared in the protos for C1/C2 to consume.
+
+## Non-RPC HTTP lanes
+
+### taskKindRegistryLane (`src/transport/registry/lanes.ts`)
+
+`GET /v1/proxy/task-kind-registry` on the unified port. Unauthenticated by design: serves the bundled, static-per-release task-kind registry JSON with the fixed registry CORS contract (allow-origin `*`, `Cache-Control: public, max-age=3600`; OPTIONS 204, other methods 405).
+
+### modelRegistryLane (`src/transport/registry/lanes.ts`)
+
+`GET /v1/proxy/model-registry` on the unified port. Same unauthenticated CORS/caching posture; serves from the domain-owned model-registry store (bundled document plus optional upstream refresh).
+
+### skillTransferLane (`src/domain/skill/transfer/handler.ts`)
+
+`PUT /v1/skill-artifacts/uploads/{ref}` and `GET /v1/skill-artifacts/{storage_key}` on the unified port. Deliberately URL-as-credential — the handler header documents this: neither route carries bearer auth, mirroring cloud's pre-signed R2 URLs. Minting an upload URL requires the same gRPC authorization as push (createArtifactUploadUrl's chain); download keys are unguessable content hashes handed out by authorized skill reads.
+
+### consoleLane (`src/transport/console/handler.ts`)
+
+Static web-console assets on the unified port, present only when a console export is bundled or configured. GET/HEAD only; never claims `/v1/*` or service-shaped RPC paths. Unauthenticated static-asset serving plus a synthesized `/config.json`.
+
+### Artifact HTTP file server (`src/domain/artifact/file-server.ts`)
+
+A SECOND listener, not a unified-port lane: `GET /<storage_key>` on `127.0.0.1:ARTIFACT_HTTP_PORT` (default grpcPort+1), started only when artifact storage is local. Serves the exact bytes local artifact storage wrote; the loopback bind is the posture (download URLs are minted for the local machine; 0.0.0.0 only inside the official container).
+
+## Notes for C1/C2
+
+- (a) The interceptor-level protovalidate interceptor runs at position 3 of the chain (`src/pipeline/chain.ts`, ratified D2 §2 order: identity source → logging → protovalidate → apiresource), before any handler or pipeline — a malformed request answers INVALID_ARGUMENT before the Authorize step ever runs. Pre-existing, ratified ordering.
+- (b) The in-process router transport (`src/boot/inprocess.ts`) runs the same chain except position 1, which stamps the `internal` caller class only that chain can mint (ruling Q4). The Authorize step returns immediately for `callerClass === "internal"`, so cross-domain in-process calls skip the authorization decision while still traversing validation, logging, and kind-tagging.
+- (c) The Temporal worker's status-merge activity (`src/temporal/agentexecution/activities.ts`) calls the domain `updateStatus` — the full pipeline, Authorize step included — with `trustedLocalIdentity()`; no wire request exists at that point, so the trusted-local identity is the caller.
+- (d) Methods with NO config annotation skip the authorizer by design (`authorize.ts`: no `config` option → the step returns before consulting the Authorizer), and every such method is visible in the tables above — the annotation column says `none`, `is_public`, or `is_skip_authorization`.

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -72,7 +72,10 @@ import { registerPlatformServices } from "../domain/platform/controller.js";
 import { registerProjectServices } from "../domain/project/controller.js";
 import { registerSessionServices } from "../domain/session/controller.js";
 import { registerSkillServices } from "../domain/skill/controller.js";
-import { DEFAULT_SLOT_TTL_MS, MAX_ZIP_SIZE } from "../domain/skill/constants.js";
+import {
+  DEFAULT_SLOT_TTL_MS,
+  MAX_ZIP_SIZE,
+} from "../domain/skill/constants.js";
 import { LocalFileStorage as SkillLocalFileStorage } from "../domain/skill/storage/artifact-storage.js";
 import { newSkillTransferLane } from "../domain/skill/transfer/handler.js";
 import { UploadSlots } from "../domain/skill/transfer/slots.js";
@@ -84,6 +87,8 @@ import { SearchHandler } from "../query/search/handler.js";
 import { SqliteSearchQueryStore } from "../query/search/query-store.js";
 import { newSearchableResourceRegistry } from "../query/search/registry.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
+import { createVerifierChainInterceptor } from "../pipeline/interceptors/auth.js";
+import { newPermissiveSingleTeamAuthorizer } from "../pipeline/steps/authorize.js";
 import { RunnerAuthService } from "../runnerauth/runnerauth.js";
 import { PostgresStore } from "../store/postgres/store.js";
 import { SqliteStore } from "../store/sqlite/store.js";
@@ -146,11 +151,13 @@ export interface ComposedServer {
   workflowExecutionStreamBroker: WorkflowExecutionStreamBroker;
   /**
    * The in-process router transport — the same routes and interceptor
-   * chain as the serving router (DD-002's bufconn shape). Exposed because
-   * it is the one lane that reaches EVERY registered service, extension
-   * services included (blueprint 20260826.02/03 §8): compositions build
-   * clients to their extension services over it, and the O1 extension
-   * suite proves both-router visibility through it.
+   * chain as the serving router EXCEPT the position-1 identity source
+   * (DD-002's bufconn shape; O2 ruling Q4: this lane stamps the internal
+   * caller class, the serving chain runs the verifier chassis). Exposed
+   * because it is the one lane that reaches EVERY registered service,
+   * extension services included (blueprint 20260826.02/03 §8):
+   * compositions build clients to their extension services over it, and
+   * the O1 extension suite proves both-router visibility through it.
    */
   inProcessTransport: Transport;
   /** Completes wiring, flips SERVING, binds the port; returns the bound port. */
@@ -190,6 +197,12 @@ export async function composeServer(
       units: extensions.unitNames.join(", "),
     });
   }
+  // The ONE composed Authorizer (DD-007 §3): an extension's registration
+  // or the OSS permissive single-team default. Resolved here, handed to
+  // every controller as an explicit dependency — the Authorize step at
+  // position 1 of every chain calls it (O2).
+  const authorizer =
+    extensions.authorizer ?? newPermissiveSingleTeamAuthorizer();
 
   // Stage: storage — the driver selection seam (DD-010): DATABASE_URL
   // present → Postgres (async connect + advisory-locked migrations), else
@@ -334,6 +347,7 @@ export async function composeServer(
         store,
         logger,
         broker: agentExecutionStreamBroker,
+        authorizer,
         temporalConfig,
       }),
       newWorkflowExecutionWorkerFactory({
@@ -365,13 +379,11 @@ export async function composeServer(
   });
   // The workflow-execution twin: the same provider-is-the-injection
   // mechanism, filling the seam #20 left disconnected.
-  const workflowExecutionEngineState = newWorkflowExecutionEngineStateProvider(
-    {
-      manager: temporalManager,
-      config: workflowExecutionTemporalConfig,
-      logger,
-    },
-  );
+  const workflowExecutionEngineState = newWorkflowExecutionEngineStateProvider({
+    manager: temporalManager,
+    config: workflowExecutionTemporalConfig,
+    logger,
+  });
   // The artifact blob store (Go server.go 349: shared by agentexecution
   // attachments, the artifact domain (#13), and skill push (#8)). The r2
   // arm landed with #13; the health probe runs in start(), matching Go's
@@ -500,7 +512,9 @@ export async function composeServer(
   // Handlers are stateless over the same store, so the two routers behave
   // as one server — Go's single-server bufconn shape. Chain traversal on
   // internal calls is the point (DD-002): an in-process apply/get is
-  // validated, logged, and kind-tagged exactly like an external one.
+  // validated, logged, and kind-tagged exactly like an external one — the
+  // one deliberate difference is position 1 (O2): internal calls carry the
+  // internal caller class, wire calls the verifier chassis's identity.
   //
   // requireInProcess breaks the routes↔clients definition cycle: the lazy
   // domain providers are only invoked at request time, after boot
@@ -515,30 +529,44 @@ export async function composeServer(
   }
   const routes = (router: ConnectRouter): void => {
     registerHealthService(router, healthState);
-    registerOrganizationServices(router, { store, logger });
-    registerEnvironmentServices(router, { store, logger, secretService });
+    registerOrganizationServices(router, { store, logger, authorizer });
+    registerEnvironmentServices(router, {
+      store,
+      logger,
+      authorizer,
+      secretService,
+    });
     // OAuthApp reuses the environment's SecretService instance — Go wires
     // ONE encryption service for both (server.go 302–307).
-    registerOAuthAppServices(router, { store, secretService, logger });
+    registerOAuthAppServices(router, {
+      store,
+      secretService,
+      logger,
+      authorizer,
+    });
     registerExecutionContextServices(router, {
       store,
       logger,
+      authorizer,
       secretService,
       runnerAuthService,
     });
     registerAgentServices(router, {
       store,
       logger,
+      authorizer,
       agentInstanceApplier: () => requireInProcess().agentInstanceApplier,
     });
     registerAgentInstanceServices(router, {
       store,
       logger,
+      authorizer,
       parentAgentLoader: () => requireInProcess().parentAgentLoader,
     });
     registerSessionServices(router, {
       store,
       logger,
+      authorizer,
       temporalConfig,
       agentInstanceCreator: () => requireInProcess().agentInstanceCreator,
     });
@@ -547,10 +575,11 @@ export async function composeServer(
     // channelmessage 399 → channelconversation 408 → channelapp 416).
     // ChannelApp shares the ONE SecretService instance with Environment —
     // one key, one enc:v1: format (Go wires the same pointer).
-    registerAgentShareServices(router, { store, logger });
+    registerAgentShareServices(router, { store, logger, authorizer });
     registerAgentChannelServices(router, {
       store,
       logger,
+      authorizer,
       // The SAME domain-owned registry instance the workflow validator
       // and the registry lanes read — the channel model-pin rule
       // (stigmer/stigmer#774) can never drift from the served pickers.
@@ -558,7 +587,12 @@ export async function composeServer(
     });
     registerChannelMessageServices(router);
     registerChannelConversationServices(router);
-    registerChannelAppServices(router, { store, logger, secretService });
+    registerChannelAppServices(router, {
+      store,
+      logger,
+      authorizer,
+      secretService,
+    });
     // Schedule registers between channelapp and memory (Go server.go
     // 417 → 426 → 436). The clock and runner ride constant providers —
     // production wiring always has both (Go SetClock/SetRunner beside the
@@ -567,14 +601,16 @@ export async function composeServer(
     registerScheduleServices(router, {
       store,
       logger,
+      authorizer,
       modelRegistry: modelRegistryStore,
       clock: () => scheduleSyncer,
       runner: () => scheduleRunStarter,
     });
-    registerMemoryServices(router, { store, logger });
+    registerMemoryServices(router, { store, logger, authorizer });
     registerAgentExecutionServices(router, {
       store,
       logger,
+      authorizer,
       broker: agentExecutionStreamBroker,
       engineState: executionEngineState,
       modelRegistry: modelRegistryStore,
@@ -590,8 +626,7 @@ export async function composeServer(
         agentInstanceLoader: () =>
           requireInProcess().executionAgentInstanceLoader,
         sessionLoader: () => requireInProcess().executionSessionLoader,
-        environmentReader: () =>
-          requireInProcess().executionEnvironmentReader,
+        environmentReader: () => requireInProcess().executionEnvironmentReader,
         environmentResolution,
         executionContextCreator: () =>
           requireInProcess().executionContextCreator,
@@ -601,17 +636,20 @@ export async function composeServer(
     registerWorkflowServices(router, {
       store,
       logger,
+      authorizer,
       validator: workflowValidator,
       workflowInstanceCreator: () => requireInProcess().workflowInstanceCreator,
     });
     registerWorkflowInstanceServices(router, {
       store,
       logger,
+      authorizer,
       parentWorkflowLoader: () => requireInProcess().parentWorkflowLoader,
     });
     registerWorkflowExecutionServices(router, {
       store,
       logger,
+      authorizer,
       engineState: workflowExecutionEngineState,
       broker: workflowExecutionStreamBroker,
       workflowInstanceCreator: () =>
@@ -638,6 +676,7 @@ export async function composeServer(
     registerMcpServerServices(router, {
       store,
       logger,
+      authorizer,
       connect: {
         store,
         logger,
@@ -667,6 +706,7 @@ export async function composeServer(
     registerSkillServices(router, {
       store,
       logger,
+      authorizer,
       artifactStorage: skillArtifactStorage,
       // The agentexecution blob store (server.go:362-363) — read side of
       // pushFromExecutionArtifact.
@@ -678,7 +718,12 @@ export async function composeServer(
     });
     // Artifact CRUD shares the ONE blob store with agentexecution's
     // attachment lanes (Go server.go 347–374).
-    registerArtifactServices(router, { store, artifactStorage, logger });
+    registerArtifactServices(router, {
+      store,
+      artifactStorage,
+      logger,
+      authorizer,
+    });
     // Project registers after all four reconciled kinds (agent, workflow,
     // mcpserver, skill) — the last Class A domain. The lazy deleter
     // provider replaces Go's SetReconciliationService late-bind
@@ -687,6 +732,7 @@ export async function composeServer(
     registerProjectServices(router, {
       store,
       logger,
+      authorizer,
       orphanDeleter: () => requireInProcess().projectOrphanDeleter,
     });
     // The two CQRS query services register between the domains and the
@@ -724,7 +770,15 @@ export async function composeServer(
   const server = createUnifiedPortServer({
     logger,
     routes,
-    interceptors: buildInterceptorChain(logger),
+    // The serving chain's position-1 identity source is the verifier
+    // chassis over the composed verifiers (O2; zero verifiers = the
+    // trusted-local posture, byte-identical wire behavior). The in-process
+    // transport above carries its own position-1 source — the internal
+    // caller class only it can mint (ruling Q4).
+    interceptors: buildInterceptorChain(
+      logger,
+      createVerifierChainInterceptor(extensions.identityVerifiers, logger),
+    ),
     taskKindRegistryLane: registryLanes.taskKindRegistryLane,
     modelRegistryLane: registryLanes.modelRegistryLane,
     skillTransferLane,

--- a/backend/services/stigmer-server/src/boot/inprocess.ts
+++ b/backend/services/stigmer-server/src/boot/inprocess.ts
@@ -5,8 +5,11 @@
  * executes: an internal call is validated, logged, and kind-tagged exactly
  * like an external one. Here the bufconn equivalent is ConnectRPC's
  * `createRouterTransport` built from the SAME routes registration function
- * the unified-port server uses, with the SAME interceptor chain — proven by
- * spike SP-B (src/pipeline/__tests__/router-transport.test.ts): every
+ * the unified-port server uses, with the SAME interceptor chain EXCEPT the
+ * position-1 identity source (O2, ruling Q4): this chain stamps the
+ * `internal` caller class only it can mint, where the serving chain runs
+ * the verifier chassis over the wire's credentials. Chain traversal proven
+ * by spike SP-B (src/pipeline/__tests__/router-transport.test.ts): every
  * interceptor runs, in registration order, and a chain rejection
  * short-circuits with a ConnectError the in-process caller sees (DD-002).
  *
@@ -71,6 +74,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import type { OrphanDeleter } from "../domain/project/reconcile.js";
 import type { ScheduleExecutionCreator } from "../temporal/schedule/run-starter.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
+import { createInProcessCallerInterceptor } from "../pipeline/interceptors/auth.js";
 import type { Logger } from "./logger.js";
 
 /** The narrow in-process surfaces the domains consume (DD-002). */
@@ -154,8 +158,18 @@ export function createInProcessClients(
   routes: (router: ConnectRouter) => void,
   logger: Logger,
 ): InProcessWiring {
+  // Position 1 of this chain is the in-process identity stamper, NOT the
+  // serving chassis (O2, ruling Q4): every call through this transport
+  // carries the internal caller class, which only this chain can mint —
+  // the TS rendering of the Java in-process authorization skip. Positions
+  // 2–4 stay identical to the serving chain (validation parity, DD-002).
   const transport = createRouterTransport(routes, {
-    router: { interceptors: buildInterceptorChain(logger) },
+    router: {
+      interceptors: buildInterceptorChain(
+        logger,
+        createInProcessCallerInterceptor(),
+      ),
+    },
   });
 
   const agentInstanceCommand = createClient(
@@ -197,10 +211,10 @@ export function createInProcessClients(
   const skillCommand = createClient(SkillCommandController, transport);
 
   const clients: InProcessClients = {
-    // Go's ApplyAsSystem is the Apply RPC with no extra identity attached:
-    // the audit actor comes from the process-global operator identity
-    // (installed once by main.ts, #400), so a plain apply IS the
-    // system-actor apply in this edition.
+    // Go's ApplyAsSystem is the Apply RPC through this transport: the
+    // position-1 interceptor stamps the internal caller identity (O2),
+    // whose audit derivation equals the #400 operator actor — so a plain
+    // apply IS the system-actor apply in this edition.
     agentInstanceApplier: {
       applyAsSystem: (instance) => agentInstanceCommand.apply(instance),
     },
@@ -291,9 +305,10 @@ export function createInProcessClients(
       submitFileDecision: (input) =>
         agentExecutionCommand.submitFileDecision(input),
     },
-    // The schedule clock's fire edge — the plain Create RPC under the
-    // process-global operator identity (Go's ExecutionCreator; OSS has no
-    // caller identity by design, DD-015 D-G).
+    // The schedule clock's fire edge — the plain Create RPC (Go's
+    // ExecutionCreator). Since O2 every call through this transport
+    // carries the internal caller class stamped at position 1; its audit
+    // derivation equals the old process-global operator identity.
     scheduleExecutionCreator: {
       create: (execution) => agentExecutionCommand.create(execution),
     },

--- a/backend/services/stigmer-server/src/domain/agent/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agent/controller.ts
@@ -20,7 +20,10 @@ import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent
 import { AgentQueryController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/query_pb";
 import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
-import type { AgentId, GetDefaultAgentRequest } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/io_pb";
+import type {
+  AgentId,
+  GetDefaultAgentRequest,
+} from "@stigmer/protos/ai/stigmer/agentic/agent/v1/io_pb";
 import type {
   ApiResourceReference,
   UpdateVisibilityInput,
@@ -28,12 +31,18 @@ import type {
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError, notFoundError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
-import { newBuildNewStateStep, setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import {
+  newBuildNewStateStep,
+  setAuditFieldsForUpdate,
+} from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
 import {
@@ -45,10 +54,19 @@ import {
   newDeleteSearchIndexStep,
   newIndexSearchStep,
 } from "../../pipeline/steps/index-search.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
-import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
-import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
 import {
   newNormalizeReferencesStep,
   newValidateReferencesStep,
@@ -76,6 +94,8 @@ import type { AgentInstanceApplierProvider } from "./steps.js";
 export interface AgentControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   /**
    * The agentinstance in-process edge — a lazy provider because
    * agent↔agentinstance is a true dependency cycle (DD-002; the ratified
@@ -118,8 +138,16 @@ async function createAgent(
   agent: Agent,
   ctx: HandlerContext,
 ): Promise<Agent> {
-  const reqCtx = new RequestContext(AgentSchema, agent, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    AgentSchema,
+    agent,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof AgentSchema>("agent-create", deps.logger)
+    .addStep(
+      newAuthorizeStep(AgentCommandController.method.create, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveSlugStep())
@@ -130,8 +158,12 @@ async function createAgent(
     .addStep(newValidateEnabledToolsStep(deps.store))
     .addStep(newMergeMcpServerEnvSpecsStep(deps.store, deps.logger))
     .addStep(newPersistStep(deps.store))
-    .addStep(newCreateDefaultInstanceStep(deps.agentInstanceApplier, deps.logger))
-    .addStep(newUpdateAgentStatusWithDefaultInstanceStep(deps.store, deps.logger))
+    .addStep(
+      newCreateDefaultInstanceStep(deps.agentInstanceApplier, deps.logger),
+    )
+    .addStep(
+      newUpdateAgentStatusWithDefaultInstanceStep(deps.store, deps.logger),
+    )
     .addStep(newIndexSearchStep(deps.store, agentSearchExtractor, deps.logger))
     .build()
     .execute(reqCtx);
@@ -144,8 +176,16 @@ async function update(
   agent: Agent,
   ctx: HandlerContext,
 ): Promise<Agent> {
-  const reqCtx = new RequestContext(AgentSchema, agent, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    AgentSchema,
+    agent,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof AgentSchema>("agent-update", deps.logger)
+    .addStep(
+      newAuthorizeStep(AgentCommandController.method.update, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
@@ -171,8 +211,16 @@ async function apply(
   agent: Agent,
   ctx: HandlerContext,
 ): Promise<Agent> {
-  const reqCtx = new RequestContext(AgentSchema, agent, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    AgentSchema,
+    agent,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof AgentSchema>("agent-apply", deps.logger)
+    .addStep(
+      newAuthorizeStep(AgentCommandController.method.apply, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -186,7 +234,9 @@ async function apply(
       "apply operation failed to determine create vs update",
     );
   }
-  return shouldCreate ? createAgent(deps, agent, ctx) : update(deps, agent, ctx);
+  return shouldCreate
+    ? createAgent(deps, agent, ctx)
+    : update(deps, agent, ctx);
 }
 
 /**
@@ -202,12 +252,16 @@ async function deleteAgent(
   const reqCtx = new RequestContext(
     AgentCommandController.method.delete.input,
     agentId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentCommandController.method.delete.input>(
     "agent-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(AgentCommandController.method.delete, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, AgentSchema))
@@ -248,12 +302,19 @@ async function updateVisibility(
   const reqCtx = new RequestContext(
     AgentCommandController.method.updateVisibility.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<UpdateVisibilityDesc>(
     "agent-update-visibility",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentCommandController.method.updateVisibility,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadAgentForVisibilityUpdateStep(deps.store))
     .addStep(newValidateVisibilityUpdateStep())
@@ -298,7 +359,12 @@ function newSetAgentVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
       if (agent.metadata !== undefined) {
         agent.metadata.visibility = ctx.input.visibility;
       }
-      setAuditFieldsForUpdate(AgentSchema, agent, "status_audit");
+      setAuditFieldsForUpdate(
+        AgentSchema,
+        agent,
+        "status_audit",
+        ctx.callerIdentity,
+      );
     },
   };
 }
@@ -371,12 +437,14 @@ async function get(
   const reqCtx = new RequestContext(
     AgentQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentQueryController.method.get.input>(
     "agent-get",
     deps.logger,
   )
+    .addStep(newAuthorizeStep(AgentQueryController.method.get, deps.authorizer))
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, AgentSchema))
     .build()
@@ -393,12 +461,19 @@ async function getByReference(
   const reqCtx = new RequestContext(
     AgentQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentQueryController.method.getByReference.input>(
     "agent-get-by-reference",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, AgentSchema))
     .build()
@@ -419,12 +494,16 @@ async function getDefault(
   const reqCtx = new RequestContext(
     AgentQueryController.method.getDefault.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentQueryController.method.getDefault.input>(
     "agent-get-default",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(AgentQueryController.method.getDefault, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadDefaultAgentStep(deps.store, deps.logger))
     .build()

--- a/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
@@ -45,6 +45,7 @@ import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/ap
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
   failedPreconditionError,
@@ -53,7 +54,9 @@ import {
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
@@ -62,11 +65,23 @@ import {
   newExtractResourceIdStep,
   newLoadExistingForDeleteStep,
 } from "../../pipeline/steps/delete.js";
-import { compareCreatedAtDesc, matchesAllLabels } from "../../pipeline/steps/helpers.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
-import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import {
+  compareCreatedAtDesc,
+  matchesAllLabels,
+} from "../../pipeline/steps/helpers.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
-import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
@@ -84,6 +99,8 @@ import {
 export interface AgentChannelControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly modelRegistry: ModelRegistryStore;
 }
 
@@ -122,8 +139,22 @@ async function createChannel(
   channel: AgentChannel,
   ctx: HandlerContext,
 ): Promise<AgentChannel> {
-  const reqCtx = new RequestContext(AgentChannelSchema, channel, kindOf(ctx));
-  await newPipeline<typeof AgentChannelSchema>("agent-channel-create", deps.logger)
+  const reqCtx = new RequestContext(
+    AgentChannelSchema,
+    channel,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentChannelSchema>(
+    "agent-channel-create",
+    deps.logger,
+  )
+    .addStep(
+      newAuthorizeStep(
+        AgentChannelCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveChannelDefaultsStep(deps.store, deps.modelRegistry))
@@ -149,8 +180,22 @@ async function update(
   channel: AgentChannel,
   ctx: HandlerContext,
 ): Promise<AgentChannel> {
-  const reqCtx = new RequestContext(AgentChannelSchema, channel, kindOf(ctx));
-  await newPipeline<typeof AgentChannelSchema>("agent-channel-update", deps.logger)
+  const reqCtx = new RequestContext(
+    AgentChannelSchema,
+    channel,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentChannelSchema>(
+    "agent-channel-update",
+    deps.logger,
+  )
+    .addStep(
+      newAuthorizeStep(
+        AgentChannelCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
@@ -179,8 +224,22 @@ async function apply(
   channel: AgentChannel,
   ctx: HandlerContext,
 ): Promise<AgentChannel> {
-  const reqCtx = new RequestContext(AgentChannelSchema, channel, kindOf(ctx));
-  await newPipeline<typeof AgentChannelSchema>("agent-channel-apply", deps.logger)
+  const reqCtx = new RequestContext(
+    AgentChannelSchema,
+    channel,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
+  await newPipeline<typeof AgentChannelSchema>(
+    "agent-channel-apply",
+    deps.logger,
+  )
+    .addStep(
+      newAuthorizeStep(
+        AgentChannelCommandController.method.apply,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveChannelDefaultsStep(deps.store, deps.modelRegistry))
     .addStep(newResolveSlugStep())
@@ -260,12 +319,19 @@ async function deleteChannel(
   const reqCtx = new RequestContext(
     AgentChannelCommandController.method.delete.input,
     channelId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentChannelCommandController.method.delete.input>(
     "agent-channel-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentChannelCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, AgentChannelSchema))
@@ -292,12 +358,16 @@ async function get(
   const reqCtx = new RequestContext(
     AgentChannelQueryController.method.get.input,
     channelId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentChannelQueryController.method.get.input>(
     "agent-channel-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(AgentChannelQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, AgentChannelSchema))
     .build()
@@ -314,12 +384,18 @@ async function getByReference(
   const reqCtx = new RequestContext(
     AgentChannelQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof AgentChannelQueryController.method.getByReference.input>(
-    "agent-channel-get-by-reference",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof AgentChannelQueryController.method.getByReference.input
+  >("agent-channel-get-by-reference", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentChannelQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, AgentChannelSchema))
     .build()
@@ -346,12 +422,19 @@ async function getByAgent(
   const reqCtx = new RequestContext(
     AgentChannelQueryController.method.getByAgent.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentChannelQueryController.method.getByAgent.input>(
     "agent-channel-get-by-agent",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentChannelQueryController.method.getByAgent,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadChannelsByAgentStep(deps.store))
     .build()
@@ -374,10 +457,15 @@ function newLoadChannelsByAgentStep(
   return {
     name: "LoadChannelsByAgent",
     async execute(
-      ctx: RequestContext<typeof AgentChannelQueryController.method.getByAgent.input>,
+      ctx: RequestContext<
+        typeof AgentChannelQueryController.method.getByAgent.input
+      >,
     ): Promise<void> {
       const req = ctx.input;
-      const emptyList = create(AgentChannelListSchema, { totalCount: 0, items: [] });
+      const emptyList = create(AgentChannelListSchema, {
+        totalCount: 0,
+        items: [],
+      });
 
       let agentOrg: string;
       let agentSlug: string;
@@ -441,12 +529,19 @@ async function list(
   const reqCtx = new RequestContext(
     AgentChannelQueryController.method.list.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentChannelQueryController.method.list.input>(
     "agent-channel-list",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentChannelQueryController.method.list,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newListByOrgAndLabelsStep(deps.store))
     .build()

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/agentexecution.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/agentexecution.test.ts
@@ -20,6 +20,8 @@
  *     avg duration, failure ranks) that the zero-record conformance arm
  *     cannot reach.
  */
+import { newPermissiveSingleTeamAuthorizer } from "../../../pipeline/steps/authorize.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -90,7 +92,10 @@ let query: QueryClient;
 beforeAll(async () => {
   dir = mkdtempSync(path.join(tmpdir(), "aexec-domain-test-"));
   vi.stubEnv("STIGMER_ENCRYPTION_KEY", Buffer.alloc(32, 7).toString("base64"));
-  vi.stubEnv("STIGMER_RUNNER_TOKEN_KEY", Buffer.alloc(32, 8).toString("base64"));
+  vi.stubEnv(
+    "STIGMER_RUNNER_TOKEN_KEY",
+    Buffer.alloc(32, 8).toString("base64"),
+  );
   server = await composeServer({
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
@@ -136,7 +141,9 @@ function seedInput(overrides?: {
   phase?: ExecutionPhase;
   startedAt?: string;
   completedAt?: string;
-}): MessageInitShape<typeof AgentExecutionSchema> & { metadata: { id: string } } {
+}): MessageInitShape<typeof AgentExecutionSchema> & {
+  metadata: { id: string };
+} {
   counter += 1;
   const id = overrides?.id ?? `aexec_test_${counter}`;
   const slug = `exec-${id.replaceAll("_", "-")}`;
@@ -584,10 +591,7 @@ describe("subscribe — the first domain stream through the real transport", () 
         }
         return "server-ended" as const;
       } catch (error) {
-        if (
-          error instanceof ConnectError &&
-          error.code === Code.Canceled
-        ) {
+        if (error instanceof ConnectError && error.code === Code.Canceled) {
           return "client-cancelled" as const;
         }
         throw error;
@@ -677,7 +681,11 @@ describe("subscribe — the first domain stream through the real transport", () 
       }),
     );
     await expect(stream.done).resolves.toBe("server-ended");
-    expect(stream.frames).toEqual(["", "marker-live-update", "marker-terminal"]);
+    expect(stream.frames).toEqual([
+      "",
+      "marker-live-update",
+      "marker-terminal",
+    ]);
     expect(server.agentExecutionStreamBroker.getSubscriberCount(id)).toBe(0);
   });
 
@@ -720,7 +728,11 @@ function gatedSeed(overrides?: {
     apiVersion: API_VERSION,
     kind: KIND,
     metadata: { id, name: slug, slug, org: ORG },
-    spec: { sessionId: `ses_${id}`, agentId: `agt_${id}`, message: "Say hello." },
+    spec: {
+      sessionId: `ses_${id}`,
+      agentId: `agt_${id}`,
+      message: "Say hello.",
+    },
     status: {
       phase: ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
       messages: [
@@ -995,13 +1007,21 @@ describe("submitApproval over the wire (submit_approval_contract_test.go arms)",
           {
             type: MessageType.MESSAGE_AI,
             toolCalls: [
-              { id: "tc-click", name: "click", status: ToolCallStatus.TOOL_CALL_COMPLETED },
+              {
+                id: "tc-click",
+                name: "click",
+                status: ToolCallStatus.TOOL_CALL_COMPLETED,
+              },
             ],
           },
           {
             type: MessageType.MESSAGE_AI,
             toolCalls: [
-              { id: "tc-scroll", name: "scroll", status: ToolCallStatus.TOOL_CALL_COMPLETED },
+              {
+                id: "tc-scroll",
+                name: "scroll",
+                status: ToolCallStatus.TOOL_CALL_COMPLETED,
+              },
             ],
           },
           { type: MessageType.MESSAGE_AI, content: "done" },
@@ -1066,9 +1086,9 @@ describe("submitApproval over the wire (submit_approval_contract_test.go arms)",
       expect(tc?.approvalAction, `iteration ${i}: decision lost`).toBe(
         ApprovalAction.APPROVE,
       );
-      const events = (
-        final.status?.approvalEventStream?.events ?? []
-      ).filter((ev) => ev.approvalRequestId === "tc-1");
+      const events = (final.status?.approvalEventStream?.events ?? []).filter(
+        (ev) => ev.approvalRequestId === "tc-1",
+      );
       expect(
         events.filter((ev) => ev.eventType === ApprovalEventType.REQUESTED),
         `iteration ${i}: REQUESTED duplicated`,
@@ -1086,9 +1106,9 @@ describe("the engine-connected signal arms (stubbed engine, direct calls)", () =
     return {
       store: server.store,
       logger: silentLogger,
+      authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: server.agentExecutionStreamBroker,
-      engineState: () =>
-        ({ connected: true, engine }) as ExecutionEngineState,
+      engineState: () => ({ connected: true, engine }) as ExecutionEngineState,
     };
   }
 
@@ -1111,28 +1131,34 @@ describe("the engine-connected signal arms (stubbed engine, direct calls)", () =
     );
 
     // First decision: a different-class call stays gated → no signal.
-    await submitApproval(deps,
+    await submitApproval(
+      deps,
       create(SubmitApprovalInputSchema, {
         agentExecutionId: id,
         toolCallId: "tc-shell",
         action: ApprovalAction.APPROVE,
       }),
+      testCallerIdentity(),
     );
     expect(signalled).toHaveLength(0);
 
     // Second decision clears the gate → exactly one signal.
-    await submitApproval(deps,
+    await submitApproval(
+      deps,
       create(SubmitApprovalInputSchema, {
         agentExecutionId: id,
         toolCallId: "tc-write",
         action: ApprovalAction.REJECT,
       }),
+      testCallerIdentity(),
     );
     expect(signalled).toEqual([id]);
   });
 
   it("a vanished workflow reconciles the execution to FAILED with settled tool calls (pinned copy)", async () => {
-    const id = await seed(gatedSeed({ toolCalls: [{ id: "tc-1", name: "Write" }] }));
+    const id = await seed(
+      gatedSeed({ toolCalls: [{ id: "tc-1", name: "Write" }] }),
+    );
     const deps = stubDeps(
       stubConnectedEngine({
         signalApprovalGateResolved: async (executionId) => {
@@ -1143,12 +1169,14 @@ describe("the engine-connected signal arms (stubbed engine, direct calls)", () =
 
     const err = await expectCode(
       () =>
-        submitApproval(deps,
+        submitApproval(
+          deps,
           create(SubmitApprovalInputSchema, {
             agentExecutionId: id,
             toolCallId: "tc-1",
             action: ApprovalAction.APPROVE,
           }),
+          testCallerIdentity(),
         ),
       Code.FailedPrecondition,
     );
@@ -1162,9 +1190,9 @@ describe("the engine-connected signal arms (stubbed engine, direct calls)", () =
       "Workflow backing this execution is no longer running. Execution has been marked as failed.",
     );
     // The system message is appended and in-flight calls settle (#207).
-    expect(
-      final.status?.messages.at(-1)?.type,
-    ).toBe(MessageType.MESSAGE_SYSTEM);
+    expect(final.status?.messages.at(-1)?.type).toBe(
+      MessageType.MESSAGE_SYSTEM,
+    );
     const tc = final.status?.messages
       .flatMap((m) => m.toolCalls)
       .find((c) => c.id === "tc-1");

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/create-steps.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/create-steps.test.ts
@@ -8,6 +8,7 @@
  * providers — reaching the client would fail the test just as a nil
  * dereference would panic Go.
  */
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -91,6 +92,7 @@ function newContext(
   return new RequestContext(
     AgentExecutionSchema,
     execution,
+    testCallerIdentity(),
     ApiResourceKind.agent_execution,
   );
 }
@@ -192,7 +194,10 @@ describe("newResolveDefaultAgentStep", () => {
   });
 
   it("public default agent -> resolves agent_id onto newState", async () => {
-    await seedDefaultAgent("agt_default", ApiResourceVisibility.visibility_public);
+    await seedDefaultAgent(
+      "agt_default",
+      ApiResourceVisibility.visibility_public,
+    );
     const step = newResolveDefaultAgentStep(store, silentLogger);
     const ctx = newContext(newExecution("", ""));
 
@@ -250,7 +255,10 @@ describe("newResolveDefaultAgentStep", () => {
     // A one-call bootstrap naming an explicit instance must NOT resolve
     // the platform default agent: doing so would stamp misleading
     // metadata pointing at an agent the session does not run against.
-    await seedDefaultAgent("agt_default", ApiResourceVisibility.visibility_public);
+    await seedDefaultAgent(
+      "agt_default",
+      ApiResourceVisibility.visibility_public,
+    );
     const step = newResolveDefaultAgentStep(store, silentLogger);
     const execution = newExecution("", "");
     execution.spec!.sessionSpec = create(SessionSpecSchema, {
@@ -521,19 +529,19 @@ describe("newComposeDeclaredPreferencesStep", () => {
       execution.metadata!.org = tt.orgId;
       // The injection attempt: a caller-supplied value must never survive
       // — the field is server-owned (DD-002 D2).
-      execution.spec!.declaredPreferences = create(
-        DeclaredPreferencesSchema,
-        {
-          orgContext: "injected org context",
-          userContext: "injected user context",
-        },
-      );
+      execution.spec!.declaredPreferences = create(DeclaredPreferencesSchema, {
+        orgContext: "injected org context",
+        userContext: "injected user context",
+      });
       const ctx = newContext(execution);
 
       await step.execute(ctx);
 
       const got = ctx.newState.spec?.declaredPreferences;
-      expect(got, "server-owned field must be stamped on every path").toBeDefined();
+      expect(
+        got,
+        "server-owned field must be stamped on every path",
+      ).toBeDefined();
       expect(got?.orgContext).toBe(tt.wantOrgContext);
       // user_context must stay empty in OSS (no per-request user identity).
       expect(got?.userContext).toBe("");
@@ -821,7 +829,10 @@ describe("newComposeRecalledMemoriesStep", () => {
       ).toBeUndefined();
 
       const got = ctx.newState.spec?.recalledMemories;
-      expect(got, "server-owned field must be stamped on every path").toBeDefined();
+      expect(
+        got,
+        "server-owned field must be stamped on every path",
+      ).toBeDefined();
       expect(got?.enabled).toBe(tt.wantEnabled);
       expect(got?.facts.map((f) => f.memoryId)).toEqual(tt.wantMemoryIds);
       for (const fact of got?.facts ?? []) {

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/engine.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/engine.test.ts
@@ -6,6 +6,7 @@
  * EXECUTION time (a reconnect between requests must be observed, Go's
  * SetWorkflowCreator re-injection).
  */
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { create } from "@bufbuild/protobuf";
 import { Code, ConnectError } from "@connectrpc/connect";
 import { describe, expect, it } from "vitest";
@@ -26,6 +27,7 @@ function contextFor(): RequestContext<typeof AgentExecutionSchema> {
   return new RequestContext(
     AgentExecutionSchema,
     create(AgentExecutionSchema, {}),
+    testCallerIdentity(),
     ApiResourceKind.agent_execution,
   );
 }

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/lifecycle.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/lifecycle.test.ts
@@ -14,6 +14,8 @@
  *     store.updateResource under the write lock, so a concurrent approval
  *     append is never clobbered (the Go 50-iteration regression).
  */
+import { newPermissiveSingleTeamAuthorizer } from "../../../pipeline/steps/authorize.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -437,6 +439,7 @@ function lifecycleDeps(engineState: ExecutionEngineState): LifecycleDeps {
   return {
     store,
     logger: silentLogger,
+    authorizer: newPermissiveSingleTeamAuthorizer(),
     broker: new StreamBroker(silentLogger),
     engineState: () => engineState,
     executionContextBuilder: stubBuilderDeps(),
@@ -466,10 +469,7 @@ async function expectCode(
 function cancelInput(id: string): CancelAgentExecutionInput {
   return create(CancelAgentExecutionInputSchema, { id });
 }
-function terminateInput(
-  id: string,
-  reason = "",
-): TerminateAgentExecutionInput {
+function terminateInput(id: string, reason = ""): TerminateAgentExecutionInput {
   return create(TerminateAgentExecutionInputSchema, { id, reason });
 }
 function pauseInput(id: string, reason = ""): PauseAgentExecutionInput {
@@ -486,7 +486,7 @@ describe("lifecycle pipelines", () => {
   it("empty id refuses InvalidArgument before any load", async () => {
     const deps = lifecycleDeps(DISCONNECTED);
     const err = await expectCode(
-      () => cancelExecution(deps, cancelInput("")),
+      () => cancelExecution(deps, cancelInput(""), testCallerIdentity()),
       Code.InvalidArgument,
     );
     expect(err.rawMessage).toBe("execution id is required");
@@ -495,7 +495,12 @@ describe("lifecycle pipelines", () => {
   it("unknown id answers NotFound", async () => {
     const deps = lifecycleDeps(DISCONNECTED);
     await expectCode(
-      () => cancelExecution(deps, cancelInput("aexec_missing")),
+      () =>
+        cancelExecution(
+          deps,
+          cancelInput("aexec_missing"),
+          testCallerIdentity(),
+        ),
       Code.NotFound,
     );
   });
@@ -506,7 +511,7 @@ describe("lifecycle pipelines", () => {
       phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
     });
     const err = await expectCode(
-      () => cancelExecution(deps, cancelInput(id)),
+      () => cancelExecution(deps, cancelInput(id), testCallerIdentity()),
       Code.FailedPrecondition,
     );
     expect(err.rawMessage).toBe("Temporal is not available");
@@ -519,23 +524,31 @@ describe("lifecycle pipelines", () => {
     });
     const cases: Array<[() => Promise<unknown>, string]> = [
       [
-        () => cancelExecution(deps, cancelInput(completed)),
+        () =>
+          cancelExecution(deps, cancelInput(completed), testCallerIdentity()),
         "cannot cancel execution in phase EXECUTION_COMPLETED; only PENDING or IN_PROGRESS can be cancelled",
       ],
       [
-        () => terminateExecution(deps, terminateInput(completed)),
+        () =>
+          terminateExecution(
+            deps,
+            terminateInput(completed),
+            testCallerIdentity(),
+          ),
         "cannot terminate execution in phase EXECUTION_COMPLETED; only PENDING or IN_PROGRESS can be terminated",
       ],
       [
-        () => pauseExecution(deps, pauseInput(completed)),
+        () => pauseExecution(deps, pauseInput(completed), testCallerIdentity()),
         "cannot pause execution in phase EXECUTION_COMPLETED; only PENDING or IN_PROGRESS can be paused",
       ],
       [
-        () => resumeExecution(deps, resumeInput(completed)),
+        () =>
+          resumeExecution(deps, resumeInput(completed), testCallerIdentity()),
         "cannot resume execution in phase EXECUTION_COMPLETED; only PAUSED executions can be resumed",
       ],
       [
-        () => recoverExecution(deps, recoverInput(completed)),
+        () =>
+          recoverExecution(deps, recoverInput(completed), testCallerIdentity()),
         "cannot recover execution in phase EXECUTION_COMPLETED; only FAILED executions can be recovered",
       ],
     ];
@@ -559,7 +572,11 @@ describe("lifecycle pipelines", () => {
     const id = await seedExecution({
       phase: ExecutionPhase.EXECUTION_CANCELLED,
     });
-    const result = await cancelExecution(deps, cancelInput(id));
+    const result = await cancelExecution(
+      deps,
+      cancelInput(id),
+      testCallerIdentity(),
+    );
     expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
     expect(engineCalls).toBe(0);
   });
@@ -578,7 +595,11 @@ describe("lifecycle pipelines", () => {
     const id = await seedExecution({
       phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
     });
-    const result = await cancelExecution(deps, cancelInput(id));
+    const result = await cancelExecution(
+      deps,
+      cancelInput(id),
+      testCallerIdentity(),
+    );
     expect(cancelled).toEqual([id]);
     expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
     expect(result.status?.completedAt).not.toBe("");
@@ -604,7 +625,11 @@ describe("lifecycle pipelines", () => {
     const id = await seedExecution({
       phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
     });
-    const result = await cancelExecution(deps, cancelInput(id));
+    const result = await cancelExecution(
+      deps,
+      cancelInput(id),
+      testCallerIdentity(),
+    );
     expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
   });
 
@@ -616,6 +641,7 @@ describe("lifecycle pipelines", () => {
     const result = await terminateExecution(
       deps,
       terminateInput(id, "disk full"),
+      testCallerIdentity(),
     );
     expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_TERMINATED);
     expect(result.status?.error).toBe("Terminated: disk full");
@@ -633,7 +659,11 @@ describe("lifecycle pipelines", () => {
       ),
     );
     const id = await seedExecution({ phase: ExecutionPhase.EXECUTION_PAUSED });
-    const result = await resumeExecution(deps, resumeInput(id));
+    const result = await resumeExecution(
+      deps,
+      resumeInput(id),
+      testCallerIdentity(),
+    );
     expect(resumed).toEqual([id]);
     expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
     expect(result.status?.completedAt).toBe("");
@@ -646,6 +676,7 @@ describe("lifecycle pipelines", () => {
     const deps: LifecycleDeps = {
       store,
       logger: silentLogger,
+      authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
       engineState: () =>
         connected(
@@ -668,7 +699,11 @@ describe("lifecycle pipelines", () => {
       sessionId: "ses_lc",
       error: "runner exploded",
     });
-    const result = await recoverExecution(deps, recoverInput(id));
+    const result = await recoverExecution(
+      deps,
+      recoverInput(id),
+      testCallerIdentity(),
+    );
 
     expect(terminations).toEqual([
       {
@@ -694,6 +729,7 @@ describe("lifecycle pipelines", () => {
     const deps: LifecycleDeps = {
       store,
       logger: silentLogger,
+      authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
       engineState: () =>
         connected(
@@ -715,7 +751,11 @@ describe("lifecycle pipelines", () => {
       sessionId: "ses_lc",
       error: "runner exploded",
     });
-    const result = await recoverExecution(deps, recoverInput(id));
+    const result = await recoverExecution(
+      deps,
+      recoverInput(id),
+      testCallerIdentity(),
+    );
     expect(createdEcs).toHaveLength(1);
     expect(starts).toEqual([id]);
     expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
@@ -730,6 +770,7 @@ describe("lifecycle pipelines", () => {
     const deps: LifecycleDeps = {
       store,
       logger: silentLogger,
+      authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
       engineState: () =>
         connected(
@@ -752,7 +793,7 @@ describe("lifecycle pipelines", () => {
       error: "runner exploded",
     });
     const err = await expectCode(
-      () => recoverExecution(deps, recoverInput(id)),
+      () => recoverExecution(deps, recoverInput(id), testCallerIdentity()),
       Code.Internal,
     );
     expect(err.rawMessage).toBe(
@@ -777,6 +818,7 @@ describe("lifecycle pipelines", () => {
     const deps: LifecycleDeps = {
       store,
       logger: silentLogger,
+      authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
       engineState: () =>
         connected(
@@ -799,7 +841,11 @@ describe("lifecycle pipelines", () => {
       phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
       sessionId: "ses_lc",
     });
-    const result = await recoverExecution(deps, recoverInput(id));
+    const result = await recoverExecution(
+      deps,
+      recoverInput(id),
+      testCallerIdentity(),
+    );
     expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
     expect(engineCalls).toBe(0);
   });
@@ -813,13 +859,17 @@ describe("lifecycle pipelines", () => {
     const deps: LifecycleDeps = {
       store,
       logger: silentLogger,
+      authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
       engineState: () => connected(stubConnectedEngine()),
       executionContextBuilder: {
         ...builderDeps,
         sessionLoader: () => ({
           get: async () => {
-            throw new ConnectError("session not found: ses_gone", Code.NotFound);
+            throw new ConnectError(
+              "session not found: ses_gone",
+              Code.NotFound,
+            );
           },
         }),
       },
@@ -829,7 +879,7 @@ describe("lifecycle pipelines", () => {
       sessionId: "ses_gone",
     });
     const err = await expectCode(
-      () => recoverExecution(deps, recoverInput(id)),
+      () => recoverExecution(deps, recoverInput(id), testCallerIdentity()),
       Code.NotFound,
     );
     expect(err.rawMessage).toBe(
@@ -846,7 +896,7 @@ describe("lifecycle pipelines", () => {
       sessionId: "ses_lc",
     });
     const err = await expectCode(
-      () => recoverExecution(deps, recoverInput(id)),
+      () => recoverExecution(deps, recoverInput(id), testCallerIdentity()),
       Code.FailedPrecondition,
     );
     expect(err.rawMessage).toBe("Temporal is not available");
@@ -875,19 +925,22 @@ describe("lifecycle persist uses the atomic updateResource", () => {
   }> = [
     {
       name: "pause",
-      run: (deps, id) => pauseExecution(deps, pauseInput(id)),
+      run: (deps, id) =>
+        pauseExecution(deps, pauseInput(id), testCallerIdentity()),
       fromPhase: ExecutionPhase.EXECUTION_IN_PROGRESS,
       wantPhase: ExecutionPhase.EXECUTION_PAUSED,
     },
     {
       name: "cancel",
-      run: (deps, id) => cancelExecution(deps, cancelInput(id)),
+      run: (deps, id) =>
+        cancelExecution(deps, cancelInput(id), testCallerIdentity()),
       fromPhase: ExecutionPhase.EXECUTION_IN_PROGRESS,
       wantPhase: ExecutionPhase.EXECUTION_CANCELLED,
     },
     {
       name: "terminate",
-      run: (deps, id) => terminateExecution(deps, terminateInput(id)),
+      run: (deps, id) =>
+        terminateExecution(deps, terminateInput(id), testCallerIdentity()),
       fromPhase: ExecutionPhase.EXECUTION_IN_PROGRESS,
       wantPhase: ExecutionPhase.EXECUTION_TERMINATED,
     },
@@ -917,6 +970,7 @@ describe("lifecycle persist uses the atomic updateResource", () => {
       const deps: LifecycleDeps = {
         store: countingStore,
         logger: silentLogger,
+        authorizer: newPermissiveSingleTeamAuthorizer(),
         broker: new StreamBroker(silentLogger),
         engineState: () => connected(stubConnectedEngine()),
         executionContextBuilder: stubBuilderDeps(),
@@ -973,7 +1027,7 @@ describe("lifecycle pause racing a decision append", () => {
       );
 
       await Promise.all([
-        pauseExecution(deps, pauseInput(id)),
+        pauseExecution(deps, pauseInput(id), testCallerIdentity()),
         store.updateResource(
           ApiResourceKind.agent_execution,
           id,

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/validate-service-tier.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/validate-service-tier.test.ts
@@ -7,6 +7,7 @@
  * message — the conformance tier suite asserts the codes on every target;
  * these tests additionally pin the message fragments.
  */
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { create } from "@bufbuild/protobuf";
 import type { MessageInitShape } from "@bufbuild/protobuf";
 import { Code, ConnectError } from "@connectrpc/connect";
@@ -49,11 +50,14 @@ function contextFor(
         ...(config === undefined ? {} : { executionConfig: config }),
       },
     }),
+    testCallerIdentity(),
     ApiResourceKind.agent_execution,
   );
 }
 
-function refusal(config: MessageInitShape<typeof ExecutionConfigSchema>): ConnectError {
+function refusal(
+  config: MessageInitShape<typeof ExecutionConfigSchema>,
+): ConnectError {
   try {
     step.execute(contextFor(config));
   } catch (error) {

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/validate-thinking-mode.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/validate-thinking-mode.test.ts
@@ -8,6 +8,7 @@
  * capability but only on its NATIVE entry, which has no thinking wire
  * mapping in v1 and must refuse.
  */
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { create } from "@bufbuild/protobuf";
 import type { MessageInitShape } from "@bufbuild/protobuf";
 import { Code, ConnectError } from "@connectrpc/connect";
@@ -53,11 +54,14 @@ function contextFor(
         ...(config === undefined ? {} : { executionConfig: config }),
       },
     }),
+    testCallerIdentity(),
     ApiResourceKind.agent_execution,
   );
 }
 
-function refusal(config: MessageInitShape<typeof ExecutionConfigSchema>): ConnectError {
+function refusal(
+  config: MessageInitShape<typeof ExecutionConfigSchema>,
+): ConnectError {
   try {
     step.execute(contextFor(config));
   } catch (error) {

--- a/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
@@ -29,10 +29,13 @@ import type { ApiResourceId } from "@stigmer/protos/ai/stigmer/commons/apiresour
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import {
   newDeleteResourceStep,
@@ -122,6 +125,8 @@ import {
 export interface AgentExecutionControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   /**
    * The shared broadcast fabric for subscribe streams. ONE instance spans
    * both routers (serving + in-process) — see stream-broker.ts; the
@@ -163,6 +168,7 @@ export function registerAgentExecutionServices(
   const lifecycleDeps = {
     store: deps.store,
     logger: deps.logger,
+    authorizer: deps.authorizer,
     broker: deps.broker,
     engineState: deps.engineState,
     executionContextBuilder: deps.executionContextBuilder,
@@ -175,14 +181,22 @@ export function registerAgentExecutionServices(
   router.service(AgentExecutionCommandController, {
     create: (execution, ctx) => createExecution(deps, execution, ctx),
     update: (execution, ctx) => update(deps, execution, ctx),
-    updateStatus: (input) => updateStatus(deps, input),
-    submitApproval: (input) => submitApproval(deps, input),
-    submitFileDecision: (input) => submitFileDecision(deps, input),
-    cancel: (input) => cancelExecution(lifecycleDeps, input),
-    terminate: (input) => terminateExecution(lifecycleDeps, input),
-    recover: (input) => recoverExecution(lifecycleDeps, input),
-    pause: (input) => pauseExecution(lifecycleDeps, input),
-    resume: (input) => resumeExecution(lifecycleDeps, input),
+    updateStatus: (input, ctx) =>
+      updateStatus(deps, input, callerIdentityOf(ctx)),
+    submitApproval: (input, ctx) =>
+      submitApproval(deps, input, callerIdentityOf(ctx)),
+    submitFileDecision: (input, ctx) =>
+      submitFileDecision(deps, input, callerIdentityOf(ctx)),
+    cancel: (input, ctx) =>
+      cancelExecution(lifecycleDeps, input, callerIdentityOf(ctx)),
+    terminate: (input, ctx) =>
+      terminateExecution(lifecycleDeps, input, callerIdentityOf(ctx)),
+    recover: (input, ctx) =>
+      recoverExecution(lifecycleDeps, input, callerIdentityOf(ctx)),
+    pause: (input, ctx) =>
+      pauseExecution(lifecycleDeps, input, callerIdentityOf(ctx)),
+    resume: (input, ctx) =>
+      resumeExecution(lifecycleDeps, input, callerIdentityOf(ctx)),
     uploadAttachment: (req) => uploadAttachment(artifactDeps, req),
     delete: (id, ctx) => deleteExecution(deps, id, ctx),
   });
@@ -193,10 +207,14 @@ export function registerAgentExecutionServices(
     subscribe: (id, ctx) => subscribeExecution(deps, id, ctx),
     getArtifactDownloadUrl: (req) => getArtifactDownloadUrl(artifactDeps, req),
     getArtifactContent: (req) => getArtifactContent(artifactDeps, req),
-    getExecutionUsageReport: (req) => getExecutionUsageReport(deps, req),
-    getSessionUsageReport: (req) => getSessionUsageReport(deps, req),
-    getAgentUsageReport: (req) => getAgentUsageReport(deps, req),
-    getOrgUsageReport: (req) => getOrgUsageReport(deps, req),
+    getExecutionUsageReport: (req, ctx) =>
+      getExecutionUsageReport(deps, req, callerIdentityOf(ctx)),
+    getSessionUsageReport: (req, ctx) =>
+      getSessionUsageReport(deps, req, callerIdentityOf(ctx)),
+    getAgentUsageReport: (req, ctx) =>
+      getAgentUsageReport(deps, req, callerIdentityOf(ctx)),
+    getOrgUsageReport: (req, ctx) =>
+      getOrgUsageReport(deps, req, callerIdentityOf(ctx)),
     getExecutionSummary: (req) => getExecutionSummary(deps, req),
   });
 }
@@ -220,12 +238,19 @@ async function createExecution(
   const reqCtx = new RequestContext(
     AgentExecutionSchema,
     execution,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentExecutionSchema>(
     "agent-execution-create",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newValidateServiceTierStep(deps.modelRegistry))
@@ -292,12 +317,19 @@ async function update(
   const reqCtx = new RequestContext(
     AgentExecutionSchema,
     execution,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentExecutionSchema>(
     "agent-execution-update",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
@@ -328,12 +360,19 @@ async function deleteExecution(
   const reqCtx = new RequestContext(
     AgentExecutionCommandController.method.delete.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentExecutionCommandController.method.delete.input>(
     "agent-execution-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, AgentExecutionSchema))
@@ -361,12 +400,19 @@ async function get(
   const reqCtx = new RequestContext(
     AgentExecutionQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentExecutionQueryController.method.get.input>(
     "agent-execution-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionQueryController.method.get,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, AgentExecutionSchema))
     .build()
@@ -387,12 +433,19 @@ async function list(
   const reqCtx = new RequestContext(
     AgentExecutionQueryController.method.list.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentExecutionQueryController.method.list.input>(
     "agent-execution-list",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionQueryController.method.list,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateListRequestStep())
     .addStep(newQueryAllExecutionsStep(deps.store, deps.logger))
     .addStep(newApplyPhaseFilterStep(deps.logger))
@@ -411,11 +464,18 @@ async function listBySession(
   const reqCtx = new RequestContext(
     AgentExecutionQueryController.method.listBySession.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<
     typeof AgentExecutionQueryController.method.listBySession.input
   >("agent-execution-list-by-session", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionQueryController.method.listBySession,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateListBySessionRequestStep())
     .addStep(newQueryExecutionsBySessionStep(deps.store, deps.logger))
     .addStep(newBuildExecutionListResponseStep())

--- a/backend/services/stigmer-server/src/domain/agentexecution/lifecycle.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/lifecycle.ts
@@ -41,10 +41,11 @@ import type {
 import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import type { SubAgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/subagent_pb";
-import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
+import type { DescMessage, DescMethod, MessageShape } from "@bufbuild/protobuf";
 import { enumToJson } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import {
   failedPreconditionError,
   internalError,
@@ -53,19 +54,16 @@ import {
 } from "../../pipeline/errors.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
 
-import type {
-  ExecutionContextBuilderDeps,
-} from "./create-execution-context-step.js";
+import type { ExecutionContextBuilderDeps } from "./create-execution-context-step.js";
 import { buildAndPersistExecutionContext } from "./create-execution-context-step.js";
 import type { ExecutionEngineStateProvider } from "./engine.js";
-import {
-  EngineDispatchError,
-  EngineWorkflowNotFoundError,
-} from "./engine.js";
+import { EngineDispatchError, EngineWorkflowNotFoundError } from "./engine.js";
 import { settleInterruptedToolCalls } from "./tool-call-settle.js";
 import type { StreamBroker } from "./stream-broker.js";
 
@@ -80,6 +78,8 @@ export const TEMPORAL_UNAVAILABLE_MESSAGE = "Temporal is not available";
 export interface LifecycleDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly broker: StreamBroker;
   readonly engineState: ExecutionEngineStateProvider;
   /** The shared EC-builder deps, consumed by recover's recreate step. */
@@ -268,7 +268,8 @@ export function applyLifecyclePhaseTransition(
   }
 
   if (setError) {
-    status.error = reason !== "" ? `Terminated: ${reason}` : "Terminated by user";
+    status.error =
+      reason !== "" ? `Terminated: ${reason}` : "Terminated by user";
   }
   if (clearError) {
     status.error = "";
@@ -381,14 +382,18 @@ async function runLifecyclePipeline<Desc extends DescMessage>(
   pipelineName: string,
   schema: Desc,
   input: MessageShape<Desc>,
+  method: DescMethod,
+  identity: CallerIdentity,
   steps: PipelineStep<Desc>[],
 ): Promise<AgentExecution> {
   const reqCtx = new RequestContext(
     schema,
     input,
+    identity,
     ApiResourceKind.agent_execution,
   );
   const builder = newPipeline<Desc>(pipelineName, deps.logger);
+  builder.addStep(newAuthorizeStep(method, deps.authorizer));
   for (const step of steps) {
     builder.addStep(step);
   }
@@ -411,6 +416,7 @@ async function runLifecyclePipeline<Desc extends DescMessage>(
 export async function cancelExecution(
   deps: LifecycleDeps,
   input: CancelAgentExecutionInput,
+  identity: CallerIdentity,
 ): Promise<AgentExecution> {
   type Desc = typeof AgentExecutionCommandController.method.cancel.input;
   deps.logger.info("Cancel agent execution request", {
@@ -422,6 +428,8 @@ export async function cancelExecution(
     "agentexecution-cancel",
     AgentExecutionCommandController.method.cancel.input,
     input,
+    AgentExecutionCommandController.method.cancel,
+    identity,
     [
       newLoadExecutionByIdStep(deps),
       newValidatePhaseStep({
@@ -457,6 +465,7 @@ export async function cancelExecution(
 export async function terminateExecution(
   deps: LifecycleDeps,
   input: TerminateAgentExecutionInput,
+  identity: CallerIdentity,
 ): Promise<AgentExecution> {
   type Desc = typeof AgentExecutionCommandController.method.terminate.input;
   deps.logger.info("Terminate agent execution request", {
@@ -468,6 +477,8 @@ export async function terminateExecution(
     "agentexecution-terminate",
     AgentExecutionCommandController.method.terminate.input,
     input,
+    AgentExecutionCommandController.method.terminate,
+    identity,
     [
       newLoadExecutionByIdStep(deps),
       newValidatePhaseStep({
@@ -486,8 +497,8 @@ export async function terminateExecution(
         deps,
         invoke: async (engine, executionId, ctx) => {
           const reason =
-            (ctx.newState as unknown as LifecycleInputWithReasonShape)
-              .reason || "Terminated by user";
+            (ctx.newState as unknown as LifecycleInputWithReasonShape).reason ||
+            "Terminated by user";
           await engine.engine.terminateWorkflow(executionId, reason);
           // Store the resolved reason for the phase update's error text.
           ctx.set(REASON_KEY, reason);
@@ -509,6 +520,7 @@ export async function terminateExecution(
 export async function pauseExecution(
   deps: LifecycleDeps,
   input: PauseAgentExecutionInput,
+  identity: CallerIdentity,
 ): Promise<AgentExecution> {
   type Desc = typeof AgentExecutionCommandController.method.pause.input;
   deps.logger.info("Pause agent execution request", {
@@ -520,6 +532,8 @@ export async function pauseExecution(
     "agentexecution-pause",
     AgentExecutionCommandController.method.pause.input,
     input,
+    AgentExecutionCommandController.method.pause,
+    identity,
     [
       newLoadExecutionByIdStep(deps),
       newValidatePhaseStep({
@@ -538,8 +552,8 @@ export async function pauseExecution(
         deps,
         invoke: async (engine, executionId, ctx) => {
           const reason =
-            (ctx.newState as unknown as LifecycleInputWithReasonShape)
-              .reason || "Paused by user";
+            (ctx.newState as unknown as LifecycleInputWithReasonShape).reason ||
+            "Paused by user";
           await engine.engine.signalPause(executionId, reason);
           ctx.set(REASON_KEY, reason);
         },
@@ -560,6 +574,7 @@ export async function pauseExecution(
 export async function resumeExecution(
   deps: LifecycleDeps,
   input: ResumeAgentExecutionInput,
+  identity: CallerIdentity,
 ): Promise<AgentExecution> {
   type Desc = typeof AgentExecutionCommandController.method.resume.input;
   deps.logger.info("Resume agent execution request", {
@@ -570,6 +585,8 @@ export async function resumeExecution(
     "agentexecution-resume",
     AgentExecutionCommandController.method.resume.input,
     input,
+    AgentExecutionCommandController.method.resume,
+    identity,
     [
       newLoadExecutionByIdStep(deps),
       newValidatePhaseStep({
@@ -611,6 +628,7 @@ export async function resumeExecution(
 export async function recoverExecution(
   deps: LifecycleDeps,
   input: RecoverAgentExecutionInput,
+  identity: CallerIdentity,
 ): Promise<AgentExecution> {
   type Desc = typeof AgentExecutionCommandController.method.recover.input;
   deps.logger.info("Recover agent execution request", {
@@ -621,6 +639,8 @@ export async function recoverExecution(
     "agentexecution-recover",
     AgentExecutionCommandController.method.recover.input,
     input,
+    AgentExecutionCommandController.method.recover,
+    identity,
     [
       newLoadExecutionByIdStep(deps),
       newValidatePhaseStep({
@@ -644,8 +664,7 @@ export async function recoverExecution(
             executionId,
             "Recovery: terminating before fresh workflow start",
           ),
-        failureMessage:
-          "failed to terminate previous workflow during recovery",
+        failureMessage: "failed to terminate previous workflow during recovery",
       }),
       newRecreateExecutionContextStep(deps),
       newStartFreshWorkflowStep(deps),

--- a/backend/services/stigmer-server/src/domain/agentexecution/submit-approval.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/submit-approval.ts
@@ -46,6 +46,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import { enumToJson } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import {
   failedPreconditionError,
   internalError,
@@ -54,17 +55,20 @@ import {
   unavailableError,
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
 
-import { ensureApprovalRequests, recordDecisionEvent } from "./approval/author.js";
+import {
+  ensureApprovalRequests,
+  recordDecisionEvent,
+} from "./approval/author.js";
 import { deriveLeaseScope, sameLeaseScope } from "./approval/lease-scope.js";
 import { projectPendingApprovals } from "./approval/project.js";
-import type {
-  ExecutionEngineStateProvider,
-} from "./engine.js";
+import type { ExecutionEngineStateProvider } from "./engine.js";
 import { EngineWorkflowNotFoundError } from "./engine.js";
 import { countAwaitingReview } from "./filereview/gate.js";
 import { settleInterruptedToolCalls } from "./tool-call-settle.js";
@@ -73,6 +77,8 @@ import type { StreamBroker } from "./stream-broker.js";
 export interface SubmitApprovalDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly broker: StreamBroker;
   readonly engineState: ExecutionEngineStateProvider;
 }
@@ -87,16 +93,24 @@ const TARGET_RESOURCE_KEY = "targetResource";
 export async function submitApproval(
   deps: SubmitApprovalDeps,
   input: SubmitApprovalInput,
+  identity: CallerIdentity,
 ): Promise<AgentExecution> {
   const reqCtx = new RequestContext(
     AgentExecutionCommandController.method.submitApproval.input,
     input,
+    identity,
     ApiResourceKind.agent_execution,
   );
   await newPipeline<SubmitApprovalDesc>(
     "agent-execution-submit-approval",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionCommandController.method.submitApproval,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep({
       name: "LoadExisting",
@@ -129,8 +143,7 @@ export async function submitApproval(
         const requestedToolCallId = ctx.input.toolCallId;
         const requestedAction = ctx.input.action;
         const currentPhase =
-          execution.status?.phase ??
-          ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
+          execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
 
         // Approval is accepted during active execution phases where tool
         // calls may await decisions; terminal and pre-start phases refuse.
@@ -305,8 +318,7 @@ export async function submitApproval(
 
         const execution = ctx.get(TARGET_RESOURCE_KEY) as AgentExecution;
         const executionId = execution.metadata?.id ?? "";
-        const pendingRemaining =
-          execution.status?.pendingApprovals.length ?? 0;
+        const pendingRemaining = execution.status?.pendingApprovals.length ?? 0;
         const awaitingReview = countAwaitingReview(
           execution.status?.fileChangeSets ?? [],
         );
@@ -440,10 +452,9 @@ async function reconcileStaleExecution(
     return;
   }
 
-  deps.logger.info(
-    "RECONCILIATION: Updated stale execution status to FAILED",
-    { executionId },
-  );
+  deps.logger.info("RECONCILIATION: Updated stale execution status to FAILED", {
+    executionId,
+  });
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/agentexecution/submit-file-decision.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/submit-file-decision.ts
@@ -45,6 +45,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import { enumToJson } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import {
   failedPreconditionError,
   internalError,
@@ -53,7 +54,9 @@ import {
   unavailableError,
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
@@ -77,6 +80,8 @@ import type { StreamBroker } from "./stream-broker.js";
 export interface SubmitFileDecisionDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly broker: StreamBroker;
   readonly engineState: ExecutionEngineStateProvider;
 }
@@ -91,16 +96,24 @@ const TARGET_RESOURCE_KEY = "targetResource";
 export async function submitFileDecision(
   deps: SubmitFileDecisionDeps,
   input: SubmitFileDecisionInput,
+  identity: CallerIdentity,
 ): Promise<AgentExecution> {
   const reqCtx = new RequestContext(
     AgentExecutionCommandController.method.submitFileDecision.input,
     input,
+    identity,
     ApiResourceKind.agent_execution,
   );
   await newPipeline<SubmitFileDecisionDesc>(
     "agent-execution-submit-file-decision",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionCommandController.method.submitFileDecision,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep({
       name: "LoadExisting",

--- a/backend/services/stigmer-server/src/domain/agentexecution/update-status.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/update-status.ts
@@ -43,13 +43,16 @@ import type { AgentMessage } from "@stigmer/protos/ai/stigmer/agentic/agentexecu
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import {
   internalError,
   invalidArgumentError,
   notFoundError,
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
 
@@ -70,6 +73,8 @@ import type { StreamBroker } from "./stream-broker.js";
 export interface UpdateStatusDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly broker: StreamBroker;
 }
 
@@ -81,16 +86,24 @@ const EXECUTION_KEY = "execution";
 export async function updateStatus(
   deps: UpdateStatusDeps,
   input: AgentExecutionUpdateStatusInput,
+  identity: CallerIdentity,
 ): Promise<UpdateStatusResponse> {
   const reqCtx = new RequestContext(
     AgentExecutionCommandController.method.updateStatus.input,
     input,
+    identity,
     ApiResourceKind.agent_execution,
   );
   await newPipeline<UpdateStatusDesc>(
     "agentexecution-update-status",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionCommandController.method.updateStatus,
+        deps.authorizer,
+      ),
+    )
     .addStep({
       name: "ValidateUpdateStatusInput",
       execute(ctx) {

--- a/backend/services/stigmer-server/src/domain/agentexecution/usage.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/usage.ts
@@ -65,10 +65,13 @@ import { UsageReportAggregateSchema } from "@stigmer/protos/ai/stigmer/agentic/a
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import type { Store } from "../../store/interface.js";
 
 import { executionUsageReportNotFoundMessage } from "./constants.js";
@@ -77,6 +80,8 @@ import { EXECUTION_LIST_KEY, loadAllAgentExecutions } from "./steps.js";
 export interface UsageReportDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
 }
 
 // Context keys for inter-step communication — Go's key strings, verbatim.
@@ -397,16 +402,24 @@ type ExecutionReportDesc =
 export async function getExecutionUsageReport(
   deps: UsageReportDeps,
   req: RequestContext<ExecutionReportDesc>["input"],
+  identity: CallerIdentity,
 ): Promise<GetExecutionUsageReportOutput> {
   const reqCtx = new RequestContext(
     AgentExecutionQueryController.method.getExecutionUsageReport.input,
     req,
+    identity,
     ApiResourceKind.agent_execution,
   );
   await newPipeline<ExecutionReportDesc>(
     "get-execution-usage-report",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionQueryController.method.getExecutionUsageReport,
+        deps.authorizer,
+      ),
+    )
     .addStep({
       name: "ValidateExecutionUsageReport",
       execute(ctx) {
@@ -441,9 +454,7 @@ export async function getExecutionUsageReport(
  * (mangled, DD-001) NotFound exactly as Go's step converts every
  * GetResource error.
  */
-function newLoadExecutionStep(
-  store: Store,
-): PipelineStep<ExecutionReportDesc> {
+function newLoadExecutionStep(store: Store): PipelineStep<ExecutionReportDesc> {
   return {
     name: "LoadExecution",
     async execute(ctx) {
@@ -478,13 +489,21 @@ type SessionReportDesc =
 export async function getSessionUsageReport(
   deps: UsageReportDeps,
   req: RequestContext<SessionReportDesc>["input"],
+  identity: CallerIdentity,
 ): Promise<GetSessionUsageReportOutput> {
   const reqCtx = new RequestContext(
     AgentExecutionQueryController.method.getSessionUsageReport.input,
     req,
+    identity,
     ApiResourceKind.agent_execution,
   );
   await newPipeline<SessionReportDesc>("get-session-usage-report", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionQueryController.method.getSessionUsageReport,
+        deps.authorizer,
+      ),
+    )
     .addStep({
       name: "ValidateSessionUsageReport",
       execute(ctx) {
@@ -547,13 +566,21 @@ type AgentReportDesc =
 export async function getAgentUsageReport(
   deps: UsageReportDeps,
   req: RequestContext<AgentReportDesc>["input"],
+  identity: CallerIdentity,
 ): Promise<GetAgentUsageReportOutput> {
   const reqCtx = new RequestContext(
     AgentExecutionQueryController.method.getAgentUsageReport.input,
     req,
+    identity,
     ApiResourceKind.agent_execution,
   );
   await newPipeline<AgentReportDesc>("get-agent-usage-report", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionQueryController.method.getAgentUsageReport,
+        deps.authorizer,
+      ),
+    )
     .addStep({
       name: "ValidateAgentUsageReport",
       execute(ctx) {
@@ -644,13 +671,21 @@ type OrgReportDesc =
 export async function getOrgUsageReport(
   deps: UsageReportDeps,
   req: RequestContext<OrgReportDesc>["input"],
+  identity: CallerIdentity,
 ): Promise<GetOrgUsageReportOutput> {
   const reqCtx = new RequestContext(
     AgentExecutionQueryController.method.getOrgUsageReport.input,
     req,
+    identity,
     ApiResourceKind.agent_execution,
   );
   await newPipeline<OrgReportDesc>("get-org-usage-report", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentExecutionQueryController.method.getOrgUsageReport,
+        deps.authorizer,
+      ),
+    )
     .addStep({
       name: "ValidateOrgUsageReport",
       execute(ctx) {
@@ -804,9 +839,7 @@ export async function getExecutionSummary(
     for (const d of completedDurationsMs) {
       totalMs += d;
     }
-    summary.avgDuration = durationFromMs(
-      totalMs / completedDurationsMs.length,
-    );
+    summary.avgDuration = durationFromMs(totalMs / completedDurationsMs.length);
   }
 
   summary.topFailingAgents = buildAgentFailureRanks(

--- a/backend/services/stigmer-server/src/domain/agentinstance/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentinstance/controller.ts
@@ -37,11 +37,14 @@ import type {
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError, notFoundError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import {
   newBuildNewStateStep,
   setAuditFieldsForUpdate,
@@ -95,6 +98,8 @@ import type { ParentAgentLoaderProvider } from "./steps.js";
 export interface AgentInstanceControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   /**
    * The agent in-process edge — a lazy provider because
    * agent↔agentinstance is a true dependency cycle (DD-002; the ratified
@@ -138,11 +143,22 @@ async function createInstance(
   instance: AgentInstance,
   ctx: HandlerContext,
 ): Promise<AgentInstance> {
-  const reqCtx = new RequestContext(AgentInstanceSchema, instance, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    AgentInstanceSchema,
+    instance,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof AgentInstanceSchema>(
     "agent-instance-create",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentInstanceCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveSlugStep())
@@ -165,11 +181,22 @@ async function update(
   instance: AgentInstance,
   ctx: HandlerContext,
 ): Promise<AgentInstance> {
-  const reqCtx = new RequestContext(AgentInstanceSchema, instance, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    AgentInstanceSchema,
+    instance,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof AgentInstanceSchema>(
     "agent-instance-update",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentInstanceCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
@@ -196,11 +223,22 @@ async function apply(
   instance: AgentInstance,
   ctx: HandlerContext,
 ): Promise<AgentInstance> {
-  const reqCtx = new RequestContext(AgentInstanceSchema, instance, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    AgentInstanceSchema,
+    instance,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof AgentInstanceSchema>(
     "agent-instance-apply",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentInstanceCommandController.method.apply,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -228,12 +266,19 @@ async function deleteInstance(
   const reqCtx = new RequestContext(
     AgentInstanceCommandController.method.delete.input,
     instanceId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentInstanceCommandController.method.delete.input>(
     "agent-instance-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentInstanceCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, AgentInstanceSchema))
@@ -270,12 +315,19 @@ async function updateVisibility(
   const reqCtx = new RequestContext(
     AgentInstanceCommandController.method.updateVisibility.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<UpdateVisibilityDesc>(
     "agent-instance-update-visibility",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentInstanceCommandController.method.updateVisibility,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadInstanceForVisibilityUpdateStep(deps.store))
     .addStep(newRejectDefaultInstanceVisibilityUpdateStep(deps.store))
@@ -321,7 +373,12 @@ function newSetInstanceVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
       if (instance.metadata !== undefined) {
         instance.metadata.visibility = ctx.input.visibility;
       }
-      setAuditFieldsForUpdate(AgentInstanceSchema, instance, "status_audit");
+      setAuditFieldsForUpdate(
+        AgentInstanceSchema,
+        instance,
+        "status_audit",
+        ctx.callerIdentity,
+      );
     },
   };
 }
@@ -397,12 +454,19 @@ async function get(
   const reqCtx = new RequestContext(
     AgentInstanceQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentInstanceQueryController.method.get.input>(
     "agent-instance-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentInstanceQueryController.method.get,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadTargetStep(deps.store, AgentInstanceSchema))
@@ -420,11 +484,18 @@ async function getByReference(
   const reqCtx = new RequestContext(
     AgentInstanceQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<
     typeof AgentInstanceQueryController.method.getByReference.input
   >("agent-instance-get-by-reference", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentInstanceQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, AgentInstanceSchema))
     .build()
@@ -441,11 +512,18 @@ async function getByAgent(
   const reqCtx = new RequestContext(
     AgentInstanceQueryController.method.getByAgent.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<
     typeof AgentInstanceQueryController.method.getByAgent.input
   >("agent-instance-get-by-agent", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentInstanceQueryController.method.getByAgent,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByAgentStep(deps.store))
     .build()
@@ -470,12 +548,19 @@ async function list(
   const reqCtx = new RequestContext(
     AgentInstanceQueryController.method.list.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentInstanceQueryController.method.list.input>(
     "agent-instance-list",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentInstanceQueryController.method.list,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newListByOrgAndLabelsStep(deps.store, deps.logger))
     .build()

--- a/backend/services/stigmer-server/src/domain/agentshare/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentshare/controller.ts
@@ -45,6 +45,7 @@ import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/ap
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
   internalError,
@@ -53,8 +54,13 @@ import {
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
-import { newBuildNewStateStep, setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import {
+  newBuildNewStateStep,
+  setAuditFieldsForUpdate,
+} from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
 import {
@@ -62,11 +68,23 @@ import {
   newExtractResourceIdStep,
   newLoadExistingForDeleteStep,
 } from "../../pipeline/steps/delete.js";
-import { compareCreatedAtDesc, matchesAllLabels } from "../../pipeline/steps/helpers.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
-import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import {
+  compareCreatedAtDesc,
+  matchesAllLabels,
+} from "../../pipeline/steps/helpers.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
-import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
@@ -88,6 +106,8 @@ import {
 export interface AgentShareControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
 }
 
 /** Registers both agentshare services on the router (routes stage). */
@@ -108,7 +128,8 @@ export function registerAgentShareServices(
     getByAgent: (req, ctx) => getByAgent(deps, req, ctx),
     list: (req, ctx) => list(deps, req, ctx),
     getSharedProfile: (req, ctx) => getSharedProfile(deps, req, ctx),
-    getSharedProfileForMember: (ref, ctx) => getSharedProfileForMember(deps, ref, ctx),
+    getSharedProfileForMember: (ref, ctx) =>
+      getSharedProfileForMember(deps, ref, ctx),
   });
 }
 
@@ -127,8 +148,19 @@ async function createShare(
   share: AgentShare,
   ctx: HandlerContext,
 ): Promise<AgentShare> {
-  const reqCtx = new RequestContext(AgentShareSchema, share, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    AgentShareSchema,
+    share,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof AgentShareSchema>("agent-share-create", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentShareCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveShareDefaultsStep(deps.store))
@@ -155,8 +187,19 @@ async function update(
   share: AgentShare,
   ctx: HandlerContext,
 ): Promise<AgentShare> {
-  const reqCtx = new RequestContext(AgentShareSchema, share, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    AgentShareSchema,
+    share,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof AgentShareSchema>("agent-share-update", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentShareCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
@@ -182,8 +225,19 @@ async function apply(
   share: AgentShare,
   ctx: HandlerContext,
 ): Promise<AgentShare> {
-  const reqCtx = new RequestContext(AgentShareSchema, share, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    AgentShareSchema,
+    share,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof AgentShareSchema>("agent-share-apply", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentShareCommandController.method.apply,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveShareDefaultsStep(deps.store))
     .addStep(newResolveSlugStep())
@@ -213,7 +267,8 @@ async function apply(
 
 const ROTATE_SHARE_KEY = "rotateShareLinkShare";
 
-type RotateDesc = typeof AgentShareCommandController.method.rotateShareLink.input;
+type RotateDesc =
+  typeof AgentShareCommandController.method.rotateShareLink.input;
 
 async function rotateShareLink(
   deps: AgentShareControllerDeps,
@@ -223,9 +278,16 @@ async function rotateShareLink(
   const reqCtx = new RequestContext(
     AgentShareCommandController.method.rotateShareLink.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<RotateDesc>("agent-share-rotate-share-link", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentShareCommandController.method.rotateShareLink,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadShareForLinkRotationStep(deps.store))
     .addStep(newRotateShareLinkTokenStep())
@@ -236,7 +298,9 @@ async function rotateShareLink(
 }
 
 /** Loads the share by resource_id; ANY load failure → NotFound (Go). */
-function newLoadShareForLinkRotationStep(store: Store): PipelineStep<RotateDesc> {
+function newLoadShareForLinkRotationStep(
+  store: Store,
+): PipelineStep<RotateDesc> {
   return {
     name: "LoadShareForLinkRotation",
     async execute(ctx: RequestContext<RotateDesc>): Promise<void> {
@@ -279,13 +343,20 @@ function newRotateShareLinkTokenStep(): PipelineStep<RotateDesc> {
       const status = share.status ?? create(AgentShareStatusSchema);
       status.shareLinkToken = token;
       share.status = status;
-      setAuditFieldsForUpdate(AgentShareSchema, share, "status_audit");
+      setAuditFieldsForUpdate(
+        AgentShareSchema,
+        share,
+        "status_audit",
+        ctx.callerIdentity,
+      );
     },
   };
 }
 
 /** Saves the rotated share. */
-function newPersistShareForLinkRotationStep(store: Store): PipelineStep<RotateDesc> {
+function newPersistShareForLinkRotationStep(
+  store: Store,
+): PipelineStep<RotateDesc> {
   return {
     name: "PersistShareForLinkRotation",
     async execute(ctx: RequestContext<RotateDesc>): Promise<void> {
@@ -318,12 +389,19 @@ async function deleteShare(
   const reqCtx = new RequestContext(
     AgentShareCommandController.method.delete.input,
     shareId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentShareCommandController.method.delete.input>(
     "agent-share-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentShareCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, AgentShareSchema))
@@ -350,12 +428,16 @@ async function get(
   const reqCtx = new RequestContext(
     AgentShareQueryController.method.get.input,
     shareId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentShareQueryController.method.get.input>(
     "agent-share-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(AgentShareQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, AgentShareSchema))
     .build()
@@ -372,12 +454,18 @@ async function getByReference(
   const reqCtx = new RequestContext(
     AgentShareQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof AgentShareQueryController.method.getByReference.input>(
-    "agent-share-get-by-reference",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof AgentShareQueryController.method.getByReference.input
+  >("agent-share-get-by-reference", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentShareQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, AgentShareSchema))
     .build()
@@ -404,12 +492,19 @@ async function getByAgent(
   const reqCtx = new RequestContext(
     AgentShareQueryController.method.getByAgent.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentShareQueryController.method.getByAgent.input>(
     "agent-share-get-by-agent",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentShareQueryController.method.getByAgent,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadSharesByAgentStep(deps.store))
     .build()
@@ -437,10 +532,15 @@ function newLoadSharesByAgentStep(
   return {
     name: "LoadSharesByAgent",
     async execute(
-      ctx: RequestContext<typeof AgentShareQueryController.method.getByAgent.input>,
+      ctx: RequestContext<
+        typeof AgentShareQueryController.method.getByAgent.input
+      >,
     ): Promise<void> {
       const req = ctx.input;
-      const emptyList = create(AgentShareListSchema, { totalCount: 0, items: [] });
+      const emptyList = create(AgentShareListSchema, {
+        totalCount: 0,
+        items: [],
+      });
 
       let agentOrg: string;
       let agentSlug: string;
@@ -484,7 +584,10 @@ function newLoadSharesByAgentStep(
 
       ctx.set(
         SHARE_LIST_KEY,
-        create(AgentShareListSchema, { totalCount: shares.length, items: shares }),
+        create(AgentShareListSchema, {
+          totalCount: shares.length,
+          items: shares,
+        }),
       );
     },
   };
@@ -505,12 +608,16 @@ async function list(
   const reqCtx = new RequestContext(
     AgentShareQueryController.method.list.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof AgentShareQueryController.method.list.input>(
     "agent-share-list",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(AgentShareQueryController.method.list, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newListByOrgAndLabelsStep(deps.store, deps.logger))
     .build()
@@ -572,7 +679,10 @@ function newListByOrgAndLabelsStep(
 
       ctx.set(
         LIST_RESULT_KEY,
-        create(AgentShareListSchema, { totalCount: shares.length, items: shares }),
+        create(AgentShareListSchema, {
+          totalCount: shares.length,
+          items: shares,
+        }),
       );
     },
   };
@@ -591,7 +701,8 @@ function newListByOrgAndLabelsStep(
 const RESOLVED_SHARE_KEY = "resolvedAgentShare";
 const SHARED_PROFILE_KEY = "sharedAgentProfile";
 
-type ProfileDesc = typeof AgentShareQueryController.method.getSharedProfile.input;
+type ProfileDesc =
+  typeof AgentShareQueryController.method.getSharedProfile.input;
 type MemberProfileDesc =
   typeof AgentShareQueryController.method.getSharedProfileForMember.input;
 
@@ -603,9 +714,16 @@ async function getSharedProfile(
   const reqCtx = new RequestContext(
     AgentShareQueryController.method.getSharedProfile.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<ProfileDesc>("agent-share-get-shared-profile", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        AgentShareQueryController.method.getSharedProfile,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadShareForProfileStep(deps.store))
     .addStep(newProjectSharedProfileStep(deps.store))
@@ -622,12 +740,19 @@ async function getSharedProfileForMember(
   const reqCtx = new RequestContext(
     AgentShareQueryController.method.getSharedProfileForMember.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<MemberProfileDesc>(
     "agent-share-get-shared-profile-for-member",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        AgentShareQueryController.method.getSharedProfileForMember,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadShareForMemberProfileStep(deps.store))
     .addStep(newProjectMemberSharedProfileStep(deps.store))
@@ -659,7 +784,9 @@ function newLoadShareForProfileStep(store: Store): PipelineStep<ProfileDesc> {
 }
 
 /** The member path's loader — same org-required contract, same refusal. */
-function newLoadShareForMemberProfileStep(store: Store): PipelineStep<MemberProfileDesc> {
+function newLoadShareForMemberProfileStep(
+  store: Store,
+): PipelineStep<MemberProfileDesc> {
   return {
     name: "LoadShareForMemberProfile",
     async execute(ctx: RequestContext<MemberProfileDesc>): Promise<void> {
@@ -692,7 +819,12 @@ function newProjectSharedProfileStep(store: Store): PipelineStep<ProfileDesc> {
       if (share.spec?.enabled !== true) {
         throw sharedNotFound(req.slug);
       }
-      if (!sharingLinkTokenAllowed(req.linkToken, share.status?.shareLinkToken ?? "")) {
+      if (
+        !sharingLinkTokenAllowed(
+          req.linkToken,
+          share.status?.shareLinkToken ?? "",
+        )
+      ) {
         throw sharedNotFound(req.slug);
       }
 
@@ -708,7 +840,9 @@ function newProjectSharedProfileStep(store: Store): PipelineStep<ProfileDesc> {
  * through GetSharedProfile with the matching token. Org-audience shares
  * are unaffected — their gate is membership, not the link token.
  */
-function newProjectMemberSharedProfileStep(store: Store): PipelineStep<MemberProfileDesc> {
+function newProjectMemberSharedProfileStep(
+  store: Store,
+): PipelineStep<MemberProfileDesc> {
   return {
     name: "ProjectMemberSharedProfile",
     async execute(ctx: RequestContext<MemberProfileDesc>): Promise<void> {

--- a/backend/services/stigmer-server/src/domain/artifact/__tests__/artifact.test.ts
+++ b/backend/services/stigmer-server/src/domain/artifact/__tests__/artifact.test.ts
@@ -16,6 +16,7 @@
  *   - the file server's traversal guard (a crafted key must never escape
  *     the artifact root — the SQLite db file lives right next to it).
  */
+import { newPermissiveSingleTeamAuthorizer } from "../../../pipeline/steps/authorize.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { createHash } from "node:crypto";
 import net from "node:net";
@@ -23,7 +24,12 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { create } from "@bufbuild/protobuf";
-import { Code, ConnectError, createClient, createRouterTransport } from "@connectrpc/connect";
+import {
+  Code,
+  ConnectError,
+  createClient,
+  createRouterTransport,
+} from "@connectrpc/connect";
 import type { Client, Transport } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
@@ -37,13 +43,18 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import { LocalArtifactStorage } from "../../../artifactstorage/artifact-storage.js";
 import { loadConfig } from "../../../boot/config.js";
 import { composeServer } from "../../../boot/compose.js";
+import { createVerifierChainInterceptor } from "../../../pipeline/interceptors/auth.js";
 import type { ComposedServer } from "../../../boot/compose.js";
 import { createLogger } from "../../../boot/logger.js";
 import { SqliteStore } from "../../../store/sqlite/store.js";
 import { MAX_CONTENT_BYTES, artifactNotFoundMessage } from "../constants.js";
 import { registerArtifactServices } from "../controller.js";
 
-const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
 
 type CommandClient = Client<typeof ArtifactCommandController>;
 type QueryClient = Client<typeof ArtifactQueryController>;
@@ -55,7 +66,8 @@ async function freePort(): Promise<number> {
     probe.once("error", reject);
     probe.listen(0, "127.0.0.1", () => {
       const address = probe.address();
-      const port = address !== null && typeof address === "object" ? address.port : 0;
+      const port =
+        address !== null && typeof address === "object" ? address.port : 0;
       probe.close(() => resolve(port));
     });
   });
@@ -71,7 +83,10 @@ beforeAll(async () => {
   dir = mkdtempSync(path.join(tmpdir(), "artifact-domain-test-"));
   artifactPort = await freePort();
   vi.stubEnv("STIGMER_ENCRYPTION_KEY", Buffer.alloc(32, 3).toString("base64"));
-  vi.stubEnv("STIGMER_RUNNER_TOKEN_KEY", Buffer.alloc(32, 4).toString("base64"));
+  vi.stubEnv(
+    "STIGMER_RUNNER_TOKEN_KEY",
+    Buffer.alloc(32, 4).toString("base64"),
+  );
   server = await composeServer({
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
@@ -126,7 +141,8 @@ function artifactInput(overrides?: {
         ? { retention: { ttlDays: overrides.ttlDays } }
         : {}),
     },
-    content: overrides?.content ?? new TextEncoder().encode(`content ${counter}\n`),
+    content:
+      overrides?.content ?? new TextEncoder().encode(`content ${counter}\n`),
   };
 }
 
@@ -153,7 +169,9 @@ describe("artifact domain — create & content addressing", () => {
       createHash("sha256").update(input.content).digest("hex"),
     );
     expect(created.status?.sizeBytes).toBe(BigInt(input.content.byteLength));
-    expect(created.status?.storageState).toBe(ArtifactStorageState.storage_state_stored);
+    expect(created.status?.storageState).toBe(
+      ArtifactStorageState.storage_state_stored,
+    );
   });
 
   it("expires_at is RFC3339 WITHOUT fractional seconds, ~30 days out by default", async () => {
@@ -208,16 +226,28 @@ describe("artifact domain — create & content addressing", () => {
     const storeDir = mkdtempSync(path.join(tmpdir(), "artifact-cap-test-"));
     const store = SqliteStore.open(path.join(storeDir, "cap.db"), silentLogger);
     try {
-      const transport = createRouterTransport((router) => {
-        registerArtifactServices(router, {
-          store,
-          artifactStorage: new LocalArtifactStorage(
-            path.join(storeDir, "artifacts"),
-            "http://localhost:1",
-          ),
-          logger: silentLogger,
-        });
-      });
+      // ONLY the position-1 identity source (O2: an identityless
+      // transport fails loudly by design) — positions 2-4 stay absent on
+      // purpose so the DOMAIN cap is reachable past the transport's
+      // protovalidate/size gates, the whole point of this arm.
+      const transport = createRouterTransport(
+        (router) => {
+          registerArtifactServices(router, {
+            store,
+            authorizer: newPermissiveSingleTeamAuthorizer(),
+            artifactStorage: new LocalArtifactStorage(
+              path.join(storeDir, "artifacts"),
+              "http://localhost:1",
+            ),
+            logger: silentLogger,
+          });
+        },
+        {
+          router: {
+            interceptors: [createVerifierChainInterceptor([], silentLogger)],
+          },
+        },
+      );
       const local = createClient(ArtifactCommandController, transport);
       const err = await grpcError(() =>
         local.create(
@@ -245,12 +275,16 @@ describe("artifact domain — read surfaces", () => {
     const fetched = await query.get({ value: created.metadata!.id });
     expect(fetched.status?.contentHash).toBe(created.status?.contentHash);
 
-    const listed = await query.listByExecution({ workflowExecutionId: executionId });
+    const listed = await query.listByExecution({
+      workflowExecutionId: executionId,
+    });
     expect(listed.totalPages).toBe(1);
     expect(listed.entries).toHaveLength(1);
 
     // The OTHER source arm must not match the same id.
-    const other = await query.listByExecution({ agentExecutionId: executionId });
+    const other = await query.listByExecution({
+      agentExecutionId: executionId,
+    });
     expect(other.entries).toHaveLength(0);
   });
 
@@ -282,7 +316,9 @@ describe("artifact domain — read surfaces", () => {
 
   it("getDownloadUrl reports the unconditional 604800 ttl and blob facts", async () => {
     const created = await command.create(artifactInput());
-    const download = await query.getDownloadUrl({ value: created.metadata!.id });
+    const download = await query.getDownloadUrl({
+      value: created.metadata!.id,
+    });
     expect(download.url).toContain(created.status!.contentHash);
     expect(download.ttlSeconds).toBe(604800);
     expect(download.sizeBytes).toBe(created.status?.sizeBytes);
@@ -308,10 +344,14 @@ describe("artifact domain — soft delete", () => {
     const created = await command.create(artifactInput());
 
     const deleted = await command.delete({ value: created.metadata!.id });
-    expect(deleted.status?.storageState).toBe(ArtifactStorageState.storage_state_deleted);
+    expect(deleted.status?.storageState).toBe(
+      ArtifactStorageState.storage_state_deleted,
+    );
 
     const fetched = await query.get({ value: created.metadata!.id });
-    expect(fetched.status?.storageState).toBe(ArtifactStorageState.storage_state_deleted);
+    expect(fetched.status?.storageState).toBe(
+      ArtifactStorageState.storage_state_deleted,
+    );
 
     const download = await grpcError(() =>
       query.getDownloadUrl({ value: created.metadata!.id }),
@@ -327,7 +367,9 @@ describe("artifact domain — soft delete", () => {
   });
 
   it("deleting a missing artifact answers NotFound", async () => {
-    const err = await grpcError(() => command.delete({ value: "art_01nothere" }));
+    const err = await grpcError(() =>
+      command.delete({ value: "art_01nothere" }),
+    );
     expect(err.code).toBe(Code.NotFound);
   });
 });
@@ -336,7 +378,9 @@ describe("artifact domain — the local file-server lane", () => {
   it("serves the blob inline; ?download= adds the attachment disposition", async () => {
     const content = new TextEncoder().encode("file-server domain test body\n");
     const created = await command.create(artifactInput({ content }));
-    const download = await query.getDownloadUrl({ value: created.metadata!.id });
+    const download = await query.getDownloadUrl({
+      value: created.metadata!.id,
+    });
 
     const inline = await fetch(download.url);
     expect(inline.status).toBe(200);

--- a/backend/services/stigmer-server/src/domain/artifact/controller.ts
+++ b/backend/services/stigmer-server/src/domain/artifact/controller.ts
@@ -56,16 +56,23 @@ import type { ApiResourceId } from "@stigmer/protos/ai/stigmer/commons/apiresour
 
 import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import {
   generateId,
   setAuditFieldsForCreate,
   setAuditFieldsForUpdate,
 } from "../../pipeline/steps/defaults.js";
-import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import type { Store } from "../../store/interface.js";
 import {
@@ -83,6 +90,8 @@ export interface ArtifactControllerDeps {
   readonly store: Store;
   readonly artifactStorage: ArtifactStorage;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
 }
 
 /** Registers both artifact services on the router (routes stage). */
@@ -91,8 +100,8 @@ export function registerArtifactServices(
   deps: ArtifactControllerDeps,
 ): void {
   router.service(ArtifactCommandController, {
-    create: (input) => createArtifact(deps, input),
-    delete: (id) => deleteArtifact(deps, id),
+    create: (input, ctx) => createArtifact(deps, input, callerIdentityOf(ctx)),
+    delete: (id, ctx) => deleteArtifact(deps, id, callerIdentityOf(ctx)),
   });
   router.service(ArtifactQueryController, {
     get: (id, ctx) => get(deps, id, ctx),
@@ -119,6 +128,7 @@ function kindOf(ctx: HandlerContext): ApiResourceKind {
 async function createArtifact(
   deps: ArtifactControllerDeps,
   input: CreateArtifactInput,
+  identity: CallerIdentity,
 ): Promise<Artifact> {
   const spec = input.spec;
   if (spec === undefined) {
@@ -186,7 +196,7 @@ async function createArtifact(
   // Go: SetAuditFieldsForCreate failure is LOG-ONLY — an artifact write
   // must not fail over audit stamping.
   try {
-    setAuditFieldsForCreate(ArtifactSchema, artifact);
+    setAuditFieldsForCreate(ArtifactSchema, artifact, identity);
   } catch (error) {
     deps.logger.error("failed to set audit fields on artifact", {
       error: error instanceof Error ? error.message : String(error),
@@ -230,7 +240,10 @@ async function deriveOrgFromSource(
   source: ArtifactSource,
 ): Promise<string> {
   const lookups: Array<{ id: string; kind: ApiResourceKind }> = [
-    { id: source.workflowExecutionId, kind: ApiResourceKind.workflow_execution },
+    {
+      id: source.workflowExecutionId,
+      kind: ApiResourceKind.workflow_execution,
+    },
     { id: source.agentExecutionId, kind: ApiResourceKind.agent_execution },
   ];
   for (const lookup of lookups) {
@@ -279,6 +292,7 @@ function computeExpiresAt(ttlDaysInput: number | undefined): string {
 async function deleteArtifact(
   deps: ArtifactControllerDeps,
   id: ApiResourceId,
+  identity: CallerIdentity,
 ): Promise<Artifact> {
   const resourceId = id.value;
   if (resourceId === "") {
@@ -301,7 +315,7 @@ async function deleteArtifact(
   // currently stamps neither slot; OSS stays honest rather than copying
   // that omission (stigmer/stigmer#540). Failure is LOG-ONLY, as in Go.
   try {
-    setAuditFieldsForUpdate(ArtifactSchema, artifact, "status_audit");
+    setAuditFieldsForUpdate(ArtifactSchema, artifact, "status_audit", identity);
   } catch (error) {
     deps.logger.error("failed to set audit fields on artifact delete", {
       error: error instanceof Error ? error.message : String(error),
@@ -339,12 +353,16 @@ async function get(
   const reqCtx = new RequestContext(
     ArtifactQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof ArtifactQueryController.method.get.input>(
     "artifact-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(ArtifactQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, ArtifactSchema))
     .build()
@@ -369,12 +387,18 @@ async function listByExecution(
   const reqCtx = new RequestContext(
     ArtifactQueryController.method.listByExecution.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof ArtifactQueryController.method.listByExecution.input>(
-    "artifact-list-by-execution",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof ArtifactQueryController.method.listByExecution.input
+  >("artifact-list-by-execution", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ArtifactQueryController.method.listByExecution,
+        deps.authorizer,
+      ),
+    )
     .addStep({
       name: "ValidateListByExecutionRequest",
       execute(stepCtx): void {

--- a/backend/services/stigmer-server/src/domain/channelapp/controller.ts
+++ b/backend/services/stigmer-server/src/domain/channelapp/controller.ts
@@ -41,12 +41,15 @@ import type {
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
@@ -56,10 +59,19 @@ import {
   newLoadExistingForDeleteStep,
 } from "../../pipeline/steps/delete.js";
 import { compareCreatedAtDesc } from "../../pipeline/steps/helpers.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
-import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
-import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -76,6 +88,8 @@ import {
 export interface ChannelAppControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly secretService: SecretService;
 }
 
@@ -113,13 +127,26 @@ async function createChannelApp(
   app: ChannelApp,
   ctx: HandlerContext,
 ): Promise<ChannelApp> {
-  const reqCtx = new RequestContext(ChannelAppSchema, app, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    ChannelAppSchema,
+    app,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof ChannelAppSchema>("channelapp-create", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ChannelAppCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newResolveSlugStep())
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newCheckDuplicateStep(deps.store))
-    .addStep(newEncryptChannelAppSecretsForCreateStep(deps.secretService, deps.logger))
+    .addStep(
+      newEncryptChannelAppSecretsForCreateStep(deps.secretService, deps.logger),
+    )
     .addStep(newBuildNewStateStep())
     .addStep(newPersistStep(deps.store))
     .build()
@@ -140,14 +167,27 @@ async function update(
   app: ChannelApp,
   ctx: HandlerContext,
 ): Promise<ChannelApp> {
-  const reqCtx = new RequestContext(ChannelAppSchema, app, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    ChannelAppSchema,
+    app,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof ChannelAppSchema>("channelapp-update", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ChannelAppCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newValidateProviderImmutableStep())
     .addStep(newBuildUpdateStateStep())
-    .addStep(newEncryptChannelAppSecretsForUpdateStep(deps.secretService, deps.logger))
+    .addStep(
+      newEncryptChannelAppSecretsForUpdateStep(deps.secretService, deps.logger),
+    )
     .addStep(newPersistStep(deps.store))
     .build()
     .execute(reqCtx);
@@ -170,8 +210,19 @@ async function apply(
   app: ChannelApp,
   ctx: HandlerContext,
 ): Promise<ChannelApp> {
-  const reqCtx = new RequestContext(ChannelAppSchema, app, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    ChannelAppSchema,
+    app,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof ChannelAppSchema>("channelapp-apply", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ChannelAppCommandController.method.apply,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -205,6 +256,7 @@ async function deleteChannelApp(
   const reqCtx = new RequestContext(
     ChannelAppCommandController.method.delete.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   reqCtx.set(RESOURCE_ID_KEY, input.resourceId);
@@ -212,6 +264,12 @@ async function deleteChannelApp(
     "channelapp-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        ChannelAppCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, ChannelAppSchema))
     .addStep(newCheckNoReferencingChannelsStep(deps.store, deps.logger))
@@ -240,12 +298,16 @@ async function get(
   const reqCtx = new RequestContext(
     ChannelAppQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof ChannelAppQueryController.method.get.input>(
     "channelapp-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(ChannelAppQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, ChannelAppSchema))
     .build()
@@ -264,12 +326,18 @@ async function getByReference(
   const reqCtx = new RequestContext(
     ChannelAppQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof ChannelAppQueryController.method.getByReference.input>(
-    "channelapp-get-by-reference",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof ChannelAppQueryController.method.getByReference.input
+  >("channelapp-get-by-reference", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ChannelAppQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, ChannelAppSchema))
     .build()
@@ -294,12 +362,19 @@ async function listByOrg(
   const reqCtx = new RequestContext(
     ChannelAppQueryController.method.listByOrg.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof ChannelAppQueryController.method.listByOrg.input>(
     "channelapp-list-by-org",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        ChannelAppQueryController.method.listByOrg,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newListByOrgStep(deps.store, deps.logger))
     .build()
@@ -328,7 +403,9 @@ function newListByOrgStep(
   return {
     name: "ListByOrg",
     async execute(
-      ctx: RequestContext<typeof ChannelAppQueryController.method.listByOrg.input>,
+      ctx: RequestContext<
+        typeof ChannelAppQueryController.method.listByOrg.input
+      >,
     ): Promise<void> {
       const org = ctx.input.org;
 

--- a/backend/services/stigmer-server/src/domain/environment/controller.ts
+++ b/backend/services/stigmer-server/src/domain/environment/controller.ts
@@ -42,6 +42,7 @@ import type {
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
@@ -51,8 +52,13 @@ import {
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
-import { newBuildNewStateStep, setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import {
+  newBuildNewStateStep,
+  setAuditFieldsForUpdate,
+} from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
 import {
@@ -64,11 +70,23 @@ import {
   newDeleteSearchIndexStep,
   newIndexSearchStep,
 } from "../../pipeline/steps/index-search.js";
-import { compareCreatedAtDesc, matchesAllLabels } from "../../pipeline/steps/helpers.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
-import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import {
+  compareCreatedAtDesc,
+  matchesAllLabels,
+} from "../../pipeline/steps/helpers.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
-import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
@@ -96,6 +114,8 @@ import {
 export interface EnvironmentControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly secretService: SecretService;
 }
 
@@ -136,8 +156,19 @@ async function createEnvironment(
   env: Environment,
   ctx: HandlerContext,
 ): Promise<Environment> {
-  const reqCtx = new RequestContext(EnvironmentSchema, env, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    EnvironmentSchema,
+    env,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof EnvironmentSchema>("environment-create", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        EnvironmentCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveSlugStep())
@@ -147,7 +178,9 @@ async function createEnvironment(
     .addStep(newPreserveRedactedSecretsStep())
     .addStep(newEncryptSecretValuesStep(deps.secretService, deps.logger))
     .addStep(newPersistStep(deps.store))
-    .addStep(newIndexSearchStep(deps.store, environmentSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(deps.store, environmentSearchExtractor, deps.logger),
+    )
     .build()
     .execute(reqCtx);
   redactEnvironmentSecrets(reqCtx.newState);
@@ -160,8 +193,19 @@ async function update(
   env: Environment,
   ctx: HandlerContext,
 ): Promise<Environment> {
-  const reqCtx = new RequestContext(EnvironmentSchema, env, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    EnvironmentSchema,
+    env,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof EnvironmentSchema>("environment-update", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        EnvironmentCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
@@ -170,7 +214,9 @@ async function update(
     .addStep(newEncryptSecretValuesStep(deps.secretService, deps.logger))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
-    .addStep(newIndexSearchStep(deps.store, environmentSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(deps.store, environmentSearchExtractor, deps.logger),
+    )
     .build()
     .execute(reqCtx);
   redactEnvironmentSecrets(reqCtx.newState);
@@ -187,8 +233,19 @@ async function apply(
   env: Environment,
   ctx: HandlerContext,
 ): Promise<Environment> {
-  const reqCtx = new RequestContext(EnvironmentSchema, env, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    EnvironmentSchema,
+    env,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof EnvironmentSchema>("environment-apply", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        EnvironmentCommandController.method.apply,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -222,6 +279,7 @@ async function deleteEnvironment(
   const reqCtx = new RequestContext(
     EnvironmentCommandController.method.delete.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   reqCtx.set(RESOURCE_ID_KEY, input.resourceId);
@@ -229,6 +287,12 @@ async function deleteEnvironment(
     "environment-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        EnvironmentCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, EnvironmentSchema))
     .addStep(newDeleteResourceStep(deps.store))
@@ -269,12 +333,19 @@ async function updateVisibility(
   const reqCtx = new RequestContext(
     EnvironmentCommandController.method.updateVisibility.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<UpdateVisibilityDesc>(
     "environment-update-visibility",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        EnvironmentCommandController.method.updateVisibility,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadEnvironmentForVisibilityUpdateStep(deps.store))
     // After load, per the cross-edition error precedence: unknown id +
@@ -283,7 +354,9 @@ async function updateVisibility(
     .addStep(newValidateEnvironmentShareRestrictionStep())
     .addStep(newSetEnvironmentVisibilityStep())
     .addStep(newPersistEnvironmentForVisibilityUpdateStep(deps.store))
-    .addStep(newIndexEnvironmentAfterVisibilityUpdateStep(deps.store, deps.logger))
+    .addStep(
+      newIndexEnvironmentAfterVisibilityUpdateStep(deps.store, deps.logger),
+    )
     .build()
     .execute(reqCtx);
 
@@ -350,7 +423,12 @@ function newSetEnvironmentVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
       // Go wraps a stamping failure as a PLAIN error (not grpclib) — the
       // wire then carries the sanitized "internal server error", exactly
       // what the pipeline's non-Connect fallback produces here.
-      setAuditFieldsForUpdate(EnvironmentSchema, env, "status_audit");
+      setAuditFieldsForUpdate(
+        EnvironmentSchema,
+        env,
+        "status_audit",
+        ctx.callerIdentity,
+      );
     },
   };
 }
@@ -431,16 +509,26 @@ async function updateVariables(
   const reqCtx = new RequestContext(
     EnvironmentCommandController.method.updateVariables.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof EnvironmentCommandController.method.updateVariables.input>(
-    "environment-update-variables",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof EnvironmentCommandController.method.updateVariables.input
+  >("environment-update-variables", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        EnvironmentCommandController.method.updateVariables,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadEnvironmentByIdStep(deps.store))
     .addStep(
-      newMergeVariablesAndPersistStep(deps.store, deps.secretService, deps.logger),
+      newMergeVariablesAndPersistStep(
+        deps.store,
+        deps.secretService,
+        deps.logger,
+      ),
     )
     .build()
     .execute(reqCtx);
@@ -459,12 +547,18 @@ async function removeVariables(
   const reqCtx = new RequestContext(
     EnvironmentCommandController.method.removeVariables.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof EnvironmentCommandController.method.removeVariables.input>(
-    "environment-remove-variables",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof EnvironmentCommandController.method.removeVariables.input
+  >("environment-remove-variables", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        EnvironmentCommandController.method.removeVariables,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadEnvironmentByIdStep(deps.store))
     .addStep(newRemoveVariableKeysAndPersistStep(deps.store))
@@ -485,12 +579,16 @@ async function get(
   const reqCtx = new RequestContext(
     EnvironmentQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof EnvironmentQueryController.method.get.input>(
     "environment-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(EnvironmentQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, EnvironmentSchema))
     .build()
@@ -509,12 +607,18 @@ async function getByReference(
   const reqCtx = new RequestContext(
     EnvironmentQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof EnvironmentQueryController.method.getByReference.input>(
-    "environment-get-by-reference",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof EnvironmentQueryController.method.getByReference.input
+  >("environment-get-by-reference", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        EnvironmentQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, EnvironmentSchema))
     .build()
@@ -536,12 +640,18 @@ async function getSecretValue(
   const reqCtx = new RequestContext(
     EnvironmentQueryController.method.getSecretValue.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof EnvironmentQueryController.method.getSecretValue.input>(
-    "environment-get-secret-value",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof EnvironmentQueryController.method.getSecretValue.input
+  >("environment-get-secret-value", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        EnvironmentQueryController.method.getSecretValue,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadEnvironmentByIdStep(deps.store))
     .addStep(newExtractAndDecryptSingleKeyStep(deps.secretService, deps.logger))
@@ -565,12 +675,16 @@ async function list(
   const reqCtx = new RequestContext(
     EnvironmentQueryController.method.list.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof EnvironmentQueryController.method.list.input>(
     "environment-list",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(EnvironmentQueryController.method.list, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newListByOrgAndLabelsStep(deps.store))
     .build()

--- a/backend/services/stigmer-server/src/domain/environment/steps.ts
+++ b/backend/services/stigmer-server/src/domain/environment/steps.ts
@@ -192,9 +192,7 @@ export function newEncryptSecretValuesStep(
 }
 
 /** Whether any entry would have been encrypted — keeps the WARN honest. */
-function hasNonEmptySecret(
-  data: Record<string, EnvironmentValue>,
-): boolean {
+function hasNonEmptySecret(data: Record<string, EnvironmentValue>): boolean {
   return Object.values(data).some((v) => v.isSecret && v.value !== "");
 }
 
@@ -272,9 +270,8 @@ export function newLoadEnvironmentByIdStep<Desc extends DescMessage>(
   return {
     name: "LoadEnvironmentByID",
     async execute(ctx: RequestContext<Desc>): Promise<void> {
-      const environmentId = (
-        ctx.input as { environmentId?: unknown }
-      ).environmentId;
+      const environmentId = (ctx.input as { environmentId?: unknown })
+        .environmentId;
       if (typeof environmentId !== "string" || environmentId === "") {
         throw invalidArgumentError("environment_id is required");
       }
@@ -435,7 +432,12 @@ export function newMergeVariablesAndPersistStep(
       }
 
       try {
-        setAuditFieldsForUpdate(EnvironmentSchema, env, "spec_audit");
+        setAuditFieldsForUpdate(
+          EnvironmentSchema,
+          env,
+          "spec_audit",
+          ctx.callerIdentity,
+        );
       } catch (error) {
         throw internalError(error, "failed to set audit fields");
       }
@@ -490,7 +492,12 @@ export function newRemoveVariableKeysAndPersistStep(
       }
 
       try {
-        setAuditFieldsForUpdate(EnvironmentSchema, env, "spec_audit");
+        setAuditFieldsForUpdate(
+          EnvironmentSchema,
+          env,
+          "spec_audit",
+          ctx.callerIdentity,
+        );
       } catch (error) {
         throw internalError(error, "failed to set audit fields");
       }

--- a/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
@@ -47,11 +47,14 @@ import type {
 } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { alreadyExistsError, internalError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import {
   RESOURCE_ID_KEY,
@@ -92,6 +95,8 @@ import {
 export interface ExecutionContextControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   /**
    * Shared with the Environment/OAuthApp controllers so the
    * encrypt-on-write / decrypt-on-read key pair always matches.
@@ -141,11 +146,22 @@ async function createExecutionContext(
   ec: ExecutionContext,
   ctx: HandlerContext,
 ): Promise<ExecutionContext> {
-  const reqCtx = new RequestContext(ExecutionContextSchema, ec, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    ExecutionContextSchema,
+    ec,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof ExecutionContextSchema>(
     "execution-context-create",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        ExecutionContextCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newRejectCiphertextShapedStep())
@@ -182,11 +198,22 @@ async function apply(
   ec: ExecutionContext,
   ctx: HandlerContext,
 ): Promise<ExecutionContext> {
-  const reqCtx = new RequestContext(ExecutionContextSchema, ec, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    ExecutionContextSchema,
+    ec,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof ExecutionContextSchema>(
     "execution-context-apply",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        ExecutionContextCommandController.method.apply,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -226,12 +253,19 @@ async function deleteExecutionContext(
   const reqCtx = new RequestContext(
     ExecutionContextCommandController.method.delete.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   reqCtx.set(RESOURCE_ID_KEY, input.resourceId);
   await newPipeline<
     typeof ExecutionContextCommandController.method.delete.input
   >("execution-context-delete", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ExecutionContextCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, ExecutionContextSchema))
     .addStep(newDeleteResourceStep(deps.store))
@@ -260,12 +294,19 @@ async function get(
   const reqCtx = new RequestContext(
     ExecutionContextQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof ExecutionContextQueryController.method.get.input>(
     "execution-context-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        ExecutionContextQueryController.method.get,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, ExecutionContextSchema))
     .build()
@@ -284,11 +325,18 @@ async function getByReference(
   const reqCtx = new RequestContext(
     ExecutionContextQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<
     typeof ExecutionContextQueryController.method.getByReference.input
   >("execution-context-get-by-reference", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ExecutionContextQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, ExecutionContextSchema))
     .build()
@@ -318,11 +366,18 @@ async function getByExecutionId(
   const reqCtx = new RequestContext(
     ExecutionContextQueryController.method.getByExecutionId.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<
     typeof ExecutionContextQueryController.method.getByExecutionId.input
   >("execution-context-get-by-execution-id", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ExecutionContextQueryController.method.getByExecutionId,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByExecutionIdStep(deps.store))
     .build()

--- a/backend/services/stigmer-server/src/domain/executioncontext/resolve-values-for-caller.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/resolve-values-for-caller.ts
@@ -10,22 +10,25 @@
  *
  * # The lane
  *
- * getByExecutionId is the runner's secret-delivery path. OSS has no
- * caller identity, so the runner distinguishes itself with an
- * execution-scoped token minted by getRunnerScopedToken and presented as
- * a Bearer authorization header (the same header shape a cloud runner
- * uses for its sandbox credential). Decrypt requires the FULL binding: a
- * valid, unexpired token whose execution_id claim equals this EC's
- * spec.execution_id. Everything else — no header, malformed or expired
- * token, or a token minted for a different execution — falls closed to
- * the same redaction get/getByReference apply, as a SUCCESSFUL response,
- * not an error.
+ * getByExecutionId is the runner's secret-delivery path. The runner
+ * distinguishes itself with an execution-scoped token minted by
+ * getRunnerScopedToken and presented as a Bearer authorization header
+ * (the same header shape a cloud runner uses for its sandbox credential).
+ * Decrypt requires the FULL binding: a valid, unexpired token whose
+ * execution_id claim equals this EC's spec.execution_id. Everything else
+ * — no header, malformed or expired token, or a token minted for a
+ * different execution — falls closed to the same redaction
+ * get/getByReference apply, as a SUCCESSFUL response, not an error.
  *
- * Bearer verification lives HERE, in the domain, not in the interceptor
- * chain: the auth interceptor stays a pass-through seam (phase-3 server
- * mode), and this is the one RPC that reads the header — exactly the
- * consumer the runnerauth module header reserves ("the executioncontext
- * resolve step").
+ * Token verification lives HERE, in the domain, not on the identity
+ * chassis (O2, 20260827.01): the runner token is a lane discriminator,
+ * not a caller identity — the chassis deliberately lets it fall through
+ * to the trusted-local identity (ruling Q6), and this is the one RPC
+ * that reads the raw header — exactly the consumer the runnerauth module
+ * header reserves ("the executioncontext resolve step"). The
+ * redaction-as-success contract is pinned by the conformance suites and
+ * must survive every future verifier: a runner token is NEVER an
+ * authentication credential.
  *
  * # Decrypt error doctrine (the oss#405 runtime-resolution doctrine)
  *
@@ -47,6 +50,7 @@ import type { Logger } from "../../boot/logger.js";
 import { EncryptionDisabledError } from "../../encryption/encryption.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import { internalError } from "../../pipeline/errors.js";
+import { parseBearerToken } from "../../pipeline/interceptors/auth.js";
 import type { RunnerAuthService } from "../../runnerauth/runnerauth.js";
 import { encryptionKeyMissingMessage } from "./constants.js";
 import { redactExecutionContextSecrets } from "./redact.js";
@@ -124,29 +128,14 @@ function verifyRunnerToken(
 }
 
 /**
- * Go bearerToken: the Bearer credential from the request's authorization
- * header; empty when absent or differently shaped. Ports Go's exact
- * shape: case-insensitive "bearer " prefix match, the remainder must be
- * non-empty before trimming, trailing/leading whitespace trimmed.
- *
- * Repeated headers: Go's metadata.Get returns a slice and the Go server
- * reads values[0]; Node's http2 layer joins repeated headers with ", "
- * before Connect ever sees them, so the first comma segment IS Go's
- * first value — a genuine token (base64url segments joined by dots) can
- * never contain a comma, so the split is lossless for every legitimate
- * shape.
+ * The Bearer credential from the request's authorization header; empty
+ * when absent or differently shaped. The parsing shape (Go's exact
+ * bearerToken semantics, including the repeated-header first-segment
+ * rule) is the ONE shared definition in the identity chassis — promoted
+ * there when the verifier chain became its second consumer (O2).
  */
 function bearerToken(ctx: HandlerContext): string {
-  const joined = ctx.requestHeader.get("authorization") ?? "";
-  const header = joined.split(",")[0] ?? "";
-  const prefix = "bearer ";
-  if (
-    header.length <= prefix.length ||
-    header.slice(0, prefix.length).toLowerCase() !== prefix
-  ) {
-    return "";
-  }
-  return header.slice(prefix.length).trim();
+  return parseBearerToken(ctx.requestHeader.get("authorization") ?? "");
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/mcpserver/controller.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/controller.ts
@@ -44,12 +44,18 @@ import type {
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError, notFoundError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
-import { setAuditFieldsForUpdate, newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import {
+  setAuditFieldsForUpdate,
+  newBuildNewStateStep,
+} from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
 import {
@@ -61,10 +67,19 @@ import {
   newDeleteSearchIndexStep,
   newIndexSearchStep,
 } from "../../pipeline/steps/index-search.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
-import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
-import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
@@ -90,6 +105,8 @@ import {
 export interface McpServerControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   /** The connect/OAuth slice's dependencies (D4 #19). */
   readonly connect: McpServerConnectDeps;
 }
@@ -153,7 +170,10 @@ export function registerMcpServerServices(
  * stubs exist to carry that text byte-for-byte and this doc block.
  */
 function orgOAuthAppUnimplemented(method: string): ConnectError {
-  return new ConnectError(`method ${method} not implemented`, Code.Unimplemented);
+  return new ConnectError(
+    `method ${method} not implemented`,
+    Code.Unimplemented,
+  );
 }
 
 function kindOf(ctx: HandlerContext): ApiResourceKind {
@@ -166,8 +186,19 @@ async function createMcpServer(
   server: McpServer,
   ctx: HandlerContext,
 ): Promise<McpServer> {
-  const reqCtx = new RequestContext(McpServerSchema, server, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    McpServerSchema,
+    server,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof McpServerSchema>("mcpserver-create", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        McpServerCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveSlugStep())
@@ -175,7 +206,9 @@ async function createMcpServer(
     .addStep(newBuildNewStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
-    .addStep(newIndexSearchStep(deps.store, mcpServerSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(deps.store, mcpServerSearchExtractor, deps.logger),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -191,8 +224,19 @@ async function update(
   server: McpServer,
   ctx: HandlerContext,
 ): Promise<McpServer> {
-  const reqCtx = new RequestContext(McpServerSchema, server, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    McpServerSchema,
+    server,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof McpServerSchema>("mcpserver-update", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        McpServerCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
@@ -200,7 +244,9 @@ async function update(
     .addStep(newValidateDefaultEnabledToolsStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
-    .addStep(newIndexSearchStep(deps.store, mcpServerSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(deps.store, mcpServerSearchExtractor, deps.logger),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -221,8 +267,19 @@ async function apply(
   server: McpServer,
   ctx: HandlerContext,
 ): Promise<McpServer> {
-  const reqCtx = new RequestContext(McpServerSchema, server, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    McpServerSchema,
+    server,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof McpServerSchema>("mcpserver-apply", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        McpServerCommandController.method.apply,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -266,6 +323,7 @@ async function deleteMcpServer(
   const reqCtx = new RequestContext(
     McpServerCommandController.method.delete.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   reqCtx.set(RESOURCE_ID_KEY, input.resourceId);
@@ -273,6 +331,12 @@ async function deleteMcpServer(
     "mcpserver-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        McpServerCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, McpServerSchema))
     .addStep(newDeleteResourceStep(deps.store))
@@ -309,15 +373,27 @@ async function updateVisibility(
   const reqCtx = new RequestContext(
     McpServerCommandController.method.updateVisibility.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<UpdateVisibilityDesc>("mcpserver-update-visibility", deps.logger)
+  await newPipeline<UpdateVisibilityDesc>(
+    "mcpserver-update-visibility",
+    deps.logger,
+  )
+    .addStep(
+      newAuthorizeStep(
+        McpServerCommandController.method.updateVisibility,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadMcpServerForVisibilityUpdateStep(deps.store))
     .addStep(newValidateVisibilityUpdateStep())
     .addStep(newSetMcpServerVisibilityStep())
     .addStep(newPersistMcpServerForVisibilityUpdateStep(deps.store))
-    .addStep(newIndexMcpServerAfterVisibilityUpdateStep(deps.store, deps.logger))
+    .addStep(
+      newIndexMcpServerAfterVisibilityUpdateStep(deps.store, deps.logger),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.get(UPDATE_VISIBILITY_MCP_SERVER_KEY) as McpServer;
@@ -355,7 +431,12 @@ function newSetMcpServerVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
       if (mcpServer.metadata !== undefined) {
         mcpServer.metadata.visibility = ctx.input.visibility;
       }
-      setAuditFieldsForUpdate(McpServerSchema, mcpServer, "status_audit");
+      setAuditFieldsForUpdate(
+        McpServerSchema,
+        mcpServer,
+        "status_audit",
+        ctx.callerIdentity,
+      );
     },
   };
 }
@@ -406,10 +487,13 @@ function newIndexMcpServerAfterVisibilityUpdateStep(
           entry,
         );
       } catch (error) {
-        logger.warn("IndexMcpServerAfterVisibilityUpdate: failed (best-effort)", {
-          id: mcpServer.metadata?.id ?? "",
-          error: error instanceof Error ? error.message : String(error),
-        });
+        logger.warn(
+          "IndexMcpServerAfterVisibilityUpdate: failed (best-effort)",
+          {
+            id: mcpServer.metadata?.id ?? "",
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
       }
     },
   };
@@ -424,12 +508,16 @@ async function get(
   const reqCtx = new RequestContext(
     McpServerQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof McpServerQueryController.method.get.input>(
     "mcpserver-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(McpServerQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, McpServerSchema))
     .addStep(newEnrichOAuthStatusStep(deps.store, deps.logger))
@@ -447,12 +535,18 @@ async function getByReference(
   const reqCtx = new RequestContext(
     McpServerQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof McpServerQueryController.method.getByReference.input>(
-    "mcpserver-get-by-reference",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof McpServerQueryController.method.getByReference.input
+  >("mcpserver-get-by-reference", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        McpServerQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, McpServerSchema))
     .addStep(newEnrichOAuthStatusStep(deps.store, deps.logger))

--- a/backend/services/stigmer-server/src/domain/memory/controller.ts
+++ b/backend/services/stigmer-server/src/domain/memory/controller.ts
@@ -51,6 +51,7 @@
  * __tests__/memory.test.ts.
  */
 import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import type { DescMethod } from "@bufbuild/protobuf";
 
 import { MemoryCommandController } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/command_pb";
 import { MemoryQueryController } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/query_pb";
@@ -66,10 +67,13 @@ import type {
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
@@ -110,6 +114,8 @@ import {
 export interface MemoryControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
 }
 
 /** Registers both memory services on the router (routes stage). */
@@ -154,8 +160,16 @@ async function createMemory(
   memory: Memory,
   ctx: HandlerContext,
 ): Promise<Memory> {
-  const reqCtx = new RequestContext(MemorySchema, memory, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    MemorySchema,
+    memory,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof MemorySchema>("memory-create", deps.logger)
+    .addStep(
+      newAuthorizeStep(MemoryCommandController.method.create, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveMemoryDefaultsStep())
@@ -191,8 +205,16 @@ async function update(
   memory: Memory,
   ctx: HandlerContext,
 ): Promise<Memory> {
-  const reqCtx = new RequestContext(MemorySchema, memory, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    MemorySchema,
+    memory,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof MemorySchema>("memory-update", deps.logger)
+    .addStep(
+      newAuthorizeStep(MemoryCommandController.method.update, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newValidateMemoryUpdateStep())
@@ -229,6 +251,7 @@ async function confirm(
     memoryId,
     ctx,
     "memory-confirm",
+    MemoryCommandController.method.confirm,
     MemoryLifecycleState.lifecycle_state_confirmed,
     MEMORY_CONFIRM_REJECTED_MESSAGE,
   );
@@ -258,6 +281,7 @@ async function reject(
     memoryId,
     ctx,
     "memory-reject",
+    MemoryCommandController.method.reject,
     MemoryLifecycleState.lifecycle_state_rejected,
     MEMORY_REJECT_CONFIRMED_MESSAGE,
   );
@@ -277,11 +301,18 @@ async function runTransition(
   memoryId: MemoryId,
   ctx: HandlerContext,
   name: string,
+  method: DescMethod,
   target: MemoryLifecycleState,
   blockedMessage: string,
 ): Promise<Memory> {
-  const reqCtx = new RequestContext(MemoryIdSchema, memoryId, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    MemoryIdSchema,
+    memoryId,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof MemoryIdSchema>(name, deps.logger)
+    .addStep(newAuthorizeStep(method, deps.authorizer))
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, MemorySchema))
@@ -321,8 +352,16 @@ async function deleteMemory(
   memoryId: MemoryId,
   ctx: HandlerContext,
 ): Promise<Memory> {
-  const reqCtx = new RequestContext(MemoryIdSchema, memoryId, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    MemoryIdSchema,
+    memoryId,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof MemoryIdSchema>("memory-delete", deps.logger)
+    .addStep(
+      newAuthorizeStep(MemoryCommandController.method.delete, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, MemorySchema))
@@ -352,8 +391,16 @@ async function get(
   memoryId: MemoryId,
   ctx: HandlerContext,
 ): Promise<Memory> {
-  const reqCtx = new RequestContext(MemoryIdSchema, memoryId, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    MemoryIdSchema,
+    memoryId,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof MemoryIdSchema>("memory-get", deps.logger)
+    .addStep(
+      newAuthorizeStep(MemoryQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadTargetStep(deps.store, MemorySchema))
@@ -390,12 +437,16 @@ async function list(
   const reqCtx = new RequestContext(
     MemoryQueryController.method.list.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof MemoryQueryController.method.list.input>(
     "memory-list",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(MemoryQueryController.method.list, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newListMemoriesByOrgStep(deps.store))
     .build()

--- a/backend/services/stigmer-server/src/domain/memory/steps.ts
+++ b/backend/services/stigmer-server/src/domain/memory/steps.ts
@@ -449,7 +449,12 @@ export function newTransitionMemoryLifecycleStep(
             }
             row.status.lifecycleState = target;
             row.status.stateChangedAt = timestampNow();
-            setAuditFieldsForUpdate(MemorySchema, row, "status_audit");
+            setAuditFieldsForUpdate(
+              MemorySchema,
+              row,
+              "status_audit",
+              ctx.callerIdentity,
+            );
           },
         );
       } catch (error) {

--- a/backend/services/stigmer-server/src/domain/oauthapp/controller.ts
+++ b/backend/services/stigmer-server/src/domain/oauthapp/controller.ts
@@ -42,12 +42,15 @@ import type {
 import { OAuthAppQueryController } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/query_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import { internalError } from "../../pipeline/errors.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import {
@@ -57,10 +60,19 @@ import {
 } from "../../pipeline/steps/delete.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
 import { compareCreatedAtDesc } from "../../pipeline/steps/helpers.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
-import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
-import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -77,6 +89,8 @@ export interface OAuthAppControllerDeps {
   readonly store: Store;
   readonly secretService: SecretService;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
 }
 
 /** Registers both OAuthApp services on the router (routes stage). */
@@ -113,13 +127,26 @@ async function createOAuthApp(
   app: OAuthApp,
   ctx: HandlerContext,
 ): Promise<OAuthApp> {
-  const reqCtx = new RequestContext(OAuthAppSchema, app, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    OAuthAppSchema,
+    app,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof OAuthAppSchema>("oauthapp-create", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        OAuthAppCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newResolveSlugStep())
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newCheckDuplicateStep(deps.store))
-    .addStep(newEncryptClientSecretForCreateStep(deps.secretService, deps.logger))
+    .addStep(
+      newEncryptClientSecretForCreateStep(deps.secretService, deps.logger),
+    )
     .addStep(newBuildNewStateStep())
     .addStep(newPersistStep(deps.store))
     .build()
@@ -140,13 +167,26 @@ async function update(
   app: OAuthApp,
   ctx: HandlerContext,
 ): Promise<OAuthApp> {
-  const reqCtx = new RequestContext(OAuthAppSchema, app, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    OAuthAppSchema,
+    app,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof OAuthAppSchema>("oauthapp-update", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        OAuthAppCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newBuildUpdateStateStep())
-    .addStep(newEncryptClientSecretForUpdateStep(deps.secretService, deps.logger))
+    .addStep(
+      newEncryptClientSecretForUpdateStep(deps.secretService, deps.logger),
+    )
     .addStep(newPersistStep(deps.store))
     .build()
     .execute(reqCtx);
@@ -165,8 +205,16 @@ async function apply(
   app: OAuthApp,
   ctx: HandlerContext,
 ): Promise<OAuthApp> {
-  const reqCtx = new RequestContext(OAuthAppSchema, app, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    OAuthAppSchema,
+    app,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof OAuthAppSchema>("oauthapp-apply", deps.logger)
+    .addStep(
+      newAuthorizeStep(OAuthAppCommandController.method.apply, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -180,9 +228,7 @@ async function apply(
       "apply operation failed to determine create vs update",
     );
   }
-  return shouldCreate
-    ? createOAuthApp(deps, app, ctx)
-    : update(deps, app, ctx);
+  return shouldCreate ? createOAuthApp(deps, app, ctx) : update(deps, app, ctx);
 }
 
 /**
@@ -201,6 +247,7 @@ async function deleteOAuthApp(
   const reqCtx = new RequestContext(
     OAuthAppCommandController.method.delete.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   reqCtx.set(RESOURCE_ID_KEY, input.resourceId);
@@ -208,6 +255,12 @@ async function deleteOAuthApp(
     "oauthapp-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        OAuthAppCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, OAuthAppSchema))
     .addStep(newCheckNoReferencingMcpServersStep(deps.store, deps.logger))
@@ -234,12 +287,16 @@ async function get(
   const reqCtx = new RequestContext(
     OAuthAppQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof OAuthAppQueryController.method.get.input>(
     "oauthapp-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(OAuthAppQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, OAuthAppSchema))
     .build()
@@ -258,12 +315,19 @@ async function getByReference(
   const reqCtx = new RequestContext(
     OAuthAppQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof OAuthAppQueryController.method.getByReference.input>(
     "oauthapp-get-by-reference",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        OAuthAppQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, OAuthAppSchema))
     .build()
@@ -288,12 +352,19 @@ async function listByOrg(
   const reqCtx = new RequestContext(
     OAuthAppQueryController.method.listByOrg.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof OAuthAppQueryController.method.listByOrg.input>(
     "oauthapp-list-by-org",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        OAuthAppQueryController.method.listByOrg,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newListByOrgStep(deps.store, deps.logger))
     .build()
@@ -317,7 +388,9 @@ function newListByOrgStep(
   return {
     name: "ListByOrg",
     async execute(
-      ctx: RequestContext<typeof OAuthAppQueryController.method.listByOrg.input>,
+      ctx: RequestContext<
+        typeof OAuthAppQueryController.method.listByOrg.input
+      >,
     ): Promise<void> {
       const org = ctx.input.org;
 

--- a/backend/services/stigmer-server/src/domain/organization/controller.ts
+++ b/backend/services/stigmer-server/src/domain/organization/controller.ts
@@ -39,11 +39,14 @@ import type {
 } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/io_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import {
@@ -55,9 +58,18 @@ import {
   newDeleteSearchIndexStep,
   newIndexSearchStep,
 } from "../../pipeline/steps/index-search.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
-import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
-import { newLoadTargetStep, TARGET_RESOURCE_KEY } from "../../pipeline/steps/load-target.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
+import {
+  newLoadTargetStep,
+  TARGET_RESOURCE_KEY,
+} from "../../pipeline/steps/load-target.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -69,6 +81,8 @@ import { newCheckOrgDuplicateStep, newCopySlugToIdStep } from "./steps.js";
 export interface OrganizationControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
 }
 
 /** Registers both organization services on the router (routes stage). */
@@ -105,8 +119,22 @@ async function createOrganization(
   org: Organization,
   ctx: HandlerContext,
 ): Promise<Organization> {
-  const reqCtx = new RequestContext(OrganizationSchema, org, kindOf(ctx));
-  await newPipeline<typeof OrganizationSchema>("organization-create", deps.logger)
+  const reqCtx = new RequestContext(
+    OrganizationSchema,
+    org,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
+  await newPipeline<typeof OrganizationSchema>(
+    "organization-create",
+    deps.logger,
+  )
+    .addStep(
+      newAuthorizeStep(
+        OrganizationCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newResolveSlugStep())
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
@@ -114,7 +142,9 @@ async function createOrganization(
     .addStep(newBuildNewStateStep())
     .addStep(newCopySlugToIdStep())
     .addStep(newPersistStep(deps.store))
-    .addStep(newIndexSearchStep(deps.store, organizationSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(deps.store, organizationSearchExtractor, deps.logger),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -126,14 +156,30 @@ async function update(
   org: Organization,
   ctx: HandlerContext,
 ): Promise<Organization> {
-  const reqCtx = new RequestContext(OrganizationSchema, org, kindOf(ctx));
-  await newPipeline<typeof OrganizationSchema>("organization-update", deps.logger)
+  const reqCtx = new RequestContext(
+    OrganizationSchema,
+    org,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
+  await newPipeline<typeof OrganizationSchema>(
+    "organization-update",
+    deps.logger,
+  )
+    .addStep(
+      newAuthorizeStep(
+        OrganizationCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newBuildUpdateStateStep())
     .addStep(newPersistStep(deps.store))
-    .addStep(newIndexSearchStep(deps.store, organizationSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(deps.store, organizationSearchExtractor, deps.logger),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -149,8 +195,22 @@ async function apply(
   org: Organization,
   ctx: HandlerContext,
 ): Promise<Organization> {
-  const reqCtx = new RequestContext(OrganizationSchema, org, kindOf(ctx));
-  await newPipeline<typeof OrganizationSchema>("organization-apply", deps.logger)
+  const reqCtx = new RequestContext(
+    OrganizationSchema,
+    org,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
+  await newPipeline<typeof OrganizationSchema>(
+    "organization-apply",
+    deps.logger,
+  )
+    .addStep(
+      newAuthorizeStep(
+        OrganizationCommandController.method.apply,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -178,12 +238,19 @@ async function deleteOrganization(
   const reqCtx = new RequestContext(
     OrganizationCommandController.method.delete.input,
     orgId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof OrganizationCommandController.method.delete.input>(
     "organization-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        OrganizationCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, OrganizationSchema))
@@ -211,12 +278,16 @@ async function get(
   const reqCtx = new RequestContext(
     OrganizationQueryController.method.get.input,
     orgId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof OrganizationQueryController.method.get.input>(
     "organization-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(OrganizationQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, OrganizationSchema))
     .build()
@@ -241,12 +312,19 @@ async function find(
   const reqCtx = new RequestContext(
     OrganizationQueryController.method.find.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof OrganizationQueryController.method.find.input>(
     "organization-find",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        OrganizationQueryController.method.find,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newListAllOrganizationsStep(deps.store))
     .build()
@@ -307,7 +385,8 @@ function newListAllOrganizationsStep(
 
       const totalPages = Math.ceil(orgs.length / pageSize);
       const start = (pageNumber - 1) * pageSize;
-      const entries = start >= orgs.length ? [] : orgs.slice(start, start + pageSize);
+      const entries =
+        start >= orgs.length ? [] : orgs.slice(start, start + pageSize);
 
       ctx.set(
         FIND_RESULT_KEY,

--- a/backend/services/stigmer-server/src/domain/project/controller.ts
+++ b/backend/services/stigmer-server/src/domain/project/controller.ts
@@ -36,10 +36,13 @@ import { ProjectQueryController } from "@stigmer/protos/ai/stigmer/tenancy/proje
 import { ProjectStatusSchema } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/status_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { internalError } from "../../pipeline/errors.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import {
@@ -82,6 +85,8 @@ import { projectSearchExtractor } from "./search-extractor.js";
 export interface ProjectControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   /**
    * The four downstream delete edges (agent/workflow/mcp_server/skill),
    * lazy per the compose root's boot-ordering idiom — the TS replacement
@@ -122,8 +127,16 @@ async function createProject(
   project: Project,
   ctx: HandlerContext,
 ): Promise<Project> {
-  const reqCtx = new RequestContext(ProjectSchema, project, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    ProjectSchema,
+    project,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof ProjectSchema>("project-create", deps.logger)
+    .addStep(
+      newAuthorizeStep(ProjectCommandController.method.create, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveSlugStep())
@@ -131,7 +144,9 @@ async function createProject(
     .addStep(newBuildNewStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
-    .addStep(newIndexSearchStep(deps.store, projectSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(deps.store, projectSearchExtractor, deps.logger),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -147,14 +162,24 @@ async function update(
   project: Project,
   ctx: HandlerContext,
 ): Promise<Project> {
-  const reqCtx = new RequestContext(ProjectSchema, project, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    ProjectSchema,
+    project,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof ProjectSchema>("project-update", deps.logger)
+    .addStep(
+      newAuthorizeStep(ProjectCommandController.method.update, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newBuildUpdateStateStep())
     .addStep(newPersistStep(deps.store))
-    .addStep(newIndexSearchStep(deps.store, projectSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(deps.store, projectSearchExtractor, deps.logger),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -181,8 +206,16 @@ async function apply(
   project: Project,
   ctx: HandlerContext,
 ): Promise<Project> {
-  const reqCtx = new RequestContext(ProjectSchema, project, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    ProjectSchema,
+    project,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof ProjectSchema>("project-apply", deps.logger)
+    .addStep(
+      newAuthorizeStep(ProjectCommandController.method.apply, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -239,12 +272,16 @@ async function deleteProject(
   const reqCtx = new RequestContext(
     ProjectCommandController.method.delete.input,
     projectId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof ProjectCommandController.method.delete.input>(
     "project-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(ProjectCommandController.method.delete, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, ProjectSchema))
@@ -274,12 +311,16 @@ async function get(
   const reqCtx = new RequestContext(
     ProjectQueryController.method.get.input,
     projectId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof ProjectQueryController.method.get.input>(
     "project-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(ProjectQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, ProjectSchema))
     .build()
@@ -302,12 +343,19 @@ async function getByReference(
   const reqCtx = new RequestContext(
     ProjectQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof ProjectQueryController.method.getByReference.input>(
     "project-get-by-reference",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        ProjectQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, ProjectSchema))
     .build()

--- a/backend/services/stigmer-server/src/domain/schedule/controller.ts
+++ b/backend/services/stigmer-server/src/domain/schedule/controller.ts
@@ -51,11 +51,14 @@ import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/ap
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
@@ -68,10 +71,19 @@ import {
   compareCreatedAtDesc,
   matchesAllLabels,
 } from "../../pipeline/steps/helpers.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
-import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
-import { newLoadTargetStep, TARGET_RESOURCE_KEY } from "../../pipeline/steps/load-target.js";
+import {
+  newLoadTargetStep,
+  TARGET_RESOURCE_KEY,
+} from "../../pipeline/steps/load-target.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
@@ -107,6 +119,8 @@ import {
 export interface ScheduleControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly modelRegistry: ModelRegistryStore;
   /**
    * The scheduling runtime (clock.ts), resolved at call time so the
@@ -159,8 +173,19 @@ async function createSchedule(
   schedule: Schedule,
   ctx: HandlerContext,
 ): Promise<Schedule> {
-  const reqCtx = new RequestContext(ScheduleSchema, schedule, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    ScheduleSchema,
+    schedule,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof ScheduleSchema>("schedule-create", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ScheduleCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveScheduleDefaultsStep(deps))
@@ -181,8 +206,19 @@ async function update(
   schedule: Schedule,
   ctx: HandlerContext,
 ): Promise<Schedule> {
-  const reqCtx = new RequestContext(ScheduleSchema, schedule, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    ScheduleSchema,
+    schedule,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof ScheduleSchema>("schedule-update", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ScheduleCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
@@ -213,8 +249,16 @@ async function apply(
   schedule: Schedule,
   ctx: HandlerContext,
 ): Promise<Schedule> {
-  const reqCtx = new RequestContext(ScheduleSchema, schedule, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    ScheduleSchema,
+    schedule,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof ScheduleSchema>("schedule-apply", deps.logger)
+    .addStep(
+      newAuthorizeStep(ScheduleCommandController.method.apply, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveScheduleDefaultsStep(deps))
     .addStep(newResolveSlugStep())
@@ -253,9 +297,16 @@ async function deleteSchedule(
   const reqCtx = new RequestContext(
     ScheduleCommandController.method.delete.input,
     scheduleId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<DeleteInput>("schedule-delete", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ScheduleCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, ScheduleSchema))
@@ -285,9 +336,16 @@ async function resume(
   const reqCtx = new RequestContext(
     ScheduleCommandController.method.resume.input,
     scheduleId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<ResumeInput>("schedule-resume", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ScheduleCommandController.method.resume,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, ScheduleSchema))
@@ -316,14 +374,27 @@ async function trigger(
   const reqCtx = new RequestContext(
     ScheduleCommandController.method.trigger.input,
     scheduleId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<TriggerInput>("schedule-trigger", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ScheduleCommandController.method.trigger,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, ScheduleSchema))
     .addStep(newValidateTriggerableStep())
-    .addStep(newFireDirectRunStep({ store: deps.store, runner: deps.runner, logger: deps.logger }))
+    .addStep(
+      newFireDirectRunStep({
+        store: deps.store,
+        runner: deps.runner,
+        logger: deps.logger,
+      }),
+    )
     .build()
     .execute(reqCtx);
 
@@ -347,9 +418,13 @@ async function get(
   const reqCtx = new RequestContext(
     ScheduleQueryController.method.get.input,
     scheduleId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<GetInput>("schedule-get", deps.logger)
+    .addStep(
+      newAuthorizeStep(ScheduleQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, ScheduleSchema))
     .build()
@@ -367,9 +442,16 @@ async function getByReference(
   const reqCtx = new RequestContext(
     ScheduleQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<RefInput>("schedule-get-by-reference", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ScheduleQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, ScheduleSchema))
     .build()
@@ -399,9 +481,16 @@ async function getByAgent(
   const reqCtx = new RequestContext(
     ScheduleQueryController.method.getByAgent.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<ByAgentInput>("schedule-get-by-agent", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ScheduleQueryController.method.getByAgent,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadSchedulesByAgentStep(deps.store))
     .build()
@@ -423,7 +512,9 @@ function newLoadSchedulesByAgentStep(
   return {
     name: "LoadSchedulesByAgent",
     async execute(
-      ctx: RequestContext<typeof ScheduleQueryController.method.getByAgent.input>,
+      ctx: RequestContext<
+        typeof ScheduleQueryController.method.getByAgent.input
+      >,
     ): Promise<void> {
       const req = ctx.input;
 
@@ -502,9 +593,13 @@ async function list(
   const reqCtx = new RequestContext(
     ScheduleQueryController.method.list.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<ListInput>("schedule-list", deps.logger)
+    .addStep(
+      newAuthorizeStep(ScheduleQueryController.method.list, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newListByOrgAndLabelsStep(deps.store))
     .build()
@@ -582,9 +677,16 @@ async function listRuns(
   const reqCtx = new RequestContext(
     ScheduleQueryController.method.listRuns.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<ListRunsInput>("schedule-list-runs", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        ScheduleQueryController.method.listRuns,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadScheduleForRunsStep(deps.store))
     .addStep(newListRunsFromLedgerStep(deps.store))

--- a/backend/services/stigmer-server/src/domain/schedule/resume.ts
+++ b/backend/services/stigmer-server/src/domain/schedule/resume.ts
@@ -81,7 +81,12 @@ export function newClearSchedulePauseStep<Desc extends DescMessage>(
             // Resuming with strikes left would re-pause on the next
             // failure — a lie; both clear together, always.
             row.status!.consecutiveFailures = 0;
-            setAuditFieldsForUpdate(ScheduleSchema, row, "status_audit");
+            setAuditFieldsForUpdate(
+              ScheduleSchema,
+              row,
+              "status_audit",
+              ctx.callerIdentity,
+            );
           },
         );
       } catch (error) {

--- a/backend/services/stigmer-server/src/domain/schedule/trigger.ts
+++ b/backend/services/stigmer-server/src/domain/schedule/trigger.ts
@@ -41,15 +41,14 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import { ConnectError } from "@connectrpc/connect";
 
 import type { Logger } from "../../boot/logger.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import {
   failedPreconditionError,
   rethrownStatusError,
 } from "../../pipeline/errors.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import type { RequestContext } from "../../pipeline/request-context.js";
-import {
-  setAuditFieldsForUpdate,
-} from "../../pipeline/steps/defaults.js";
+import { setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
 import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
@@ -91,7 +90,10 @@ export const TRIGGER_NO_RUNNER_MESSAGE =
  * toast the owner hit (Go Runner).
  */
 export interface ScheduleRunner {
-  startRun(schedule: Schedule, nominalFireTime: Date): Promise<RunOutcomeResult>;
+  startRun(
+    schedule: Schedule,
+    nominalFireTime: Date,
+  ): Promise<RunOutcomeResult>;
 }
 
 /** A provider so the compose root can wire the runner after the clock stage. */
@@ -107,7 +109,9 @@ export const TRIGGER_RESULT_KEY = "trigger_result";
  * guards manual fires because manual fires no longer pass through the
  * tick). Go validateTriggerableStep.
  */
-export function newValidateTriggerableStep<Desc extends DescMessage>(): PipelineStep<Desc> {
+export function newValidateTriggerableStep<
+  Desc extends DescMessage,
+>(): PipelineStep<Desc> {
   return {
     name: "ValidateTriggerable",
     execute(ctx: RequestContext<Desc>): void {
@@ -157,21 +161,26 @@ export function newFireDirectRunStep<Desc extends DescMessage>(
       try {
         outcome = await runner.startRun(schedule, nominal);
       } catch (error) {
-        deps.logger.warn("Manual trigger's run start failed on infrastructure", {
-          schedule_id: scheduleId,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        deps.logger.warn(
+          "Manual trigger's run start failed on infrastructure",
+          {
+            schedule_id: scheduleId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
         // The in-process client's error instance carries the INNER
         // response's metadata; echoing it corrupts the serving HTTP/2
         // trailers (NGHTTP2_PROTOCOL_ERROR — the #18 transport finding).
         // Re-mint code + message, exactly the workflowexecution
         // forwarding posture.
-        throw error instanceof ConnectError ? rethrownStatusError(error) : error;
+        throw error instanceof ConnectError
+          ? rethrownStatusError(error)
+          : error;
       }
 
       // The fire happened: record it — last_fire_at on status (the tick is
       // not in this path to do it) and the ledger row (origin=manual).
-      await stampLastFireAt(deps, scheduleId, nominal);
+      await stampLastFireAt(deps, scheduleId, nominal, ctx.callerIdentity);
       await recordManualFire(
         deps.store,
         deps.logger,
@@ -244,6 +253,7 @@ async function stampLastFireAt(
   deps: FireDirectRunDeps,
   scheduleId: string,
   nominal: Date,
+  identity: CallerIdentity,
 ): Promise<void> {
   try {
     await deps.store.updateResource(
@@ -255,7 +265,7 @@ async function stampLastFireAt(
           live.status = create(ScheduleStatusSchema);
         }
         live.status.lastFireAt = timestampFromDate(nominal);
-        setAuditFieldsForUpdate(ScheduleSchema, live, "status_audit");
+        setAuditFieldsForUpdate(ScheduleSchema, live, "status_audit", identity);
       },
     );
   } catch (error) {

--- a/backend/services/stigmer-server/src/domain/session/__tests__/session.test.ts
+++ b/backend/services/stigmer-server/src/domain/session/__tests__/session.test.ts
@@ -27,6 +27,7 @@
  *     exists (exact count copy), terminal phases don't block, and the
  *     cascade removes exactly the session's own executions.
  */
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -502,6 +503,7 @@ describe("session update — execution-target immutability (oss#397)", () => {
       create(SessionSchema, {
         spec: { executionTarget: ExecutionTarget.CLOUD },
       }),
+      testCallerIdentity(),
       ApiResourceKind.session,
     );
     passCtx.set(EXISTING_RESOURCE_KEY, existing);
@@ -514,6 +516,7 @@ describe("session update — execution-target immutability (oss#397)", () => {
       create(SessionSchema, {
         spec: { executionTarget: ExecutionTarget.LOCAL },
       }),
+      testCallerIdentity(),
       ApiResourceKind.session,
     );
     failCtx.set(EXISTING_RESOURCE_KEY, existing);

--- a/backend/services/stigmer-server/src/domain/session/controller.ts
+++ b/backend/services/stigmer-server/src/domain/session/controller.ts
@@ -36,6 +36,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import { create } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import type { AgentExecutionTemporalConfig } from "../agentexecution/temporal/config.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
@@ -44,7 +45,10 @@ import {
   notFoundError,
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import {
   newBuildNewStateStep,
   setAuditFieldsForUpdate,
@@ -97,6 +101,8 @@ import type { AgentInstanceCreatorProvider } from "./steps.js";
 export interface SessionControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   /**
    * The agent-execution temporal config — the update pipeline's
    * execution-target immutability step resolves UNSPECIFIED through the
@@ -120,7 +126,8 @@ export function registerSessionServices(
     apply: (session, ctx) => apply(deps, session, ctx),
     create: (session, ctx) => createSession(deps, session, ctx),
     update: (session, ctx) => update(deps, session, ctx),
-    updateSubject: (req) => updateSubject(deps, req),
+    updateSubject: (req, ctx) =>
+      updateSubject(deps, req, callerIdentityOf(ctx)),
     delete: (id, ctx) => deleteSession(deps, id, ctx),
   });
   router.service(SessionQueryController, {
@@ -145,8 +152,16 @@ async function createSession(
   session: Session,
   ctx: HandlerContext,
 ): Promise<Session> {
-  const reqCtx = new RequestContext(SessionSchema, session, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    SessionSchema,
+    session,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof SessionSchema>("session-create", deps.logger)
+    .addStep(
+      newAuthorizeStep(SessionCommandController.method.create, deps.authorizer),
+    )
     .addStep(
       newResolveDefaultAgentInstanceStep(
         deps.store,
@@ -179,8 +194,16 @@ async function update(
   session: Session,
   ctx: HandlerContext,
 ): Promise<Session> {
-  const reqCtx = new RequestContext(SessionSchema, session, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    SessionSchema,
+    session,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof SessionSchema>("session-update", deps.logger)
+    .addStep(
+      newAuthorizeStep(SessionCommandController.method.update, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
@@ -207,8 +230,16 @@ async function apply(
   session: Session,
   ctx: HandlerContext,
 ): Promise<Session> {
-  const reqCtx = new RequestContext(SessionSchema, session, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    SessionSchema,
+    session,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof SessionSchema>("session-apply", deps.logger)
+    .addStep(
+      newAuthorizeStep(SessionCommandController.method.apply, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -241,12 +272,16 @@ async function deleteSession(
   const reqCtx = new RequestContext(
     SessionCommandController.method.delete.input,
     sessionId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof SessionCommandController.method.delete.input>(
     "session-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(SessionCommandController.method.delete, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, SessionSchema))
@@ -279,6 +314,7 @@ async function deleteSession(
 async function updateSubject(
   deps: SessionControllerDeps,
   req: UpdateSessionSubjectRequest,
+  identity: CallerIdentity,
 ): Promise<Session> {
   // Field validation is guaranteed at the transport boundary by the
   // protovalidate interceptor; this guard covers the direct-call path
@@ -304,7 +340,7 @@ async function updateSubject(
   }
   session.spec.subject = req.subject;
 
-  setAuditFieldsForUpdate(SessionSchema, session, "spec_audit");
+  setAuditFieldsForUpdate(SessionSchema, session, "spec_audit", identity);
 
   try {
     await deps.store.saveResource(kind, req.id, SessionSchema, session);
@@ -353,12 +389,16 @@ async function get(
   const reqCtx = new RequestContext(
     SessionQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof SessionQueryController.method.get.input>(
     "session-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(SessionQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, SessionSchema))
     .build()
@@ -375,12 +415,16 @@ async function list(
   const reqCtx = new RequestContext(
     SessionQueryController.method.list.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof SessionQueryController.method.list.input>(
     "session-list",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(SessionQueryController.method.list, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newListAllSessionsStep(deps.store, deps.logger))
     .build()
@@ -397,11 +441,18 @@ async function listByAgentInstance(
   const reqCtx = new RequestContext(
     SessionQueryController.method.listByAgentInstance.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<
     typeof SessionQueryController.method.listByAgentInstance.input
   >("session-list-by-agent-instance", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        SessionQueryController.method.listByAgentInstance,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newFilterByAgentInstanceStep(deps.store, deps.logger))
     .build()
@@ -418,12 +469,19 @@ async function listByChannel(
   const reqCtx = new RequestContext(
     SessionQueryController.method.listByChannel.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof SessionQueryController.method.listByChannel.input>(
     "session-list-by-channel",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        SessionQueryController.method.listByChannel,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newFilterByChannelStep(deps.store, deps.logger))
     .build()

--- a/backend/services/stigmer-server/src/domain/skill/__tests__/push-degradation.test.ts
+++ b/backend/services/stigmer-server/src/domain/skill/__tests__/push-degradation.test.ts
@@ -14,6 +14,7 @@
  *     tag assignment still runs (re-pushing under a new tag is skills'
  *     only retag path).
  */
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { create } from "@bufbuild/protobuf";
 import { describe, expect, it } from "vitest";
 
@@ -27,7 +28,11 @@ import { AuditNotFoundError } from "../../../store/interface.js";
 import type { Store } from "../../../store/interface.js";
 import { SKILL_KEY, newArchiveCurrentSkillStep } from "../push.js";
 
-const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
 
 const HASH = "b".repeat(64);
 
@@ -40,7 +45,10 @@ interface FakeAuditStore {
 }
 
 /** A store exposing ONLY the members the step touches; the cast is the seam. */
-function fakeStore(overrides?: Partial<FakeAuditStore>): { store: Store; state: FakeAuditStore } {
+function fakeStore(overrides?: Partial<FakeAuditStore>): {
+  store: Store;
+  state: FakeAuditStore;
+} {
   const state: FakeAuditStore = {
     getAuditByHashError: new AuditNotFoundError("not archived"),
     saveAuditError: undefined,
@@ -62,7 +70,12 @@ function fakeStore(overrides?: Partial<FakeAuditStore>): { store: Store; state: 
         throw state.saveAuditError;
       }
     },
-    async setAuditTag(_k: unknown, _r: unknown, versionHash: string, tag: string): Promise<void> {
+    async setAuditTag(
+      _k: unknown,
+      _r: unknown,
+      versionHash: string,
+      tag: string,
+    ): Promise<void> {
       state.setAuditTagCalls.push({ versionHash, tag });
       if (state.setAuditTagError !== undefined) {
         throw state.setAuditTagError;
@@ -76,6 +89,7 @@ function contextWithSkill(tag: string) {
   const ctx = new RequestContext(
     PushSkillRequestSchema,
     create(PushSkillRequestSchema, {}),
+    testCallerIdentity(),
     ApiResourceKind.skill,
   );
   const skill = create(SkillSchema, {
@@ -101,7 +115,9 @@ describe("ArchiveCurrentSkill — safe degradation", () => {
   });
 
   it("tag-assignment failure clears the live spec.tag; the archived row stands", async () => {
-    const { store, state } = fakeStore({ setAuditTagError: new Error("tag column locked") });
+    const { store, state } = fakeStore({
+      setAuditTagError: new Error("tag column locked"),
+    });
     const { ctx, skill } = contextWithSkill("stable");
 
     await newArchiveCurrentSkillStep(store, silentLogger).execute(ctx);
@@ -130,7 +146,9 @@ describe("ArchiveCurrentSkill — safe degradation", () => {
     await newArchiveCurrentSkillStep(store, silentLogger).execute(ctx);
 
     expect(state.saveAuditCalls).toBe(0);
-    expect(state.setAuditTagCalls).toEqual([{ versionHash: HASH, tag: "stable" }]);
+    expect(state.setAuditTagCalls).toEqual([
+      { versionHash: HASH, tag: "stable" },
+    ]);
   });
 
   it("a skill with no version hash is a no-op (nothing to archive)", async () => {
@@ -138,6 +156,7 @@ describe("ArchiveCurrentSkill — safe degradation", () => {
     const ctx = new RequestContext(
       PushSkillRequestSchema,
       create(PushSkillRequestSchema, {}),
+      testCallerIdentity(),
       ApiResourceKind.skill,
     );
     ctx.set(

--- a/backend/services/stigmer-server/src/domain/skill/controller.ts
+++ b/backend/services/stigmer-server/src/domain/skill/controller.ts
@@ -23,6 +23,7 @@
  */
 import { Code, ConnectError } from "@connectrpc/connect";
 import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import type { DescMethod } from "@bufbuild/protobuf";
 import { create } from "@bufbuild/protobuf";
 
 import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
@@ -55,6 +56,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
   failedPreconditionError,
@@ -64,7 +66,9 @@ import {
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
 import {
   RESOURCE_ID_KEY,
@@ -74,7 +78,10 @@ import {
 } from "../../pipeline/steps/delete.js";
 import { newDeleteSearchIndexStep } from "../../pipeline/steps/index-search.js";
 import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
-import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import { newValidateVisibilityUpdateStep } from "../../pipeline/steps/validate-visibility.js";
 import type { Store } from "../../store/interface.js";
@@ -122,6 +129,8 @@ export interface SkillTransferLaneDeps {
 export interface SkillControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly artifactStorage: SkillArtifactStorage;
   /**
    * Execution artifact storage for pushFromExecutionArtifact (Go
@@ -143,9 +152,12 @@ export function registerSkillServices(
   deps: SkillControllerDeps,
 ): void {
   router.service(SkillCommandController, {
-    push: (req, ctx) => push(deps, req, ctx),
-    createArtifactUploadUrl: (req, ctx) => createArtifactUploadUrl(deps, req, ctx),
-    pushFromExecutionArtifact: (req, ctx) => pushFromExecutionArtifact(deps, req, ctx),
+    push: (req, ctx) =>
+      push(deps, req, ctx, SkillCommandController.method.push),
+    createArtifactUploadUrl: (req, ctx) =>
+      createArtifactUploadUrl(deps, req, ctx),
+    pushFromExecutionArtifact: (req, ctx) =>
+      pushFromExecutionArtifact(deps, req, ctx),
     updateVisibility: (input, ctx) => updateVisibility(deps, input, ctx),
     delete: (id, ctx) => deleteSkill(deps, id, ctx),
   });
@@ -153,7 +165,8 @@ export function registerSkillServices(
     get: (id, ctx) => get(deps, id, ctx),
     getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
     getArtifact: (req, ctx) => getArtifact(deps, req, ctx),
-    getArtifactDownloadUrl: (req, ctx) => getArtifactDownloadUrl(deps, req, ctx),
+    getArtifactDownloadUrl: (req, ctx) =>
+      getArtifactDownloadUrl(deps, req, ctx),
     listVersions: (req, ctx) => listVersions(deps, req, ctx),
   });
 }
@@ -166,14 +179,28 @@ function kindOf(ctx: HandlerContext): ApiResourceKind {
  * Push — the 12-step upsert-by-slug pipeline (push.ts holds the steps and
  * the versioning discipline). Returns the built skill from context: the
  * pipeline's message type is the request, so the resource rides SKILL_KEY.
+ *
+ * `method` is the AUTHORIZING descriptor, passed by the caller because two
+ * RPCs run this pipeline: push itself and pushFromExecutionArtifact (which
+ * delegates here after its artifact download). Each authorizes under its
+ * OWN annotation — a hardcoded method.push would silently evaluate the
+ * wrong config the day the two annotations diverge (the runLifecyclePipeline
+ * pattern, O2).
  */
 async function push(
   deps: SkillControllerDeps,
   req: PushSkillRequest,
   ctx: HandlerContext,
+  method: DescMethod,
 ): Promise<Skill> {
-  const reqCtx = new RequestContext(PushSkillRequestSchema, req, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    PushSkillRequestSchema,
+    req,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof PushSkillRequestSchema>("skill-push", deps.logger)
+    .addStep(newAuthorizeStep(method, deps.authorizer))
     .addStep(newValidateProtoStep())
     .addStep(newResolveArtifactSourceStep(deps.transferLane?.slots))
     .addStep(newBuildInitialSkillStep())
@@ -211,12 +238,18 @@ async function createArtifactUploadUrl(
   const reqCtx = new RequestContext(
     SkillCommandController.method.createArtifactUploadUrl.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof SkillCommandController.method.createArtifactUploadUrl.input>(
-    "skill-create-artifact-upload-url",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof SkillCommandController.method.createArtifactUploadUrl.input
+  >("skill-create-artifact-upload-url", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        SkillCommandController.method.createArtifactUploadUrl,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .build()
     .execute(reqCtx);
@@ -315,6 +348,7 @@ async function pushFromExecutionArtifact(
       tag: req.tag,
     }),
     ctx,
+    SkillCommandController.method.pushFromExecutionArtifact,
   );
 
   deps.logger.info("Successfully pushed skill from execution artifact", {
@@ -347,9 +381,19 @@ async function updateVisibility(
   const reqCtx = new RequestContext(
     SkillCommandController.method.updateVisibility.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<UpdateVisibilityDesc>("skill-update-visibility", deps.logger)
+  await newPipeline<UpdateVisibilityDesc>(
+    "skill-update-visibility",
+    deps.logger,
+  )
+    .addStep(
+      newAuthorizeStep(
+        SkillCommandController.method.updateVisibility,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadSkillForVisibilityUpdateStep(deps.store))
     .addStep(newValidateVisibilityUpdateStep())
@@ -393,7 +437,12 @@ function newSetVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
       if (skill.metadata !== undefined) {
         skill.metadata.visibility = ctx.input.visibility;
       }
-      setAuditFieldsForUpdate(SkillSchema, skill, "status_audit");
+      setAuditFieldsForUpdate(
+        SkillSchema,
+        skill,
+        "status_audit",
+        ctx.callerIdentity,
+      );
     },
   };
 }
@@ -431,13 +480,20 @@ function newIndexSkillAfterVisibilityUpdateStep(
       const skill = ctx.get(UPDATE_VISIBILITY_SKILL_KEY) as Skill;
       const entry = skillSearchExtractor.getSearchIndexEntry(skill);
       if (entry === undefined) {
-        logger.warn("IndexSkillAfterVisibilityUpdate: extractor returned nil, skipping", {
-          id: skill.metadata?.id ?? "",
-        });
+        logger.warn(
+          "IndexSkillAfterVisibilityUpdate: extractor returned nil, skipping",
+          {
+            id: skill.metadata?.id ?? "",
+          },
+        );
         return;
       }
       try {
-        await store.upsertSearchIndex(ctx.apiResourceKind, skill.metadata?.id ?? "", entry);
+        await store.upsertSearchIndex(
+          ctx.apiResourceKind,
+          skill.metadata?.id ?? "",
+          entry,
+        );
       } catch (error) {
         logger.warn("IndexSkillAfterVisibilityUpdate: failed (best-effort)", {
           id: skill.metadata?.id ?? "",
@@ -461,12 +517,16 @@ async function deleteSkill(
   const reqCtx = new RequestContext(
     SkillCommandController.method.delete.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof SkillCommandController.method.delete.input>(
     "skill-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(SkillCommandController.method.delete, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, SkillSchema))
@@ -535,12 +595,14 @@ async function get(
   const reqCtx = new RequestContext(
     SkillQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof SkillQueryController.method.get.input>(
     "skill-get",
     deps.logger,
   )
+    .addStep(newAuthorizeStep(SkillQueryController.method.get, deps.authorizer))
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, SkillSchema))
     .build()
@@ -557,12 +619,19 @@ async function getByReference(
   const reqCtx = new RequestContext(
     SkillQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof SkillQueryController.method.getByReference.input>(
     "skill-get-by-reference",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        SkillQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadSkillByReferenceStep(deps.store))
     .build()
@@ -583,12 +652,19 @@ async function getArtifact(
   const reqCtx = new RequestContext(
     SkillQueryController.method.getArtifact.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof SkillQueryController.method.getArtifact.input>(
     "skill-get-artifact",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        SkillQueryController.method.getArtifact,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .build()
     .execute(reqCtx);
@@ -629,12 +705,18 @@ async function getArtifactDownloadUrl(
   const reqCtx = new RequestContext(
     SkillQueryController.method.getArtifactDownloadUrl.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof SkillQueryController.method.getArtifactDownloadUrl.input>(
-    "skill-get-artifact-download-url",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof SkillQueryController.method.getArtifactDownloadUrl.input
+  >("skill-get-artifact-download-url", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        SkillQueryController.method.getArtifactDownloadUrl,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .build()
     .execute(reqCtx);
@@ -668,12 +750,19 @@ async function listVersions(
   const reqCtx = new RequestContext(
     SkillQueryController.method.listVersions.input,
     req,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof SkillQueryController.method.listVersions.input>(
     "skill-list-versions",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        SkillQueryController.method.listVersions,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSkillBySlugStep(deps.store))
     .addStep(newLoadAndMapVersionsStep(deps.store))
@@ -683,7 +772,10 @@ async function listVersions(
 }
 
 /** Bounds a promise by the named deadline (Go's context.WithTimeout arm). */
-async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
   let timer: NodeJS.Timeout | undefined;
   try {
     return await Promise.race([

--- a/backend/services/stigmer-server/src/domain/skill/push.ts
+++ b/backend/services/stigmer-server/src/domain/skill/push.ts
@@ -35,7 +35,10 @@ import { SkillSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb"
 import type { Skill } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/api_pb";
 import type { PushSkillRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/io_pb";
 import { SkillSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/spec_pb";
-import { SkillState, SkillStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/skill/v1/status_pb";
+import {
+  SkillState,
+  SkillStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/skill/v1/status_pb";
 import {
   ApiResourceMetadataSchema,
   ApiResourceMetadataVersionSchema,
@@ -44,7 +47,10 @@ import { ApiResourceAuditSchema } from "@stigmer/protos/ai/stigmer/commons/apire
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 
 import type { Logger } from "../../boot/logger.js";
-import { defaultVisibilityFor, getIdPrefix } from "../../pipeline/apiresource-meta.js";
+import {
+  defaultVisibilityFor,
+  getIdPrefix,
+} from "../../pipeline/apiresource-meta.js";
 import {
   failedPreconditionError,
   internalError,
@@ -187,7 +193,9 @@ export function newResolveSlugForPushStep(): PipelineStep<PushDesc> {
  * FindExistingBySlug — push is upsert-by-slug: an existing skill's ID is
  * adopted (update), otherwise the create flag is raised.
  */
-export function newFindExistingBySlugStep(store: Store): PipelineStep<PushDesc> {
+export function newFindExistingBySlugStep(
+  store: Store,
+): PipelineStep<PushDesc> {
   return {
     name: "FindExistingBySlug",
     async execute(ctx: RequestContext<PushDesc>): Promise<void> {
@@ -255,7 +263,10 @@ export function newCheckAndStoreArtifactStep(
         storageKey = artifactStorage.getStorageKey(extractResult.hash);
       } else {
         try {
-          storageKey = await artifactStorage.store(extractResult.hash, artifactBytes);
+          storageKey = await artifactStorage.store(
+            extractResult.hash,
+            artifactBytes,
+          );
         } catch (error) {
           throw internalError(error, "failed to store artifact");
         }
@@ -317,7 +328,7 @@ export function newPopulateSkillFieldsStep(): PipelineStep<PushDesc> {
       });
 
       if (shouldCreate) {
-        setAuditFieldsForCreate(SkillSchema, skill);
+        setAuditFieldsForCreate(SkillSchema, skill, ctx.callerIdentity);
       } else {
         const existing = ctx.get(EXISTING_SKILL_KEY) as Skill;
         if (existing.status?.audit !== undefined) {
@@ -329,7 +340,12 @@ export function newPopulateSkillFieldsStep(): PipelineStep<PushDesc> {
           status.audit.specAudit = existing.status.audit.specAudit;
           status.audit.statusAudit = existing.status.audit.statusAudit;
         }
-        setAuditFieldsForUpdate(SkillSchema, skill, "spec_audit");
+        setAuditFieldsForUpdate(
+          SkillSchema,
+          skill,
+          "spec_audit",
+          ctx.callerIdentity,
+        );
       }
     },
   };
@@ -363,7 +379,12 @@ export function newArchiveCurrentSkillStep(
       // (readers resolve duplicates newest-wins).
       let alreadyArchived = false;
       try {
-        await store.getAuditByHash(ctx.apiResourceKind, skillId, versionHash, SkillSchema);
+        await store.getAuditByHash(
+          ctx.apiResourceKind,
+          skillId,
+          versionHash,
+          SkillSchema,
+        );
         alreadyArchived = true;
       } catch (error) {
         if (!(error instanceof AuditNotFoundError)) {
@@ -384,7 +405,14 @@ export function newArchiveCurrentSkillStep(
         // single-holder primitive — a later tag move never rewrites this
         // immutable content.
         try {
-          await store.saveAudit(ctx.apiResourceKind, skillId, SkillSchema, skill, versionHash, "");
+          await store.saveAudit(
+            ctx.apiResourceKind,
+            skillId,
+            SkillSchema,
+            skill,
+            versionHash,
+            "",
+          );
         } catch (error) {
           logger.error(
             "Failed to archive skill version — reverting the version hash to maintain the audit-resolvability invariant",
@@ -410,7 +438,12 @@ export function newArchiveCurrentSkillStep(
       // becomes the tag's sole holder; any prior holder is cleared.
       if (tag !== "") {
         try {
-          await store.setAuditTag(ctx.apiResourceKind, skillId, versionHash, tag);
+          await store.setAuditTag(
+            ctx.apiResourceKind,
+            skillId,
+            versionHash,
+            tag,
+          );
         } catch (error) {
           logger.error(
             "Archived skill version but failed to assign its tag — clearing the live tag to stay consistent with the audit column",
@@ -451,7 +484,12 @@ export function newStoreSkillStep(store: Store): PipelineStep<PushDesc> {
     async execute(ctx: RequestContext<PushDesc>): Promise<void> {
       const skill = ctx.get(SKILL_KEY) as Skill;
       try {
-        await store.saveResource(ctx.apiResourceKind, skill.metadata!.id, SkillSchema, skill);
+        await store.saveResource(
+          ctx.apiResourceKind,
+          skill.metadata!.id,
+          SkillSchema,
+          skill,
+        );
       } catch (error) {
         throw internalError(error, "failed to save skill");
       }
@@ -474,18 +512,28 @@ export function newIndexSkillSearchStep(
       const skill = ctx.get(SKILL_KEY) as Skill;
       const entry = skillSearchExtractor.getSearchIndexEntry(skill);
       if (entry === undefined) {
-        logger.warn("IndexSkillSearch: extractor returned nil entry, skipping", {
-          id: skill.metadata?.id ?? "",
-        });
+        logger.warn(
+          "IndexSkillSearch: extractor returned nil entry, skipping",
+          {
+            id: skill.metadata?.id ?? "",
+          },
+        );
         return;
       }
       try {
-        await store.upsertSearchIndex(ctx.apiResourceKind, skill.metadata!.id, entry);
+        await store.upsertSearchIndex(
+          ctx.apiResourceKind,
+          skill.metadata!.id,
+          entry,
+        );
       } catch (error) {
-        logger.warn("IndexSkillSearch: failed to update search index (best-effort)", {
-          id: skill.metadata?.id ?? "",
-          error: error instanceof Error ? error.message : String(error),
-        });
+        logger.warn(
+          "IndexSkillSearch: failed to update search index (best-effort)",
+          {
+            id: skill.metadata?.id ?? "",
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
       }
     },
   };

--- a/backend/services/stigmer-server/src/domain/workflow/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/controller.ts
@@ -41,14 +41,21 @@ import type {
   TagWorkflowVersionInput,
   WorkflowVersionEntry,
 } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/version_pb";
-import { ApiResourceKind, ApiResourceKindSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import {
+  ApiResourceKind,
+  ApiResourceKindSchema,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import type {
   ApiResourceReference,
   UpdateVisibilityInput,
 } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
-import { ApiResourceMetadataSchema, ApiResourceMetadataVersionSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+import {
+  ApiResourceMetadataSchema,
+  ApiResourceMetadataVersionSchema,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
   internalError,
@@ -57,32 +64,55 @@ import {
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
-import { setAuditFieldsForUpdate, newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
+import {
+  setAuditFieldsForUpdate,
+  newBuildNewStateStep,
+} from "../../pipeline/steps/defaults.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
 import {
   newDeleteResourceStep,
   newExtractResourceIdStep,
   newLoadExistingForDeleteStep,
 } from "../../pipeline/steps/delete.js";
-import { findResourceBySlug, requireOrgForReference } from "../../pipeline/steps/helpers.js";
+import {
+  findResourceBySlug,
+  requireOrgForReference,
+} from "../../pipeline/steps/helpers.js";
 import {
   newDeleteSearchIndexStep,
   newIndexSearchStep,
 } from "../../pipeline/steps/index-search.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
-import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
-import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
-import { newValidateProtoStep, validator } from "../../pipeline/steps/validation.js";
+import {
+  newValidateProtoStep,
+  validator,
+} from "../../pipeline/steps/validation.js";
 import {
   newValidateVisibilityStep,
   newValidateVisibilityUpdateStep,
 } from "../../pipeline/steps/validate-visibility.js";
-import { AuditNotFoundError, ResourceNotFoundError } from "../../store/interface.js";
+import {
+  AuditNotFoundError,
+  ResourceNotFoundError,
+} from "../../store/interface.js";
 import type { AuditRecord, Store } from "../../store/interface.js";
 import { formatViolation } from "./validation/format-violation.js";
 import type { InProcessValidator } from "./validation/validator.js";
@@ -105,6 +135,8 @@ import type { WorkflowInstanceCreatorProvider } from "./steps.js";
 export interface WorkflowControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   /** The Layer-2 validator (converter + structural checks + registry). */
   readonly validator: InProcessValidator;
   /**
@@ -158,8 +190,19 @@ async function createWorkflow(
   workflow: Workflow,
   ctx: HandlerContext,
 ): Promise<Workflow> {
-  const reqCtx = new RequestContext(WorkflowSchema, workflow, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    WorkflowSchema,
+    workflow,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof WorkflowSchema>("workflow-create", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        WorkflowCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newValidateWorkflowSpecStep(deps.validator, deps.logger))
@@ -171,10 +214,16 @@ async function createWorkflow(
     .addStep(newComputeVersionHashStep(deps.logger))
     .addStep(newPopulateVersionHashStep(true))
     .addStep(newPersistStep(deps.store))
-    .addStep(newCreateDefaultInstanceStep(deps.workflowInstanceCreator, deps.logger))
-    .addStep(newUpdateWorkflowStatusWithDefaultInstanceStep(deps.store, deps.logger))
+    .addStep(
+      newCreateDefaultInstanceStep(deps.workflowInstanceCreator, deps.logger),
+    )
+    .addStep(
+      newUpdateWorkflowStatusWithDefaultInstanceStep(deps.store, deps.logger),
+    )
     .addStep(newSaveVersionAuditStep(deps.store, deps.logger, true, true))
-    .addStep(newIndexSearchStep(deps.store, workflowSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(deps.store, workflowSearchExtractor, deps.logger),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -191,8 +240,19 @@ async function update(
   workflow: Workflow,
   ctx: HandlerContext,
 ): Promise<Workflow> {
-  const reqCtx = new RequestContext(WorkflowSchema, workflow, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    WorkflowSchema,
+    workflow,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof WorkflowSchema>("workflow-update", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        WorkflowCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateWorkflowSpecStep(deps.validator, deps.logger))
     .addStep(newResolveSlugStep())
@@ -205,7 +265,9 @@ async function update(
     .addStep(newPopulateVersionHashStep(false))
     .addStep(newSaveVersionAuditStep(deps.store, deps.logger, false, false))
     .addStep(newPersistStep(deps.store))
-    .addStep(newIndexSearchStep(deps.store, workflowSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(deps.store, workflowSearchExtractor, deps.logger),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -221,8 +283,16 @@ async function apply(
   workflow: Workflow,
   ctx: HandlerContext,
 ): Promise<Workflow> {
-  const reqCtx = new RequestContext(WorkflowSchema, workflow, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    WorkflowSchema,
+    workflow,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof WorkflowSchema>("workflow-apply", deps.logger)
+    .addStep(
+      newAuthorizeStep(WorkflowCommandController.method.apply, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -254,12 +324,19 @@ async function deleteWorkflow(
   const reqCtx = new RequestContext(
     WorkflowCommandController.method.delete.input,
     workflowId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof WorkflowCommandController.method.delete.input>(
     "workflow-delete",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, WorkflowSchema))
@@ -300,9 +377,19 @@ async function updateVisibility(
   const reqCtx = new RequestContext(
     WorkflowCommandController.method.updateVisibility.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<UpdateVisibilityDesc>("workflow-update-visibility", deps.logger)
+  await newPipeline<UpdateVisibilityDesc>(
+    "workflow-update-visibility",
+    deps.logger,
+  )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowCommandController.method.updateVisibility,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadWorkflowForVisibilityUpdateStep(deps.store))
     .addStep(newValidateVisibilityUpdateStep())
@@ -349,7 +436,12 @@ function newSetWorkflowVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
       workflow.metadata!.visibility = input.visibility;
 
       try {
-        setAuditFieldsForUpdate(WorkflowSchema, workflow, "status_audit");
+        setAuditFieldsForUpdate(
+          WorkflowSchema,
+          workflow,
+          "status_audit",
+          ctx.callerIdentity,
+        );
       } catch (error) {
         throw new Error(
           `failed to set audit fields: ${error instanceof Error ? error.message : String(error)}`,
@@ -406,10 +498,13 @@ function newIndexWorkflowAfterVisibilityUpdateStep(
           entry,
         );
       } catch (error) {
-        logger.warn("IndexWorkflowAfterVisibilityUpdate: failed (best-effort)", {
-          error: error instanceof Error ? error.message : String(error),
-          id: workflow.metadata?.id ?? "",
-        });
+        logger.warn(
+          "IndexWorkflowAfterVisibilityUpdate: failed (best-effort)",
+          {
+            error: error instanceof Error ? error.message : String(error),
+            id: workflow.metadata?.id ?? "",
+          },
+        );
       }
     },
   };
@@ -499,9 +594,16 @@ async function tagVersion(
   const reqCtx = new RequestContext(
     WorkflowCommandController.method.tagVersion.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<TagVersionDesc>("workflow-tag-version", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        WorkflowCommandController.method.tagVersion,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newTagWorkflowVersionStep(deps.store))
     .build()
@@ -619,12 +721,16 @@ async function get(
   const reqCtx = new RequestContext(
     WorkflowQueryController.method.get.input,
     workflowId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof WorkflowQueryController.method.get.input>(
     "workflow-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(WorkflowQueryController.method.get, deps.authorizer),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, WorkflowSchema))
     .build()
@@ -656,7 +762,10 @@ async function getByReference(
   // empty-org reference is under-specified.
   requireOrgForReference(ApiResourceKind.workflow, ref.org);
 
-  if (ref.kind !== ApiResourceKind.api_resource_kind_unknown && ref.kind !== ApiResourceKind.workflow) {
+  if (
+    ref.kind !== ApiResourceKind.api_resource_kind_unknown &&
+    ref.kind !== ApiResourceKind.workflow
+  ) {
     // Go renders both sides with .String(): the NAME for defined values and
     // the bare NUMBER for unknown ones (proto3 open enums preserve them, and
     // ref.kind carries no defined_only rule) — enumToJson would throw on the
@@ -723,8 +832,16 @@ async function findAuditWorkflowByVersion(
   let rec: AuditRecord;
   try {
     rec = WORKFLOW_HASH_PATTERN.test(version)
-      ? await store.getAuditRecordByHash(ApiResourceKind.workflow, workflowId, version)
-      : await store.getAuditRecordByTag(ApiResourceKind.workflow, workflowId, version);
+      ? await store.getAuditRecordByHash(
+          ApiResourceKind.workflow,
+          workflowId,
+          version,
+        )
+      : await store.getAuditRecordByTag(
+          ApiResourceKind.workflow,
+          workflowId,
+          version,
+        );
   } catch (error) {
     if (error instanceof AuditNotFoundError) {
       return undefined;
@@ -763,7 +880,8 @@ const LIST_VERSIONS_WORKFLOW_ID_KEY = "listVersionsWorkflowId";
 const LIST_VERSIONS_HEAD_HASH_KEY = "listVersionsHeadHash";
 const LIST_VERSIONS_RESPONSE_KEY = "listVersionsResponse";
 
-type ListVersionsDesc = typeof WorkflowQueryController.method.listVersions.input;
+type ListVersionsDesc =
+  typeof WorkflowQueryController.method.listVersions.input;
 
 async function listVersions(
   deps: WorkflowControllerDeps,
@@ -773,9 +891,16 @@ async function listVersions(
   const reqCtx = new RequestContext(
     WorkflowQueryController.method.listVersions.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<ListVersionsDesc>("workflow-list-versions", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        WorkflowQueryController.method.listVersions,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveWorkflowBySlugStep(deps.store))
     .addStep(newLoadAndMapWorkflowVersionsStep(deps.store))
@@ -786,7 +911,9 @@ async function listVersions(
 }
 
 /** Finds the workflow by org+slug; stashes its id and live head hash. */
-function newResolveWorkflowBySlugStep(store: Store): PipelineStep<ListVersionsDesc> {
+function newResolveWorkflowBySlugStep(
+  store: Store,
+): PipelineStep<ListVersionsDesc> {
   return {
     name: "ResolveWorkflowBySlug",
     async execute(ctx: RequestContext<ListVersionsDesc>): Promise<void> {
@@ -829,12 +956,16 @@ function newLoadAndMapWorkflowVersionsStep(
 
       let records: AuditRecord[];
       try {
-        records = await store.listAuditRecords(ApiResourceKind.workflow, workflowId);
+        records = await store.listAuditRecords(
+          ApiResourceKind.workflow,
+          workflowId,
+        );
       } catch (error) {
         throw internalError(error, "failed to load workflow version history");
       }
 
-      const headHash = (ctx.get(LIST_VERSIONS_HEAD_HASH_KEY) as string | undefined) ?? "";
+      const headHash =
+        (ctx.get(LIST_VERSIONS_HEAD_HASH_KEY) as string | undefined) ?? "";
       let currentMarked = false;
       const entries: WorkflowVersionEntry[] = [];
       for (const rec of records) {
@@ -845,7 +976,9 @@ function newLoadAndMapWorkflowVersionsStep(
           continue;
         }
         const isCurrent: boolean =
-          !currentMarked && headHash !== "" && (wf.status?.versionHash ?? "") === headHash;
+          !currentMarked &&
+          headHash !== "" &&
+          (wf.status?.versionHash ?? "") === headHash;
         currentMarked = currentMarked || isCurrent;
         // Tag comes from the audit column (source of truth), not the snapshot.
         entries.push(mapWorkflowToVersionEntry(wf, isCurrent, rec.tag));

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/create-steps.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/create-steps.test.ts
@@ -8,6 +8,7 @@
  * (execution marked FAILED with the error text and persisted —
  * recoverable via Recover).
  */
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -64,6 +65,7 @@ function executionCtx(
   return new RequestContext(
     WorkflowExecutionSchema,
     create(WorkflowExecutionSchema, init),
+    testCallerIdentity(),
     ApiResourceKind.workflow_execution,
   );
 }
@@ -332,6 +334,7 @@ describe("StartWorkflow failure posture (create.go startWorkflowStep)", () => {
     const ctx = new RequestContext(
       WorkflowExecutionSchema,
       execution,
+      testCallerIdentity(),
       ApiResourceKind.workflow_execution,
     );
     const step = newStartWorkflowStep({

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/lifecycle.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/lifecycle.test.ts
@@ -8,6 +8,8 @@
  * full choreography (terminate both tree members, EC recreate
  * degrade-gracefully, fresh start with recovery_mode, error clear).
  */
+import { newPermissiveSingleTeamAuthorizer } from "../../../pipeline/steps/authorize.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -114,6 +116,7 @@ function deps(engineStub?: EngineStub): LifecycleDeps {
   return {
     store,
     logger: silentLogger,
+    authorizer: newPermissiveSingleTeamAuthorizer(),
     broker,
     engineState: () => engineStub?.state ?? ENGINE_DISCONNECTED,
     executionContextBuilder: builderDeps(),
@@ -132,7 +135,10 @@ async function seed(
     WorkflowExecutionSchema,
     create(WorkflowExecutionSchema, {
       metadata: { id, name: id, org: "acme" },
-      spec: { workflowId: `wf_${counter}`, workflowInstanceId: `wfi_${counter}` },
+      spec: {
+        workflowId: `wf_${counter}`,
+        workflowInstanceId: `wfi_${counter}`,
+      },
       status: { phase, ...overrides },
     }),
   );
@@ -156,21 +162,34 @@ async function expectCode(
 describe("shared load + validation arms (lifecycle_test.go)", () => {
   it("empty id refuses InvalidArgument; unknown id NotFound", async () => {
     const err = await expectCode(
-      () => cancelExecution(deps(), cancelInput({ id: "" })),
+      () =>
+        cancelExecution(deps(), cancelInput({ id: "" }), testCallerIdentity()),
       Code.InvalidArgument,
     );
     expect(err.rawMessage).toBe("execution id is required");
     const missing = await expectCode(
-      () => cancelExecution(deps(), cancelInput({ id: "wfx_missing" })),
+      () =>
+        cancelExecution(
+          deps(),
+          cancelInput({ id: "wfx_missing" }),
+          testCallerIdentity(),
+        ),
       Code.NotFound,
     );
-    expect(missing.rawMessage).toBe("workflow_execution not found: wfx_missing");
+    expect(missing.rawMessage).toBe(
+      "workflow_execution not found: wfx_missing",
+    );
   });
 
   it("phase validators refuse with the pinned copy", async () => {
     const completed = await seed(ExecutionPhase.EXECUTION_COMPLETED);
     const cancelErr = await expectCode(
-      () => cancelExecution(deps(), cancelInput({ id: completed })),
+      () =>
+        cancelExecution(
+          deps(),
+          cancelInput({ id: completed }),
+          testCallerIdentity(),
+        ),
       Code.FailedPrecondition,
     );
     expect(cancelErr.rawMessage).toBe(
@@ -178,7 +197,12 @@ describe("shared load + validation arms (lifecycle_test.go)", () => {
     );
 
     const terminateErr = await expectCode(
-      () => terminateExecution(deps(), terminateInput({ id: completed })),
+      () =>
+        terminateExecution(
+          deps(),
+          terminateInput({ id: completed }),
+          testCallerIdentity(),
+        ),
       Code.FailedPrecondition,
     );
     expect(terminateErr.rawMessage).toBe(
@@ -187,7 +211,12 @@ describe("shared load + validation arms (lifecycle_test.go)", () => {
 
     const paused = await seed(ExecutionPhase.EXECUTION_PAUSED);
     const pauseErr = await expectCode(
-      () => pauseExecution(deps(), pauseInput({ id: completed })),
+      () =>
+        pauseExecution(
+          deps(),
+          pauseInput({ id: completed }),
+          testCallerIdentity(),
+        ),
       Code.FailedPrecondition,
     );
     expect(pauseErr.rawMessage).toBe(
@@ -195,7 +224,12 @@ describe("shared load + validation arms (lifecycle_test.go)", () => {
     );
 
     const resumeErr = await expectCode(
-      () => resumeExecution(deps(), resumeInput({ id: completed })),
+      () =>
+        resumeExecution(
+          deps(),
+          resumeInput({ id: completed }),
+          testCallerIdentity(),
+        ),
       Code.FailedPrecondition,
     );
     expect(resumeErr.rawMessage).toBe(
@@ -204,13 +238,23 @@ describe("shared load + validation arms (lifecycle_test.go)", () => {
     // PAUSED is resumable — engineless it fails at the ENGINE, not the
     // validator (proving validator pass-through).
     const engineErr = await expectCode(
-      () => resumeExecution(deps(), resumeInput({ id: paused })),
+      () =>
+        resumeExecution(
+          deps(),
+          resumeInput({ id: paused }),
+          testCallerIdentity(),
+        ),
       Code.FailedPrecondition,
     );
     expect(engineErr.rawMessage).toBe(TEMPORAL_UNAVAILABLE_MESSAGE);
 
     const recoverErr = await expectCode(
-      () => recoverExecution(deps(), recoverInput({ id: completed })),
+      () =>
+        recoverExecution(
+          deps(),
+          recoverInput({ id: completed }),
+          testCallerIdentity(),
+        ),
       Code.FailedPrecondition,
     );
     expect(recoverErr.rawMessage).toBe(
@@ -220,26 +264,61 @@ describe("shared load + validation arms (lifecycle_test.go)", () => {
 
   it("target-phase idempotency succeeds without touching the engine", async () => {
     const cancelled = await seed(ExecutionPhase.EXECUTION_CANCELLED);
-    const result = await cancelExecution(deps(), cancelInput({ id: cancelled }));
+    const result = await cancelExecution(
+      deps(),
+      cancelInput({ id: cancelled }),
+      testCallerIdentity(),
+    );
     expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
 
     const terminated = await seed(ExecutionPhase.EXECUTION_TERMINATED);
-    await terminateExecution(deps(), terminateInput({ id: terminated }));
+    await terminateExecution(
+      deps(),
+      terminateInput({ id: terminated }),
+      testCallerIdentity(),
+    );
 
     const inProgress = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
-    await resumeExecution(deps(), resumeInput({ id: inProgress }));
-    await recoverExecution(deps(), recoverInput({ id: inProgress }));
+    await resumeExecution(
+      deps(),
+      resumeInput({ id: inProgress }),
+      testCallerIdentity(),
+    );
+    await recoverExecution(
+      deps(),
+      recoverInput({ id: inProgress }),
+      testCallerIdentity(),
+    );
 
     const paused = await seed(ExecutionPhase.EXECUTION_PAUSED);
-    await pauseExecution(deps(), pauseInput({ id: paused }));
+    await pauseExecution(
+      deps(),
+      pauseInput({ id: paused }),
+      testCallerIdentity(),
+    );
   });
 
   it("engineless postures: FailedPrecondition per pinned copy", async () => {
     const running = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
     const englessOps = [
-      () => cancelExecution(deps(), cancelInput({ id: running })),
-      () => terminateExecution(deps(), terminateInput({ id: running })),
-      () => pauseExecution(deps(), pauseInput({ id: running })),
+      () =>
+        cancelExecution(
+          deps(),
+          cancelInput({ id: running }),
+          testCallerIdentity(),
+        ),
+      () =>
+        terminateExecution(
+          deps(),
+          terminateInput({ id: running }),
+          testCallerIdentity(),
+        ),
+      () =>
+        pauseExecution(
+          deps(),
+          pauseInput({ id: running }),
+          testCallerIdentity(),
+        ),
     ];
     for (const op of englessOps) {
       const err = await expectCode(op, Code.FailedPrecondition);
@@ -248,7 +327,12 @@ describe("shared load + validation arms (lifecycle_test.go)", () => {
     // Recover's first engine touch is the terminate-existing step.
     const failed = await seed(ExecutionPhase.EXECUTION_FAILED);
     const recoverErr = await expectCode(
-      () => recoverExecution(deps(), recoverInput({ id: failed })),
+      () =>
+        recoverExecution(
+          deps(),
+          recoverInput({ id: failed }),
+          testCallerIdentity(),
+        ),
       Code.FailedPrecondition,
     );
     expect(recoverErr.rawMessage).toBe(TEMPORAL_UNAVAILABLE_MESSAGE);
@@ -263,7 +347,11 @@ describe("connected-engine transitions", () => {
 
   it("cancel: CancelWorkflow on the orchestrator id, CANCELLED persisted with completed_at", async () => {
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
-    const result = await cancelExecution(deps(engine), cancelInput({ id }));
+    const result = await cancelExecution(
+      deps(engine),
+      cancelInput({ id }),
+      testCallerIdentity(),
+    );
 
     expect(engine.calls).toEqual([
       { method: "cancelWorkflow", args: [orchestratorWorkflowId(id)] },
@@ -283,7 +371,11 @@ describe("connected-engine transitions", () => {
     engine.failures.cancelWorkflow = new EngineWorkflowNotFoundError(
       orchestratorWorkflowId(id),
     );
-    const result = await cancelExecution(deps(engine), cancelInput({ id }));
+    const result = await cancelExecution(
+      deps(engine),
+      cancelInput({ id }),
+      testCallerIdentity(),
+    );
     expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
   });
 
@@ -291,7 +383,12 @@ describe("connected-engine transitions", () => {
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
     engine.failures.cancelWorkflow = new Error("temporal exploded");
     const err = await expectCode(
-      () => cancelExecution(deps(engine), cancelInput({ id })),
+      () =>
+        cancelExecution(
+          deps(engine),
+          cancelInput({ id }),
+          testCallerIdentity(),
+        ),
       Code.Internal,
     );
     expect(err.rawMessage).toBe("failed to cancel Temporal workflow");
@@ -299,8 +396,11 @@ describe("connected-engine transitions", () => {
 
   it("terminate: reason default + 'Terminated: {reason}' error copy", async () => {
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
-    const result = await terminateExecution(deps(engine), terminateInput({ id,
-      reason: "stuck", }));
+    const result = await terminateExecution(
+      deps(engine),
+      terminateInput({ id, reason: "stuck" }),
+      testCallerIdentity(),
+    );
     expect(engine.calls).toEqual([
       {
         method: "terminateWorkflow",
@@ -311,7 +411,11 @@ describe("connected-engine transitions", () => {
     expect(result.status?.error).toBe("Terminated: stuck");
 
     const defaulted = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
-    const result2 = await terminateExecution(deps(engine), terminateInput({ id: defaulted, }));
+    const result2 = await terminateExecution(
+      deps(engine),
+      terminateInput({ id: defaulted }),
+      testCallerIdentity(),
+    );
     expect(result2.status?.error).toBe("Terminated: Terminated by user");
   });
 
@@ -322,19 +426,30 @@ describe("connected-engine transitions", () => {
     );
     // Go's NotFound arm returns before ReasonKey is recorded — even an
     // explicit reason is lost and the default copy applies.
-    const result = await terminateExecution(deps(engine), terminateInput({ id,
-      reason: "explicit reason", }));
+    const result = await terminateExecution(
+      deps(engine),
+      terminateInput({ id, reason: "explicit reason" }),
+      testCallerIdentity(),
+    );
     expect(result.status?.error).toBe("Terminated by user");
   });
 
   it("pause/resume: the byte-pinned signal names with the reason payload", async () => {
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
-    const paused = await pauseExecution(deps(engine), pauseInput({ id }));
+    const paused = await pauseExecution(
+      deps(engine),
+      pauseInput({ id }),
+      testCallerIdentity(),
+    );
     expect(paused.status?.phase).toBe(ExecutionPhase.EXECUTION_PAUSED);
     // PAUSED is not terminal — completed_at stays empty.
     expect(paused.status?.completedAt).toBe("");
 
-    const resumed = await resumeExecution(deps(engine), resumeInput({ id }));
+    const resumed = await resumeExecution(
+      deps(engine),
+      resumeInput({ id }),
+      testCallerIdentity(),
+    );
     expect(resumed.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
 
     expect(engine.calls).toEqual([
@@ -354,7 +469,11 @@ describe("connected-engine transitions", () => {
       error: "boom",
       completedAt: "2026-05-23T10:00:00Z",
     });
-    const result = await recoverExecution(deps(engine), recoverInput({ id }));
+    const result = await recoverExecution(
+      deps(engine),
+      recoverInput({ id }),
+      testCallerIdentity(),
+    );
 
     expect(engine.calls[0]).toEqual({
       method: "terminateWorkflow",
@@ -376,20 +495,32 @@ describe("connected-engine transitions", () => {
 
     expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
     expect(result.status?.error, "recover clears the error").toBe("");
-    expect(result.status?.completedAt, "back to IN_PROGRESS clears completed_at").toBe("");
+    expect(
+      result.status?.completedAt,
+      "back to IN_PROGRESS clears completed_at",
+    ).toBe("");
   });
 
   it("recover: NOT_FOUND on either tree member is tolerated; orchestrator failure short-circuits the child", async () => {
     const tolerated = await seed(ExecutionPhase.EXECUTION_FAILED);
     engine.failures.terminateWorkflow = new EngineWorkflowNotFoundError("x");
-    const result = await recoverExecution(deps(engine), recoverInput({ id: tolerated, }));
+    const result = await recoverExecution(
+      deps(engine),
+      recoverInput({ id: tolerated }),
+      testCallerIdentity(),
+    );
     expect(result.status?.phase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
 
     const failing = await seed(ExecutionPhase.EXECUTION_FAILED);
     const hardFail = stubConnectedEngine();
     hardFail.failures.terminateWorkflow = new Error("terminate exploded");
     const err = await expectCode(
-      () => recoverExecution(deps(hardFail), recoverInput({ id: failing })),
+      () =>
+        recoverExecution(
+          deps(hardFail),
+          recoverInput({ id: failing }),
+          testCallerIdentity(),
+        ),
       Code.Internal,
     );
     expect(err.rawMessage).toBe(
@@ -405,7 +536,12 @@ describe("connected-engine transitions", () => {
     const id = await seed(ExecutionPhase.EXECUTION_FAILED, { error: "boom" });
     engine.failures.startInvokeWorkflow = new Error("start exploded");
     const err = await expectCode(
-      () => recoverExecution(deps(engine), recoverInput({ id })),
+      () =>
+        recoverExecution(
+          deps(engine),
+          recoverInput({ id }),
+          testCallerIdentity(),
+        ),
       Code.Internal,
     );
     expect(err.rawMessage).toBe(
@@ -426,7 +562,11 @@ describe("connected-engine transitions", () => {
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
     const subscription = broker.subscribe(id);
     try {
-      await cancelExecution(deps(engine), cancelInput({ id }));
+      await cancelExecution(
+        deps(engine),
+        cancelInput({ id }),
+        testCallerIdentity(),
+      );
       expect(subscription.queue).toHaveLength(1);
       expect(subscription.queue[0].status?.phase).toBe(
         ExecutionPhase.EXECUTION_CANCELLED,

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/send-signal.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/send-signal.test.ts
@@ -7,6 +7,8 @@
  * release-after-failure enabling an immediate retry, empty-key and
  * store-error skips, and org-scoped key isolation.
  */
+import { newPermissiveSingleTeamAuthorizer } from "../../../pipeline/steps/authorize.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -55,6 +57,7 @@ function deps(engineStub?: EngineStub): SendSignalDeps {
   return {
     store,
     logger: silentLogger,
+    authorizer: newPermissiveSingleTeamAuthorizer(),
     engineState: () => engineStub?.state ?? ENGINE_DISCONNECTED,
   };
 }
@@ -68,7 +71,10 @@ async function seed(phase: ExecutionPhase, org = "acme"): Promise<string> {
     WorkflowExecutionSchema,
     create(WorkflowExecutionSchema, {
       metadata: { id, name: id, org },
-      spec: { workflowId: `wf_${counter}`, workflowInstanceId: `wfi_${counter}` },
+      spec: {
+        workflowId: `wf_${counter}`,
+        workflowInstanceId: `wfi_${counter}`,
+      },
       status: { phase },
     }),
   );
@@ -105,13 +111,13 @@ async function expectCode(
 describe("sendSignal validation + phase arms (send_signal_test.go)", () => {
   it("requires execution_id and signal_name", async () => {
     const missing = await expectCode(
-      () => sendSignal(deps(), input("", "sig")),
+      () => sendSignal(deps(), input("", "sig"), testCallerIdentity()),
       Code.InvalidArgument,
     );
     expect(missing.rawMessage).toBe("execution_id is required");
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
     const noName = await expectCode(
-      () => sendSignal(deps(), input(id, "")),
+      () => sendSignal(deps(), input(id, ""), testCallerIdentity()),
       Code.InvalidArgument,
     );
     expect(noName.rawMessage).toBe("signal_name is required");
@@ -119,7 +125,7 @@ describe("sendSignal validation + phase arms (send_signal_test.go)", () => {
 
   it("unknown execution answers NotFound", async () => {
     const err = await expectCode(
-      () => sendSignal(deps(), input("wfx_missing")),
+      () => sendSignal(deps(), input("wfx_missing"), testCallerIdentity()),
       Code.NotFound,
     );
     expect(err.rawMessage).toBe("workflow_execution not found: wfx_missing");
@@ -128,7 +134,7 @@ describe("sendSignal validation + phase arms (send_signal_test.go)", () => {
   it("terminal phases refuse FailedPrecondition with the pinned copy", async () => {
     const completed = await seed(ExecutionPhase.EXECUTION_COMPLETED);
     const err = await expectCode(
-      () => sendSignal(deps(), input(completed)),
+      () => sendSignal(deps(), input(completed), testCallerIdentity()),
       Code.FailedPrecondition,
     );
     expect(err.rawMessage).toBe(
@@ -139,7 +145,7 @@ describe("sendSignal validation + phase arms (send_signal_test.go)", () => {
   it("engineless send refuses FailedPrecondition with the creator copy", async () => {
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
     const err = await expectCode(
-      () => sendSignal(deps(), input(id)),
+      () => sendSignal(deps(), input(id), testCallerIdentity()),
       Code.FailedPrecondition,
     );
     expect(err.rawMessage).toBe(WORKFLOW_CREATOR_UNAVAILABLE_MESSAGE);
@@ -148,7 +154,11 @@ describe("sendSignal validation + phase arms (send_signal_test.go)", () => {
   it("delivers the relay envelope on the relaySignal channel (PENDING is signalable)", async () => {
     const engine = stubConnectedEngine();
     const id = await seed(ExecutionPhase.EXECUTION_PENDING);
-    const result = await sendSignal(deps(engine), input(id, "order_arrived"));
+    const result = await sendSignal(
+      deps(engine),
+      input(id, "order_arrived"),
+      testCallerIdentity(),
+    );
     expect(result.metadata?.id).toBe(id);
 
     expect(engine.calls).toHaveLength(1);
@@ -172,6 +182,7 @@ describe("sendSignal validation + phase arms (send_signal_test.go)", () => {
     await sendSignal(
       deps(engine),
       create(SendSignalInputSchema, { executionId: id, signalName: "ping" }),
+      testCallerIdentity(),
     );
     const [, , payload] = engine.calls[0].args as [unknown, string, unknown];
     expect(payload).toEqual({ signalName: "ping", payload: null });
@@ -182,10 +193,19 @@ describe("sendSignal dedupe (send_signal_dedupe_test.go, oss#442)", () => {
   it("a DELIVERED duplicate answers AlreadyExists with the pinned shape", async () => {
     const engine = stubConnectedEngine();
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
-    await sendSignal(deps(engine), input(id, "sig", "key-delivered"));
+    await sendSignal(
+      deps(engine),
+      input(id, "sig", "key-delivered"),
+      testCallerIdentity(),
+    );
 
     const err = await expectCode(
-      () => sendSignal(deps(engine), input(id, "sig", "key-delivered")),
+      () =>
+        sendSignal(
+          deps(engine),
+          input(id, "sig", "key-delivered"),
+          testCallerIdentity(),
+        ),
       Code.AlreadyExists,
     );
     expect(err.rawMessage).toBe(
@@ -204,7 +224,12 @@ describe("sendSignal dedupe (send_signal_dedupe_test.go, oss#442)", () => {
     await store.signalDedupe.claim("acme", "key-inflight", id, "sig", 300_000);
 
     const err = await expectCode(
-      () => sendSignal(deps(engine), input(id, "sig", "key-inflight")),
+      () =>
+        sendSignal(
+          deps(engine),
+          input(id, "sig", "key-inflight"),
+          testCallerIdentity(),
+        ),
       Code.Aborted,
     );
     expect(err.rawMessage).toBe(
@@ -218,14 +243,23 @@ describe("sendSignal dedupe (send_signal_dedupe_test.go, oss#442)", () => {
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
 
     const err = await expectCode(
-      () => sendSignal(deps(engine), input(id, "sig", "key-retry")),
+      () =>
+        sendSignal(
+          deps(engine),
+          input(id, "sig", "key-retry"),
+          testCallerIdentity(),
+        ),
       Code.Internal,
     );
     expect(err.rawMessage).toBe("failed to send signal to workflow");
 
     // The retry with the same key must claim freshly and deliver.
     const healthy = stubConnectedEngine();
-    await sendSignal(deps(healthy), input(id, "sig", "key-retry"));
+    await sendSignal(
+      deps(healthy),
+      input(id, "sig", "key-retry"),
+      testCallerIdentity(),
+    );
     expect(
       healthy.calls.filter((call) => call.method === "signalWithStart"),
     ).toHaveLength(1);
@@ -234,8 +268,8 @@ describe("sendSignal dedupe (send_signal_dedupe_test.go, oss#442)", () => {
   it("no idempotency key skips dedupe entirely (backward compatible)", async () => {
     const engine = stubConnectedEngine();
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
-    await sendSignal(deps(engine), input(id, "sig", ""));
-    await sendSignal(deps(engine), input(id, "sig", ""));
+    await sendSignal(deps(engine), input(id, "sig", ""), testCallerIdentity());
+    await sendSignal(deps(engine), input(id, "sig", ""), testCallerIdentity());
     expect(
       engine.calls.filter((call) => call.method === "signalWithStart"),
     ).toHaveLength(2);
@@ -244,12 +278,24 @@ describe("sendSignal dedupe (send_signal_dedupe_test.go, oss#442)", () => {
   it("distinct keys do not collide; keys are org-scoped", async () => {
     const engine = stubConnectedEngine();
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
-    await sendSignal(deps(engine), input(id, "sig", "key-a"));
-    await sendSignal(deps(engine), input(id, "sig", "key-b"));
+    await sendSignal(
+      deps(engine),
+      input(id, "sig", "key-a"),
+      testCallerIdentity(),
+    );
+    await sendSignal(
+      deps(engine),
+      input(id, "sig", "key-b"),
+      testCallerIdentity(),
+    );
 
     // The same key under ANOTHER org claims independently ({org}:{key}).
     const otherOrg = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS, "beta");
-    await sendSignal(deps(engine), input(otherOrg, "sig", "key-a"));
+    await sendSignal(
+      deps(engine),
+      input(otherOrg, "sig", "key-a"),
+      testCallerIdentity(),
+    );
 
     expect(
       engine.calls.filter((call) => call.method === "signalWithStart"),
@@ -259,12 +305,21 @@ describe("sendSignal dedupe (send_signal_dedupe_test.go, oss#442)", () => {
   it("engineless failure after a claim also releases it (the send step is the failure)", async () => {
     const id = await seed(ExecutionPhase.EXECUTION_IN_PROGRESS);
     await expectCode(
-      () => sendSignal(deps(), input(id, "sig", "key-engineless")),
+      () =>
+        sendSignal(
+          deps(),
+          input(id, "sig", "key-engineless"),
+          testCallerIdentity(),
+        ),
       Code.FailedPrecondition,
     );
     // The claim was released: a healthy retry delivers instead of Aborted.
     const healthy = stubConnectedEngine();
-    await sendSignal(deps(healthy), input(id, "sig", "key-engineless"));
+    await sendSignal(
+      deps(healthy),
+      input(id, "sig", "key-engineless"),
+      testCallerIdentity(),
+    );
     expect(
       healthy.calls.filter((call) => call.method === "signalWithStart"),
     ).toHaveLength(1);

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/update-status.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/update-status.test.ts
@@ -13,6 +13,8 @@
  * different-children race through the REAL sqlite store, where
  * load-then-save would drop one child's gate.
  */
+import { newPermissiveSingleTeamAuthorizer } from "../../../pipeline/steps/authorize.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -140,7 +142,10 @@ describe("pending_approvals per-child merge (update_status_test.go)", () => {
   // The core regression: two parallel children must not clobber each other.
   it("parallel children not clobbered on set", () => {
     const existing = makeExecution({
-      pendingApprovals: [wfApproval("aex_A", "tc_A"), wfApproval("aex_B", "tc_B")],
+      pendingApprovals: [
+        wfApproval("aex_A", "tc_A"),
+        wfApproval("aex_B", "tc_B"),
+      ],
     });
     const result = executeMerge(existing, {
       executionId: "wfx_test",
@@ -161,7 +166,10 @@ describe("pending_approvals per-child merge (update_status_test.go)", () => {
 
   it("scoped clear preserves siblings", () => {
     const existing = makeExecution({
-      pendingApprovals: [wfApproval("aex_A", "tc_A"), wfApproval("aex_B", "tc_B")],
+      pendingApprovals: [
+        wfApproval("aex_A", "tc_A"),
+        wfApproval("aex_B", "tc_B"),
+      ],
     });
     const result = executeMerge(existing, {
       executionId: "wfx_test",
@@ -290,10 +298,7 @@ describe("mergePendingByChild (pure contract)", () => {
     expect(mergePendingByChild(["A", "B"], [], childOf, "B")).toEqual(["A"]);
   });
   it("adds new child", () => {
-    expect(mergePendingByChild(["A"], ["C"], childOf, "C")).toEqual([
-      "A",
-      "C",
-    ]);
+    expect(mergePendingByChild(["A"], ["C"], childOf, "C")).toEqual(["A", "C"]);
   });
   it("empty existing", () => {
     expect(mergePendingByChild([], ["A"], childOf, "A")).toEqual(["A"]);
@@ -427,11 +432,17 @@ describe("updateStatus persistence mechanism (DD-001)", () => {
   it("unknown execution answers NotFound (Go LoadExistingExecution)", async () => {
     try {
       await updateStatus(
-        { store, logger: silentLogger, broker },
+        {
+          store,
+          logger: silentLogger,
+          broker,
+          authorizer: newPermissiveSingleTeamAuthorizer(),
+        },
         create(WorkflowExecutionUpdateStatusInputSchema, {
           executionId: "wfx_missing",
           status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
         }),
+        testCallerIdentity(),
       );
       expect.unreachable("expected NotFound");
     } catch (error) {
@@ -457,13 +468,22 @@ describe("updateStatus persistence mechanism (DD-001)", () => {
 
     await seed("wfx_mechanism");
     await updateStatus(
-      { store: countingStore, logger: silentLogger, broker },
+      {
+        store: countingStore,
+        logger: silentLogger,
+        broker,
+        authorizer: newPermissiveSingleTeamAuthorizer(),
+      },
       create(WorkflowExecutionUpdateStatusInputSchema, {
         executionId: "wfx_mechanism",
         status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
       }),
+      testCallerIdentity(),
     );
-    expect(calls.updateResource, "the merge must run inside updateResource").toBe(1);
+    expect(
+      calls.updateResource,
+      "the merge must run inside updateResource",
+    ).toBe(1);
     expect(
       calls.saveResource,
       "a saveResource write here would reintroduce the lost-update window",
@@ -480,13 +500,19 @@ describe("updateStatus persistence mechanism (DD-001)", () => {
     for (let iteration = 0; iteration < 25; iteration++) {
       const writeFor = (child: string, toolCallId: string) =>
         updateStatus(
-          { store, logger: silentLogger, broker },
+          {
+            store,
+            logger: silentLogger,
+            broker,
+            authorizer: newPermissiveSingleTeamAuthorizer(),
+          },
           create(WorkflowExecutionUpdateStatusInputSchema, {
             executionId: id,
             status: { pendingApprovals: [wfApproval(child, toolCallId)] },
             updatePendingApprovals: true,
             pendingUpdateChildAgentExecutionId: child,
           }),
+          testCallerIdentity(),
         );
       await Promise.all([
         writeFor("aex_A", `tc_A_${iteration}`),
@@ -516,11 +542,17 @@ describe("updateStatus persistence mechanism (DD-001)", () => {
     const subscription = broker.subscribe(id);
     try {
       await updateStatus(
-        { store, logger: silentLogger, broker },
+        {
+          store,
+          logger: silentLogger,
+          broker,
+          authorizer: newPermissiveSingleTeamAuthorizer(),
+        },
         create(WorkflowExecutionUpdateStatusInputSchema, {
           executionId: id,
           status: { phase: ExecutionPhase.EXECUTION_COMPLETED },
         }),
+        testCallerIdentity(),
       );
       expect(subscription.queue).toHaveLength(1);
       expect(subscription.queue[0].status?.phase).toBe(

--- a/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
@@ -36,10 +36,13 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import { create } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
@@ -67,13 +70,9 @@ import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import type { Store } from "../../store/interface.js";
 
-import type {
-  AgentExecutionApprovalForwarderProvider,
-} from "./submit-approval.js";
+import type { AgentExecutionApprovalForwarderProvider } from "./submit-approval.js";
 import { submitApproval } from "./submit-approval.js";
-import type {
-  AgentExecutionFileDecisionForwarderProvider,
-} from "./submit-file-decision.js";
+import type { AgentExecutionFileDecisionForwarderProvider } from "./submit-file-decision.js";
 import { submitFileDecision } from "./submit-file-decision.js";
 import { submitWorkflowTaskApproval } from "./submit-workflow-task-approval.js";
 import type { ExecutionWorkflowInstanceCreatorProvider } from "./create-steps.js";
@@ -115,6 +114,8 @@ import { updateStatus } from "./update-status.js";
 export interface WorkflowExecutionControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   /**
    * The workflow-execution engine seam (engine.ts): permanently
    * disconnected until #21's TemporalManager flips it. Consumed by the
@@ -150,6 +151,7 @@ export function registerWorkflowExecutionServices(
   const lifecycleDeps = {
     store: deps.store,
     logger: deps.logger,
+    authorizer: deps.authorizer,
     broker: deps.broker,
     engineState: deps.engineState,
     executionContextBuilder: deps.executionContextBuilder,
@@ -157,18 +159,26 @@ export function registerWorkflowExecutionServices(
   router.service(WorkflowExecutionCommandController, {
     create: (execution, ctx) => createExecution(deps, execution, ctx),
     update: (execution, ctx) => update(deps, execution, ctx),
-    updateStatus: (input) => updateStatus(deps, input),
-    submitApproval: (input) => submitApproval(deps, input),
-    submitFileDecision: (input) => submitFileDecision(deps, input),
-    submitWorkflowTaskApproval: (input) =>
-      submitWorkflowTaskApproval(deps, input),
+    updateStatus: (input, ctx) =>
+      updateStatus(deps, input, callerIdentityOf(ctx)),
+    submitApproval: (input, ctx) =>
+      submitApproval(deps, input, callerIdentityOf(ctx)),
+    submitFileDecision: (input, ctx) =>
+      submitFileDecision(deps, input, callerIdentityOf(ctx)),
+    submitWorkflowTaskApproval: (input, ctx) =>
+      submitWorkflowTaskApproval(deps, input, callerIdentityOf(ctx)),
     delete: (id, ctx) => deleteExecution(deps, id, ctx),
-    sendSignal: (input) => sendSignal(deps, input),
-    cancel: (input) => cancelExecution(lifecycleDeps, input),
-    terminate: (input) => terminateExecution(lifecycleDeps, input),
-    recover: (input) => recoverExecution(lifecycleDeps, input),
-    pause: (input) => pauseExecution(lifecycleDeps, input),
-    resume: (input) => resumeExecution(lifecycleDeps, input),
+    sendSignal: (input, ctx) => sendSignal(deps, input, callerIdentityOf(ctx)),
+    cancel: (input, ctx) =>
+      cancelExecution(lifecycleDeps, input, callerIdentityOf(ctx)),
+    terminate: (input, ctx) =>
+      terminateExecution(lifecycleDeps, input, callerIdentityOf(ctx)),
+    recover: (input, ctx) =>
+      recoverExecution(lifecycleDeps, input, callerIdentityOf(ctx)),
+    pause: (input, ctx) =>
+      pauseExecution(lifecycleDeps, input, callerIdentityOf(ctx)),
+    resume: (input, ctx) =>
+      resumeExecution(lifecycleDeps, input, callerIdentityOf(ctx)),
   });
   router.service(WorkflowExecutionQueryController, {
     get: (id, ctx) => get(deps, id, ctx),
@@ -202,12 +212,19 @@ async function createExecution(
   const reqCtx = new RequestContext(
     WorkflowExecutionSchema,
     execution,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof WorkflowExecutionSchema>(
     "workflowexecution-create",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowExecutionCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveSlugStep())
@@ -264,12 +281,19 @@ async function update(
   const reqCtx = new RequestContext(
     WorkflowExecutionSchema,
     execution,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof WorkflowExecutionSchema>(
     "workflowexecution-update",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowExecutionCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
@@ -302,16 +326,21 @@ async function deleteExecution(
   const reqCtx = new RequestContext(
     WorkflowExecutionCommandController.method.delete.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<
     typeof WorkflowExecutionCommandController.method.delete.input
   >("workflowexecution-delete", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        WorkflowExecutionCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
-    .addStep(
-      newLoadExistingForDeleteStep(deps.store, WorkflowExecutionSchema),
-    )
+    .addStep(newLoadExistingForDeleteStep(deps.store, WorkflowExecutionSchema))
     .addStep(newDeleteResourceStep(deps.store))
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
@@ -336,12 +365,19 @@ async function get(
   const reqCtx = new RequestContext(
     WorkflowExecutionQueryController.method.get.input,
     id,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof WorkflowExecutionQueryController.method.get.input>(
     "workflowexecution-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowExecutionQueryController.method.get,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, WorkflowExecutionSchema))
     .build()

--- a/backend/services/stigmer-server/src/domain/workflowexecution/lifecycle.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/lifecycle.ts
@@ -21,7 +21,7 @@
  * sequential flows; disclosed with DD-001.
  */
 import { create } from "@bufbuild/protobuf";
-import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
+import type { DescMessage, DescMethod, MessageShape } from "@bufbuild/protobuf";
 import { ConnectError } from "@connectrpc/connect";
 
 import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
@@ -45,6 +45,7 @@ import type { WorkflowInstance } from "@stigmer/protos/ai/stigmer/agentic/workfl
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import {
   filterByDeclaredKeys,
   mergeEnvironmentLayers,
@@ -58,7 +59,9 @@ import {
 } from "../../pipeline/errors.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 
 import {
@@ -82,6 +85,8 @@ const ALREADY_IN_TARGET_STATE_KEY = "alreadyInTargetState";
 export interface LifecycleDeps {
   readonly store: WorkflowExecutionContextBuilderDeps["store"];
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly broker: StreamBroker;
   readonly engineState: WorkflowExecutionEngineStateProvider;
   /** Recover's RecreateExecutionContext consumes the same builder deps. */
@@ -404,7 +409,9 @@ function newRecreateExecutionContextStep<Desc extends DescMessage>(
 
       let instance: WorkflowInstance;
       try {
-        instance = await builder.workflowInstanceLoader().get(workflowInstanceId);
+        instance = await builder
+          .workflowInstanceLoader()
+          .get(workflowInstanceId);
       } catch (error) {
         deps.logger.warn(
           "WorkflowInstance not found during recovery EC recreation. Proceeding without environment — workflow tasks may fail if they need env vars.",
@@ -589,14 +596,18 @@ async function runLifecyclePipeline<Desc extends DescMessage>(
   pipelineName: string,
   schema: Desc,
   input: MessageShape<Desc>,
+  method: DescMethod,
+  identity: CallerIdentity,
   steps: PipelineStep<Desc>[],
 ): Promise<WorkflowExecution> {
   const reqCtx = new RequestContext(
     schema,
     input,
+    identity,
     ApiResourceKind.workflow_execution,
   );
   const builder = newPipeline<Desc>(pipelineName, deps.logger);
+  builder.addStep(newAuthorizeStep(method, deps.authorizer));
   for (const step of steps) {
     builder.addStep(step);
   }
@@ -619,6 +630,7 @@ async function runLifecyclePipeline<Desc extends DescMessage>(
 export async function cancelExecution(
   deps: LifecycleDeps,
   input: CancelWorkflowExecutionInput,
+  identity: CallerIdentity,
 ): Promise<WorkflowExecution> {
   type Desc = typeof WorkflowExecutionCommandController.method.cancel.input;
   return runLifecyclePipeline<Desc>(
@@ -626,6 +638,8 @@ export async function cancelExecution(
     "workflowexecution-cancel",
     WorkflowExecutionCommandController.method.cancel.input,
     input,
+    WorkflowExecutionCommandController.method.cancel,
+    identity,
     [
       newLoadExecutionByIdStep(deps),
       newValidatePhaseStep(
@@ -667,6 +681,7 @@ export async function cancelExecution(
 export async function terminateExecution(
   deps: LifecycleDeps,
   input: TerminateWorkflowExecutionInput,
+  identity: CallerIdentity,
 ): Promise<WorkflowExecution> {
   type Desc = typeof WorkflowExecutionCommandController.method.terminate.input;
   return runLifecyclePipeline<Desc>(
@@ -674,6 +689,8 @@ export async function terminateExecution(
     "workflowexecution-terminate",
     WorkflowExecutionCommandController.method.terminate.input,
     input,
+    WorkflowExecutionCommandController.method.terminate,
+    identity,
     [
       newLoadExecutionByIdStep(deps),
       newValidatePhaseStep(
@@ -695,9 +712,10 @@ export async function terminateExecution(
           // The reason default and its ReasonKey record happen HERE, on
           // the successful-send path only (Go's quirk: a workflow-gone
           // terminate falls back to "Terminated by user").
-          const inputReason =
-            (ctx.input as unknown as { reason: string }).reason;
-          const reason = inputReason !== "" ? inputReason : "Terminated by user";
+          const inputReason = (ctx.input as unknown as { reason: string })
+            .reason;
+          const reason =
+            inputReason !== "" ? inputReason : "Terminated by user";
           await engine.terminateWorkflow(
             orchestratorWorkflowId(execution.metadata?.id ?? ""),
             reason,
@@ -724,6 +742,7 @@ export async function terminateExecution(
 export async function pauseExecution(
   deps: LifecycleDeps,
   input: PauseWorkflowExecutionInput,
+  identity: CallerIdentity,
 ): Promise<WorkflowExecution> {
   type Desc = typeof WorkflowExecutionCommandController.method.pause.input;
   return runLifecyclePipeline<Desc>(
@@ -731,6 +750,8 @@ export async function pauseExecution(
     "workflowexecution-pause",
     WorkflowExecutionCommandController.method.pause.input,
     input,
+    WorkflowExecutionCommandController.method.pause,
+    identity,
     [
       newLoadExecutionByIdStep(deps),
       newValidatePhaseStep(
@@ -748,8 +769,8 @@ export async function pauseExecution(
         "SignalPauseToTemporal",
         "failed to send pause signal to Temporal workflow",
         async (engine, execution, ctx) => {
-          const inputReason =
-            (ctx.input as unknown as { reason: string }).reason;
+          const inputReason = (ctx.input as unknown as { reason: string })
+            .reason;
           const reason = inputReason !== "" ? inputReason : "Paused by user";
           await engine.signalWorkflow(
             orchestratorWorkflowId(execution.metadata?.id ?? ""),
@@ -778,6 +799,7 @@ export async function pauseExecution(
 export async function resumeExecution(
   deps: LifecycleDeps,
   input: ResumeWorkflowExecutionInput,
+  identity: CallerIdentity,
 ): Promise<WorkflowExecution> {
   type Desc = typeof WorkflowExecutionCommandController.method.resume.input;
   return runLifecyclePipeline<Desc>(
@@ -785,6 +807,8 @@ export async function resumeExecution(
     "workflowexecution-resume",
     WorkflowExecutionCommandController.method.resume.input,
     input,
+    WorkflowExecutionCommandController.method.resume,
+    identity,
     [
       newLoadExecutionByIdStep(deps),
       newValidatePhaseStep(
@@ -828,6 +852,7 @@ export async function resumeExecution(
 export async function recoverExecution(
   deps: LifecycleDeps,
   input: RecoverWorkflowExecutionInput,
+  identity: CallerIdentity,
 ): Promise<WorkflowExecution> {
   type Desc = typeof WorkflowExecutionCommandController.method.recover.input;
   return runLifecyclePipeline<Desc>(
@@ -835,6 +860,8 @@ export async function recoverExecution(
     "workflowexecution-recover",
     WorkflowExecutionCommandController.method.recover.input,
     input,
+    WorkflowExecutionCommandController.method.recover,
+    identity,
     [
       newLoadExecutionByIdStep(deps),
       newValidatePhaseStep(

--- a/backend/services/stigmer-server/src/domain/workflowexecution/send-signal.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/send-signal.ts
@@ -28,6 +28,7 @@ import type { SendSignalInput } from "@stigmer/protos/ai/stigmer/agentic/workflo
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import {
   abortedError,
   alreadyExistsError,
@@ -37,7 +38,9 @@ import {
   notFoundError,
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { IN_FLIGHT_CLAIM_TTL_MS } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
 
@@ -50,6 +53,8 @@ import type { WorkflowExecutionEngineStateProvider } from "./engine.js";
 export interface SendSignalDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly engineState: WorkflowExecutionEngineStateProvider;
 }
 
@@ -64,10 +69,12 @@ const DEDUPE_SKIPPED_KEY = "dedupe_skipped";
 export async function sendSignal(
   deps: SendSignalDeps,
   input: SendSignalInput,
+  identity: CallerIdentity,
 ): Promise<WorkflowExecution> {
   const reqCtx = new RequestContext(
     WorkflowExecutionCommandController.method.sendSignal.input,
     input,
+    identity,
     ApiResourceKind.workflow_execution,
   );
 
@@ -75,6 +82,12 @@ export async function sendSignal(
     "workflowexecution-send-signal",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowExecutionCommandController.method.sendSignal,
+        deps.authorizer,
+      ),
+    )
     .addStep({
       name: "ValidateSignalInput",
       execute(ctx) {

--- a/backend/services/stigmer-server/src/domain/workflowexecution/submit-approval.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/submit-approval.ts
@@ -24,6 +24,7 @@ import { create } from "@bufbuild/protobuf";
 import { ConnectError } from "@connectrpc/connect";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import {
   failedPreconditionError,
   goGrpcErrorText,
@@ -33,7 +34,9 @@ import {
   unavailableError,
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { RequestContext } from "../../pipeline/request-context.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import type { Store } from "../../store/interface.js";
 
@@ -52,6 +55,8 @@ export type AgentExecutionApprovalForwarderProvider =
 export interface SubmitApprovalDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly approvalForwarder: AgentExecutionApprovalForwarderProvider;
 }
 
@@ -64,16 +69,24 @@ const CHILD_EXECUTION_ID_KEY = "childAgentExecutionId";
 export async function submitApproval(
   deps: SubmitApprovalDeps,
   input: SubmitWorkflowApprovalInput,
+  identity: CallerIdentity,
 ): Promise<WorkflowExecution> {
   const reqCtx = new RequestContext(
     WorkflowExecutionCommandController.method.submitApproval.input,
     input,
+    identity,
     ApiResourceKind.workflow_execution,
   );
   await newPipeline<SubmitApprovalDesc>(
     "workflow-execution-submit-approval",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowExecutionCommandController.method.submitApproval,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep({
       name: "LoadExisting",

--- a/backend/services/stigmer-server/src/domain/workflowexecution/submit-file-decision.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/submit-file-decision.ts
@@ -31,6 +31,9 @@ import {
   notFoundError,
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import type { Store } from "../../store/interface.js";
@@ -51,6 +54,8 @@ export type AgentExecutionFileDecisionForwarderProvider =
 export interface SubmitFileDecisionDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly fileDecisionForwarder: AgentExecutionFileDecisionForwarderProvider;
 }
 
@@ -62,16 +67,24 @@ const TARGET_EXECUTION_KEY = "targetResource";
 export async function submitFileDecision(
   deps: SubmitFileDecisionDeps,
   input: SubmitWorkflowFileDecisionInput,
+  identity: CallerIdentity,
 ): Promise<WorkflowExecution> {
   const reqCtx = new RequestContext(
     WorkflowExecutionCommandController.method.submitFileDecision.input,
     input,
+    identity,
     ApiResourceKind.workflow_execution,
   );
   await newPipeline<SubmitFileDecisionDesc>(
     "workflow-execution-submit-file-decision",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowExecutionCommandController.method.submitFileDecision,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep({
       name: "LoadExisting",

--- a/backend/services/stigmer-server/src/domain/workflowexecution/submit-workflow-task-approval.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/submit-workflow-task-approval.ts
@@ -36,6 +36,9 @@ import {
   unavailableError,
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import type { Store } from "../../store/interface.js";
 
@@ -48,6 +51,8 @@ import type { WorkflowExecutionEngineStateProvider } from "./engine.js";
 export interface SubmitWorkflowTaskApprovalDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly engineState: WorkflowExecutionEngineStateProvider;
 }
 
@@ -59,16 +64,24 @@ const LOADED_EXECUTION_KEY = "loadedExecution";
 export async function submitWorkflowTaskApproval(
   deps: SubmitWorkflowTaskApprovalDeps,
   input: SubmitWorkflowTaskApprovalInput,
+  identity: CallerIdentity,
 ): Promise<WorkflowExecution> {
   const reqCtx = new RequestContext(
     WorkflowExecutionCommandController.method.submitWorkflowTaskApproval.input,
     input,
+    identity,
     ApiResourceKind.workflow_execution,
   );
   await newPipeline<TaskApprovalDesc>(
     "workflowexecution-submit-task-approval",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowExecutionCommandController.method.submitWorkflowTaskApproval,
+        deps.authorizer,
+      ),
+    )
     .addStep({
       name: "ValidateTaskApprovalInput",
       execute(ctx) {

--- a/backend/services/stigmer-server/src/domain/workflowexecution/update-status.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/update-status.ts
@@ -51,6 +51,9 @@ import {
   notFoundError,
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import type {
@@ -63,6 +66,8 @@ import type { StreamBroker } from "./stream-broker.js";
 export interface UpdateStatusDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   readonly broker: StreamBroker;
 }
 
@@ -74,16 +79,24 @@ const EXECUTION_KEY = "execution";
 export async function updateStatus(
   deps: UpdateStatusDeps,
   input: WorkflowExecutionUpdateStatusInput,
+  identity: CallerIdentity,
 ): Promise<WorkflowExecution> {
   const reqCtx = new RequestContext(
     WorkflowExecutionCommandController.method.updateStatus.input,
     input,
+    identity,
     ApiResourceKind.workflow_execution,
   );
   await newPipeline<UpdateStatusDesc>(
     "workflowexecution-update-status",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowExecutionCommandController.method.updateStatus,
+        deps.authorizer,
+      ),
+    )
     .addStep({
       name: "ValidateUpdateStatusInput",
       execute(ctx) {
@@ -285,8 +298,7 @@ export function applyUpdateStatusMerge(
   if (isPhaseTransition) {
     const audit = status.audit ?? create(ApiResourceAuditSchema);
     status.audit = audit;
-    const statusAudit =
-      audit.statusAudit ?? create(ApiResourceAuditInfoSchema);
+    const statusAudit = audit.statusAudit ?? create(ApiResourceAuditInfoSchema);
     audit.statusAudit = statusAudit;
     statusAudit.updatedAt = timestampNow();
     statusAudit.event = "updated";

--- a/backend/services/stigmer-server/src/domain/workflowinstance/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowinstance/controller.ts
@@ -31,7 +31,10 @@ import type {
 } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/io_pb";
 import { WorkflowInstanceSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/spec_pb";
 import { WorkflowInstanceListSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/io_pb";
-import type { GetWorkflowInstancesByWorkflowRequest, WorkflowInstanceList } from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/io_pb";
+import type {
+  GetWorkflowInstancesByWorkflowRequest,
+  WorkflowInstanceList,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowinstance/v1/io_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import type {
   ApiResourceReference,
@@ -39,12 +42,18 @@ import type {
 } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError, notFoundError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
-import { newBuildNewStateStep, setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
+import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import {
+  newBuildNewStateStep,
+  setAuditFieldsForUpdate,
+} from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
 import {
@@ -56,10 +65,19 @@ import {
   newDeleteSearchIndexStep,
   newIndexSearchStep,
 } from "../../pipeline/steps/index-search.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../../pipeline/steps/load-existing.js";
-import { SHOULD_CREATE_KEY, newLoadForApplyStep } from "../../pipeline/steps/load-for-apply.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../../pipeline/steps/load-existing.js";
+import {
+  SHOULD_CREATE_KEY,
+  newLoadForApplyStep,
+} from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
-import { TARGET_RESOURCE_KEY, newLoadTargetStep } from "../../pipeline/steps/load-target.js";
+import {
+  TARGET_RESOURCE_KEY,
+  newLoadTargetStep,
+} from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
@@ -81,6 +99,8 @@ import type { ParentWorkflowLoaderProvider } from "./steps.js";
 export interface WorkflowInstanceControllerDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
+  readonly authorizer: Authorizer;
   /**
    * The workflow in-process edge — a lazy provider because
    * workflow↔workflowinstance is a true dependency cycle (DD-002).
@@ -123,11 +143,22 @@ async function createInstance(
   instance: WorkflowInstance,
   ctx: HandlerContext,
 ): Promise<WorkflowInstance> {
-  const reqCtx = new RequestContext(WorkflowInstanceSchema, instance, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    WorkflowInstanceSchema,
+    instance,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof WorkflowInstanceSchema>(
     "workflow-instance-create",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowInstanceCommandController.method.create,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveSlugStep())
@@ -137,7 +168,13 @@ async function createInstance(
     .addStep(newBuildNewStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
-    .addStep(newIndexSearchStep(deps.store, workflowInstanceSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(
+        deps.store,
+        workflowInstanceSearchExtractor,
+        deps.logger,
+      ),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -149,11 +186,22 @@ async function update(
   instance: WorkflowInstance,
   ctx: HandlerContext,
 ): Promise<WorkflowInstance> {
-  const reqCtx = new RequestContext(WorkflowInstanceSchema, instance, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    WorkflowInstanceSchema,
+    instance,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof WorkflowInstanceSchema>(
     "workflow-instance-update",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowInstanceCommandController.method.update,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
@@ -161,7 +209,13 @@ async function update(
     .addStep(newBuildUpdateStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
-    .addStep(newIndexSearchStep(deps.store, workflowInstanceSearchExtractor, deps.logger))
+    .addStep(
+      newIndexSearchStep(
+        deps.store,
+        workflowInstanceSearchExtractor,
+        deps.logger,
+      ),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -173,11 +227,22 @@ async function apply(
   instance: WorkflowInstance,
   ctx: HandlerContext,
 ): Promise<WorkflowInstance> {
-  const reqCtx = new RequestContext(WorkflowInstanceSchema, instance, kindOf(ctx));
+  const reqCtx = new RequestContext(
+    WorkflowInstanceSchema,
+    instance,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
   await newPipeline<typeof WorkflowInstanceSchema>(
     "workflow-instance-apply",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowInstanceCommandController.method.apply,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
@@ -209,12 +274,18 @@ async function deleteInstance(
   const reqCtx = new RequestContext(
     WorkflowInstanceCommandController.method.delete.input,
     instanceId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof WorkflowInstanceCommandController.method.delete.input>(
-    "workflow-instance-delete",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof WorkflowInstanceCommandController.method.delete.input
+  >("workflow-instance-delete", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        WorkflowInstanceCommandController.method.delete,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, WorkflowInstanceSchema))
@@ -253,12 +324,19 @@ async function updateVisibility(
   const reqCtx = new RequestContext(
     WorkflowInstanceCommandController.method.updateVisibility.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<UpdateVisibilityDesc>(
     "workflow-instance-update-visibility",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowInstanceCommandController.method.updateVisibility,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(
       newLoadInstanceStep<UpdateVisibilityDesc>(
@@ -303,12 +381,19 @@ function newSetInstanceVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
     name: "SetInstanceVisibility",
     execute(ctx: RequestContext<UpdateVisibilityDesc>): void {
       const input = ctx.input;
-      const instance = ctx.get(UPDATE_VISIBILITY_INSTANCE_KEY) as WorkflowInstance;
+      const instance = ctx.get(
+        UPDATE_VISIBILITY_INSTANCE_KEY,
+      ) as WorkflowInstance;
 
       instance.metadata!.visibility = input.visibility;
 
       try {
-        setAuditFieldsForUpdate(WorkflowInstanceSchema, instance, "status_audit");
+        setAuditFieldsForUpdate(
+          WorkflowInstanceSchema,
+          instance,
+          "status_audit",
+          ctx.callerIdentity,
+        );
       } catch (error) {
         throw new Error(
           `failed to set audit fields: ${error instanceof Error ? error.message : String(error)}`,
@@ -330,7 +415,8 @@ function newSetInstanceVisibilityStep(): PipelineStep<UpdateVisibilityDesc> {
 // cloud allows it on them too; do not "fix" that.
 // ---------------------------------------------------------------------------
 
-const UPDATE_EXECUTION_VISIBILITY_INSTANCE_KEY = "updateExecutionVisibilityInstance";
+const UPDATE_EXECUTION_VISIBILITY_INSTANCE_KEY =
+  "updateExecutionVisibilityInstance";
 
 type UpdateExecutionVisibilityDesc =
   typeof WorkflowInstanceCommandController.method.updateExecutionVisibility.input;
@@ -343,12 +429,19 @@ async function updateExecutionVisibility(
   const reqCtx = new RequestContext(
     WorkflowInstanceCommandController.method.updateExecutionVisibility.input,
     input,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<UpdateExecutionVisibilityDesc>(
     "workflow-instance-update-execution-visibility",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowInstanceCommandController.method.updateExecutionVisibility,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(
       newLoadInstanceStep<UpdateExecutionVisibilityDesc>(
@@ -377,7 +470,9 @@ async function updateExecutionVisibility(
     .build()
     .execute(reqCtx);
 
-  return reqCtx.get(UPDATE_EXECUTION_VISIBILITY_INSTANCE_KEY) as WorkflowInstance;
+  return reqCtx.get(
+    UPDATE_EXECUTION_VISIBILITY_INSTANCE_KEY,
+  ) as WorkflowInstance;
 }
 
 /** Sets spec.execution_visibility and refreshes the status-audit fields. */
@@ -394,7 +489,12 @@ function newSetInstanceExecutionVisibilityStep(): PipelineStep<UpdateExecutionVi
       instance.spec.executionVisibility = input.executionVisibility;
 
       try {
-        setAuditFieldsForUpdate(WorkflowInstanceSchema, instance, "status_audit");
+        setAuditFieldsForUpdate(
+          WorkflowInstanceSchema,
+          instance,
+          "status_audit",
+          ctx.callerIdentity,
+        );
       } catch (error) {
         throw new Error(
           `failed to set audit fields: ${error instanceof Error ? error.message : String(error)}`,
@@ -476,7 +576,8 @@ function newIndexInstanceStep<Desc extends DescMessage>(
     name: stepName,
     async execute(ctx: RequestContext<Desc>): Promise<void> {
       const instance = ctx.get(instanceKey) as WorkflowInstance;
-      const entry = workflowInstanceSearchExtractor.getSearchIndexEntry(instance);
+      const entry =
+        workflowInstanceSearchExtractor.getSearchIndexEntry(instance);
       if (entry === undefined) {
         logger.warn(`${stepName}: extractor returned nil, skipping`, {
           id: instance.metadata?.id ?? "",
@@ -511,12 +612,19 @@ async function get(
   const reqCtx = new RequestContext(
     WorkflowInstanceQueryController.method.get.input,
     instanceId,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<typeof WorkflowInstanceQueryController.method.get.input>(
     "workflow-instance-get",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowInstanceQueryController.method.get,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadTargetStep(deps.store, WorkflowInstanceSchema))
     .build()
@@ -532,12 +640,18 @@ async function getByReference(
   const reqCtx = new RequestContext(
     WorkflowInstanceQueryController.method.getByReference.input,
     ref,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof WorkflowInstanceQueryController.method.getByReference.input>(
-    "workflow-instance-get-by-reference",
-    deps.logger,
-  )
+  await newPipeline<
+    typeof WorkflowInstanceQueryController.method.getByReference.input
+  >("workflow-instance-get-by-reference", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        WorkflowInstanceQueryController.method.getByReference,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByReferenceStep(deps.store, WorkflowInstanceSchema))
     .build()
@@ -567,12 +681,19 @@ async function getByWorkflow(
   const reqCtx = new RequestContext(
     WorkflowInstanceQueryController.method.getByWorkflow.input,
     request,
+    callerIdentityOf(ctx),
     kindOf(ctx),
   );
   await newPipeline<GetByWorkflowDesc>(
     "workflow-instance-get-by-workflow",
     deps.logger,
   )
+    .addStep(
+      newAuthorizeStep(
+        WorkflowInstanceQueryController.method.getByWorkflow,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateProtoStep())
     .addStep(newLoadByWorkflowStep(deps.store, deps.logger))
     .build()

--- a/backend/services/stigmer-server/src/extensions/identity.ts
+++ b/backend/services/stigmer-server/src/extensions/identity.ts
@@ -1,8 +1,8 @@
 /**
  * Identity extension-point types — the verifier-chain contract of the
  * convergence blueprint (20260826.02 blueprint/03 §4, DD-007), carried by
- * the extension registry from O1 (20260826.09) and CONSUMED by O2, which
- * turns the pass-through auth interceptor into the ordered verifier chain.
+ * the extension registry from O1 (20260826.09) and consumed by the
+ * verifier-chain chassis (O2, 20260827.01 — pipeline/interceptors/auth.ts).
  *
  * The shapes are transcribed from the ratified design, not invented here:
  * a verifier either CLAIMS a token (verifying it fully, throwing on
@@ -14,13 +14,26 @@
  */
 
 /**
- * The caller-class discriminant. OSS knows user / machine / runner; the
- * cloud composition extends the vocabulary (guest / channel / schedule)
- * without an OSS enum change — hence the open string arm. `string & {}`
- * keeps literal autocomplete while admitting extension values (a plain
- * `string` would erase the known classes from the type surface).
+ * The caller-class discriminant. OSS knows user / machine / runner plus
+ * the in-process `internal` class (O2 ruling Q4: the TS rendering of the
+ * Java in-process authorization skip); the cloud composition extends the
+ * vocabulary (guest / channel / schedule) without an OSS enum change —
+ * hence the open string arm. `string & {}` keeps literal autocomplete
+ * while admitting extension values (a plain `string` would erase the
+ * known classes from the type surface).
+ *
+ * `internal` is ratified contract with a structural guarantee: it is
+ * minted ONLY by the in-process chain's identity interceptor
+ * (boot/inprocess.ts). No IdentityVerifier may produce it — the serving
+ * chain always overwrites the position-1 identity from the wire, so a
+ * spoofed internal class cannot enter through a transport.
  */
-export type CallerClass = "user" | "machine" | "runner" | (string & {});
+export type CallerClass =
+  | "user"
+  | "machine"
+  | "runner"
+  | "internal"
+  | (string & {});
 
 /**
  * The authenticated caller, produced by the verifier chain and read by the
@@ -36,6 +49,15 @@ export interface CallerIdentity {
   readonly issuer: string;
   /** The raw presented token, carried for downstream propagation. */
   readonly rawToken: string;
+  /**
+   * Optional display identity for the audit-actor seam (O2 ruling Q5, the
+   * ratified DD-007 amendment): OIDC-class verifiers carry the caller's
+   * email/name claims here; the trusted-local identity carries the #400
+   * operator identity. Absent on identities whose issuer provides no
+   * display claims — the audit actor then falls back to identityId alone.
+   */
+  readonly email?: string;
+  readonly displayName?: string;
 }
 
 /**

--- a/backend/services/stigmer-server/src/pipeline/__tests__/chain.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/__tests__/chain.test.ts
@@ -33,6 +33,7 @@ import { describe, expect, it } from "vitest";
 import { createLogger } from "../../boot/logger.js";
 import type { LogFields } from "../../boot/logger.js";
 import { buildInterceptorChain } from "../chain.js";
+import { createVerifierChainInterceptor } from "../interceptors/auth.js";
 import { apiResourceKindKey } from "../interceptors/apiresource.js";
 
 const VALID_AGENT = {
@@ -75,7 +76,16 @@ function testHarness(handlers: {
         watch: async function* () {},
       });
     },
-    { router: { interceptors: buildInterceptorChain(logger) } },
+    // The serving-shape identity source with zero verifiers — the OSS
+    // default posture (O2): every request resolves to trusted-local.
+    {
+      router: {
+        interceptors: buildInterceptorChain(
+          logger,
+          createVerifierChainInterceptor([], logger),
+        ),
+      },
+    },
   );
   return { transport, lines };
 }

--- a/backend/services/stigmer-server/src/pipeline/__tests__/pipeline.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/__tests__/pipeline.test.ts
@@ -5,6 +5,7 @@
  * error reaches the wire as Internal/"internal server error" with the real
  * cause kept server-side. Also pins RequestContext's input immutability.
  */
+import { testCallerIdentity } from "./support.js";
 import { Code, ConnectError } from "@connectrpc/connect";
 import { describe, expect, it } from "vitest";
 
@@ -31,6 +32,7 @@ function orgContext(): RequestContext<typeof OrganizationSchema> {
       kind: "Organization",
       metadata: { name: "Acme" },
     }),
+    testCallerIdentity(),
   );
 }
 
@@ -50,7 +52,10 @@ function step(
 describe("pipeline execution", () => {
   it("runs steps in order and stops on the first error", async () => {
     const order: string[] = [];
-    const pipeline = newPipeline<typeof OrganizationSchema>("test", silentLogger)
+    const pipeline = newPipeline<typeof OrganizationSchema>(
+      "test",
+      silentLogger,
+    )
       .addStep(step("First", (o) => o.push("first"), order))
       .addStep({
         name: "Boom",
@@ -66,11 +71,17 @@ describe("pipeline execution", () => {
   });
 
   it("preserves a ConnectError's code and clean message on the wire", async () => {
-    const pipeline = newPipeline<typeof OrganizationSchema>("test", silentLogger)
+    const pipeline = newPipeline<typeof OrganizationSchema>(
+      "test",
+      silentLogger,
+    )
       .addStep({
         name: "Reject",
         execute() {
-          throw new ConnectError("Organization already exists: slug 'acme'", Code.AlreadyExists);
+          throw new ConnectError(
+            "Organization already exists: slug 'acme'",
+            Code.AlreadyExists,
+          );
         },
       })
       .build();
@@ -85,8 +96,13 @@ describe("pipeline execution", () => {
   });
 
   it("sanitizes a plain error to Internal/'internal server error' with the cause kept server-side (#478)", async () => {
-    const raw = new Error("SQLITE_IOERR: /home/user/.stigmer/stigmer.db is corrupt");
-    const pipeline = newPipeline<typeof OrganizationSchema>("test", silentLogger)
+    const raw = new Error(
+      "SQLITE_IOERR: /home/user/.stigmer/stigmer.db is corrupt",
+    );
+    const pipeline = newPipeline<typeof OrganizationSchema>(
+      "test",
+      silentLogger,
+    )
       .addStep({
         name: "Leaky",
         execute() {

--- a/backend/services/stigmer-server/src/pipeline/__tests__/steps.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/__tests__/steps.test.ts
@@ -10,6 +10,8 @@
  * Uses the organization resource (the vertical slice) and agent (whose
  * spec carries ApiResourceReference fields) as vehicles.
  */
+import { testCallerIdentity } from "./support.js";
+import { trustedLocalIdentity } from "../interceptors/auth.js";
 import { create, clone } from "@bufbuild/protobuf";
 import { TimestampSchema } from "@bufbuild/protobuf/wkt";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -30,7 +32,7 @@ import {
   generateId,
   setOperatorIdentity,
   resetOperatorIdentityForTests,
-  currentAuditActor,
+  auditActorFor,
 } from "../steps/defaults.js";
 import { newBuildUpdateStateStep } from "../steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../steps/duplicate.js";
@@ -42,13 +44,19 @@ import {
 } from "../steps/delete.js";
 import { compareCreatedAtDesc, matchesAllLabels } from "../steps/helpers.js";
 import { newIndexSearchStep } from "../steps/index-search.js";
-import { EXISTING_RESOURCE_KEY, newLoadExistingStep } from "../steps/load-existing.js";
+import {
+  EXISTING_RESOURCE_KEY,
+  newLoadExistingStep,
+} from "../steps/load-existing.js";
 import {
   EXISTS_IN_DATABASE_KEY,
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
 } from "../steps/load-for-apply.js";
-import { newLoadTargetStep, TARGET_RESOURCE_KEY } from "../steps/load-target.js";
+import {
+  newLoadTargetStep,
+  TARGET_RESOURCE_KEY,
+} from "../steps/load-target.js";
 import { newPersistStep } from "../steps/persist.js";
 import {
   newNormalizeReferencesStep,
@@ -89,7 +97,12 @@ afterEach(async () => {
   resetOperatorIdentityForTests();
 });
 
-function org(overrides?: { id?: string; name?: string; slug?: string; org?: string }) {
+function org(overrides?: {
+  id?: string;
+  name?: string;
+  slug?: string;
+  org?: string;
+}) {
   return create(OrganizationSchema, {
     apiVersion: "tenancy.stigmer.ai/v1",
     kind: "Organization",
@@ -104,7 +117,12 @@ function org(overrides?: { id?: string; name?: string; slug?: string; org?: stri
 }
 
 function orgCtx(input = org()): RequestContext<typeof OrganizationSchema> {
-  return new RequestContext(OrganizationSchema, input, ORG);
+  return new RequestContext(
+    OrganizationSchema,
+    input,
+    testCallerIdentity(),
+    ORG,
+  );
 }
 
 describe("generateSlug (Go GenerateSlug, cloud-Java-identical)", () => {
@@ -137,7 +155,9 @@ describe("ResolveSlug", () => {
       .then(() => newResolveSlugStep<typeof OrganizationSchema>().execute(ctx))
       .catch((e: unknown) => e);
     expect((error as ConnectError).code).toBe(Code.InvalidArgument);
-    expect((error as ConnectError).rawMessage).toBe("resource name is required");
+    expect((error as ConnectError).rawMessage).toBe(
+      "resource name is required",
+    );
   });
 });
 
@@ -180,9 +200,14 @@ describe("BuildNewState", () => {
     expect(state.metadata?.id).toMatch(/^org_[0-9a-hjkmnp-tv-z]{26}$/);
     expect(state.status?.audit?.specAudit?.event).toBe("created");
     expect(state.status?.audit?.statusAudit?.event).toBe("created");
-    expect(state.status?.audit?.specAudit?.createdBy?.id).toBe("system");
+    // O2 ruling Q5: the audit actor derives from the REQUEST's caller
+    // identity — here the explicit test identity (production wire
+    // requests derive the same bytes as the retired process-global seam).
+    expect(state.status?.audit?.specAudit?.createdBy?.id).toBe("test-caller");
     // Organization is not a blueprint kind → private default.
-    expect(state.metadata?.visibility).toBe(ApiResourceVisibility.visibility_private);
+    expect(state.metadata?.visibility).toBe(
+      ApiResourceVisibility.visibility_private,
+    );
   });
 
   it("keeps a client-provided id and explicit visibility (idempotent)", async () => {
@@ -190,7 +215,9 @@ describe("BuildNewState", () => {
     ctx.newState.metadata!.visibility = ApiResourceVisibility.visibility_org;
     await newBuildNewStateStep<typeof OrganizationSchema>().execute(ctx);
     expect(ctx.newState.metadata?.id).toBe("acme");
-    expect(ctx.newState.metadata?.visibility).toBe(ApiResourceVisibility.visibility_org);
+    expect(ctx.newState.metadata?.visibility).toBe(
+      ApiResourceVisibility.visibility_org,
+    );
   });
 });
 
@@ -202,12 +229,12 @@ describe("generateId", () => {
   });
 });
 
-describe("operator identity (#400)", () => {
-  it("stamps the system placeholder when unconfigured and the operator when configured", () => {
-    expect(currentAuditActor().id).toBe("system");
+describe("operator identity (#400) → audit-actor derivation (O2 ruling Q5)", () => {
+  it("derives the system placeholder when unconfigured and the operator when configured — the pre-O2 bytes", () => {
+    expect(auditActorFor(trustedLocalIdentity()).id).toBe("system");
 
     setOperatorIdentity("op@example.test", "Op");
-    const actor = currentAuditActor();
+    const actor = auditActorFor(trustedLocalIdentity());
     expect(actor.id).toBe("op@example.test");
     expect(actor.email).toBe("op@example.test");
     expect(actor.displayName).toBe("Op");
@@ -245,7 +272,9 @@ describe("BuildUpdateState", () => {
     expect(updated.metadata?.id).toBe(existing.metadata?.id);
     expect(updated.metadata?.slug).toBe(existing.metadata?.slug);
     expect(updated.metadata?.org).toBe(existing.metadata?.org);
-    expect(updated.metadata?.visibility).toBe(ApiResourceVisibility.visibility_org);
+    expect(updated.metadata?.visibility).toBe(
+      ApiResourceVisibility.visibility_org,
+    );
     expect(updated.metadata?.name).toBe("Acme Renamed");
     expect(updated.spec?.description).toBe("updated description");
     expect(updated.status?.audit?.specAudit?.event).toBe("updated");
@@ -272,7 +301,9 @@ describe("loaders", () => {
       newLoadExistingStep<typeof OrganizationSchema>(store).execute(missing),
     );
     expect((error as ConnectError).code).toBe(Code.NotFound);
-    expect((error as ConnectError).rawMessage).toBe("Organization not found: ghost");
+    expect((error as ConnectError).rawMessage).toBe(
+      "Organization not found: ghost",
+    );
 
     const neither = orgCtx(org({ name: "" }));
     const iaError = await captureError(() =>
@@ -289,7 +320,12 @@ describe("loaders", () => {
     expect(fresh.get(SHOULD_CREATE_KEY)).toBe(true);
     expect(fresh.get(EXISTS_IN_DATABASE_KEY)).toBe(false);
 
-    await store.saveResource(ORG, "acme", OrganizationSchema, org({ id: "acme", slug: "acme" }));
+    await store.saveResource(
+      ORG,
+      "acme",
+      OrganizationSchema,
+      org({ id: "acme", slug: "acme" }),
+    );
     const found = orgCtx(org({ slug: "acme" }));
     await newLoadForApplyStep<typeof OrganizationSchema>(store).execute(found);
     expect(found.get(SHOULD_CREATE_KEY)).toBe(false);
@@ -297,11 +333,17 @@ describe("loaders", () => {
   });
 
   it("LoadTarget loads by id-wrapper and rejects empty/unknown ids", async () => {
-    await store.saveResource(ORG, "acme", OrganizationSchema, org({ id: "acme", slug: "acme" }));
+    await store.saveResource(
+      ORG,
+      "acme",
+      OrganizationSchema,
+      org({ id: "acme", slug: "acme" }),
+    );
 
     const ctx = new RequestContext(
       ApiResourceIdSchema,
       create(ApiResourceIdSchema, { value: "acme" }),
+      testCallerIdentity(),
       ORG,
     );
     await newLoadTargetStep(store, OrganizationSchema).execute(ctx);
@@ -310,6 +352,7 @@ describe("loaders", () => {
     const empty = new RequestContext(
       ApiResourceIdSchema,
       create(ApiResourceIdSchema, { value: "" }),
+      testCallerIdentity(),
       ORG,
     );
     const error = await captureError(() =>
@@ -321,11 +364,17 @@ describe("loaders", () => {
 
 describe("delete steps + persist", () => {
   it("Extract → LoadForDelete → Delete round-trips through the store", async () => {
-    await store.saveResource(ORG, "acme", OrganizationSchema, org({ id: "acme", slug: "acme" }));
+    await store.saveResource(
+      ORG,
+      "acme",
+      OrganizationSchema,
+      org({ id: "acme", slug: "acme" }),
+    );
 
     const ctx = new RequestContext(
       ApiResourceIdSchema,
       create(ApiResourceIdSchema, { value: "acme" }),
+      testCallerIdentity(),
       ORG,
     );
     await newExtractResourceIdStep<typeof ApiResourceIdSchema>().execute(ctx);
@@ -370,13 +419,17 @@ describe("IndexSearch (best-effort)", () => {
 
   it("indexes the persisted resource", async () => {
     const ctx = orgCtx(org({ id: "acme", slug: "acme" }));
-    await newIndexSearchStep<typeof OrganizationSchema>(store, extractor, silentLogger).execute(ctx);
+    await newIndexSearchStep<typeof OrganizationSchema>(
+      store,
+      extractor,
+      silentLogger,
+    ).execute(ctx);
 
     const { DatabaseSync } = await import("node:sqlite");
     const db = new DatabaseSync(store.path());
-    const row = db.prepare(`SELECT name FROM search_index WHERE resource_id = 'acme'`).get() as
-      | { name: string }
-      | undefined;
+    const row = db
+      .prepare(`SELECT name FROM search_index WHERE resource_id = 'acme'`)
+      .get() as { name: string } | undefined;
     db.close();
     expect(row?.name).toBe("Acme");
   });
@@ -392,7 +445,11 @@ describe("IndexSearch (best-effort)", () => {
     };
     const ctx = orgCtx(org({ id: "acme" }));
     await expect(
-      newIndexSearchStep<typeof OrganizationSchema>(store, extractor, logger).execute(ctx),
+      newIndexSearchStep<typeof OrganizationSchema>(
+        store,
+        extractor,
+        logger,
+      ).execute(ctx),
     ).resolves.toBeUndefined();
     expect(warnings.some((w) => w.includes("best-effort"))).toBe(true);
   });
@@ -401,12 +458,16 @@ describe("IndexSearch (best-effort)", () => {
 describe("ValidateProto", () => {
   it("passes a valid resource and maps violations to InvalidArgument", async () => {
     await expect(
-      Promise.resolve(newValidateProtoStep<typeof OrganizationSchema>().execute(orgCtx())),
+      Promise.resolve(
+        newValidateProtoStep<typeof OrganizationSchema>().execute(orgCtx()),
+      ),
     ).resolves.toBeUndefined();
 
     const bad = orgCtx(org({ slug: "BadSlug" }));
     const error = await Promise.resolve()
-      .then(() => newValidateProtoStep<typeof OrganizationSchema>().execute(bad))
+      .then(() =>
+        newValidateProtoStep<typeof OrganizationSchema>().execute(bad),
+      )
       .catch((e: unknown) => e);
     expect((error as ConnectError).code).toBe(Code.InvalidArgument);
   });
@@ -418,18 +479,26 @@ describe("ValidateVisibility", () => {
     input.metadata!.visibility = ApiResourceVisibility.visibility_platform;
     const ctx = orgCtx(input);
     const error = await Promise.resolve()
-      .then(() => newValidateVisibilityStep<typeof OrganizationSchema>().execute(ctx))
+      .then(() =>
+        newValidateVisibilityStep<typeof OrganizationSchema>().execute(ctx),
+      )
       .catch((e: unknown) => e);
     expect((error as ConnectError).code).toBe(Code.InvalidArgument);
     expect((error as ConnectError).rawMessage).toContain(
       "organization resources cannot be set to visibility_platform",
     );
-    expect((error as ConnectError).rawMessage).toContain("Supported visibility levels:");
+    expect((error as ConnectError).rawMessage).toContain(
+      "Supported visibility levels:",
+    );
   });
 
   it("always accepts private and unspecified (no visibility grant)", async () => {
     await expect(
-      Promise.resolve(newValidateVisibilityStep<typeof OrganizationSchema>().execute(orgCtx())),
+      Promise.resolve(
+        newValidateVisibilityStep<typeof OrganizationSchema>().execute(
+          orgCtx(),
+        ),
+      ),
     ).resolves.toBeUndefined();
   });
 });
@@ -450,11 +519,21 @@ describe("references (agent spec as the vehicle)", () => {
   }
 
   it("NormalizeReferences fills EMPTY ref orgs from metadata.org and preserves explicit ones", async () => {
-    const ctx = new RequestContext(AgentSchema, agent(""), ApiResourceKind.agent);
+    const ctx = new RequestContext(
+      AgentSchema,
+      agent(""),
+      testCallerIdentity(),
+      ApiResourceKind.agent,
+    );
     await newNormalizeReferencesStep<typeof AgentSchema>().execute(ctx);
     expect(ctx.newState.spec?.skillRefs[0]?.org).toBe("acme");
 
-    const explicit = new RequestContext(AgentSchema, agent("other-org"), ApiResourceKind.agent);
+    const explicit = new RequestContext(
+      AgentSchema,
+      agent("other-org"),
+      testCallerIdentity(),
+      ApiResourceKind.agent,
+    );
     await newNormalizeReferencesStep<typeof AgentSchema>().execute(explicit);
     expect(explicit.newState.spec?.skillRefs[0]?.org).toBe("other-org");
   });
@@ -467,11 +546,22 @@ describe("references (agent spec as the vehicle)", () => {
       spec: {
         instructions: "help the user with their tasks",
         mcpServerUsages: [
-          { mcpServerRef: { kind: ApiResourceKind.mcp_server, slug: "ghost", org: "acme" } },
+          {
+            mcpServerRef: {
+              kind: ApiResourceKind.mcp_server,
+              slug: "ghost",
+              org: "acme",
+            },
+          },
         ],
       },
     });
-    const ctx = new RequestContext(AgentSchema, withMcp, ApiResourceKind.agent);
+    const ctx = new RequestContext(
+      AgentSchema,
+      withMcp,
+      testCallerIdentity(),
+      ApiResourceKind.agent,
+    );
     const error = await captureError(() =>
       newValidateReferencesStep<typeof AgentSchema>(store).execute(ctx),
     );

--- a/backend/services/stigmer-server/src/pipeline/__tests__/support.ts
+++ b/backend/services/stigmer-server/src/pipeline/__tests__/support.ts
@@ -1,0 +1,20 @@
+/**
+ * Shared test identity for RequestContext construction (O2, ruling Q3):
+ * the identity parameter is required, so every test constructs one
+ * explicitly — never a hidden default that could mask a missed threading
+ * site in production code. Overrides let adversarial tests pin specific
+ * caller classes.
+ */
+import type { CallerIdentity } from "../../extensions/identity.js";
+
+export function testCallerIdentity(
+  overrides: Partial<CallerIdentity> = {},
+): CallerIdentity {
+  return {
+    identityId: "test-caller",
+    callerClass: "user",
+    issuer: "",
+    rawToken: "",
+    ...overrides,
+  };
+}

--- a/backend/services/stigmer-server/src/pipeline/chain.ts
+++ b/backend/services/stigmer-server/src/pipeline/chain.ts
@@ -1,26 +1,35 @@
 /**
  * The server's interceptor chain, in the ratified order (D2 §2):
  *
- *   1. auth seam        — pass-through slot, outermost (DD-004)
+ *   1. identity source  — REQUIRED parameter, outermost (DD-004; O2)
  *   2. logging          — level-tiered per outcome
  *   3. protovalidate    — boundary validation before any handler
  *   4. apiresource      — kind context from the service option
  *
  * ConnectRPC applies array order as nesting order (first = outermost),
- * verified by spike SP-B. The SAME chain serves external transports and
- * in-process router-transport calls — validation parity is the point.
+ * verified by spike SP-B. Positions 2–4 are the SAME for external
+ * transports and in-process router-transport calls — validation parity is
+ * the point. Position 1 deliberately differs per transport (O2, ruling
+ * Q4): the serving chain runs the verifier chassis over the wire's
+ * credentials, the in-process chain stamps the internal caller class its
+ * own interceptor mints (interceptors/auth.ts owns both sources and the
+ * spoofing-impossible invariant). The parameter is required — a chain
+ * without an identity source is a compile error, never a silently
+ * unauthenticated transport.
  */
 import type { Interceptor } from "@connectrpc/connect";
 
 import type { Logger } from "../boot/logger.js";
 import { createApiResourceInterceptor } from "./interceptors/apiresource.js";
-import { createAuthPassThroughInterceptor } from "./interceptors/auth.js";
 import { createLoggingInterceptor } from "./interceptors/logging.js";
 import { createProtovalidateInterceptor } from "./interceptors/protovalidate.js";
 
-export function buildInterceptorChain(logger: Logger): Interceptor[] {
+export function buildInterceptorChain(
+  logger: Logger,
+  identitySource: Interceptor,
+): Interceptor[] {
   return [
-    createAuthPassThroughInterceptor(),
+    identitySource,
     createLoggingInterceptor(logger),
     createProtovalidateInterceptor(),
     createApiResourceInterceptor(),

--- a/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/auth.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/auth.test.ts
@@ -1,0 +1,242 @@
+/**
+ * Pins the identity chassis (O2, DD-007 §1): the claim-or-pass verifier
+ * walk, the Q6 conditional-strictness contract (zero verifiers = silent
+ * fall-through for unclaimed tokens; any verifier configured = unclaimed
+ * is UNAUTHENTICATED), the trusted-local modeled state in both operator
+ * postures, the internal caller class's structural minting invariant
+ * (ruling Q4 — a wire request can never carry it), and the shared bearer
+ * parser's shape.
+ */
+import { describe, expect, it, afterEach } from "vitest";
+import { Code, ConnectError, createContextValues } from "@connectrpc/connect";
+import type { Interceptor } from "@connectrpc/connect";
+
+import type {
+  CallerIdentity,
+  IdentityVerifier,
+} from "../../../extensions/identity.js";
+import {
+  callerIdentityKey,
+  createInProcessCallerInterceptor,
+  createVerifierChainInterceptor,
+  parseBearerToken,
+  trustedLocalIdentity,
+} from "../auth.js";
+import {
+  resetOperatorIdentityForTests,
+  setOperatorIdentity,
+} from "../../steps/defaults.js";
+
+const silentLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+afterEach(() => {
+  resetOperatorIdentityForTests();
+});
+
+/**
+ * Drives an interceptor with a minimal unary-shaped request and returns
+ * the identity it stamped (undefined when it rejected before next()).
+ */
+async function runInterceptor(
+  interceptor: Interceptor,
+  authorizationHeader?: string,
+): Promise<CallerIdentity | undefined> {
+  const header = new Headers();
+  if (authorizationHeader !== undefined) {
+    header.set("authorization", authorizationHeader);
+  }
+  const contextValues = createContextValues();
+  let stamped: CallerIdentity | undefined;
+  const next = (request: { contextValues: typeof contextValues }) => {
+    stamped = request.contextValues.get(callerIdentityKey);
+    return Promise.resolve({} as never);
+  };
+  await interceptor(next as never)({
+    header,
+    contextValues,
+    stream: false,
+  } as never);
+  return stamped;
+}
+
+function verifier(
+  name: string,
+  verify: (token: string) => Promise<CallerIdentity | null>,
+): IdentityVerifier {
+  return { name, verify };
+}
+
+const CLAIMED: CallerIdentity = {
+  identityId: "ida_claimed",
+  callerClass: "user",
+  issuer: "https://issuer.test",
+  rawToken: "tok",
+};
+
+describe("verifier chain walk", () => {
+  it("first claim wins; later verifiers never run", async () => {
+    let secondRan = false;
+    const identity = await runInterceptor(
+      createVerifierChainInterceptor(
+        [
+          verifier("first", () => Promise.resolve(CLAIMED)),
+          verifier("second", () => {
+            secondRan = true;
+            return Promise.resolve(null);
+          }),
+        ],
+        silentLogger,
+      ),
+      "Bearer tok",
+    );
+    expect(identity).toEqual(CLAIMED);
+    expect(secondRan).toBe(false);
+  });
+
+  it("a pass (null) moves to the next verifier in order", async () => {
+    const order: string[] = [];
+    const identity = await runInterceptor(
+      createVerifierChainInterceptor(
+        [
+          verifier("first", () => {
+            order.push("first");
+            return Promise.resolve(null);
+          }),
+          verifier("second", () => {
+            order.push("second");
+            return Promise.resolve(CLAIMED);
+          }),
+        ],
+        silentLogger,
+      ),
+      "Bearer tok",
+    );
+    expect(order).toEqual(["first", "second"]);
+    expect(identity).toEqual(CLAIMED);
+  });
+
+  it("a verifier's ConnectError is its own wire mapping (propagated)", async () => {
+    const reject = new ConnectError("token expired", Code.Unauthenticated);
+    await expect(
+      runInterceptor(
+        createVerifierChainInterceptor(
+          [verifier("oidc", () => Promise.reject(reject))],
+          silentLogger,
+        ),
+        "Bearer tok",
+      ),
+    ).rejects.toBe(reject);
+  });
+
+  it("a verifier's plain throw is an infrastructure fault → INTERNAL, never a denial", async () => {
+    const error = await runInterceptor(
+      createVerifierChainInterceptor(
+        [verifier("oidc", () => Promise.reject(new Error("JWKS unreachable")))],
+        silentLogger,
+      ),
+      "Bearer tok",
+    ).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.Internal);
+    expect((error as ConnectError).rawMessage).toBe("internal server error");
+  });
+});
+
+describe("conditional strictness (ruling Q6 — both postures)", () => {
+  it("zero verifiers: a presented-but-unclaimed token falls through SILENTLY to trusted-local", async () => {
+    const identity = await runInterceptor(
+      createVerifierChainInterceptor([], silentLogger),
+      "Bearer garbage-token",
+    );
+    expect(identity).toEqual(trustedLocalIdentity());
+  });
+
+  it("any verifier configured: a presented-but-unclaimed token is UNAUTHENTICATED", async () => {
+    const error = await runInterceptor(
+      createVerifierChainInterceptor(
+        [verifier("oidc", () => Promise.resolve(null))],
+        silentLogger,
+      ),
+      "Bearer garbage-token",
+    ).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.Unauthenticated);
+    expect((error as ConnectError).rawMessage).toBe(
+      "the presented token was not accepted by any configured identity verifier",
+    );
+  });
+
+  it("an absent token falls to trusted-local in both postures (the require-auth posture is O3's)", async () => {
+    expect(
+      await runInterceptor(createVerifierChainInterceptor([], silentLogger)),
+    ).toEqual(trustedLocalIdentity());
+    expect(
+      await runInterceptor(
+        createVerifierChainInterceptor(
+          [verifier("oidc", () => Promise.resolve(null))],
+          silentLogger,
+        ),
+      ),
+    ).toEqual(trustedLocalIdentity());
+  });
+});
+
+describe("trusted-local identity (the explicit modeled state)", () => {
+  it("unconfigured operator = the 'system' principal (pre-O2 audit bytes)", () => {
+    expect(trustedLocalIdentity()).toEqual({
+      identityId: "system",
+      callerClass: "user",
+      issuer: "",
+      rawToken: "",
+    });
+  });
+
+  it("configured operator = email-first identity with display fields", () => {
+    setOperatorIdentity("op@example.com", "Op Erator");
+    expect(trustedLocalIdentity()).toEqual({
+      identityId: "op@example.com",
+      callerClass: "user",
+      issuer: "",
+      rawToken: "",
+      email: "op@example.com",
+      displayName: "Op Erator",
+    });
+  });
+});
+
+describe("internal caller class (ruling Q4 — structurally unmintable from the wire)", () => {
+  it("the in-process interceptor stamps the internal class", async () => {
+    const identity = await runInterceptor(createInProcessCallerInterceptor());
+    expect(identity?.callerClass).toBe("internal");
+  });
+
+  it("a wire request can never mint it: any token through the serving chassis stays a wire class", async () => {
+    // Zero verifiers: even a forged token resolves to trusted-local
+    // ("user"), never "internal" — the serving chain has no code path
+    // that produces the class.
+    const identity = await runInterceptor(
+      createVerifierChainInterceptor([], silentLogger),
+      "Bearer forged.internal.token",
+    );
+    expect(identity?.callerClass).toBe("user");
+  });
+});
+
+describe("parseBearerToken (the one shared bearer shape)", () => {
+  it.each([
+    ["Bearer abc.def.ghi", "abc.def.ghi"],
+    ["bearer abc", "abc"],
+    ["BEARER abc  ", "abc"],
+    ["Bearer abc, Bearer second", "abc"],
+    ["Basic abc", ""],
+    ["Bearer ", ""],
+    ["", ""],
+  ])("%j → %j", (header, expected) => {
+    expect(parseBearerToken(header)).toBe(expected);
+  });
+});

--- a/backend/services/stigmer-server/src/pipeline/interceptors/auth.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/auth.ts
@@ -1,16 +1,229 @@
 /**
- * Authentication seam — chain position 1, a deliberate pass-through
- * (DD-004, parent project).
+ * Identity chassis — chain position 1, outermost (reserved by DD-004;
+ * filled by O2, 20260827.01, per DD-007 §1). Every request enters the
+ * server through exactly one of the two identity sources this module
+ * owns, and every request leaves position 1 with a CallerIdentity stashed
+ * under `callerIdentityKey`:
  *
- * Phase 1 changes no security posture: the OSS server trusts its local
- * caller exactly as the Go server does. The slot exists so phase-3 server
- * mode can drop a real authenticator into an already-reserved outermost
- * position — an implementation change, not a chain restructuring. Outermost
- * is deliberate: when auth arrives, it must run before anything else
- * observes the request.
+ *   - createVerifierChainInterceptor — the serving chain's source: an
+ *     ordered claim-or-pass walk over the composed IdentityVerifiers (the
+ *     TS rendering of the Java ProviderManager chain).
+ *   - createInProcessCallerInterceptor — the in-process router
+ *     transport's source: stamps the `internal` caller class (ruling Q4,
+ *     the TS rendering of the Java in-process authorization skip).
+ *
+ * The internal class is mintable ONLY here, only by the in-process
+ * interceptor: the serving chain always overwrites the position-1 value
+ * from the wire, contextValues never cross a transport, and no
+ * IdentityVerifier may produce the class (contract on CallerClass).
+ * Spoofing is structurally impossible, not policed.
+ *
+ * # Conditional strictness (ruling Q6 — pinned contract)
+ *
+ * Strictness is a function of whether any verifier is configured:
+ *
+ *   - ZERO verifiers (every shipped OSS composition today): a presented
+ *     token that nothing claims falls through SILENTLY to the
+ *     trusted-local identity. This preserves wire behavior byte-for-byte
+ *     — the runner presents a Bearer token on every control-plane RPC
+ *     when STIGMER_TOKEN is set, and domains that verify tokens (the
+ *     executioncontext decrypt lane) read the raw header themselves.
+ *   - ONE OR MORE verifiers: a presented-but-unclaimed token is
+ *     UNAUTHENTICATED. A configured issuer must never silently admit
+ *     garbage tokens as trusted-local.
+ *   - An ABSENT token falls to trusted-local in both postures. The
+ *     require-authentication question for issuer-configured deployments
+ *     (and its interplay with is_public methods) is O3's ruling — this
+ *     chassis deliberately does not invent it.
+ *
+ * # Trusted-local identity (the explicit modeled state)
+ *
+ * No issuer + no claim = the single-operator trust domain's one
+ * principal, minted from the #400 operator seam (steps/defaults.ts):
+ * identityId is the operator email (email-first, matching the audit
+ * doctrine there), or "system" when unconfigured. The audit-actor seam
+ * derives from this identity the exact bytes currentAuditActor stamped
+ * before O2.
+ *
+ * # Verifier faults
+ *
+ * A verifier that throws a ConnectError chose its wire shape (signature/
+ * expiry/audience failures are UNAUTHENTICATED by the verifier's own
+ * mapping); any other throw is an infrastructure fault — INTERNAL, never
+ * softened into an auth denial (the DD-007 unavailable doctrine, applied
+ * to the verification side).
  */
-import type { Interceptor } from "@connectrpc/connect";
+import { Code, ConnectError, createContextKey } from "@connectrpc/connect";
+import type { HandlerContext, Interceptor } from "@connectrpc/connect";
 
-export function createAuthPassThroughInterceptor(): Interceptor {
-  return (next) => (request) => next(request);
+import type { Logger } from "../../boot/logger.js";
+import type {
+  CallerIdentity,
+  IdentityVerifier,
+} from "../../extensions/identity.js";
+import { internalError } from "../errors.js";
+import { operatorIdentitySnapshot } from "../steps/defaults.js";
+
+/**
+ * Context key for the request's caller identity. The default is
+ * `undefined` so a read BEFORE position 1 has stamped (a wiring bug — both
+ * chains stamp unconditionally) is loud through callerIdentityOf, never a
+ * silent placeholder principal.
+ */
+export const callerIdentityKey = createContextKey<CallerIdentity | undefined>(
+  undefined,
+  { description: "caller identity produced at chain position 1" },
+);
+
+/**
+ * The request's caller identity — the ONE read idiom for controllers
+ * (threaded into RequestContext exactly once, ruling Q3). Throws the
+ * composition-root wiring fault when position 1 did not stamp: that state
+ * is unreachable through either chain, so reaching it means a transport
+ * was built without an identity source.
+ */
+export function callerIdentityOf(ctx: HandlerContext): CallerIdentity {
+  const identity = ctx.values.get(callerIdentityKey);
+  if (identity === undefined) {
+    throw internalError(
+      new Error("no caller identity in context (chain wiring bug)"),
+      "internal server error",
+    );
+  }
+  return identity;
+}
+
+/**
+ * The trusted-local single-user identity — the explicit modeled state for
+ * "no verifier claimed this request". Read per request (not cached at
+ * chain build) so composeServer stays re-entrant for tests while the
+ * operator seam remains process-global.
+ */
+export function trustedLocalIdentity(): CallerIdentity {
+  const operator = operatorIdentitySnapshot();
+  if (operator.email === "") {
+    return {
+      identityId: "system",
+      callerClass: "user",
+      issuer: "",
+      rawToken: "",
+    };
+  }
+  return {
+    identityId: operator.email,
+    callerClass: "user",
+    issuer: "",
+    rawToken: "",
+    email: operator.email,
+    displayName: operator.displayName,
+  };
+}
+
+/**
+ * The serving chain's position-1 identity source: walks the composed
+ * verifiers in order (OSS entries first, extension entries after, in
+ * extension-unit order — registry contract), stamps the claimed identity
+ * or the trusted-local fallback per the strictness contract above.
+ * Covers unary AND streams — identity is per-request state, not a
+ * unary-pipeline concern like the apiresource kind.
+ */
+export function createVerifierChainInterceptor(
+  verifiers: ReadonlyArray<IdentityVerifier>,
+  logger: Logger,
+): Interceptor {
+  return (next) => async (request) => {
+    const token = parseBearerToken(request.header.get("authorization") ?? "");
+    let identity: CallerIdentity | undefined;
+    if (token !== "") {
+      identity = await runVerifierChain(verifiers, token, logger);
+      if (identity === undefined && verifiers.length > 0) {
+        // Position 1 is outside the logging interceptor, so the rejection
+        // is recorded here (the wire carries only the sanitized copy).
+        logger.warn("presented token not claimed by any identity verifier", {
+          verifiers: verifiers.map((v) => v.name).join(", "),
+        });
+        throw new ConnectError(
+          "the presented token was not accepted by any configured identity verifier",
+          Code.Unauthenticated,
+        );
+      }
+    }
+    request.contextValues.set(
+      callerIdentityKey,
+      identity ?? trustedLocalIdentity(),
+    );
+    return next(request);
+  };
+}
+
+/**
+ * The in-process transport's position-1 identity source: stamps the
+ * internal caller class carrying the operator's identity fields, so
+ * audit stamps on in-process writes stay byte-identical to the wire
+ * lane's (both derive from the same #400 seam). The Authorize step treats
+ * the internal class as the in-process authorization skip (ruling Q4).
+ */
+export function createInProcessCallerInterceptor(): Interceptor {
+  return (next) => (request) => {
+    request.contextValues.set(callerIdentityKey, {
+      ...trustedLocalIdentity(),
+      callerClass: "internal",
+    });
+    return next(request);
+  };
+}
+
+/**
+ * The claim-or-pass walk (identity.ts contract): a claim wins, null moves
+ * to the next verifier, a ConnectError throw is the verifier's own wire
+ * mapping, any other throw is an infrastructure fault (INTERNAL — a JWKS
+ * outage must never read as a credential rejection).
+ */
+async function runVerifierChain(
+  verifiers: ReadonlyArray<IdentityVerifier>,
+  token: string,
+  logger: Logger,
+): Promise<CallerIdentity | undefined> {
+  for (const verifier of verifiers) {
+    let claimed: CallerIdentity | null;
+    try {
+      claimed = await verifier.verify(token);
+    } catch (error) {
+      if (error instanceof ConnectError) {
+        throw error;
+      }
+      logger.error("identity verifier failed", {
+        verifier: verifier.name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw internalError(error, "internal server error");
+    }
+    if (claimed !== null) {
+      return claimed;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The Bearer credential from a (possibly comma-joined) authorization
+ * header value; empty when absent or differently shaped. One shared
+ * definition of the shape both consumers use (this chassis and the
+ * executioncontext decrypt lane): case-insensitive "bearer " prefix, the
+ * remainder non-empty before trimming. Node's http2 layer joins repeated
+ * headers with ", " — the first comma segment IS the first value, and a
+ * genuine token (base64url segments joined by dots) can never contain a
+ * comma, so the split is lossless for every legitimate shape (the Go
+ * server read metadata values[0], same result).
+ */
+export function parseBearerToken(joinedHeaderValue: string): string {
+  const header = joinedHeaderValue.split(",")[0] ?? "";
+  const prefix = "bearer ";
+  if (
+    header.length <= prefix.length ||
+    header.slice(0, prefix.length).toLowerCase() !== prefix
+  ) {
+    return "";
+  }
+  return header.slice(prefix.length).trim();
 }

--- a/backend/services/stigmer-server/src/pipeline/request-context.ts
+++ b/backend/services/stigmer-server/src/pipeline/request-context.ts
@@ -6,13 +6,18 @@
  * original request pristine for debugging, logging, and idempotency —
  * steps read from and modify newState, never input.
  *
- * Two mechanics differ from Go, deliberately:
+ * Three mechanics differ from Go, deliberately:
  *   - The resolved ApiResourceKind is a constructor parameter instead of a
  *     hidden context.Context value. Go's steps fish it out of ctx (injected
  *     by the apiresource interceptor); here the controller reads it from
  *     the ConnectRPC contextValues (apiResourceKindKey) once and passes it
  *     explicitly — a missing kind is a compile error, not a zero-value
  *     surprise (the composition-root idiom, guidelines §4).
+ *   - The CallerIdentity is a REQUIRED constructor parameter (O2, ruling
+ *     Q3 — the same doctrine delivered for real): position 1 of every
+ *     chain stamps it, the controller reads it once (callerIdentityOf),
+ *     and every construction site that forgets it is a compile error.
+ *     The Authorize step and the audit-actor derivation read it here.
  *   - metadata values are typed per key via the small helpers below rather
  *     than blind interface{} casts; the KEY STRINGS stay identical to Go's
  *     so the inventory's step notes read straight onto this code.
@@ -22,11 +27,15 @@ import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
 
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
+import type { CallerIdentity } from "../extensions/identity.js";
+
 export class RequestContext<Desc extends DescMessage> {
   /** The original, immutable request message. */
   readonly input: MessageShape<Desc>;
   /** The request's message schema (steps clone/compare through it). */
   readonly schema: Desc;
+  /** The authenticated caller, produced at chain position 1 (O2). */
+  readonly callerIdentity: CallerIdentity;
   /**
    * The resource kind of the target service (Go: injected by the
    * apiresource interceptor; unknown when the service carries no
@@ -40,11 +49,13 @@ export class RequestContext<Desc extends DescMessage> {
   constructor(
     schema: Desc,
     input: MessageShape<Desc>,
+    callerIdentity: CallerIdentity,
     apiResourceKind: ApiResourceKind = ApiResourceKind.api_resource_kind_unknown,
   ) {
     this.schema = schema;
     this.input = input;
     this.state = clone(schema, input);
+    this.callerIdentity = callerIdentity;
     this.apiResourceKind = apiResourceKind;
   }
 

--- a/backend/services/stigmer-server/src/pipeline/steps/__tests__/authorize.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/__tests__/authorize.test.ts
@@ -1,0 +1,278 @@
+/**
+ * Pins the Authorize step's wire contract (O2, DD-007 §3): the three
+ * decision arms (allow proceeds; deny → PERMISSION_DENIED carrying the
+ * annotation's byte-pinned error_msg; unavailable → INTERNAL, never a
+ * softened denial), the skip arms (internal caller class, is_public,
+ * is_skip_authorization, no-config methods), check-target resolution
+ * (field_path, static resource_id, absent field = empty id — never a
+ * throw), and the mid-chain resolved-id pattern the traced ListVersions
+ * handlers port onto.
+ */
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { IamPolicyCommandController } from "@stigmer/protos/ai/stigmer/iam/iampolicy/v1/command_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+import { PlatformQueryController } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type {
+  Authorizer,
+  AuthzCheck,
+  AuthzDecision,
+} from "../../../extensions/authorizer.js";
+import { testCallerIdentity } from "../../__tests__/support.js";
+import { RequestContext } from "../../request-context.js";
+import {
+  AUTHORIZATION_UNAVAILABLE_MESSAGE,
+  newAuthorizeStep,
+  newPermissiveSingleTeamAuthorizer,
+} from "../authorize.js";
+
+/** A fake Authorizer that records every check and answers a fixed arm. */
+function fakeAuthorizer(decision: AuthzDecision): {
+  authorizer: Authorizer;
+  checks: AuthzCheck[];
+} {
+  const checks: AuthzCheck[] = [];
+  return {
+    checks,
+    authorizer: {
+      authorize(_caller, check) {
+        checks.push(check);
+        return Promise.resolve(decision);
+      },
+    },
+  };
+}
+
+function agentCreateCtx() {
+  return new RequestContext(
+    AgentSchema,
+    create(AgentSchema, { metadata: { name: "a", org: "acme" } }),
+    testCallerIdentity(),
+    ApiResourceKind.agent,
+  );
+}
+
+describe("decision arms (wire contract, both pinned)", () => {
+  it("deny → PERMISSION_DENIED carrying the annotation's byte-pinned error_msg", async () => {
+    const { authorizer } = fakeAuthorizer({ kind: "deny", reason: "nope" });
+    const step = newAuthorizeStep<typeof AgentSchema>(
+      AgentCommandController.method.create,
+      authorizer,
+    );
+    const error = await step
+      .execute(agentCreateCtx())
+      ?.catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.PermissionDenied);
+    // The annotation IS the refusal copy (apis/.../agent/v1/command.proto).
+    expect((error as ConnectError).rawMessage).toBe(
+      "unauthorized to create agent in this organization",
+    );
+  });
+
+  it("unavailable → INTERNAL with the sanitized static copy — NEVER a softened denial", async () => {
+    const { authorizer } = fakeAuthorizer({
+      kind: "unavailable",
+      cause: new Error("FGA store timeout"),
+    });
+    const step = newAuthorizeStep<typeof AgentSchema>(
+      AgentCommandController.method.create,
+      authorizer,
+    );
+    const error = await step
+      .execute(agentCreateCtx())
+      ?.catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.Internal);
+    expect((error as ConnectError).code).not.toBe(Code.PermissionDenied);
+    expect((error as ConnectError).rawMessage).toBe(
+      AUTHORIZATION_UNAVAILABLE_MESSAGE,
+    );
+  });
+
+  it("an Authorizer that THROWS is normalized to the unavailable arm (INTERNAL)", async () => {
+    const throwing: Authorizer = {
+      authorize() {
+        return Promise.reject(new Error("connection refused"));
+      },
+    };
+    const step = newAuthorizeStep<typeof AgentSchema>(
+      AgentCommandController.method.create,
+      throwing,
+    );
+    const error = await step
+      .execute(agentCreateCtx())
+      ?.catch((e: unknown) => e);
+    expect((error as ConnectError).code).toBe(Code.Internal);
+  });
+
+  it("allow proceeds (the permissive single-team default allows everything)", async () => {
+    const step = newAuthorizeStep<typeof AgentSchema>(
+      AgentCommandController.method.create,
+      newPermissiveSingleTeamAuthorizer(),
+    );
+    await expect(step.execute(agentCreateCtx())).resolves.toBeUndefined();
+  });
+});
+
+describe("skip arms (the authorizer is never consulted)", () => {
+  function denyAll() {
+    return fakeAuthorizer({ kind: "deny", reason: "must not be called" });
+  }
+
+  it("internal caller class = the in-process authorization skip (ruling Q4)", async () => {
+    const { authorizer, checks } = denyAll();
+    const step = newAuthorizeStep<typeof AgentSchema>(
+      AgentCommandController.method.create,
+      authorizer,
+    );
+    const ctx = new RequestContext(
+      AgentSchema,
+      create(AgentSchema, { metadata: { name: "a", org: "acme" } }),
+      testCallerIdentity({ callerClass: "internal" }),
+      ApiResourceKind.agent,
+    );
+    await expect(step.execute(ctx)).resolves.toBeUndefined();
+    expect(checks).toHaveLength(0);
+  });
+
+  it("is_public methods skip (getServerInfo)", async () => {
+    const { authorizer, checks } = denyAll();
+    const step = newAuthorizeStep(
+      PlatformQueryController.method.getServerInfo,
+      authorizer,
+    );
+    const ctx = new RequestContext(
+      PlatformQueryController.method.getServerInfo.input,
+      create(PlatformQueryController.method.getServerInfo.input),
+      testCallerIdentity(),
+    );
+    await expect(step.execute(ctx)).resolves.toBeUndefined();
+    expect(checks).toHaveLength(0);
+  });
+
+  it("is_skip_authorization methods skip (agentexecution create — handler-owned checks)", async () => {
+    const { authorizer, checks } = denyAll();
+    const step = newAuthorizeStep<typeof AgentExecutionSchema>(
+      AgentExecutionCommandController.method.create,
+      authorizer,
+    );
+    const ctx = new RequestContext(
+      AgentExecutionSchema,
+      create(AgentExecutionSchema),
+      testCallerIdentity(),
+      ApiResourceKind.agent_execution,
+    );
+    await expect(step.execute(ctx)).resolves.toBeUndefined();
+    expect(checks).toHaveLength(0);
+  });
+
+  it("methods with NO config skip (uploadAttachment — storage_key is the capability)", async () => {
+    const { authorizer, checks } = denyAll();
+    const method = AgentExecutionCommandController.method.uploadAttachment;
+    const step = newAuthorizeStep(method, authorizer);
+    const ctx = new RequestContext(
+      method.input,
+      create(method.input),
+      testCallerIdentity(),
+    );
+    await expect(step.execute(ctx)).resolves.toBeUndefined();
+    expect(checks).toHaveLength(0);
+  });
+});
+
+describe("check-target resolution (never a throw — byte-identity)", () => {
+  it("field_path resolves through the request (metadata.org)", async () => {
+    const { authorizer, checks } = fakeAuthorizer({ kind: "allow" });
+    const step = newAuthorizeStep<typeof AgentSchema>(
+      AgentCommandController.method.create,
+      authorizer,
+    );
+    await step.execute(agentCreateCtx());
+    expect(checks).toEqual([
+      {
+        permission: IamPermission.can_create_agent,
+        resourceKind: ApiResourceKind.organization,
+        resourceId: "acme",
+      },
+    ]);
+  });
+
+  it("an absent field resolves to the EMPTY id — the check still reaches the authorizer", async () => {
+    const { authorizer, checks } = fakeAuthorizer({ kind: "allow" });
+    const step = newAuthorizeStep<typeof AgentSchema>(
+      AgentCommandController.method.create,
+      authorizer,
+    );
+    const ctx = new RequestContext(
+      AgentSchema,
+      create(AgentSchema), // no metadata at all
+      testCallerIdentity(),
+      ApiResourceKind.agent,
+    );
+    await expect(step.execute(ctx)).resolves.toBeUndefined();
+    expect(checks[0].resourceId).toBe("");
+  });
+
+  it("a static resource_id wins over any request field (platform RPCs)", async () => {
+    const { authorizer, checks } = fakeAuthorizer({ kind: "allow" });
+    const method = IamPolicyCommandController.method.cleanupResourcePolicies;
+    const step = newAuthorizeStep(method, authorizer);
+    const ctx = new RequestContext(
+      method.input,
+      create(method.input),
+      testCallerIdentity(),
+    );
+    await step.execute(ctx);
+    expect(checks).toEqual([
+      {
+        permission: IamPermission.can_bootstrap_iam,
+        resourceKind: ApiResourceKind.platform,
+        resourceId: "stigmer",
+      },
+    ]);
+  });
+});
+
+describe("mid-chain resolved-id checks (the ListVersions pattern)", () => {
+  it("a later step authorizes against the id a LOAD step resolved — deny maps to the wire", async () => {
+    // The pattern: position 1 authorized the request-shaped check; a
+    // mid-chain step re-checks against the RESOLVED resource once loading
+    // established what is actually being read. The two traced
+    // ListVersions handlers port onto exactly this shape (blueprint §5b).
+    const { authorizer, checks } = fakeAuthorizer({
+      kind: "deny",
+      reason: "caller cannot read the resolved skill",
+    });
+    const ctx = new RequestContext(
+      AgentSchema,
+      create(AgentSchema, { metadata: { name: "a", org: "acme" } }),
+      testCallerIdentity(),
+      ApiResourceKind.agent,
+    );
+    ctx.set("resolvedId", "skl_01resolved");
+
+    const midChainCheck = async () => {
+      const decision = await authorizer.authorize(ctx.callerIdentity, {
+        permission: IamPermission.can_view,
+        resourceKind: ApiResourceKind.skill,
+        resourceId: ctx.get("resolvedId") as string,
+      });
+      if (decision.kind === "deny") {
+        throw new ConnectError(decision.reason, Code.PermissionDenied);
+      }
+    };
+
+    const error = await midChainCheck().catch((e: unknown) => e);
+    expect(checks[0].resourceId).toBe("skl_01resolved");
+    expect((error as ConnectError).code).toBe(Code.PermissionDenied);
+  });
+});

--- a/backend/services/stigmer-server/src/pipeline/steps/authorize.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/authorize.ts
@@ -1,0 +1,199 @@
+/**
+ * Authorize — the ONE shared authorization step (O2, 20260827.01; DD-007
+ * §3), added explicitly as the FIRST .addStep of every pipeline chain
+ * (ruling Q1: visible and greppable — step order is OSS-owned contract,
+ * never hidden behind a chain-builder wrapper).
+ *
+ * The step reads the same declarative proto method options the Java
+ * edition's authorization step reads — `(ai.stigmer.commons.rpc.config)`,
+ * `is_public` (50057), `is_skip_authorization` (50058) — resolves the
+ * check target from the request, and maps the Authorizer's three decision
+ * arms to the wire:
+ *
+ *   allow       → the chain proceeds;
+ *   deny        → PERMISSION_DENIED, carrying the annotation's byte-pinned
+ *                 `error_msg` (the reason arm is the fallback copy);
+ *   unavailable → INTERNAL — an authorization-backend outage is NEVER
+ *                 softened into a denial (the verified Java StepResult
+ *                 lesson, DD-007's wire-visible contract).
+ *
+ * Skip arms, in order: the `internal` caller class (the in-process chain's
+ * own calls — the TS rendering of the Java in-process authorization skip,
+ * ruling Q4), `is_public`, `is_skip_authorization`, and methods carrying
+ * no config at all (no authorization requirement is declared; the O2
+ * coverage inventory records every such method, so C1/C2 inherit the map
+ * instead of discovering it).
+ *
+ * Resolution never throws: an unresolvable `field_path` yields an empty
+ * resource id and an unresolvable `resource_kind_path` yields the unknown
+ * kind — the check still reaches the Authorizer, which owns the decision.
+ * A thrown resolution would be a NEW wire behavior on requests that are
+ * legal today (byte-identity forbids it); an implementation that wants to
+ * refuse empty ids does so as a deny, visibly.
+ */
+import { Code, ConnectError } from "@connectrpc/connect";
+import type { DescMethod, DescMessage, Message } from "@bufbuild/protobuf";
+import { getOption, hasOption } from "@bufbuild/protobuf";
+
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { RpcAuthorizationConfig } from "@stigmer/protos/ai/stigmer/commons/rpc/authorization_config_pb";
+import {
+  config as rpcAuthorizationConfig,
+  is_public,
+  is_skip_authorization,
+} from "@stigmer/protos/ai/stigmer/commons/rpc/method_options_pb";
+
+import type { Authorizer, AuthzDecision } from "../../extensions/authorizer.js";
+import { internalError } from "../errors.js";
+import type { PipelineStep } from "../pipeline.js";
+import type { RequestContext } from "../request-context.js";
+
+/**
+ * The wire copy for the unavailable arm — static and sanitized (#478):
+ * the backend's real error rides ConnectError.cause into the server log,
+ * never to an anonymous caller.
+ */
+export const AUTHORIZATION_UNAVAILABLE_MESSAGE =
+  "authorization check could not be completed";
+
+/** The deny copy when the method's annotation carries no error_msg. */
+export const AUTHORIZATION_DENIED_FALLBACK_MESSAGE = "permission denied";
+
+/**
+ * The OSS default Authorizer: the permissive single-team posture (DD-007
+ * §3) — one trust domain, every authenticated caller may do everything,
+ * exactly the pre-O2 behavior. Installed by the composition root when no
+ * extension registers an Authorizer (the default lives with the consumer
+ * that defines its semantics — registry.ts contract).
+ */
+export function newPermissiveSingleTeamAuthorizer(): Authorizer {
+  return {
+    authorize(): Promise<AuthzDecision> {
+      return Promise.resolve({ kind: "allow" });
+    },
+  };
+}
+
+/**
+ * Builds the Authorize step for one RPC method. The descriptor comes in
+ * at construction (descriptors are static imports — the apiresource.ts
+ * idiom); the caller identity comes from the RequestContext at execution.
+ */
+export function newAuthorizeStep<Desc extends DescMessage>(
+  method: DescMethod,
+  authorizer: Authorizer,
+): PipelineStep<Desc> {
+  return {
+    name: "Authorize",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      if (ctx.callerIdentity.callerClass === "internal") {
+        return;
+      }
+      if (getOption(method, is_public) || getOption(method, is_skip_authorization)) {
+        return;
+      }
+      if (!hasOption(method, rpcAuthorizationConfig)) {
+        return;
+      }
+      const config = getOption(method, rpcAuthorizationConfig);
+
+      const decision = await runAuthorizer(authorizer, ctx, config);
+      switch (decision.kind) {
+        case "allow":
+          return;
+        case "deny":
+          throw new ConnectError(
+            config.errorMsg !== ""
+              ? config.errorMsg
+              : decision.reason !== ""
+                ? decision.reason
+                : AUTHORIZATION_DENIED_FALLBACK_MESSAGE,
+            Code.PermissionDenied,
+          );
+        case "unavailable":
+          throw internalError(decision.cause, AUTHORIZATION_UNAVAILABLE_MESSAGE);
+        default: {
+          const exhaustive: never = decision;
+          throw internalError(
+            new Error(`unknown decision ${JSON.stringify(exhaustive)}`),
+            AUTHORIZATION_UNAVAILABLE_MESSAGE,
+          );
+        }
+      }
+    },
+  };
+}
+
+/**
+ * An Authorizer that THROWS is an evaluation failure by definition —
+ * normalized into the unavailable arm so a buggy implementation can never
+ * soften an outage into a denial by accident.
+ */
+async function runAuthorizer<Desc extends DescMessage>(
+  authorizer: Authorizer,
+  ctx: RequestContext<Desc>,
+  config: RpcAuthorizationConfig,
+): Promise<AuthzDecision> {
+  try {
+    return await authorizer.authorize(ctx.callerIdentity, {
+      permission: config.permission,
+      resourceKind: resolveResourceKind(ctx.input, config),
+      resourceId: resolveResourceId(ctx.input, config),
+    });
+  } catch (error) {
+    return {
+      kind: "unavailable",
+      cause: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}
+
+/** Static kind, or the resource_kind_path read, or unknown — never a throw. */
+function resolveResourceKind(
+  input: Message,
+  config: RpcAuthorizationConfig,
+): ApiResourceKind {
+  if (config.resourceKindPath === "") {
+    return config.resourceKind;
+  }
+  const value = resolveDotPath(input, config.resourceKindPath);
+  return typeof value === "number"
+    ? (value as ApiResourceKind)
+    : ApiResourceKind.api_resource_kind_unknown;
+}
+
+/** Static resource_id, or the field_path read, or "" — never a throw. */
+function resolveResourceId(
+  input: Message,
+  config: RpcAuthorizationConfig,
+): string {
+  if (config.resourceId !== "") {
+    return config.resourceId;
+  }
+  if (config.fieldPath === "") {
+    return "";
+  }
+  const value = resolveDotPath(input, config.fieldPath);
+  return typeof value === "string" ? value : "";
+}
+
+/**
+ * Walks a proto-snake-case dot path ("metadata.org") over the generated
+ * message's camelCase properties. Undefined at any absent link — the
+ * caller maps that to its empty value.
+ */
+function resolveDotPath(input: Message, path: string): unknown {
+  let current: unknown = input;
+  for (const segment of path.split(".")) {
+    if (current === null || typeof current !== "object") {
+      return undefined;
+    }
+    current = (current as Record<string, unknown>)[snakeToCamel(segment)];
+  }
+  return current;
+}
+
+/** "agent_execution_id" → "agentExecutionId" (protobuf-es property names). */
+function snakeToCamel(segment: string): string {
+  return segment.replace(/_([a-z0-9])/g, (_, ch: string) => ch.toUpperCase());
+}

--- a/backend/services/stigmer-server/src/pipeline/steps/build-update-state.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/build-update-state.ts
@@ -25,17 +25,20 @@ import {
 import { internalError } from "../errors.js";
 import type { PipelineStep } from "../pipeline.js";
 import type { RequestContext } from "../request-context.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import {
+  auditActorFor,
   clearStatusField,
   creationAuditOf,
-  currentAuditActor,
   setAuditReflect,
   updatedAuditInfo,
 } from "./defaults.js";
 import { EXISTING_RESOURCE_KEY } from "./load-existing.js";
 import { hasStatusField, messageFieldByName, metadataOf } from "./shapes.js";
 
-export function newBuildUpdateStateStep<Desc extends DescMessage>(): PipelineStep<Desc> {
+export function newBuildUpdateStateStep<
+  Desc extends DescMessage,
+>(): PipelineStep<Desc> {
   return {
     name: "BuildUpdateState",
     execute(ctx: RequestContext<Desc>): void {
@@ -44,7 +47,9 @@ export function newBuildUpdateStateStep<Desc extends DescMessage>(): PipelineSte
         | undefined;
       if (existing === undefined) {
         throw internalError(
-          new Error("existing resource not found in context - LoadExisting must run first"),
+          new Error(
+            "existing resource not found in context - LoadExisting must run first",
+          ),
           "build update state",
         );
       }
@@ -60,7 +65,7 @@ export function newBuildUpdateStateStep<Desc extends DescMessage>(): PipelineSte
         // carried over — only audit gets refreshed below.
         clearStatusField(ctx.schema, merged);
         copyStatusFromExisting(ctx.schema, merged, existing);
-        updateAuditFields(ctx.schema, merged, existing);
+        updateAuditFields(ctx.schema, merged, existing, ctx.callerIdentity);
       }
 
       ctx.setNewState(merged);
@@ -77,7 +82,10 @@ function preserveImmutableFields(merged: Message, existing: Message): void {
   const mergedMeta = metadataOf(merged);
   const existingMeta = metadataOf(existing);
   if (mergedMeta === undefined || existingMeta === undefined) {
-    throw internalError(new Error("metadata is nil"), "preserve immutable fields");
+    throw internalError(
+      new Error("metadata is nil"),
+      "preserve immutable fields",
+    );
   }
   mergedMeta.id = existingMeta.id;
   mergedMeta.slug = existingMeta.slug;
@@ -113,10 +121,15 @@ function updateAuditFields(
   schema: DescMessage,
   resource: Message,
   existing: Message,
+  identity: CallerIdentity,
 ): void {
   const now = timestampNow();
-  const actor = currentAuditActor();
-  const { createdBy, createdAt } = creationAuditOf(schema, existing, "spec_audit");
+  const actor = auditActorFor(identity);
+  const { createdBy, createdAt } = creationAuditOf(
+    schema,
+    existing,
+    "spec_audit",
+  );
 
   setAuditReflect(
     schema,

--- a/backend/services/stigmer-server/src/pipeline/steps/defaults.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/defaults.ts
@@ -35,6 +35,7 @@ import type {
   ApiResourceAuditInfo,
 } from "@stigmer/protos/ai/stigmer/commons/apiresource/status_pb";
 
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { defaultVisibilityFor, getIdPrefix } from "../apiresource-meta.js";
 import { internalError } from "../errors.js";
 import type { PipelineStep } from "../pipeline.js";
@@ -47,14 +48,19 @@ import {
   metadataOf,
 } from "./shapes.js";
 
-export function newBuildNewStateStep<Desc extends DescMessage>(): PipelineStep<Desc> {
+export function newBuildNewStateStep<
+  Desc extends DescMessage,
+>(): PipelineStep<Desc> {
   return {
     name: "BuildNewState",
     execute(ctx: RequestContext<Desc>): void {
       const resource = ctx.newState;
       const metadata = metadataOf(resource);
       if (metadata === undefined) {
-        throw internalError(new Error("resource metadata is nil"), "build new state");
+        throw internalError(
+          new Error("resource metadata is nil"),
+          "build new state",
+        );
       }
 
       // 1. Clear the status field — system-managed, never client-provided.
@@ -67,9 +73,10 @@ export function newBuildNewStateStep<Desc extends DescMessage>(): PipelineStep<D
         metadata.id = generateId(getIdPrefix(ctx.apiResourceKind));
       }
 
-      // 3. Stamp both audit slots identically with event "created".
+      // 3. Stamp both audit slots identically with event "created",
+      // attributed to the request's caller (O2 ruling Q5).
       if (hasStatusField(ctx.schema)) {
-        setAuditFieldsForCreate(ctx.schema, resource);
+        setAuditFieldsForCreate(ctx.schema, resource, ctx.callerIdentity);
       }
 
       // 4. Default visibility from the kind's proto config when the client
@@ -97,14 +104,18 @@ export function clearStatusField(schema: DescMessage, msg: Message): void {
 
 /**
  * Go SetAuditFieldsForCreate: both slots identical, event "created". A
- * resource without a status (or audit) field is a no-op.
+ * resource without a status (or audit) field is a no-op. The actor is
+ * derived from the REQUEST's caller identity (O2 ruling Q5 — the
+ * DD-007 amendment): every call site holds a RequestContext, so audit
+ * attribution follows the caller, not a process-global.
  */
 export function setAuditFieldsForCreate(
   schema: DescMessage,
   resource: Message,
+  identity: CallerIdentity,
 ): void {
   const now = timestampNow();
-  const actor = currentAuditActor();
+  const actor = auditActorFor(identity);
   const info = create(ApiResourceAuditInfoSchema, {
     createdBy: actor,
     createdAt: now,
@@ -139,9 +150,10 @@ export function setAuditFieldsForUpdate(
   schema: DescMessage,
   resource: Message,
   slot: AuditSlot,
+  identity: CallerIdentity,
 ): void {
   const now = timestampNow();
-  const actor = currentAuditActor();
+  const actor = auditActorFor(identity);
   const { createdBy, createdAt } = creationAuditOf(schema, resource, slot);
   setAuditSlotReflect(
     schema,
@@ -152,11 +164,14 @@ export function setAuditFieldsForUpdate(
 }
 
 // Operator identity (stigmer/stigmer#400): installed once at boot — before
-// any request — and read on every audit stamp. The module-level seam is
-// Go's, kept deliberately: threading a boot-time constant through every
-// step constructor would be machinery without a beneficiary. The one-shot
-// guard adds the composition-root idiom's loudness: a second install is a
-// wiring bug and throws at boot, not a silent overwrite.
+// any request — and read by the identity chassis when it mints the
+// trusted-local CallerIdentity (O2; audit stamping now derives its actor
+// from that identity rather than reading this seam directly). The
+// module-level seam is Go's, kept deliberately: threading a boot-time
+// constant through every step constructor would be machinery without a
+// beneficiary. The one-shot guard adds the composition-root idiom's
+// loudness: a second install is a wiring bug and throws at boot, not a
+// silent overwrite.
 let operatorEmail = "";
 let operatorName = "";
 let operatorIdentityInstalled = false;
@@ -183,26 +198,41 @@ export function resetOperatorIdentityForTests(): void {
 }
 
 /**
- * Go currentAuditActor: a FRESH message per call (audit stamping shares
- * the returned reference across created_by/updated_by; a singleton would
- * alias unrelated resources' audit state).
- *
- * With a configured operator, every write this process makes is attributed
- * to that operator — a self-hosted install is a single-operator trust
- * domain. The id deliberately carries the email (no local identity
- * accounts exist to reference; downstream caller-identity resolution is
- * email-first). Unconfigured keeps the "system" placeholder, which the
- * runner deliberately demotes to anonymous (SYSTEM_CREATOR_SENTINEL).
+ * The installed operator identity, read by the verifier-chain chassis to
+ * mint the trusted-local CallerIdentity (O2): the single-operator trust
+ * domain's one principal. Empty email = unconfigured, the "system"
+ * placeholder posture. Audit stamping no longer reads this seam directly —
+ * it derives the actor from the request's CallerIdentity (ruling Q5),
+ * which for local postures carries exactly these values, so the stamped
+ * bytes are unchanged.
  */
-export function currentAuditActor(): ApiResourceAuditActor {
-  if (operatorEmail !== "") {
-    return create(ApiResourceAuditActorSchema, {
-      id: operatorEmail,
-      email: operatorEmail,
-      displayName: operatorName,
-    });
-  }
-  return create(ApiResourceAuditActorSchema, { id: "system", avatar: "" });
+export function operatorIdentitySnapshot(): {
+  email: string;
+  displayName: string;
+} {
+  return { email: operatorEmail, displayName: operatorName };
+}
+
+/**
+ * The audit actor derived from a caller identity (O2 ruling Q5 — replaces
+ * the retired process-global currentAuditActor). A FRESH message per call
+ * (audit stamping shares the returned reference across created_by/
+ * updated_by; a singleton would alias unrelated resources' audit state).
+ *
+ * For local postures the trusted-local identity carries the #400 operator
+ * identity, so the derived actor is byte-identical to what the retired
+ * seam stamped: configured operator → email-first id with display fields;
+ * unconfigured → the "system" placeholder, which the runner deliberately
+ * demotes to anonymous (SYSTEM_CREATOR_SENTINEL). Verifier-produced
+ * identities (O3's OIDC claims onward) stamp their own email/displayName
+ * when present, identityId alone otherwise.
+ */
+export function auditActorFor(identity: CallerIdentity): ApiResourceAuditActor {
+  return create(ApiResourceAuditActorSchema, {
+    id: identity.identityId,
+    email: identity.email ?? "",
+    displayName: identity.displayName ?? "",
+  });
 }
 
 /**
@@ -244,7 +274,8 @@ export function creationAuditOf(
       info?.createdBy !== undefined
         ? clone(ApiResourceAuditActorSchema, info.createdBy)
         : undefined,
-    createdAt: info?.createdAt !== undefined ? { ...info.createdAt } : undefined,
+    createdAt:
+      info?.createdAt !== undefined ? { ...info.createdAt } : undefined,
   };
 }
 

--- a/backend/services/stigmer-server/src/runnerauth/runnerauth.ts
+++ b/backend/services/stigmer-server/src/runnerauth/runnerauth.ts
@@ -6,15 +6,20 @@
  * caller — the same contract the cloud edition enforces — but the runner
  * still needs the real values to serve executions. Cloud distinguishes the
  * runner by the token_type claim of its platform-minted credential; OSS
- * has no authentication at all, so this module supplies the minimal
- * equivalent: the platform exchange mints a short-lived token bound to ONE
- * execution, and the EC handler decrypts only for a token whose binding
- * matches the requested ExecutionContext.
+ * ships no token VERIFIERS on its identity chassis (O2, 20260827.01 — the
+ * verifier chain exists but resolves every request to the trusted-local
+ * identity until O3 lands the first verifiers), so this module supplies
+ * the minimal equivalent: the platform exchange mints a short-lived token
+ * bound to ONE execution, and the EC handler decrypts only for a token
+ * whose binding matches the requested ExecutionContext.
  *
- * A LANE DISCRIMINATOR, NOT A TRUST BOUNDARY (DD-004): single-user OSS has
- * no identity to verify — anyone who can reach the server can mint. What
- * the token buys is the redaction-by-default read contract converging with
- * cloud, on top of oss#405's encryption at rest.
+ * A LANE DISCRIMINATOR, NOT A TRUST BOUNDARY (DD-004): in the trusted-local
+ * posture anyone who can reach the server can mint. What the token buys is
+ * the redaction-by-default read contract converging with cloud, on top of
+ * oss#405's encryption at rest. It is deliberately NOT an IdentityVerifier
+ * on the chassis: presenting it must never change the caller's identity
+ * (the Q6 fall-through keeps the runner's Bearer-on-every-RPC behavior
+ * byte-identical), only unlock this one decrypt lane.
  *
  * Token shape (field names are wire contract — the runner's
  * token-claims.ts reads token_type by name):

--- a/backend/services/stigmer-server/src/temporal/agentexecution/__tests__/activities.test.ts
+++ b/backend/services/stigmer-server/src/temporal/agentexecution/__tests__/activities.test.ts
@@ -14,6 +14,7 @@
  *     error-over-result precedence — the DD-001 lane Go cannot deliver
  *     (oss#861), so the ERROR path is the load-bearing assertion.
  */
+import { newPermissiveSingleTeamAuthorizer } from "../../../pipeline/steps/authorize.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -92,6 +93,7 @@ function newFixture() {
     store,
     logger: silentLogger,
     broker,
+    authorizer: newPermissiveSingleTeamAuthorizer(),
     client: () => stubClient,
   });
   return { store, broker, activities, completions };

--- a/backend/services/stigmer-server/src/temporal/agentexecution/activities.ts
+++ b/backend/services/stigmer-server/src/temporal/agentexecution/activities.ts
@@ -41,6 +41,8 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import type { Logger } from "../../boot/logger.js";
 import type { StreamBroker } from "../../domain/agentexecution/stream-broker.js";
 import { updateStatus } from "../../domain/agentexecution/update-status.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
+import { trustedLocalIdentity } from "../../pipeline/interceptors/auth.js";
 import {
   DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME,
   deleteExecutionContextForExecution,
@@ -57,6 +59,8 @@ export interface AgentExecutionActivityDeps {
   readonly store: Store;
   readonly logger: Logger;
   readonly broker: StreamBroker;
+  /** The composed Authorizer, required by the status-merge updateStatus pipeline (O2). */
+  readonly authorizer: Authorizer;
   /** Live Temporal client (reads the manager's CURRENT client). */
   readonly client: () => Client;
 }
@@ -81,7 +85,7 @@ export interface CompleteExternalActivityInput {
 export function createAgentExecutionActivities(
   deps: AgentExecutionActivityDeps,
 ): Record<string, (...args: never[]) => Promise<unknown>> {
-  const { store, logger, broker } = deps;
+  const { store, logger, broker, authorizer } = deps;
 
   return {
     /**
@@ -95,12 +99,17 @@ export function createAgentExecutionActivities(
       statusJson: JsonValue,
     ): Promise<void> => {
       const status = fromJson(AgentExecutionStatusSchema, statusJson);
+      // The worker is the server process acting as itself — no wire
+      // request exists here, so the trusted-local operator identity is
+      // the one honest principal (O2; audit bytes unchanged: the derived
+      // actor equals the pre-O2 process-global operator actor).
       await updateStatus(
-        { store, logger, broker },
+        { store, logger, broker, authorizer },
         create(AgentExecutionUpdateStatusInputSchema, {
           executionId,
           status,
         }),
+        trustedLocalIdentity(),
       );
     },
 

--- a/backend/services/stigmer-server/src/temporal/agentexecution/worker.ts
+++ b/backend/services/stigmer-server/src/temporal/agentexecution/worker.ts
@@ -25,6 +25,7 @@ import type { Logger } from "../../boot/logger.js";
 import type { AgentExecutionTemporalConfig } from "../../domain/agentexecution/temporal/config.js";
 import type { StreamBroker } from "../../domain/agentexecution/stream-broker.js";
 import type { Store } from "../../store/interface.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
 import type { WorkerFactory } from "../manager.js";
 import { resolveWorkflowSource } from "../workflow-source.js";
 import { createAgentExecutionActivities } from "./activities.js";
@@ -33,6 +34,8 @@ export interface AgentExecutionWorkerDeps {
   readonly store: Store;
   readonly logger: Logger;
   readonly broker: StreamBroker;
+  /** The composed Authorizer — the status-merge activity's updateStatus pipeline carries the Authorize step like every chain (O2). */
+  readonly authorizer: Authorizer;
   readonly temporalConfig: AgentExecutionTemporalConfig;
 }
 
@@ -44,6 +47,7 @@ export function newAgentExecutionWorkerFactory(
       store: deps.store,
       logger: deps.logger,
       broker: deps.broker,
+      authorizer: deps.authorizer,
       client,
     });
 
@@ -77,9 +81,7 @@ export function newAgentExecutionWorkerFactory(
       // The decode-only codec chain: workflow tasks replay history
       // containing runner-encrypted activity results (manager.ts's
       // choke-point note).
-      ...(payloadCodecs.length > 0
-        ? { dataConverter: { payloadCodecs } }
-        : {}),
+      ...(payloadCodecs.length > 0 ? { dataConverter: { payloadCodecs } } : {}),
     });
   };
 }


### PR DESCRIPTION
## Summary

O2 of the cloud-TS-convergence program (20260826.02): the identity and authorization foundation the cloud composition plugs into. The pass-through auth interceptor becomes the ordered verifier-chain chassis producing an explicit `CallerIdentity` for every request; the identity threads into every controller's `RequestContext` as a required constructor parameter; one shared `Authorize` step runs at position 1 of every pipeline chain, reading the `RpcAuthorizationConfig` / `is_public` / `is_skip_authorization` proto method options with the three-arm decision mapping; and the audit-actor seam derives from the caller identity. OSS ships ZERO verifiers plus the permissive single-team `Authorizer` default — which is what makes byte-identity provable.

## Context

Blueprint 03 §11 items 3 (threading) + 4; binding design DD-007; all six plan-gate rulings (Q1–Q6) in the sub-project's `T01_1_review.md` implemented as ratified. This is the invasive-exactly-once work the program pre-named: O3 (API tokens + OIDC), O4 (gate slots), and C1/C2 (cloud boot, IAM/FGA) all build on these seams.

## Changes

- **Verifier chassis** (`pipeline/interceptors/auth.ts`): ordered claim-or-pass walk over the registry's `identityVerifiers`; trusted-local single-user identity (minted from the #400 operator seam) as an explicit modeled state; conditional strictness per ruling Q6 — zero verifiers = silent fall-through for unclaimed tokens (the runner's Bearer-on-every-RPC behavior is untouched), any verifier configured = unclaimed is UNAUTHENTICATED. Covers unary and streams.
- **Internal caller class** (ruling Q4): the in-process transport's own position-1 interceptor stamps `internal` — mintable ONLY there; the serving chain always overwrites from the wire, so spoofing is structurally impossible. The Authorize step treats it as the Java in-process authorization skip.
- **Identity threading** (ruling Q3): `RequestContext` takes the caller identity as a REQUIRED constructor parameter — the compiler enumerated all 163 construction sites across 31 files (plus 18 test sites) as the acceptance checklist; every controller reads it exactly once via `callerIdentityOf(ctx)`, which fails loudly if position 1 did not stamp.
- **Authorize step** (`pipeline/steps/authorize.ts`, ruling Q1): the explicit FIRST `.addStep` of every one of the 163 pipeline chains (verified mechanically: zero exceptions). Three-arm wire mapping — allow; deny → PERMISSION_DENIED carrying the annotation's byte-pinned `error_msg`; unavailable → INTERNAL, never a softened denial (a throwing Authorizer is normalized to unavailable). Check-target resolution never throws (absent field = empty id — a resolution throw would be new wire behavior on legal requests). Shared pipelines take the authorizing descriptor from their caller (lifecycle helpers, skill push) so delegating RPCs authorize under their OWN annotation.
- **Permissive single-team default**: installed by the composition root when no extension registers an Authorizer; the cloud composition registers OpenFGA through the O1 registry point.
- **Audit-actor seam** (ruling Q5, the ratified DD-007 amendment): `CallerIdentity` gains optional email/displayName; `setAuditFieldsForCreate/ForUpdate` take the identity; `auditActorFor(identity)` replaces the process-global `currentAuditActor()` with byte-identical derivation for local postures.
- **Coverage inventory** (ruling Q2): `docs/authorization-coverage.md` — a permanent artifact classifying all 27 registered services and 227 RPC methods (173 chain-with-Authorize, 54 direct with documented postures; 136 config / 71 skip-auth / 2 public / 18 none annotations), the four HTTP lanes, the artifact file server, and the 30 config-annotated direct handlers C1/C2 must resolve against FGA.
- **Doctrine sweep**: the intent headers O2 falsifies updated (`inprocess.ts`, `runnerauth.ts`, `resolve-values-for-caller.ts`, `chain.ts`, `compose.ts`, `defaults.ts`); the executioncontext bearer parser now delegates to the chassis's one shared `parseBearerToken`.

## Implementation notes

- The Q6 ruling pins strictness for PRESENTED tokens; the absent-token-with-verifiers-configured arm deliberately falls to trusted-local with an intent-header note that the require-authentication posture is O3's ruling (unreachable in every shipped OSS composition).
- The Temporal worker's status-merge activity calls `updateStatus` with `trustedLocalIdentity()` — the process acting as its operator; audit bytes unchanged. The internal class was deliberately NOT used there (Q4 reserves it to the in-process chain).
- Formatting: the ~65 touched files are prettier-normalized against the repo `.prettierrc` (their committed >80-column imports predated enforcement); untouched files were left exactly as committed.

## Breaking changes

- None on the wire (all four conformance rosters byte-identical). For embedders of `@stigmer/server` internals: `RequestContext` now requires the caller identity, `buildInterceptorChain` requires a position-1 identity source, and `setAuditFieldsForCreate/ForUpdate` take the identity — all compile-time-visible.

## Test plan

- All four conformance rosters green, byte-identical to baseline: `local` 492 passed / 1 skipped, `local-postgres` 492 / 1, `local-execution` 160 / 1, `local-postgres-execution` 160 / 1 (Node 22.22.1, throwaway Postgres 16 via `make postgres-dev`).
- Full unit suite: 1806 passed / 0 failed; `tsc --noEmit` clean; prettier clean on touched files.
- New suites: `interceptors/__tests__/auth.test.ts` (verifier walk claim/pass/throw/fallback, both Q6 postures byte-pinned, trusted-local in both operator postures, internal-class wire-unmintability, bearer parser shapes) and `steps/__tests__/authorize.test.ts` (both wire arms pinned including the annotation's exact deny copy, throwing-authorizer normalization, all four skip arms with real descriptors, field_path/static-resource_id/absent-field resolution, the mid-chain resolved-id pattern the ListVersions handlers port onto).
- The runner-token redaction-as-success contract is pinned by the pre-existing executioncontext suite (malformed/forged/expired/cross-execution tokens), now running through the new chain.

## Risks

- The chassis and Authorize step are live on every request path; the permissive default preserves today's decisions, and the conformance matrix pins the wire. Rollback is a revert — no data or schema changes.

## Checklist

- [x] Docs updated (`docs/authorization-coverage.md`; intent headers)
- [x] Tests added/updated
- [x] Backward compatible on the wire (conformance-pinned)

Made with [Cursor](https://cursor.com)