### PR TITLE
feat(backend/stigmer-server): export the document-catalog and R2 driver seams (C1)

### DIFF
--- a/backend/services/stigmer-server/src/artifactstorage/r2-storage.ts
+++ b/backend/services/stigmer-server/src/artifactstorage/r2-storage.ts
@@ -60,6 +60,19 @@ export interface R2Clients {
   readonly presign: typeof presignGetObject;
 }
 
+/**
+ * The exported R2 driver constructor (C1 seam, 20260827.04): a composition
+ * registers R2-backed drivers with ITS OWN config — the cloud's verified
+ * shape is distinct buckets/credentials per domain (blueprint §6b) — while
+ * the S3 plumbing, presign clamp, and not-found mapping live exactly once
+ * here. Loud-fail: the required-config throws below fire at driver
+ * construction, which the registered lazy factory defers to first use of
+ * the named driver (the factory contract in drivers.ts).
+ */
+export function newR2ArtifactStorage(config: R2StorageConfig): ArtifactStorage {
+  return new R2ArtifactStorage(config);
+}
+
 export class R2ArtifactStorage implements ArtifactStorage {
   private readonly client: S3Client;
   private readonly presign: typeof presignGetObject;

--- a/backend/services/stigmer-server/src/domain/workflow/registry/__tests__/document-catalog.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/registry/__tests__/document-catalog.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Document-catalog unit tests, pinning the exported seam the C1 cloud
+ * composition builds its DB-resident provider on (20260827.04): the
+ * loud-fail constructor contract, and — through the constructor, the way a
+ * composition consumes it — the interpretation rules the extraction moved
+ * out of ModelRegistryStore (sanity gate, api-id acceptance, tri-state
+ * capabilities, sorted suggestion pools). The store's own suite keeps
+ * pinning the same rules through the delegation path, so a divergence
+ * between the two surfaces fails one of the two files.
+ */
+import { describe, expect, it } from "vitest";
+
+import { newModelCatalogProviderFromDocument } from "../document-catalog.js";
+
+const DOCUMENT = JSON.stringify({
+  models: [
+    {
+      id: "anthropic/claude",
+      harness: "native",
+      apiModelId: "claude-x",
+      pricingVariants: { fast: { input: 1 } },
+      capabilities: { thinking: true },
+    },
+    { id: "openai/gpt", harness: "native" },
+    { id: "anthropic/claude", harness: "cursor" },
+    // A section divider: no id/harness, indexes nothing.
+    { $comment: "---- cursor models ----" },
+    // Tri-state rule: false and non-boolean values declare nothing.
+    {
+      id: "meta/llama",
+      harness: "native",
+      capabilities: { thinking: false, vision: "yes" },
+    },
+  ],
+});
+
+describe("newModelCatalogProviderFromDocument", () => {
+  it("throws on an unparseable document", () => {
+    expect(() => newModelCatalogProviderFromDocument("not json")).toThrow(
+      "model-registry document is invalid or indexes no models",
+    );
+  });
+
+  it("throws on a parseable document that indexes no models", () => {
+    expect(() =>
+      newModelCatalogProviderFromDocument(
+        JSON.stringify({ models: [{ $comment: "dividers only" }] }),
+      ),
+    ).toThrow("model-registry document is invalid or indexes no models");
+  });
+
+  it("serves the exact document bytes it was built from", () => {
+    const catalog = newModelCatalogProviderFromDocument(DOCUMENT);
+    expect(catalog.document()).toBe(DOCUMENT);
+  });
+
+  it("validates canonical ids and provider api ids per harness", () => {
+    const catalog = newModelCatalogProviderFromDocument(DOCUMENT);
+    expect(catalog.isValidModel("native", "anthropic/claude")).toBe(true);
+    expect(catalog.isValidModel("native", "claude-x")).toBe(true);
+    expect(catalog.isValidModel("cursor", "claude-x")).toBe(false);
+    expect(catalog.isValidModelOnAnyHarness("anthropic/claude")).toBe(true);
+    expect(catalog.isValidModelOnAnyHarness("unknown/model")).toBe(false);
+    expect(catalog.hasHarness("native")).toBe(true);
+    expect(catalog.hasHarness("java")).toBe(false);
+    expect(catalog.hasAnyModels()).toBe(true);
+  });
+
+  it("answers sorted canonical suggestion pools without api ids", () => {
+    const catalog = newModelCatalogProviderFromDocument(DOCUMENT);
+    expect(catalog.canonicalModels("native")).toEqual([
+      "anthropic/claude",
+      "meta/llama",
+      "openai/gpt",
+    ]);
+    expect(catalog.canonicalModelsAcrossHarnesses()).toEqual([
+      "anthropic/claude",
+      "meta/llama",
+      "openai/gpt",
+    ]);
+  });
+
+  it("indexes pricing variants by key set, any-harness and per-harness", () => {
+    const catalog = newModelCatalogProviderFromDocument(DOCUMENT);
+    expect(catalog.hasPricingVariant("anthropic/claude", "fast")).toBe(true);
+    expect(catalog.hasPricingVariant("openai/gpt", "fast")).toBe(false);
+    expect(
+      catalog.hasPricingVariantForHarness("native", "claude-x", "fast"),
+    ).toBe(true);
+    expect(
+      catalog.hasPricingVariantForHarness("cursor", "anthropic/claude", "fast"),
+    ).toBe(false);
+    expect(catalog.canonicalModelsWithVariant("fast")).toEqual([
+      "anthropic/claude",
+    ]);
+    expect(
+      catalog.canonicalModelsWithVariantForHarness("native", "fast"),
+    ).toEqual(["anthropic/claude"]);
+  });
+
+  it("declares capabilities only on literal true (tri-state rule)", () => {
+    const catalog = newModelCatalogProviderFromDocument(DOCUMENT);
+    expect(
+      catalog.hasCapabilityForHarness("native", "anthropic/claude", "thinking"),
+    ).toBe(true);
+    expect(
+      catalog.hasCapabilityForHarness("native", "meta/llama", "thinking"),
+    ).toBe(false);
+    expect(
+      catalog.hasCapabilityForHarness("native", "meta/llama", "vision"),
+    ).toBe(false);
+    expect(
+      catalog.canonicalModelsWithCapabilityForHarness("native", "thinking"),
+    ).toEqual(["anthropic/claude"]);
+  });
+});

--- a/backend/services/stigmer-server/src/domain/workflow/registry/document-catalog.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/registry/document-catalog.ts
@@ -1,0 +1,355 @@
+/**
+ * Document-driven ModelCatalogProvider — the registry-document
+ * interpretation extracted from ModelRegistryStore (C1 seam request,
+ * 20260827.04; DD-008's "validation logic stays OSS and edition-neutral"
+ * applied to the interpretation itself).
+ *
+ * Why the extraction exists: a composition whose catalog comes from
+ * somewhere other than the bundled-snapshot-plus-upstream-refresh
+ * lifecycle (the cloud's DB-resident operator baseline) still needs the
+ * IDENTICAL document semantics — the sanity gate, apiModelId acceptance,
+ * the tri-state capability rule, the sorted suggestion pools. Before this
+ * module those semantics were private to ModelRegistryStore, so any other
+ * provider implementation had to fork them and drift silently. Now the
+ * interpretation lives here exactly once: ModelRegistryStore delegates to
+ * it per document swap, and compositions build their own providers from
+ * documents via newModelCatalogProviderFromDocument (exported through the
+ * DD-005 map).
+ *
+ * The interpretation is byte-identical to the pre-extraction store (which
+ * ported Go's applyDocument, model_registry_store.go:302-412): both
+ * canonical ids and provider api ids validate (oss#240); pricing-variant
+ * VALUES are not modeled, only the key set; capability values declare
+ * only on literal `true` (the tri-state rule — absence is "unknown").
+ */
+import type { ModelCatalogProvider } from "./model-catalog-provider.js";
+
+/**
+ * The subset of a registry entry the catalog indexes (Go
+ * modelRegistryEntry). See the module header for the acceptance rules.
+ */
+interface ModelRegistryEntry {
+  id?: unknown;
+  harness?: unknown;
+  apiModelId?: unknown;
+  pricingVariants?: Record<string, unknown>;
+  capabilities?: Record<string, unknown>;
+}
+
+/** The derived valid-model indexes, built once per document. */
+interface RegistryIndexes {
+  /** harness → model reference (canonical or api id) → true. */
+  modelsByHarness: Map<string, Set<string>>;
+  /** harness → sorted canonical ids (suggestion pools; may repeat a
+   *  duplicated document entry, exactly as Go's per-harness list does). */
+  sortedModelsByHarness: Map<string, string[]>;
+  /** variant → harness → model reference → true (oss#357). */
+  modelsByVariant: Map<string, Map<string, Set<string>>>;
+  /** variant → sorted deduped canonical ids across harnesses. */
+  sortedModelsByVariant: Map<string, string[]>;
+  /** variant → harness → sorted canonical ids. */
+  sortedModelsByVariantHarness: Map<string, Map<string, string[]>>;
+  /** capability → harness → model reference → true (oss#772). */
+  modelsByCapability: Map<string, Map<string, Set<string>>>;
+  /** capability → harness → sorted canonical ids. */
+  sortedModelsByCapabilityHarness: Map<string, Map<string, string[]>>;
+}
+
+/**
+ * A ModelCatalogProvider over one parsed document. Immutable after
+ * construction — a source with a refresh lifecycle (ModelRegistryStore's
+ * hourly upstream pull, a DB-resident baseline's reload) builds a fresh
+ * catalog per accepted document and swaps atomically, so a reader never
+ * sees a document whose indexes describe a different registry.
+ */
+export class DocumentModelCatalog implements ModelCatalogProvider {
+  private constructor(
+    private readonly registryDocument: string,
+    private readonly indexes: RegistryIndexes,
+  ) {}
+
+  /**
+   * Builds a catalog, or undefined when the document fails the sanity
+   * gate: it must parse AND index at least one model entry ($comment
+   * section dividers carry no id/harness and index nothing, so a
+   * divider-only document is as unusable as an empty one).
+   */
+  static tryBuild(document: string): DocumentModelCatalog | undefined {
+    const indexes = buildIndexes(document);
+    if (indexes === undefined) {
+      return undefined;
+    }
+    return new DocumentModelCatalog(document, indexes);
+  }
+
+  document(): string {
+    return this.registryDocument;
+  }
+
+  isValidModel(harness: string, model: string): boolean {
+    return this.indexes.modelsByHarness.get(harness)?.has(model) ?? false;
+  }
+
+  hasHarness(harness: string): boolean {
+    return (this.indexes.modelsByHarness.get(harness)?.size ?? 0) > 0;
+  }
+
+  hasAnyModels(): boolean {
+    return this.indexes.modelsByHarness.size > 0;
+  }
+
+  isValidModelOnAnyHarness(model: string): boolean {
+    for (const models of this.indexes.modelsByHarness.values()) {
+      if (models.has(model)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /** Computed per call (refusal-path only). */
+  canonicalModelsAcrossHarnesses(): string[] {
+    const seen = new Set<string>();
+    for (const models of this.indexes.sortedModelsByHarness.values()) {
+      for (const name of models) {
+        seen.add(name);
+      }
+    }
+    return [...seen].sort();
+  }
+
+  canonicalModels(harness: string): string[] {
+    return this.indexes.sortedModelsByHarness.get(harness) ?? [];
+  }
+
+  hasPricingVariant(model: string, variant: string): boolean {
+    const byHarness = this.indexes.modelsByVariant.get(variant);
+    if (byHarness === undefined) {
+      return false;
+    }
+    for (const refs of byHarness.values()) {
+      if (refs.has(model)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  hasPricingVariantForHarness(
+    harness: string,
+    model: string,
+    variant: string,
+  ): boolean {
+    return (
+      this.indexes.modelsByVariant.get(variant)?.get(harness)?.has(model) ??
+      false
+    );
+  }
+
+  canonicalModelsWithVariant(variant: string): string[] {
+    return this.indexes.sortedModelsByVariant.get(variant) ?? [];
+  }
+
+  canonicalModelsWithVariantForHarness(
+    harness: string,
+    variant: string,
+  ): string[] {
+    return (
+      this.indexes.sortedModelsByVariantHarness.get(variant)?.get(harness) ?? []
+    );
+  }
+
+  hasCapabilityForHarness(
+    harness: string,
+    model: string,
+    capability: string,
+  ): boolean {
+    return (
+      this.indexes.modelsByCapability.get(capability)?.get(harness)?.has(model) ??
+      false
+    );
+  }
+
+  canonicalModelsWithCapabilityForHarness(
+    harness: string,
+    capability: string,
+  ): string[] {
+    return (
+      this.indexes.sortedModelsByCapabilityHarness
+        .get(capability)
+        ?.get(harness) ?? []
+    );
+  }
+}
+
+/**
+ * The exported constructor (DD-005 map): a provider over one document,
+ * for compositions whose catalog source is their own (the cloud's
+ * DB-resident baseline). Loud-fail by contract — a document that fails
+ * the sanity gate throws, because a composition-supplied catalog that
+ * indexes nothing is a wiring bug, not a degraded mode (the bundled-
+ * snapshot fallback is ModelRegistryStore's lifecycle, not this one's).
+ */
+export function newModelCatalogProviderFromDocument(
+  document: string,
+): ModelCatalogProvider {
+  const catalog = DocumentModelCatalog.tryBuild(document);
+  if (catalog === undefined) {
+    throw new Error(
+      "model-registry document is invalid or indexes no models",
+    );
+  }
+  return catalog;
+}
+
+/**
+ * Parses a registry document and derives the valid-model indexes — the TS
+ * half of Go's applyDocument (:302-412). Returns undefined when the
+ * document fails the sanity gate.
+ */
+function buildIndexes(document: string): RegistryIndexes | undefined {
+  let parsed: { models?: unknown };
+  try {
+    parsed = JSON.parse(document) as { models?: unknown };
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(parsed.models)) {
+    return undefined;
+  }
+
+  const modelsByHarness = new Map<string, Set<string>>();
+  const sortedModelsByHarness = new Map<string, string[]>();
+  const modelsByVariant = new Map<string, Map<string, Set<string>>>();
+  // Set-backed: the same canonical id may price a variant under more than
+  // one harness, and the union list must not repeat it.
+  const canonicalByVariantSet = new Map<string, Set<string>>();
+  const sortedModelsByVariantHarness = new Map<string, Map<string, string[]>>();
+  const modelsByCapability = new Map<string, Map<string, Set<string>>>();
+  const sortedModelsByCapabilityHarness = new Map<
+    string,
+    Map<string, string[]>
+  >();
+
+  for (const raw of parsed.models as ModelRegistryEntry[]) {
+    if (raw === null || typeof raw !== "object") {
+      continue;
+    }
+    const id = typeof raw.id === "string" ? raw.id : "";
+    const harness = typeof raw.harness === "string" ? raw.harness : "";
+    if (id === "" || harness === "") {
+      continue;
+    }
+    const apiModelId =
+      typeof raw.apiModelId === "string" ? raw.apiModelId : "";
+
+    mapSet(modelsByHarness, harness).add(id);
+    mapList(sortedModelsByHarness, harness).push(id);
+    if (apiModelId !== "") {
+      mapSet(modelsByHarness, harness).add(apiModelId);
+    }
+
+    if (raw.pricingVariants !== null && typeof raw.pricingVariants === "object") {
+      for (const variant of Object.keys(raw.pricingVariants)) {
+        const byHarness = mapMap(modelsByVariant, variant);
+        mapSet(byHarness, harness).add(id);
+        if (apiModelId !== "") {
+          mapSet(byHarness, harness).add(apiModelId);
+        }
+        mapSet(canonicalByVariantSet, variant).add(id);
+        mapList(mapMapList(sortedModelsByVariantHarness, variant), harness).push(id);
+      }
+    }
+
+    if (raw.capabilities !== null && typeof raw.capabilities === "object") {
+      for (const [capability, value] of Object.entries(raw.capabilities)) {
+        // Only literal `true` declares the capability; false, null, or a
+        // future non-boolean shape indexes nothing (tri-state rule:
+        // absence is "unknown", never a claim either way).
+        if (value !== true) {
+          continue;
+        }
+        const byHarness = mapMap(modelsByCapability, capability);
+        mapSet(byHarness, harness).add(id);
+        if (apiModelId !== "") {
+          mapSet(byHarness, harness).add(apiModelId);
+        }
+        mapList(mapMapList(sortedModelsByCapabilityHarness, capability), harness).push(id);
+      }
+    }
+  }
+
+  if (modelsByHarness.size === 0) {
+    return undefined;
+  }
+
+  for (const ids of sortedModelsByHarness.values()) {
+    ids.sort();
+  }
+  const sortedModelsByVariant = new Map<string, string[]>();
+  for (const [variant, idSet] of canonicalByVariantSet) {
+    sortedModelsByVariant.set(variant, [...idSet].sort());
+  }
+  for (const byHarness of sortedModelsByVariantHarness.values()) {
+    for (const ids of byHarness.values()) {
+      ids.sort();
+    }
+  }
+  for (const byHarness of sortedModelsByCapabilityHarness.values()) {
+    for (const ids of byHarness.values()) {
+      ids.sort();
+    }
+  }
+
+  return {
+    modelsByHarness,
+    sortedModelsByHarness,
+    modelsByVariant,
+    sortedModelsByVariant,
+    sortedModelsByVariantHarness,
+    modelsByCapability,
+    sortedModelsByCapabilityHarness,
+  };
+}
+
+function mapSet(m: Map<string, Set<string>>, key: string): Set<string> {
+  let v = m.get(key);
+  if (v === undefined) {
+    v = new Set();
+    m.set(key, v);
+  }
+  return v;
+}
+
+function mapList(m: Map<string, string[]>, key: string): string[] {
+  let v = m.get(key);
+  if (v === undefined) {
+    v = [];
+    m.set(key, v);
+  }
+  return v;
+}
+
+function mapMap(
+  m: Map<string, Map<string, Set<string>>>,
+  key: string,
+): Map<string, Set<string>> {
+  let v = m.get(key);
+  if (v === undefined) {
+    v = new Map();
+    m.set(key, v);
+  }
+  return v;
+}
+
+function mapMapList(
+  m: Map<string, Map<string, string[]>>,
+  key: string,
+): Map<string, string[]> {
+  let v = m.get(key);
+  if (v === undefined) {
+    v = new Map();
+    m.set(key, v);
+  }
+  return v;
+}

--- a/backend/services/stigmer-server/src/domain/workflow/registry/model-registry-store.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/registry/model-registry-store.ts
@@ -23,8 +23,14 @@
  * Since O5 (20260827.02) this class is the OSS implementation of the
  * ModelCatalogProvider seam (DD-008) — consumers hold the interface; the
  * refresh lifecycle below stays composition-owned, outside the contract.
+ * The document INTERPRETATION (sanity gate, indexes, the query methods)
+ * lives in document-catalog.ts since the C1 seam extraction (20260827.04):
+ * this class owns only the bundled/upstream lifecycle and delegates every
+ * read to the current DocumentModelCatalog, swapped atomically per
+ * accepted document.
  */
 import type { Logger } from "../../../boot/logger.js";
+import { DocumentModelCatalog } from "./document-catalog.js";
 import type { ModelCatalogProvider } from "./model-catalog-provider.js";
 
 /** Upstream refresh cadence (Go modelRegistryRefreshInterval, :34). */
@@ -67,45 +73,8 @@ export interface ModelRegistryStoreOptions {
   fetchImpl?: typeof fetch;
 }
 
-/**
- * The subset of a registry entry the store indexes (Go modelRegistryEntry).
- * Both canonical ids and provider api ids are accepted as valid references
- * because the runner resolves canonical ids via the registry and passes
- * unknown-but-registered api ids to the provider verbatim (oss#240).
- * Pricing-variant VALUES are deliberately not modeled — only the key set
- * matters for capability; capability values are checked for literal `true`
- * only (the tri-state rule: absence is "unknown", never a claim either way).
- */
-interface ModelRegistryEntry {
-  id?: unknown;
-  harness?: unknown;
-  apiModelId?: unknown;
-  pricingVariants?: Record<string, unknown>;
-  capabilities?: Record<string, unknown>;
-}
-
-/** The derived valid-model indexes, swapped atomically per document. */
-interface RegistryIndexes {
-  /** harness → model reference (canonical or api id) → true. */
-  modelsByHarness: Map<string, Set<string>>;
-  /** harness → sorted canonical ids (suggestion pools; may repeat a
-   *  duplicated document entry, exactly as Go's per-harness list does). */
-  sortedModelsByHarness: Map<string, string[]>;
-  /** variant → harness → model reference → true (oss#357). */
-  modelsByVariant: Map<string, Map<string, Set<string>>>;
-  /** variant → sorted deduped canonical ids across harnesses. */
-  sortedModelsByVariant: Map<string, string[]>;
-  /** variant → harness → sorted canonical ids. */
-  sortedModelsByVariantHarness: Map<string, Map<string, string[]>>;
-  /** capability → harness → model reference → true (oss#772). */
-  modelsByCapability: Map<string, Map<string, Set<string>>>;
-  /** capability → harness → sorted canonical ids. */
-  sortedModelsByCapabilityHarness: Map<string, Map<string, string[]>>;
-}
-
 export class ModelRegistryStore implements ModelCatalogProvider {
-  private currentDocument: string;
-  private indexes: RegistryIndexes;
+  private currentCatalog: DocumentModelCatalog;
   private refreshTimer: NodeJS.Timeout | undefined;
   private failureLogged = false;
   private readonly options: ModelRegistryStoreOptions;
@@ -114,20 +83,19 @@ export class ModelRegistryStore implements ModelCatalogProvider {
     // A broken bundled snapshot is a build defect, not a runtime condition:
     // fail loud at construction rather than serving an empty registry
     // (Go log.Fatal in Store()).
-    const indexes = buildIndexes(options.bundledDocument);
-    if (indexes === undefined) {
+    const catalog = DocumentModelCatalog.tryBuild(options.bundledDocument);
+    if (catalog === undefined) {
       throw new Error(
         "bundled model-registry snapshot is invalid or indexes no models",
       );
     }
-    this.currentDocument = options.bundledDocument;
-    this.indexes = indexes;
+    this.currentCatalog = catalog;
     this.options = options;
   }
 
   /** The served bytes; always complete and valid by construction. */
   document(): string {
-    return this.currentDocument;
+    return this.currentCatalog.document();
   }
 
   /**
@@ -135,12 +103,12 @@ export class ModelRegistryStore implements ModelCatalogProvider {
    * executable on the given harness.
    */
   isValidModel(harness: string, model: string): boolean {
-    return this.indexes.modelsByHarness.get(harness)?.has(model) ?? false;
+    return this.currentCatalog.isValidModel(harness, model);
   }
 
   /** Whether the registry knows any models for a harness. */
   hasHarness(harness: string): boolean {
-    return (this.indexes.modelsByHarness.get(harness)?.size ?? 0) > 0;
+    return this.currentCatalog.hasHarness(harness);
   }
 
   /**
@@ -148,7 +116,7 @@ export class ModelRegistryStore implements ModelCatalogProvider {
    * rather than rejecting everything when it did not.
    */
   hasAnyModels(): boolean {
-    return this.indexes.modelsByHarness.size > 0;
+    return this.currentCatalog.hasAnyModels();
   }
 
   /**
@@ -158,12 +126,7 @@ export class ModelRegistryStore implements ModelCatalogProvider {
    * pin valid anywhere may be right where the spec actually serves.
    */
   isValidModelOnAnyHarness(model: string): boolean {
-    for (const models of this.indexes.modelsByHarness.values()) {
-      if (models.has(model)) {
-        return true;
-      }
-    }
-    return false;
+    return this.currentCatalog.isValidModelOnAnyHarness(model);
   }
 
   /**
@@ -172,13 +135,7 @@ export class ModelRegistryStore implements ModelCatalogProvider {
    * existence check. Computed per call (refusal-path only).
    */
   canonicalModelsAcrossHarnesses(): string[] {
-    const seen = new Set<string>();
-    for (const models of this.indexes.sortedModelsByHarness.values()) {
-      for (const name of models) {
-        seen.add(name);
-      }
-    }
-    return [...seen].sort();
+    return this.currentCatalog.canonicalModelsAcrossHarnesses();
   }
 
   /**
@@ -187,7 +144,7 @@ export class ModelRegistryStore implements ModelCatalogProvider {
    * suggestions never surface provider api ids). Callers must not mutate.
    */
   canonicalModels(harness: string): string[] {
-    return this.indexes.sortedModelsByHarness.get(harness) ?? [];
+    return this.currentCatalog.canonicalModels(harness);
   }
 
   /**
@@ -197,16 +154,7 @@ export class ModelRegistryStore implements ModelCatalogProvider {
    * deliberately harness-free (it never resolves the session).
    */
   hasPricingVariant(model: string, variant: string): boolean {
-    const byHarness = this.indexes.modelsByVariant.get(variant);
-    if (byHarness === undefined) {
-      return false;
-    }
-    for (const refs of byHarness.values()) {
-      if (refs.has(model)) {
-        return true;
-      }
-    }
-    return false;
+    return this.currentCatalog.hasPricingVariant(model, variant);
   }
 
   /**
@@ -220,9 +168,10 @@ export class ModelRegistryStore implements ModelCatalogProvider {
     model: string,
     variant: string,
   ): boolean {
-    return (
-      this.indexes.modelsByVariant.get(variant)?.get(harness)?.has(model) ??
-      false
+    return this.currentCatalog.hasPricingVariantForHarness(
+      harness,
+      model,
+      variant,
     );
   }
 
@@ -231,7 +180,7 @@ export class ModelRegistryStore implements ModelCatalogProvider {
    * any harness, for actionable refusal messages. Callers must not mutate.
    */
   canonicalModelsWithVariant(variant: string): string[] {
-    return this.indexes.sortedModelsByVariant.get(variant) ?? [];
+    return this.currentCatalog.canonicalModelsWithVariant(variant);
   }
 
   /**
@@ -242,8 +191,9 @@ export class ModelRegistryStore implements ModelCatalogProvider {
     harness: string,
     variant: string,
   ): string[] {
-    return (
-      this.indexes.sortedModelsByVariantHarness.get(variant)?.get(harness) ?? []
+    return this.currentCatalog.canonicalModelsWithVariantForHarness(
+      harness,
+      variant,
     );
   }
 
@@ -261,9 +211,10 @@ export class ModelRegistryStore implements ModelCatalogProvider {
     model: string,
     capability: string,
   ): boolean {
-    return (
-      this.indexes.modelsByCapability.get(capability)?.get(harness)?.has(model) ??
-      false
+    return this.currentCatalog.hasCapabilityForHarness(
+      harness,
+      model,
+      capability,
     );
   }
 
@@ -275,10 +226,9 @@ export class ModelRegistryStore implements ModelCatalogProvider {
     harness: string,
     capability: string,
   ): string[] {
-    return (
-      this.indexes.sortedModelsByCapabilityHarness
-        .get(capability)
-        ?.get(harness) ?? []
+    return this.currentCatalog.canonicalModelsWithCapabilityForHarness(
+      harness,
+      capability,
     );
   }
 
@@ -316,16 +266,15 @@ export class ModelRegistryStore implements ModelCatalogProvider {
       if (Buffer.byteLength(body) > MODEL_REGISTRY_MAX_BYTES) {
         throw new Error("upstream document exceeds the size cap");
       }
-      const indexes = buildIndexes(body);
-      if (indexes === undefined) {
+      const catalog = DocumentModelCatalog.tryBuild(body);
+      if (catalog === undefined) {
         throw new Error(
           "upstream document failed the sanity gate (no indexable models)",
         );
       }
       // Document and indexes swap together — a reader never sees a
       // document whose indexes describe a different registry.
-      this.currentDocument = body;
-      this.indexes = indexes;
+      this.currentCatalog = catalog;
       this.failureLogged = false;
     } catch (error) {
       const fields = {
@@ -346,158 +295,4 @@ export class ModelRegistryStore implements ModelCatalogProvider {
       }
     }
   }
-}
-
-/**
- * Parses a registry document and derives the valid-model indexes — the TS
- * half of Go's applyDocument (:302-412). Returns undefined when the
- * document fails the sanity gate: it must parse AND index at least one
- * model entry ($comment section dividers carry no id/harness and index
- * nothing, so a divider-only document is as unusable as an empty one).
- */
-function buildIndexes(document: string): RegistryIndexes | undefined {
-  let parsed: { models?: unknown };
-  try {
-    parsed = JSON.parse(document) as { models?: unknown };
-  } catch {
-    return undefined;
-  }
-  if (!Array.isArray(parsed.models)) {
-    return undefined;
-  }
-
-  const modelsByHarness = new Map<string, Set<string>>();
-  const sortedModelsByHarness = new Map<string, string[]>();
-  const modelsByVariant = new Map<string, Map<string, Set<string>>>();
-  // Set-backed: the same canonical id may price a variant under more than
-  // one harness, and the union list must not repeat it.
-  const canonicalByVariantSet = new Map<string, Set<string>>();
-  const sortedModelsByVariantHarness = new Map<string, Map<string, string[]>>();
-  const modelsByCapability = new Map<string, Map<string, Set<string>>>();
-  const sortedModelsByCapabilityHarness = new Map<
-    string,
-    Map<string, string[]>
-  >();
-
-  for (const raw of parsed.models as ModelRegistryEntry[]) {
-    if (raw === null || typeof raw !== "object") {
-      continue;
-    }
-    const id = typeof raw.id === "string" ? raw.id : "";
-    const harness = typeof raw.harness === "string" ? raw.harness : "";
-    if (id === "" || harness === "") {
-      continue;
-    }
-    const apiModelId =
-      typeof raw.apiModelId === "string" ? raw.apiModelId : "";
-
-    mapSet(modelsByHarness, harness).add(id);
-    mapList(sortedModelsByHarness, harness).push(id);
-    if (apiModelId !== "") {
-      mapSet(modelsByHarness, harness).add(apiModelId);
-    }
-
-    if (raw.pricingVariants !== null && typeof raw.pricingVariants === "object") {
-      for (const variant of Object.keys(raw.pricingVariants)) {
-        const byHarness = mapMap(modelsByVariant, variant);
-        mapSet(byHarness, harness).add(id);
-        if (apiModelId !== "") {
-          mapSet(byHarness, harness).add(apiModelId);
-        }
-        mapSet(canonicalByVariantSet, variant).add(id);
-        mapList(mapMapList(sortedModelsByVariantHarness, variant), harness).push(id);
-      }
-    }
-
-    if (raw.capabilities !== null && typeof raw.capabilities === "object") {
-      for (const [capability, value] of Object.entries(raw.capabilities)) {
-        // Only literal `true` declares the capability; false, null, or a
-        // future non-boolean shape indexes nothing (tri-state rule:
-        // absence is "unknown", never a claim either way).
-        if (value !== true) {
-          continue;
-        }
-        const byHarness = mapMap(modelsByCapability, capability);
-        mapSet(byHarness, harness).add(id);
-        if (apiModelId !== "") {
-          mapSet(byHarness, harness).add(apiModelId);
-        }
-        mapList(mapMapList(sortedModelsByCapabilityHarness, capability), harness).push(id);
-      }
-    }
-  }
-
-  if (modelsByHarness.size === 0) {
-    return undefined;
-  }
-
-  for (const ids of sortedModelsByHarness.values()) {
-    ids.sort();
-  }
-  const sortedModelsByVariant = new Map<string, string[]>();
-  for (const [variant, idSet] of canonicalByVariantSet) {
-    sortedModelsByVariant.set(variant, [...idSet].sort());
-  }
-  for (const byHarness of sortedModelsByVariantHarness.values()) {
-    for (const ids of byHarness.values()) {
-      ids.sort();
-    }
-  }
-  for (const byHarness of sortedModelsByCapabilityHarness.values()) {
-    for (const ids of byHarness.values()) {
-      ids.sort();
-    }
-  }
-
-  return {
-    modelsByHarness,
-    sortedModelsByHarness,
-    modelsByVariant,
-    sortedModelsByVariant,
-    sortedModelsByVariantHarness,
-    modelsByCapability,
-    sortedModelsByCapabilityHarness,
-  };
-}
-
-function mapSet(m: Map<string, Set<string>>, key: string): Set<string> {
-  let v = m.get(key);
-  if (v === undefined) {
-    v = new Set();
-    m.set(key, v);
-  }
-  return v;
-}
-
-function mapList(m: Map<string, string[]>, key: string): string[] {
-  let v = m.get(key);
-  if (v === undefined) {
-    v = [];
-    m.set(key, v);
-  }
-  return v;
-}
-
-function mapMap(
-  m: Map<string, Map<string, Set<string>>>,
-  key: string,
-): Map<string, Set<string>> {
-  let v = m.get(key);
-  if (v === undefined) {
-    v = new Map();
-    m.set(key, v);
-  }
-  return v;
-}
-
-function mapMapList(
-  m: Map<string, Map<string, string[]>>,
-  key: string,
-): Map<string, string[]> {
-  let v = m.get(key);
-  if (v === undefined) {
-    v = new Map();
-    m.set(key, v);
-  }
-  return v;
 }

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -92,6 +92,11 @@ export { ArtifactStorageNotFoundError } from "./artifactstorage/artifact-storage
 // seam with its OSS lane constant (an extension's verify callers name the
 // lane they accept).
 export type { ModelCatalogProvider } from "./domain/workflow/registry/model-catalog-provider.js";
+// The document-driven provider constructor (C1 seam, 20260827.04): a
+// composition whose catalog source is its own (the cloud's DB-resident
+// baseline) builds providers from documents with the SAME interpretation
+// ModelRegistryStore uses — the semantics live exactly once in OSS.
+export { newModelCatalogProviderFromDocument } from "./domain/workflow/registry/document-catalog.js";
 export type { RunnerCredentialProvider } from "./runnerauth/runner-credential-provider.js";
 export type { MintedToken } from "./runnerauth/runnerauth.js";
 export {

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -86,6 +86,11 @@ export type {
   StagedUploadLane,
 } from "./artifactstorage/artifact-storage.js";
 export { ArtifactStorageNotFoundError } from "./artifactstorage/artifact-storage.js";
+// The R2 driver constructor (C1 seam, 20260827.04): compositions register
+// per-domain R2 drivers with their own bucket/credential config while the
+// S3 plumbing lives exactly once in OSS (the §6b registration shape).
+export { newR2ArtifactStorage } from "./artifactstorage/r2-storage.js";
+export type { R2StorageConfig } from "./artifactstorage/r2-storage.js";
 
 // The O5 driver seams (§6a/§6c): the model-catalog read surface with the
 // DD-008 disciplines in its contract, and the per-lane runner-credential

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -33,6 +33,7 @@ import {
   InvalidTokenError,
   loadConfig,
   MintingDisabledError,
+  newModelCatalogProviderFromDocument,
   notFoundError,
   ResourceNotFoundError,
   TOKEN_TYPE_EXECUTION_SCOPED,
@@ -124,24 +125,15 @@ const workerFactory: WorkerFactory = () =>
   Promise.reject(new Error("compile-proof worker — never started"));
 
 /**
- * A consumer-shaped model-catalog provider (the O5 §6a shape — the cloud's
- * DB-resident baseline implements exactly this surface, read per call).
+ * A consumer-shaped model-catalog provider built the way the cloud's
+ * DB-resident baseline builds one (the C1 seam, 20260827.04): a document
+ * from the consumer's own source, interpreted by the exported constructor
+ * so the semantics stay OSS-owned. The interface remains implementable by
+ * hand (ConsumerDriverBundle below keeps the type position covered).
  */
-const catalogProvider: ModelCatalogProvider = {
-  document: () => `{"models":[]}`,
-  isValidModel: () => false,
-  hasHarness: () => false,
-  hasAnyModels: () => false,
-  isValidModelOnAnyHarness: () => false,
-  canonicalModelsAcrossHarnesses: () => [],
-  canonicalModels: () => [],
-  hasPricingVariant: () => false,
-  hasPricingVariantForHarness: () => false,
-  canonicalModelsWithVariant: () => [],
-  canonicalModelsWithVariantForHarness: () => [],
-  hasCapabilityForHarness: () => false,
-  canonicalModelsWithCapabilityForHarness: () => [],
-};
+const catalogProvider: ModelCatalogProvider = newModelCatalogProviderFromDocument(
+  `{"models":[{"id":"consumer-model","harness":"native"}]}`,
+);
 
 /**
  * A consumer-shaped runner-credential provider (the O5 §6c shape). The

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -34,6 +34,7 @@ import {
   loadConfig,
   MintingDisabledError,
   newModelCatalogProviderFromDocument,
+  newR2ArtifactStorage,
   notFoundError,
   ResourceNotFoundError,
   TOKEN_TYPE_EXECUTION_SCOPED,
@@ -156,6 +157,20 @@ const credentialProvider: RunnerCredentialProvider = {
 };
 
 /**
+ * A consumer-registered R2 driver built through the exported constructor
+ * (the C1 seam, 20260827.04) — the cloud's per-domain-bucket registration
+ * shape: the composition owns the config, OSS owns the S3 plumbing.
+ */
+const consumerR2Driver: ArtifactStorageDriverFactory = () =>
+  newR2ArtifactStorage({
+    bucket: "consumer-domain-bucket",
+    endpoint: "https://r2.invalid",
+    accessKeyId: "consumer-key",
+    secretAccessKey: "consumer-secret",
+    region: "auto",
+  });
+
+/**
  * A consumer-registered blob driver (the O5 §6b registration shape) —
  * lazy factory, typed not-found, the widened size/presignPut surface.
  */
@@ -196,7 +211,10 @@ export const fakeExtension: ServerExtension = {
   drivers: {
     modelCatalogProvider: catalogProvider,
     runnerCredentialProvider: credentialProvider,
-    artifactStorageDrivers: new Map([["consumer-blob", consumerBlobDriver]]),
+    artifactStorageDrivers: new Map([
+      ["consumer-blob", consumerBlobDriver],
+      ["consumer-r2", consumerR2Driver],
+    ]),
   },
   services: [registerBillingService],
   workers: [workerFactory],


### PR DESCRIPTION
## Summary

Two DD-005 seam requests from convergence entry C1 (`20260827.04.sp.cloud-composition-boot-spike`), both applying the same ruling: implementation lives exactly once in OSS; compositions bring their own config/source.

1. **Document-driven model-catalog provider.** Extracts the registry-document interpretation (sanity gate, `apiModelId` acceptance, tri-state capabilities, sorted suggestion pools, the thirteen `ModelCatalogProvider` query methods) from `ModelRegistryStore` into `DocumentModelCatalog`; the store keeps its bundled/upstream refresh lifecycle and delegates per accepted document. Exports `newModelCatalogProviderFromDocument` so the cloud's DB-resident baseline builds providers with the SAME OSS-owned semantics instead of forking them (the drift DD-008 forbids).
2. **R2 driver constructor.** Exports `newR2ArtifactStorage` + `R2StorageConfig` so the composition registers per-domain R2 drivers (distinct buckets/credentials — blueprint §6b's verified cloud shape) while the S3 plumbing, 7-day presign clamp, and not-found mapping stay in OSS.

Both are delegation/exposure-only on the OSS path — no wire behavior changes with an empty extension set.

## Verification

- `npm run typecheck` + full server unit suite: 1839 passed (Node 22.22.1), incl. 7 new `document-catalog` tests; artifactstorage suite 53/53
- `test/extension-consumer` compile proof green, extended with both new seams (document-built catalog provider + a `consumer-r2` registration)
- Conformance `local`: `workflow` (34/34) + `registry-proxy` (8/8) green

The C1 composition bumps its `third_party/stigmer` submodule pin to this commit after merge.