### PR TITLE
feat(backend/stigmer-server): add the SandboxProvisioner driver seam with local-process, Docker, and Kubernetes drivers (O6)

### DIFF
--- a/backend/services/stigmer-server/package-lock.json
+++ b/backend/services/stigmer-server/package-lock.json
@@ -15,6 +15,7 @@
         "@bufbuild/protovalidate": "^1.1.1",
         "@connectrpc/connect": "^2.0.0",
         "@connectrpc/connect-node": "^2.0.0",
+        "@kubernetes/client-node": "2.0.0",
         "@stigmer/protos": "file:../../../apis/stubs/ts",
         "@stigmer/temporal-codecs": "file:../../libs/ts/temporal-codecs",
         "@stigmer/zip-structure": "file:../../libs/ts/zip-structure",
@@ -1013,6 +1014,30 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@jsonjoy.com/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
@@ -1422,6 +1447,67 @@
       "peerDependencies": {
         "tslib": "2"
       }
+    },
+    "node_modules/@kubernetes/client-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-2.0.0.tgz",
+      "integrity": "sha512-Jx2cRxEVb4XkDNiR/cg8SX9dH6ZHdMhKmZdQcfhn2vdBWHdb2ldwM0P3I0dK4msYhFmC6TCODsNHH144IpA06w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/js-yaml": "^4.0.1",
+        "@types/node": "^26.0.0",
+        "@types/stream-buffers": "^3.0.3",
+        "form-data": "^4.0.0",
+        "hpagent": "^1.2.0",
+        "isomorphic-ws": "^5.0.0",
+        "js-yaml": "^5.1.0",
+        "jsonpath-plus": "^10.3.0",
+        "openid-client": "^6.1.3",
+        "rfc4648": "^1.3.0",
+        "socks": "^2.8.4",
+        "socks-proxy-agent": "^10.0.0",
+        "stream-buffers": "^3.0.2",
+        "tar-fs": "^3.0.9",
+        "undici": "^8.7.0",
+        "ws": "^8.18.2"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/@types/node": {
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/js-yaml": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
+    "node_modules/@kubernetes/client-node/node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/lzma-linux-x64-gnu": {
       "version": "1.5.1",
@@ -2380,7 +2466,6 @@
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -2408,6 +2493,15 @@
         "@types/node": "*",
         "pg-protocol": "*",
         "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/stream-buffers": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/stream-buffers/-/stream-buffers-3.0.8.tgz",
+      "integrity": "sha512-J+7VaHKNvlNPJPEJXX/fKa9DZtR/xPMwuIbe+yNOwp1YB+ApUOBv2aUpEoBJEi8nJgbgs1x8e73ttg0r1rSUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2707,6 +2801,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -2792,6 +2895,106 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.2.tgz",
+      "integrity": "sha512-AIPKioV7/Y/8KfZ3AAhjPJxLLbY49S64Ym5DakZlUg75qQiTgUq9hEJoEwa4eUezPUlXRy/i5NpsKvo9jgKmoA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.1.tgz",
+      "integrity": "sha512-N1nnXdHZAOSstz0XiHikGS4HGMH4CnSwhqWdGQQMqqdvp4Jybm9sE3R1WVnpWVd4SFkc8ryPDBLViNLwiEqECg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.28.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.4",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.4.tgz",
+      "integrity": "sha512-PcrQ8lVLbiJscNm1Kez+Yp4Gy4AHGcN1lzwjvf5NybWen7VvEgUfyfnXYJ2zNqWnzOfCb1Abq6lH8ti0syQszA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.8.1",
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
+      "integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.11.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.19.tgz",
@@ -2857,6 +3060,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2947,6 +3163,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
@@ -2957,7 +3185,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2981,6 +3208,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.414",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.414.tgz",
@@ -2992,6 +3242,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.24.5",
@@ -3006,12 +3265,57 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.2",
@@ -3135,6 +3439,15 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -3149,6 +3462,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -3191,6 +3510,22 @@
       "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
       "license": "MIT"
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs-monkey": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.1.0.tgz",
@@ -3212,6 +3547,15 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -3219,6 +3563,43 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob-to-regex.js": {
@@ -3237,6 +3618,18 @@
         "tslib": "2"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -3252,6 +3645,45 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/heap-js": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/heap-js/-/heap-js-2.7.1.tgz",
@@ -3259,6 +3691,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/hyperdyperid": {
@@ -3282,6 +3723,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3289,6 +3739,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
       }
     },
     "node_modules/jest-worker": {
@@ -3303,6 +3762,15 @@
       },
       "engines": {
         "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.10",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.10.tgz",
+      "integrity": "sha512-iiW7J9qRFlGxvCOIBDBDxFePQSn7ZMAnrYGhrrOo6siO/MIqwfyilLR27pkfDgUk+raLuzADS8A3S/KLBisc0g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -3334,11 +3802,38 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.4.0.tgz",
+      "integrity": "sha512-T92WWatJXmhBbKsgH/0hl+jxjdXrifi5IKeMY02DWggRxX0UElcbVzPlmgLTbvsPeW1PasQ6xE2Q75stkhGbsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/layerr": {
       "version": "3.0.0",
@@ -3373,6 +3868,15 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/memfs": {
@@ -3411,6 +3915,27 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3480,7 +4005,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3524,6 +4048,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/oauth4webapi": {
+      "version": "3.8.7",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-3.8.7.tgz",
+      "integrity": "sha512-4RxcKxXjuItDFZ20RRPf4YTw3kpeXJyCgJFxVzJ068A7PNJ18st2Dg90tlC1LkSDS0GecroagCLHYEIVUhCAkw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "6.8.7",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-6.8.7.tgz",
+      "integrity": "sha512-gtKthNu7evSBvTdrrlHb4F3Fi9dcwlb5QaITlCs+9mfpvuOi0Q3qtBf5+iY4sEP8hy1qCoAdxBNPDcmZeVSDzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^6.2.8",
+        "oauth4webapi": "^3.8.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/pathe": {
@@ -3754,6 +4309,16 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3771,6 +4336,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfc4648": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.4.tgz",
+      "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.62.5",
@@ -3859,6 +4430,44 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-10.1.0.tgz",
+      "integrity": "sha512-WlMj/67cEJ6MDI1OcsnjuYKDNDoyPCCYZ249kuuXPiMDw9F8PXkVaQ7YWu3siTydfQ/4BEZcvGzu+aYvz7dDCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -3938,6 +4547,26 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stream-buffers": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-3.0.3.tgz",
+      "integrity": "sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.1.tgz",
+      "integrity": "sha512-zEzXb0s5Cds7tqMH6rhZ05lcJydCWiQPEwiNngVqzsxCc962vLY4Uw+mW7od8kDH258k2Uz/JrOkdIAAhSh9VA==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -4019,6 +4648,41 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.3.tgz",
+      "integrity": "sha512-/hU4AXnIdZu+Gvl1pk0oI5f5HxWsCJRtY2aFaJdk9VvyL48DWU6iU5WAIPG+wIi1YvWA6eTJvIviP/tMAZZNwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.1.tgz",
+      "integrity": "sha512-nqsEO8zLZJvrOMdEwkA0QdCLFbetHMn95Zqu4fKwX+hkaTWJPZZOrxx/PwtxoK0MMGQmBQNRW3CPs8IFYQz4cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/terser": {
       "version": "5.50.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.50.0.tgz",
@@ -4035,6 +4699,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/thingies": {
@@ -4179,6 +4852,15 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -4511,6 +5193,33 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/backend/services/stigmer-server/package.json
+++ b/backend/services/stigmer-server/package.json
@@ -39,6 +39,7 @@
     "@bufbuild/protovalidate": "^1.1.1",
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0",
+    "@kubernetes/client-node": "2.0.0",
     "@stigmer/protos": "file:../../../apis/stubs/ts",
     "@stigmer/temporal-codecs": "file:../../libs/ts/temporal-codecs",
     "@stigmer/zip-structure": "file:../../libs/ts/zip-structure",

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -31,7 +31,10 @@ import type { ConnectRouter, Transport } from "@connectrpc/connect";
 import { HealthCheckResponse_ServingStatus as ServingStatus } from "@stigmer/protos/grpc/health/v1/health_pb";
 
 import { registerAgentServices } from "../domain/agent/controller.js";
-import { newConfigFromEnv } from "../domain/agentexecution/temporal/config.js";
+import {
+  newConfigFromEnv,
+  ROUTING_SESSION,
+} from "../domain/agentexecution/temporal/config.js";
 import { registerAgentExecutionServices } from "../domain/agentexecution/controller.js";
 import {
   LocalArtifactStorage,
@@ -115,7 +118,14 @@ import { InProcessValidator } from "../domain/workflow/validation/validator.js";
 import { registerWorkflowInstanceServices } from "../domain/workflowinstance/controller.js";
 import { registerWorkflowExecutionServices } from "../domain/workflowexecution/controller.js";
 import { StreamBroker as WorkflowExecutionStreamBroker } from "../domain/workflowexecution/stream-broker.js";
-import { newWorkflowExecutionConfigFromEnv } from "../domain/workflowexecution/temporal/config.js";
+import {
+  newWorkflowExecutionConfigFromEnv,
+  WORKFLOW_ROUTING_EXECUTION,
+} from "../domain/workflowexecution/temporal/config.js";
+import { builtInSandboxProvisionerFactories } from "../sandbox/builtins.js";
+import { newSandboxLane } from "../sandbox/lane.js";
+import { newSandboxProvisioner } from "../sandbox/provisioner.js";
+import { newWorkflowSandboxTerminalObserver } from "../sandbox/steps.js";
 import { newWorkflowExecutionEngineStateProvider } from "../temporal/workflowexecution/engine-client.js";
 import { newWorkflowExecutionWorkerFactory } from "../temporal/workflowexecution/worker.js";
 import { HealthState, registerHealthService } from "../transport/health.js";
@@ -286,6 +296,52 @@ export async function composeServer(
   // The workflow-execution twin (#21) — its config has no policy
   // consumer, so it lives here with the temporal stage.
   const workflowExecutionTemporalConfig = newWorkflowExecutionConfigFromEnv();
+  // The sandbox lane (§6d, O6): the configured driver — built-in tier or
+  // composition-registered — or the default external-runner posture
+  // (SANDBOX_PROVISIONER_TYPE unset: no driver constructed, the ensure
+  // steps short-circuit, an operator-managed runner polls the queues).
+  // Selection is loud-fail inside newSandboxProvisioner; the routing
+  // coherence check lives HERE because both temporal configs do — a
+  // provisioner that no routing mode can ever dispatch to is dark
+  // configuration, the validateR2Config class of boot fault.
+  const sandboxProvisioner = newSandboxProvisioner(
+    config.sandboxProvisionerType,
+    {
+      config: {
+        backendEndpoint: config.sandboxBackendEndpoint,
+        temporalAddress: config.sandboxTemporalAddress,
+        runnerImage: config.sandboxRunnerImage,
+        runnerCommand: config.sandboxRunnerCommand,
+        kubernetesNamespace: config.sandboxKubernetesNamespace,
+      },
+      logger,
+    },
+    builtInSandboxProvisionerFactories(),
+    extensions.drivers.sandboxProvisionerDrivers,
+  );
+  if (
+    sandboxProvisioner !== undefined &&
+    temporalConfig.activityRouting !== ROUTING_SESSION &&
+    workflowExecutionTemporalConfig.workflowActivityRouting !==
+      WORKFLOW_ROUTING_EXECUTION
+  ) {
+    throw new Error(
+      `SANDBOX_PROVISIONER_TYPE='${config.sandboxProvisionerType}' requires a per-queue routing mode — set STIGMER_ACTIVITY_ROUTING=session and/or STIGMER_WORKFLOW_ACTIVITY_ROUTING=execution (a provisioner no dispatch can reach must fail loudly, not sit dark)`,
+    );
+  }
+  const sandboxLane = newSandboxLane(sandboxProvisioner, runnerCredentials);
+  if (sandboxLane.enabled) {
+    logger.info("sandbox provisioner composed", {
+      type: config.sandboxProvisionerType,
+    });
+  }
+  // ONE terminal observer instance feeds all three workflow-execution
+  // status write sites (the UpdateStatus RPC, the orchestrator's persist
+  // activity, the lifecycle persists) — gate ruling Q3b.
+  const workflowSandboxTerminalObserver = newWorkflowSandboxTerminalObserver(
+    sandboxLane,
+    logger,
+  );
   const healthState = new HealthState();
   // The model catalog (DD-008, O5): ONE provider instance feeds workflow
   // validation, the pin checks, and the transport's registry lane, so the
@@ -384,6 +440,7 @@ export async function composeServer(
         logger,
         broker: workflowExecutionStreamBroker,
         temporalConfig: workflowExecutionTemporalConfig,
+        sandboxTerminalObserver: workflowSandboxTerminalObserver,
       }),
       newScheduleWorkerFactory({
         store,
@@ -651,6 +708,7 @@ export async function composeServer(
       authorizer,
       temporalConfig,
       agentInstanceCreator: () => requireInProcess().agentInstanceCreator,
+      sandboxLane,
     });
     // The sharing/channel family registers after the agent family, as in
     // Go server.go (agent 378 → agentshare 384 → agentchannel 391 →
@@ -697,6 +755,8 @@ export async function composeServer(
       engineState: executionEngineState,
       modelRegistry: modelCatalog,
       artifactStorage,
+      sandboxLane,
+      temporalConfig,
       agentLoader: () => requireInProcess().executionAgentLoader,
       agentInstanceCreator: () =>
         requireInProcess().executionAgentInstanceCreator,
@@ -734,6 +794,9 @@ export async function composeServer(
       authorizer,
       engineState: workflowExecutionEngineState,
       broker: workflowExecutionStreamBroker,
+      sandboxLane,
+      temporalConfig: workflowExecutionTemporalConfig,
+      sandboxTerminalObserver: workflowSandboxTerminalObserver,
       workflowInstanceCreator: () =>
         requireInProcess().workflowExecutionInstanceCreator,
       approvalForwarder: () =>

--- a/backend/services/stigmer-server/src/boot/config.ts
+++ b/backend/services/stigmer-server/src/boot/config.ts
@@ -150,6 +150,51 @@ export interface ServerConfig {
    * and pins fixture exports in tests.
    */
   readonly consoleDir: string;
+  /**
+   * Sandbox provisioner driver (SANDBOX_PROVISIONER_TYPE; §6d, O6). ""
+   * — the default — is the external-runner posture: no provisioner is
+   * constructed and an operator-managed runner polls the queues (today's
+   * behavior, named). "local-process" / "docker" / "kubernetes" select
+   * the built-in isolation tiers (DD-002's ladder); any other name
+   * selects a composition-registered driver, and an unknown name is a
+   * boot throw. Routing coherence (a selected driver requires at least
+   * one per-queue routing mode) is validated in compose.ts where the
+   * temporal configs live — one definition, oss#397's discipline.
+   */
+  readonly sandboxProvisionerType: string;
+  /**
+   * The server endpoint as reachable FROM INSIDE a provisioned sandbox
+   * (STIGMER_SANDBOX_BACKEND_ENDPOINT) — a container cannot use this
+   * process's localhost. Required (boot-fatal in compose.ts) when a
+   * container-based provisioner is selected; ignored on the default arm.
+   */
+  readonly sandboxBackendEndpoint: string;
+  /**
+   * Temporal address as reachable from inside a sandbox
+   * (STIGMER_SANDBOX_TEMPORAL_ADDRESS). Defaults to TEMPORAL_HOST_PORT —
+   * right whenever both resolve the same way (host networking,
+   * cluster-internal DNS); overridden when the sandbox network differs.
+   */
+  readonly sandboxTemporalAddress: string;
+  /**
+   * The runner image container-based provisioners launch
+   * (STIGMER_SANDBOX_RUNNER_IMAGE). The default is the published cloud
+   * sandbox image (Dockerfile.sandbox's `sandbox` stage — DD-014's
+   * release lane).
+   */
+  readonly sandboxRunnerImage: string;
+  /**
+   * The runner executable the local-process driver spawns
+   * (STIGMER_SANDBOX_RUNNER_COMMAND). The default is the npm-distributed
+   * `stigmer-runner` binary on PATH.
+   */
+  readonly sandboxRunnerCommand: string;
+  /**
+   * The namespace the kubernetes driver provisions into
+   * (STIGMER_SANDBOX_K8S_NAMESPACE) — one shared namespace, never
+   * per-sandbox namespaces (the cloud provisioner's verified posture).
+   */
+  readonly sandboxKubernetesNamespace: string;
 }
 
 // The bundled "Stigmer Local" OAuth App credentials (callback:
@@ -177,6 +222,12 @@ export const DEFAULT_GRPC_PORT = 7234;
 
 /** Default model-registry origin (model_registry_store.go). */
 export const DEFAULT_MODEL_REGISTRY_UPSTREAM = "https://api.stigmer.ai";
+
+/**
+ * The published cloud sandbox runner image (release.sandbox-cloud.yaml
+ * pushes it; the cloud's Kubernetes provisioner launches the same image).
+ */
+export const DEFAULT_SANDBOX_RUNNER_IMAGE = "ghcr.io/stigmer/runner:latest";
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
   const { operatorEmail, operatorName } = loadOperatorIdentity(env);
@@ -257,6 +308,32 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): ServerConfig {
     ),
     oauthRedirectUri: envString(env, "STIGMER_OAUTH_REDIRECT_URI", ""),
     consoleDir: envString(env, "STIGMER_CONSOLE_DIR", ""),
+    sandboxProvisionerType: envString(env, "SANDBOX_PROVISIONER_TYPE", ""),
+    sandboxBackendEndpoint: envString(
+      env,
+      "STIGMER_SANDBOX_BACKEND_ENDPOINT",
+      "",
+    ),
+    sandboxTemporalAddress: envString(
+      env,
+      "STIGMER_SANDBOX_TEMPORAL_ADDRESS",
+      envString(env, "TEMPORAL_HOST_PORT", "localhost:7233"),
+    ),
+    sandboxRunnerImage: envString(
+      env,
+      "STIGMER_SANDBOX_RUNNER_IMAGE",
+      DEFAULT_SANDBOX_RUNNER_IMAGE,
+    ),
+    sandboxRunnerCommand: envString(
+      env,
+      "STIGMER_SANDBOX_RUNNER_COMMAND",
+      "stigmer-runner",
+    ),
+    sandboxKubernetesNamespace: envString(
+      env,
+      "STIGMER_SANDBOX_K8S_NAMESPACE",
+      "stigmer-sandboxes",
+    ),
   };
 }
 

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/lifecycle.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/lifecycle.test.ts
@@ -66,6 +66,7 @@ import {
   recordDecisionEvent,
 } from "../approval/author.js";
 import type { ExecutionContextBuilderDeps } from "../create-execution-context-step.js";
+import { newConfigFromEnv } from "../temporal/config.js";
 import type {
   ConnectedExecutionEngine,
   ExecutionEngineState,
@@ -443,6 +444,10 @@ function lifecycleDeps(engineState: ExecutionEngineState): LifecycleDeps {
     broker: new StreamBroker(silentLogger),
     engineState: () => engineState,
     executionContextBuilder: stubBuilderDeps(),
+    // The OSS default sandbox posture (§6d, O6): lane disabled — the
+    // recover chain's EnsureSessionSandbox step short-circuits.
+    sandboxLane: { enabled: false },
+    temporalConfig: newConfigFromEnv(),
   };
 }
 
@@ -678,6 +683,8 @@ describe("lifecycle pipelines", () => {
       logger: silentLogger,
       authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
+      sandboxLane: { enabled: false },
+      temporalConfig: newConfigFromEnv(),
       engineState: () =>
         connected(
           stubConnectedEngine({
@@ -731,6 +738,8 @@ describe("lifecycle pipelines", () => {
       logger: silentLogger,
       authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
+      sandboxLane: { enabled: false },
+      temporalConfig: newConfigFromEnv(),
       engineState: () =>
         connected(
           stubConnectedEngine({
@@ -772,6 +781,8 @@ describe("lifecycle pipelines", () => {
       logger: silentLogger,
       authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
+      sandboxLane: { enabled: false },
+      temporalConfig: newConfigFromEnv(),
       engineState: () =>
         connected(
           stubConnectedEngine({
@@ -820,6 +831,8 @@ describe("lifecycle pipelines", () => {
       logger: silentLogger,
       authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
+      sandboxLane: { enabled: false },
+      temporalConfig: newConfigFromEnv(),
       engineState: () =>
         connected(
           stubConnectedEngine({
@@ -861,6 +874,8 @@ describe("lifecycle pipelines", () => {
       logger: silentLogger,
       authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
+      sandboxLane: { enabled: false },
+      temporalConfig: newConfigFromEnv(),
       engineState: () => connected(stubConnectedEngine()),
       executionContextBuilder: {
         ...builderDeps,
@@ -974,6 +989,8 @@ describe("lifecycle persist uses the atomic updateResource", () => {
         broker: new StreamBroker(silentLogger),
         engineState: () => connected(stubConnectedEngine()),
         executionContextBuilder: stubBuilderDeps(),
+        sandboxLane: { enabled: false },
+        temporalConfig: newConfigFromEnv(),
       };
 
       // Seed through the RAW store so the seed write is not counted.

--- a/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
@@ -84,8 +84,11 @@ import {
   newSetInitialPhaseStep,
   newStartWorkflowStep,
 } from "./create-steps.js";
+import type { SandboxLane } from "../../sandbox/lane.js";
+import { newEnsureSessionSandboxStep } from "../../sandbox/steps.js";
 import type { ExecutionContextBuilderDeps } from "./create-execution-context-step.js";
 import { newCreateExecutionContextStep } from "./create-execution-context-step.js";
+import type { AgentExecutionTemporalConfig } from "./temporal/config.js";
 import type { ExecutionEngineStateProvider } from "./engine.js";
 import { newEnsureEngineAvailableStep } from "./engine.js";
 import {
@@ -158,6 +161,14 @@ export interface AgentExecutionControllerDeps {
   readonly sessionCreator: SessionCreatorProvider;
   /** The shared EC-builder deps (create's step 16 + recover's recreate). */
   readonly executionContextBuilder: ExecutionContextBuilderDeps;
+  /**
+   * The sandbox lane (§6d, O6): disabled on the OSS default; the create
+   * and recover chains ensure the session sandbox through it after their
+   * workflow starts.
+   */
+  readonly sandboxLane: SandboxLane;
+  /** Dispatch config — the sandbox ensure resolves target/queue through it. */
+  readonly temporalConfig: AgentExecutionTemporalConfig;
 }
 
 /** Registers both agentexecution services on the router (routes stage). */
@@ -172,6 +183,8 @@ export function registerAgentExecutionServices(
     broker: deps.broker,
     engineState: deps.engineState,
     executionContextBuilder: deps.executionContextBuilder,
+    sandboxLane: deps.sandboxLane,
+    temporalConfig: deps.temporalConfig,
   };
   const artifactDeps = {
     store: deps.store,
@@ -293,6 +306,18 @@ async function createExecution(
         store: deps.store,
         logger: deps.logger,
         engineState: deps.engineState,
+      }),
+    )
+    // The session-lane sandbox ensure (§6d, O6): after StartWorkflow,
+    // NON-critical — a provisioning failure pre-stamps status.error and
+    // never fails the create (sandbox/steps.ts carries the posture's
+    // full rationale). Skips instantly when no provisioner is composed.
+    .addStep(
+      newEnsureSessionSandboxStep({
+        store: deps.store,
+        logger: deps.logger,
+        lane: deps.sandboxLane,
+        temporalConfig: deps.temporalConfig,
       }),
     )
     .build()

--- a/backend/services/stigmer-server/src/domain/agentexecution/lifecycle.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/lifecycle.ts
@@ -60,8 +60,11 @@ import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
 
+import type { SandboxLane } from "../../sandbox/lane.js";
+import { ensureSessionSandboxForExecution } from "../../sandbox/steps.js";
 import type { ExecutionContextBuilderDeps } from "./create-execution-context-step.js";
 import { buildAndPersistExecutionContext } from "./create-execution-context-step.js";
+import type { AgentExecutionTemporalConfig } from "./temporal/config.js";
 import type { ExecutionEngineStateProvider } from "./engine.js";
 import { EngineDispatchError, EngineWorkflowNotFoundError } from "./engine.js";
 import { settleInterruptedToolCalls } from "./tool-call-settle.js";
@@ -84,6 +87,10 @@ export interface LifecycleDeps {
   readonly engineState: ExecutionEngineStateProvider;
   /** The shared EC-builder deps, consumed by recover's recreate step. */
   readonly executionContextBuilder: ExecutionContextBuilderDeps;
+  /** The sandbox lane (§6d, O6) — recover re-ensures the session sandbox. */
+  readonly sandboxLane: SandboxLane;
+  /** Dispatch config for the sandbox ensure's target/queue resolution. */
+  readonly temporalConfig: AgentExecutionTemporalConfig;
 }
 
 /** Inputs that carry an execution id (Go LifecycleInput). */
@@ -668,6 +675,27 @@ export async function recoverExecution(
       }),
       newRecreateExecutionContextStep(deps),
       newStartFreshWorkflowStep(deps),
+      // The session-lane sandbox ensure (§6d, O6) — same position and
+      // non-critical posture as the create chain's step: after the
+      // workflow start, never failing the recover (the shared body
+      // pre-stamps failures onto status.error instead).
+      {
+        name: "EnsureSessionSandbox",
+        async execute(ctx) {
+          if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+            return;
+          }
+          await ensureSessionSandboxForExecution(
+            {
+              store: deps.store,
+              logger: deps.logger,
+              lane: deps.sandboxLane,
+              temporalConfig: deps.temporalConfig,
+            },
+            loadedExecution(ctx),
+          );
+        },
+      },
       newUpdateExecutionPhaseAndPersistStep(
         deps,
         ExecutionPhase.EXECUTION_IN_PROGRESS,

--- a/backend/services/stigmer-server/src/domain/session/controller.ts
+++ b/backend/services/stigmer-server/src/domain/session/controller.ts
@@ -83,6 +83,8 @@ import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
+import type { SandboxLane } from "../../sandbox/lane.js";
+import { deprovisionSessionSandboxBestEffort } from "../../sandbox/steps.js";
 import { sessionSearchExtractor } from "./search-extractor.js";
 import {
   LIST_RESULT_KEY,
@@ -115,6 +117,11 @@ export interface SessionControllerDeps {
    * DI story, DD-002).
    */
   readonly agentInstanceCreator: AgentInstanceCreatorProvider;
+  /**
+   * The sandbox lane (§6d, O6): session delete tears the session's
+   * sandbox down best-effort (the Java SessionDeleteHandler posture).
+   */
+  readonly sandboxLane: SandboxLane;
 }
 
 /** Registers both session services on the router (routes stage). */
@@ -299,6 +306,14 @@ async function deleteSession(
       "deleted session not found in context",
     );
   }
+  // The session's sandbox tears down AFTER the row is gone (§6d, O6) —
+  // best-effort, never failing the delete (the Java SessionDeleteHandler
+  // posture; the helper carries the leak-logging rationale).
+  await deprovisionSessionSandboxBestEffort(
+    deps.sandboxLane,
+    deps.logger,
+    (deleted as Session).metadata?.id ?? "",
+  );
   return deleted as Session;
 }
 

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/lifecycle.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/lifecycle.test.ts
@@ -40,6 +40,7 @@ import {
   TEMPORAL_UNAVAILABLE_MESSAGE,
 } from "../constants.js";
 import type { WorkflowExecutionContextBuilderDeps } from "../create-execution-context-step.js";
+import { newWorkflowExecutionConfigFromEnv } from "../temporal/config.js";
 import { ENGINE_DISCONNECTED, EngineWorkflowNotFoundError } from "../engine.js";
 import type { LifecycleDeps } from "../lifecycle.js";
 import {
@@ -120,6 +121,11 @@ function deps(engineStub?: EngineStub): LifecycleDeps {
     broker,
     engineState: () => engineStub?.state ?? ENGINE_DISCONNECTED,
     executionContextBuilder: builderDeps(),
+    // The OSS default sandbox posture (§6d, O6): lane disabled — the
+    // recover ensure short-circuits and the terminal observer no-ops.
+    sandboxLane: { enabled: false },
+    temporalConfig: newWorkflowExecutionConfigFromEnv(),
+    sandboxTerminalObserver: () => {},
   };
 }
 

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/update-status.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/update-status.test.ts
@@ -437,6 +437,7 @@ describe("updateStatus persistence mechanism (DD-001)", () => {
           logger: silentLogger,
           broker,
           authorizer: newPermissiveSingleTeamAuthorizer(),
+          sandboxTerminalObserver: () => {},
         },
         create(WorkflowExecutionUpdateStatusInputSchema, {
           executionId: "wfx_missing",
@@ -473,6 +474,7 @@ describe("updateStatus persistence mechanism (DD-001)", () => {
         logger: silentLogger,
         broker,
         authorizer: newPermissiveSingleTeamAuthorizer(),
+        sandboxTerminalObserver: () => {},
       },
       create(WorkflowExecutionUpdateStatusInputSchema, {
         executionId: "wfx_mechanism",
@@ -505,6 +507,7 @@ describe("updateStatus persistence mechanism (DD-001)", () => {
             logger: silentLogger,
             broker,
             authorizer: newPermissiveSingleTeamAuthorizer(),
+            sandboxTerminalObserver: () => {},
           },
           create(WorkflowExecutionUpdateStatusInputSchema, {
             executionId: id,
@@ -547,6 +550,7 @@ describe("updateStatus persistence mechanism (DD-001)", () => {
           logger: silentLogger,
           broker,
           authorizer: newPermissiveSingleTeamAuthorizer(),
+          sandboxTerminalObserver: () => {},
         },
         create(WorkflowExecutionUpdateStatusInputSchema, {
           executionId: id,

--- a/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
@@ -106,6 +106,10 @@ import { getExecutionSummary } from "./get-execution-summary.js";
 import { listPendingApprovals } from "./list-pending-approvals.js";
 import { loadAllWorkflowExecutions } from "./queries.js";
 import { workflowExecutionSearchExtractor } from "./search-extractor.js";
+import type { SandboxLane } from "../../sandbox/lane.js";
+import type { WorkflowSandboxTerminalObserver } from "../../sandbox/steps.js";
+import { newEnsureWorkflowSandboxStep } from "../../sandbox/steps.js";
+import type { WorkflowExecutionTemporalConfig } from "./temporal/config.js";
 import type { StreamBroker } from "./stream-broker.js";
 import { subscribeExecution } from "./subscribe.js";
 import { subscribeEvents } from "./subscribe-events.js";
@@ -141,6 +145,21 @@ export interface WorkflowExecutionControllerDeps {
   readonly fileDecisionForwarder: AgentExecutionFileDecisionForwarderProvider;
   /** The shared EC-builder deps (create's step 12 + recover's recreate). */
   readonly executionContextBuilder: WorkflowExecutionContextBuilderDeps;
+  /**
+   * The sandbox lane (§6d, O6): disabled on the OSS default. Create and
+   * recover ensure the per-execution sandbox CRITICALLY (pre-persist /
+   * pre-start — a refusal orphans nothing); the terminal observer below
+   * tears it down.
+   */
+  readonly sandboxLane: SandboxLane;
+  /** Dispatch config — the sandbox ensure resolves target/queue through it. */
+  readonly temporalConfig: WorkflowExecutionTemporalConfig;
+  /**
+   * Fired after every persisted status write that transitions the phase
+   * (gate ruling Q3b) — updateStatus and the lifecycle persists call it;
+   * the worker's activity carries its own copy of the same observer.
+   */
+  readonly sandboxTerminalObserver: WorkflowSandboxTerminalObserver;
 }
 
 /** Registers both workflowexecution services on the router (routes stage). */
@@ -155,6 +174,9 @@ export function registerWorkflowExecutionServices(
     broker: deps.broker,
     engineState: deps.engineState,
     executionContextBuilder: deps.executionContextBuilder,
+    sandboxLane: deps.sandboxLane,
+    temporalConfig: deps.temporalConfig,
+    sandboxTerminalObserver: deps.sandboxTerminalObserver,
   };
   router.service(WorkflowExecutionCommandController, {
     create: (execution, ctx) => createExecution(deps, execution, ctx),
@@ -244,6 +266,17 @@ async function createExecution(
     .addStep(newNormalizeWorkflowRefStep(deps.store, deps.logger))
     .addStep(newPinWorkflowVersionStep(deps.store, deps.logger))
     .addStep(newCreateExecutionContextStep(deps.executionContextBuilder))
+    // The workflow-lane sandbox ensure (§6d, O6): CRITICAL and
+    // pre-persist — a provisioning refusal answers Unavailable with zero
+    // orphaned state (no row, no Temporal workflow), the verified Java
+    // ordering. Skips instantly when no provisioner is composed.
+    .addStep(
+      newEnsureWorkflowSandboxStep({
+        logger: deps.logger,
+        lane: deps.sandboxLane,
+        temporalConfig: deps.temporalConfig,
+      }),
+    )
     .addStep(newPersistStep(deps.store))
     .addStep(
       newIndexSearchStep(

--- a/backend/services/stigmer-server/src/domain/workflowexecution/lifecycle.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/lifecycle.ts
@@ -72,6 +72,10 @@ import {
   childWorkflowId,
   orchestratorWorkflowId,
 } from "./constants.js";
+import type { SandboxLane } from "../../sandbox/lane.js";
+import type { WorkflowSandboxTerminalObserver } from "../../sandbox/steps.js";
+import { ensureWorkflowSandboxForExecution } from "../../sandbox/steps.js";
+import type { WorkflowExecutionTemporalConfig } from "./temporal/config.js";
 import type { WorkflowExecutionContextBuilderDeps } from "./create-execution-context-step.js";
 import { EngineWorkflowNotFoundError } from "./engine.js";
 import type { WorkflowExecutionEngineStateProvider } from "./engine.js";
@@ -91,6 +95,12 @@ export interface LifecycleDeps {
   readonly engineState: WorkflowExecutionEngineStateProvider;
   /** Recover's RecreateExecutionContext consumes the same builder deps. */
   readonly executionContextBuilder: WorkflowExecutionContextBuilderDeps;
+  /** The sandbox lane (§6d, O6) — recover re-ensures the workflow sandbox. */
+  readonly sandboxLane: SandboxLane;
+  /** Dispatch config for the sandbox ensure's target/queue resolution. */
+  readonly temporalConfig: WorkflowExecutionTemporalConfig;
+  /** Fires the workflow-sandbox teardown on terminal transitions (§6d, O6). */
+  readonly sandboxTerminalObserver: WorkflowSandboxTerminalObserver;
 }
 
 // ---------------------------------------------------------------------------
@@ -277,12 +287,18 @@ function newUpdateExecutionPhaseAndPersistStep<Desc extends DescMessage>(
       const reason = typeof reasonValue === "string" ? reasonValue : "";
 
       let updated: WorkflowExecution;
+      // The phase BEFORE this transition, read under the write lock —
+      // the sandbox observer below keys on the transition (§6d, O6).
+      let previousPhase = ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
       try {
         updated = await deps.store.updateResource(
           ApiResourceKind.workflow_execution,
           executionId,
           WorkflowExecutionSchema,
           (loaded) => {
+            previousPhase =
+              loaded.status?.phase ??
+              ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
             applyLifecyclePhaseTransition(
               loaded,
               targetPhase,
@@ -299,6 +315,13 @@ function newUpdateExecutionPhaseAndPersistStep<Desc extends DescMessage>(
         throw internalError(error, "failed to persist execution");
       }
       ctx.set(LOADED_EXECUTION_KEY, updated);
+      // AFTER the persist commits: cancel/terminate are terminal —
+      // the per-execution sandbox tears down, fire-and-forget.
+      deps.sandboxTerminalObserver(
+        executionId,
+        previousPhase,
+        updated.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED,
+      );
     },
   };
 }
@@ -873,6 +896,27 @@ export async function recoverExecution(
       ),
       newTerminateExistingWorkflowStep(deps),
       newRecreateExecutionContextStep(deps),
+      // The workflow-lane sandbox re-ensure (§6d, O6): the terminal
+      // FAILED deprovisioned the previous sandbox, so a recovered
+      // execution needs a fresh one BEFORE its fresh workflow starts —
+      // the same critical posture as the create chain (a provisioning
+      // refusal leaves the execution FAILED, recover retryable).
+      {
+        name: "EnsureWorkflowSandbox",
+        async execute(ctx) {
+          if (ctx.get(ALREADY_IN_TARGET_STATE_KEY) === true) {
+            return;
+          }
+          await ensureWorkflowSandboxForExecution(
+            {
+              logger: deps.logger,
+              lane: deps.sandboxLane,
+              temporalConfig: deps.temporalConfig,
+            },
+            loadedExecution(ctx),
+          );
+        },
+      },
       newStartFreshWorkflowStep(deps),
       newUpdateExecutionPhaseAndPersistStep(
         deps,

--- a/backend/services/stigmer-server/src/domain/workflowexecution/update-status.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/update-status.ts
@@ -60,6 +60,7 @@ import type {
   Store,
   WorkflowExecutionEventRecord,
 } from "../../store/interface.js";
+import type { WorkflowSandboxTerminalObserver } from "../../sandbox/steps.js";
 
 import type { StreamBroker } from "./stream-broker.js";
 
@@ -69,6 +70,8 @@ export interface UpdateStatusDeps {
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
   readonly broker: StreamBroker;
+  /** Fires the workflow-sandbox teardown on terminal transitions (§6d, O6). */
+  readonly sandboxTerminalObserver: WorkflowSandboxTerminalObserver;
 }
 
 type UpdateStatusDesc =
@@ -112,12 +115,19 @@ export async function updateStatus(
       name: "MergeAndPersistExecution",
       async execute(ctx) {
         let updated: WorkflowExecution;
+        // Captured inside the modify closure — the phase BEFORE this
+        // merge, read under the same write lock that persists it (the
+        // sandbox observer below keys on the transition, §6d/O6).
+        let previousPhase = ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
         try {
           updated = await deps.store.updateResource(
             ApiResourceKind.workflow_execution,
             ctx.input.executionId,
             WorkflowExecutionSchema,
             (execution) => {
+              previousPhase =
+                execution.status?.phase ??
+                ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
               applyUpdateStatusMerge(execution, ctx.input);
             },
           );
@@ -129,6 +139,13 @@ export async function updateStatus(
           throw internalError(error, "failed to update execution status");
         }
         ctx.set(EXECUTION_KEY, updated);
+        // AFTER the persist commits: a terminal transition tears the
+        // per-execution sandbox down, fire-and-forget.
+        deps.sandboxTerminalObserver(
+          ctx.input.executionId,
+          previousPhase,
+          updated.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED,
+        );
         deps.logger.info("Successfully updated execution status", {
           executionId: ctx.input.executionId,
           phase:

--- a/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
@@ -19,6 +19,7 @@ import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js"
 import type { ModelCatalogProvider } from "../../domain/workflow/registry/model-catalog-provider.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
+import type { SandboxProvisionerFactory } from "../../sandbox/provisioner.js";
 import type { WorkerFactory } from "../../temporal/manager.js";
 import type { Authorizer } from "../authorizer.js";
 import type { GateSlotName } from "../gate-slots.js";
@@ -77,6 +78,10 @@ const fakeStorageDriver = (): ArtifactStorage => {
   throw new Error("unit-test storage driver factory — never constructed");
 };
 
+const fakeSandboxDriver: SandboxProvisionerFactory = () => {
+  throw new Error("unit-test sandbox driver factory — never constructed");
+};
+
 describe("resolveExtensions — defaults", () => {
   it("resolves the omitted set to explicit empty defaults, edition oss", () => {
     const resolved = resolveExtensions();
@@ -90,6 +95,7 @@ describe("resolveExtensions — defaults", () => {
     expect(resolved.drivers.modelCatalogProvider).toBeUndefined();
     expect(resolved.drivers.runnerCredentialProvider).toBeUndefined();
     expect(resolved.drivers.artifactStorageDrivers.size).toBe(0);
+    expect(resolved.drivers.sandboxProvisionerDrivers.size).toBe(0);
     expect(resolved.services).toEqual([]);
     expect(resolved.workers).toEqual([]);
   });
@@ -163,6 +169,33 @@ describe("resolveExtensions — merge semantics", () => {
     ]);
     expect(resolved.drivers.artifactStorageDrivers.get("r2-skill")).toBe(
       fakeStorageDriver,
+    );
+  });
+
+  it("merges the O6 sandbox-provisioner drivers as a name-keyed map across units", () => {
+    const resolved = resolveExtensions([
+      {
+        name: "fly-unit",
+        drivers: {
+          sandboxProvisionerDrivers: new Map([
+            ["fly-machines", fakeSandboxDriver],
+          ]),
+        },
+      },
+      {
+        name: "firecracker-unit",
+        drivers: {
+          sandboxProvisionerDrivers: new Map([
+            ["firecracker", fakeSandboxDriver],
+          ]),
+        },
+      },
+    ]);
+    expect(
+      [...resolved.drivers.sandboxProvisionerDrivers.keys()].sort(),
+    ).toEqual(["firecracker", "fly-machines"]);
+    expect(resolved.drivers.sandboxProvisionerDrivers.get("fly-machines")).toBe(
+      fakeSandboxDriver,
     );
   });
 });
@@ -289,6 +322,46 @@ describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
       ).toThrowError(
         new RegExp(
           `extension 'shadowing' registers artifact-storage driver '${name}', which shadows a built-in backend`,
+        ),
+      );
+    }
+  });
+
+  it("throws on a duplicated sandbox-provisioner name across units, naming both", () => {
+    expect(() =>
+      resolveExtensions([
+        {
+          name: "first-sbx",
+          drivers: {
+            sandboxProvisionerDrivers: new Map([["fly", fakeSandboxDriver]]),
+          },
+        },
+        {
+          name: "second-sbx",
+          drivers: {
+            sandboxProvisionerDrivers: new Map([["fly", fakeSandboxDriver]]),
+          },
+        },
+      ]),
+    ).toThrowError(
+      /extension 'second-sbx' registers sandbox provisioner 'fly', but 'first-sbx' already did/,
+    );
+  });
+
+  it("throws on a sandbox-provisioner name shadowing a built-in driver", () => {
+    for (const name of ["local-process", "docker", "kubernetes"]) {
+      expect(() =>
+        resolveExtensions([
+          {
+            name: "shadowing",
+            drivers: {
+              sandboxProvisionerDrivers: new Map([[name, fakeSandboxDriver]]),
+            },
+          },
+        ]),
+      ).toThrowError(
+        new RegExp(
+          `extension 'shadowing' registers sandbox provisioner '${name}', which shadows a built-in driver`,
         ),
       );
     }

--- a/backend/services/stigmer-server/src/extensions/drivers.ts
+++ b/backend/services/stigmer-server/src/extensions/drivers.ts
@@ -8,20 +8,22 @@
  *   - model-catalog provider (§6a) and artifact-storage driver
  *     registration + runner-credential provider (§6b/§6c) — landed, O5
  *     (20260827.02)
- *   - sandbox provisioners (§6d) — O6
+ *   - sandbox provisioners (§6d) — landed, O6 (20260827.05)
  *
  * Merge rules (enforced by resolveExtensions, DD-006 §2b): the two
  * provider kinds are single-instance points — a second declaring unit is
  * a boot throw naming both units (the authorizer rule); artifact-storage
- * drivers merge as a name-keyed map — a duplicated name, or a name
- * shadowing a built-in backend, is a boot throw (the gateSteps rule: a
- * registration the factory could never reach must fail loudly, not sit
- * dark). OSS defaults install at the boot/compose.ts consumption sites,
- * never here (the default-lives-with-the-consumer doctrine).
+ * and sandbox-provisioner drivers merge as name-keyed maps — a
+ * duplicated name, or a name shadowing a built-in, is a boot throw (the
+ * gateSteps rule: a registration the factory could never reach must fail
+ * loudly, not sit dark). OSS defaults install at the boot/compose.ts
+ * consumption sites, never here (the default-lives-with-the-consumer
+ * doctrine).
  */
 import type { ArtifactStorageDriverFactory } from "../artifactstorage/artifact-storage.js";
 import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
 import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
+import type { SandboxProvisionerFactory } from "../sandbox/provisioner.js";
 
 /** The driver contributions of one extension unit. */
 export interface ExtensionDrivers {
@@ -46,5 +48,16 @@ export interface ExtensionDrivers {
   readonly artifactStorageDrivers?: ReadonlyMap<
     string,
     ArtifactStorageDriverFactory
+  >;
+  /**
+   * Sandbox provisioners registrable by name (§6d), selectable through
+   * the SANDBOX_PROVISIONER_TYPE config knob. Factories, not instances —
+   * an unselected driver constructs nothing. The built-in names
+   * (local-process, docker, kubernetes — src/sandbox/provisioner.ts) are
+   * reserved.
+   */
+  readonly sandboxProvisionerDrivers?: ReadonlyMap<
+    string,
+    SandboxProvisionerFactory
   >;
 }

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -25,8 +25,8 @@
  * edition are consumed here in O1; identity verifiers + authorizer land
  * with O2; gate steps + status hooks with O4; the O5 driver kinds
  * (catalog provider, artifact-storage registration, runner-credential
- * provider) are consumed at their compose.ts construction sites; sandbox
- * provisioners land with O6.
+ * provider) and O6's sandbox provisioners are consumed at their
+ * compose.ts construction sites.
  */
 import type { DescMessage } from "@bufbuild/protobuf";
 import type { ConnectRouter } from "@connectrpc/connect";
@@ -38,6 +38,8 @@ import { BUILT_IN_STORAGE_TYPES } from "../artifactstorage/artifact-storage.js";
 import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
 import type { PipelineStep } from "../pipeline/pipeline.js";
 import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
+import type { SandboxProvisionerFactory } from "../sandbox/provisioner.js";
+import { BUILT_IN_SANDBOX_PROVISIONER_TYPES } from "../sandbox/provisioner.js";
 import type { WorkerFactory } from "../temporal/manager.js";
 import type { Authorizer } from "./authorizer.js";
 import type { ExtensionDrivers } from "./drivers.js";
@@ -144,6 +146,11 @@ export interface ResolvedExtensionDrivers {
     string,
     ArtifactStorageDriverFactory
   >;
+  /** Registered name → factory, validated against the built-in names (§6d). */
+  readonly sandboxProvisionerDrivers: ReadonlyMap<
+    string,
+    SandboxProvisionerFactory
+  >;
 }
 
 /**
@@ -176,6 +183,11 @@ export function resolveExtensions(
     ArtifactStorageDriverFactory
   >();
   const storageDriverDeclaredBy = new Map<string, string>();
+  const sandboxProvisionerDrivers = new Map<
+    string,
+    SandboxProvisionerFactory
+  >();
+  const sandboxDriverDeclaredBy = new Map<string, string>();
 
   for (const unit of units) {
     if (unit.name === "") {
@@ -253,6 +265,28 @@ export function resolveExtensions(
       }
     }
 
+    if (unit.drivers?.sandboxProvisionerDrivers !== undefined) {
+      for (const [name, factory] of unit.drivers.sandboxProvisionerDrivers) {
+        if (
+          (BUILT_IN_SANDBOX_PROVISIONER_TYPES as ReadonlyArray<string>).includes(
+            name,
+          )
+        ) {
+          throw new Error(
+            `extension '${unit.name}' registers sandbox provisioner '${name}', which shadows a built-in driver — built-in names are reserved`,
+          );
+        }
+        const declaredBy = sandboxDriverDeclaredBy.get(name);
+        if (declaredBy !== undefined) {
+          throw new Error(
+            `extension '${unit.name}' registers sandbox provisioner '${name}', but '${declaredBy}' already did — driver names must be unique across the composed set`,
+          );
+        }
+        sandboxProvisionerDrivers.set(name, factory);
+        sandboxDriverDeclaredBy.set(name, unit.name);
+      }
+    }
+
     if (unit.gateSteps !== undefined) {
       for (const [slot, steps] of unit.gateSteps) {
         if (!DECLARED_GATE_SLOTS.has(slot)) {
@@ -292,6 +326,7 @@ export function resolveExtensions(
       modelCatalogProvider,
       runnerCredentialProvider,
       artifactStorageDrivers,
+      sandboxProvisionerDrivers,
     },
     services,
     workers,

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -20,7 +20,8 @@
  *     not-found errors the ratified store-fault mapping keys on)
  *   - the driver interfaces (Store, ArtifactStorage; O5 added §6a/§6b/§6c —
  *     ModelCatalogProvider, the widened storage surface, and
- *     RunnerCredentialProvider; §6d's sandbox provisioner joins with O6)
+ *     RunnerCredentialProvider; O6 added §6d — SandboxProvisioner and its
+ *     factory/registration types)
  *   - the worker factory types extension workers implement (§8)
  *
  * The package stays private and unpublished: this is the library contract
@@ -33,7 +34,12 @@ export type { ComposeOptions, ComposedServer } from "./boot/compose.js";
 export { loadConfig } from "./boot/config.js";
 export type { ServerConfig } from "./boot/config.js";
 export { createLogger } from "./boot/logger.js";
-export type { LogFields, Logger, LoggerOptions, LogLevel } from "./boot/logger.js";
+export type {
+  LogFields,
+  Logger,
+  LoggerOptions,
+  LogLevel,
+} from "./boot/logger.js";
 
 // The extension-point types (DD-006 — the seven-point registry).
 export type {
@@ -78,7 +84,10 @@ export {
 // keys on (typed not-found → NotFound; anything else rethrows as an
 // infrastructure fault — the guidelines' instanceof idiom).
 export type { Store } from "./store/interface.js";
-export { AuditNotFoundError, ResourceNotFoundError } from "./store/interface.js";
+export {
+  AuditNotFoundError,
+  ResourceNotFoundError,
+} from "./store/interface.js";
 export type {
   ArtifactStorage,
   ArtifactStorageDriverFactory,
@@ -99,6 +108,20 @@ export {
   MintingDisabledError,
   TOKEN_TYPE_EXECUTION_SCOPED,
 } from "./runnerauth/runnerauth.js";
+
+// The O6 driver seam (§6d): the sandbox-provisioner contract an extension
+// implements to register its own isolation driver (selected through the
+// SANDBOX_PROVISIONER_TYPE knob), plus the reserved built-in names its
+// registrations may never shadow.
+export type {
+  SandboxDriverConfig,
+  SandboxEnvironment,
+  SandboxProbeState,
+  SandboxProvisioner,
+  SandboxProvisionerFactory,
+  SandboxScope,
+} from "./sandbox/provisioner.js";
+export { BUILT_IN_SANDBOX_PROVISIONER_TYPES } from "./sandbox/provisioner.js";
 
 // The worker factory types extension workers implement (§8).
 export type { WorkerFactory, WorkerFactoryDeps } from "./temporal/manager.js";

--- a/backend/services/stigmer-server/src/sandbox/__tests__/docker.integration.test.ts
+++ b/backend/services/stigmer-server/src/sandbox/__tests__/docker.integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Integration smoke for the Docker driver (§6d, O6): the real docker
+ * CLI, the full provision → probe → stop/start → deprovision cycle, and
+ * the label/env contract on the live container.
+ *
+ * Gated HONESTLY, never silently: it runs only when Docker answers AND
+ * the operator opts in with STIGMER_SANDBOX_DOCKER_SMOKE=1 — the smoke
+ * pulls the published runner image (the breakdown's acceptance names
+ * it), which is far too heavy for every `npm test`. CI's opt-in lane and
+ * the PR's recorded run are the proof points. Override the image with
+ * STIGMER_SANDBOX_RUNNER_IMAGE to smoke against a local build.
+ */
+import { execFileSync } from "node:child_process";
+
+import { afterAll, describe, expect, it } from "vitest";
+
+import { createLogger } from "../../boot/logger.js";
+import { newDockerSandboxProvisioner } from "../docker.js";
+import { sandboxBaseName } from "../naming.js";
+import type { SandboxDriverConfig } from "../provisioner.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+function dockerAnswers(): boolean {
+  try {
+    execFileSync("docker", ["version", "--format", "{{.Server.Version}}"], {
+      stdio: "pipe",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const optedIn = process.env["STIGMER_SANDBOX_DOCKER_SMOKE"] === "1";
+
+describe.skipIf(!optedIn || !dockerAnswers())(
+  "docker driver (integration smoke — opt-in)",
+  () => {
+    const config: SandboxDriverConfig = {
+      // host.docker.internal: reachable-from-container on Docker Desktop;
+      // the smoke only needs the vars INJECTED, not a live server behind
+      // them (the runner tolerates an unreachable backend at boot).
+      backendEndpoint: "http://host.docker.internal:7234",
+      temporalAddress: "host.docker.internal:7233",
+      runnerImage:
+        process.env["STIGMER_SANDBOX_RUNNER_IMAGE"] ??
+        "ghcr.io/stigmer/runner:latest",
+      runnerCommand: "unused-by-this-driver",
+      kubernetesNamespace: "unused-by-this-driver",
+    };
+    const driver = newDockerSandboxProvisioner({
+      config,
+      logger: silentLogger,
+    });
+    const sessionId = `ses_docker_smoke_${Date.now()}`;
+    const containerName = sandboxBaseName("session", sessionId);
+
+    afterAll(async () => {
+      await driver.deprovisionSessionSandbox(sessionId);
+    });
+
+    it("provisions a labeled container with the env contract, probes, and tears down", async () => {
+      await driver.ensureSessionSandbox(sessionId, {
+        taskQueue: `session:${sessionId}`,
+        stigmerToken: "tok-docker-smoke",
+      });
+      expect(await driver.probe("session", sessionId)).toBe("running");
+
+      const inspect = JSON.parse(
+        execFileSync("docker", ["inspect", containerName], {
+          stdio: "pipe",
+        }).toString(),
+      ) as Array<{
+        Config: { Env: string[]; Labels: Record<string, string> };
+      }>;
+      const container = inspect[0];
+      expect(container?.Config.Labels["stigmer.ai/sandbox-id"]).toBe(sessionId);
+      expect(container?.Config.Labels["stigmer.ai/scope"]).toBe("session");
+      expect(container?.Config.Env).toContain(
+        `STIGMER_TASK_QUEUE=session:${sessionId}`,
+      );
+      expect(container?.Config.Env).toContain("STIGMER_TOKEN=tok-docker-smoke");
+      expect(container?.Config.Env).toContain("MODE=local");
+
+      // Idempotent fast path.
+      await driver.ensureSessionSandbox(sessionId, {
+        taskQueue: `session:${sessionId}`,
+        stigmerToken: "tok-docker-smoke",
+      });
+      expect(await driver.probe("session", sessionId)).toBe("running");
+
+      await driver.deprovisionSessionSandbox(sessionId);
+      expect(await driver.probe("session", sessionId)).toBe("absent");
+      // Idempotent teardown.
+      await driver.deprovisionSessionSandbox(sessionId);
+    });
+  },
+);

--- a/backend/services/stigmer-server/src/sandbox/__tests__/kubernetes.test.ts
+++ b/backend/services/stigmer-server/src/sandbox/__tests__/kubernetes.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Pins the Kubernetes driver's ensure state machine and manifest shapes
+ * against the Java provisioner it generalizes (§6d, O6) — over a fake
+ * gateway, no cluster:
+ *
+ *   - absent → Secret first, PVC for persistent scopes, then Deployment;
+ *     no readiness wait (gate ruling Q5);
+ *   - replicas 0 → scale to 1, nothing re-applied;
+ *   - running → the fast path applies nothing (defer-restart, Q6);
+ *   - deprovision deletes Deployment + Secret (+ PVC when persistent);
+ *   - the manifests carry the Java shapes: Recreate, the runner command,
+ *     MODE=local, the secretKeyRef token env only when a token exists,
+ *     the empty Secret for token-less sandboxes.
+ */
+import { describe, expect, it } from "vitest";
+
+import type {
+  V1Deployment,
+  V1PersistentVolumeClaim,
+  V1Secret,
+} from "@kubernetes/client-node";
+
+import { sandboxBaseName } from "../naming.js";
+import type { SandboxDriverConfig } from "../provisioner.js";
+import type { KubernetesSandboxGateway } from "../kubernetes.js";
+import {
+  buildSandboxDeployment,
+  buildSandboxSecret,
+  newKubernetesSandboxProvisionerOverGateway,
+} from "../kubernetes.js";
+
+const silentLogger = { info: () => {} };
+
+const config: SandboxDriverConfig = {
+  backendEndpoint: "http://stigmer-server.stigmer.svc:7234",
+  temporalAddress: "temporal.stigmer.svc:7233",
+  runnerImage: "ghcr.io/stigmer/runner:latest",
+  runnerCommand: "stigmer-runner",
+  kubernetesNamespace: "stigmer-sandboxes",
+};
+
+function fakeGateway(
+  replicasByName: Map<string, number>,
+): KubernetesSandboxGateway & {
+  calls: string[];
+  applied: {
+    secrets: V1Secret[];
+    pvcs: V1PersistentVolumeClaim[];
+    deployments: V1Deployment[];
+  };
+} {
+  const calls: string[] = [];
+  const applied = {
+    secrets: [] as V1Secret[],
+    pvcs: [] as V1PersistentVolumeClaim[],
+    deployments: [] as V1Deployment[],
+  };
+  return {
+    calls,
+    applied,
+    async deploymentReplicas(name) {
+      calls.push(`replicas:${name}`);
+      return replicasByName.get(name);
+    },
+    async applySecret(secret) {
+      calls.push(`applySecret:${secret.metadata?.name ?? ""}`);
+      applied.secrets.push(secret);
+    },
+    async applyPvc(pvc) {
+      calls.push(`applyPvc:${pvc.metadata?.name ?? ""}`);
+      applied.pvcs.push(pvc);
+    },
+    async applyDeployment(deployment) {
+      calls.push(`applyDeployment:${deployment.metadata?.name ?? ""}`);
+      applied.deployments.push(deployment);
+    },
+    async scaleDeployment(name, replicas) {
+      calls.push(`scale:${name}:${replicas}`);
+    },
+    async deleteDeployment(name) {
+      calls.push(`deleteDeployment:${name}`);
+    },
+    async deleteSecret(name) {
+      calls.push(`deleteSecret:${name}`);
+    },
+    async deletePvc(name) {
+      calls.push(`deletePvc:${name}`);
+    },
+  };
+}
+
+const env = { taskQueue: "session:ses_1", stigmerToken: "tok-1" };
+
+describe("the ensure state machine", () => {
+  it("absent → Secret, PVC, Deployment — in that order, no readiness wait", async () => {
+    const gateway = fakeGateway(new Map());
+    const driver = newKubernetesSandboxProvisionerOverGateway(
+      gateway,
+      config,
+      silentLogger,
+    );
+    await driver.ensureSessionSandbox("ses_1", env);
+    const base = sandboxBaseName("session", "ses_1");
+    expect(gateway.calls).toEqual([
+      `replicas:${base}`,
+      `applySecret:${base}-env`,
+      `applyPvc:${base}-workspace`,
+      `applyDeployment:${base}`,
+    ]);
+  });
+
+  it("connect scope rides emptyDir — no PVC applied", async () => {
+    const gateway = fakeGateway(new Map());
+    const driver = newKubernetesSandboxProvisionerOverGateway(
+      gateway,
+      config,
+      silentLogger,
+    );
+    await driver.createConnectSandbox("mcp_1", env);
+    expect(gateway.calls.some((c) => c.startsWith("applyPvc"))).toBe(false);
+    const deployment = gateway.applied.deployments[0];
+    expect(
+      deployment?.spec?.template.spec?.volumes?.[0]?.emptyDir,
+    ).toBeDefined();
+  });
+
+  it("stopped (replicas 0) → scale to 1, nothing re-applied", async () => {
+    const base = sandboxBaseName("session", "ses_1");
+    const gateway = fakeGateway(new Map([[base, 0]]));
+    const driver = newKubernetesSandboxProvisionerOverGateway(
+      gateway,
+      config,
+      silentLogger,
+    );
+    await driver.ensureSessionSandbox("ses_1", env);
+    expect(gateway.calls).toEqual([`replicas:${base}`, `scale:${base}:1`]);
+  });
+
+  it("running → the fast path applies nothing (defer-restart)", async () => {
+    const base = sandboxBaseName("session", "ses_1");
+    const gateway = fakeGateway(new Map([[base, 1]]));
+    const driver = newKubernetesSandboxProvisionerOverGateway(
+      gateway,
+      config,
+      silentLogger,
+    );
+    await driver.ensureSessionSandbox("ses_1", env);
+    expect(gateway.calls).toEqual([`replicas:${base}`]);
+  });
+
+  it("deprovision deletes Deployment + Secret + PVC for persistent scopes", async () => {
+    const gateway = fakeGateway(new Map());
+    const driver = newKubernetesSandboxProvisionerOverGateway(
+      gateway,
+      config,
+      silentLogger,
+    );
+    await driver.deprovisionWorkflowSandbox("wfx_1");
+    const base = sandboxBaseName("workflow", "wfx_1");
+    expect(gateway.calls).toEqual([
+      `deleteDeployment:${base}`,
+      `deleteSecret:${base}-env`,
+      `deletePvc:${base}-workspace`,
+    ]);
+  });
+
+  it("probe maps replicas onto absent/stopped/running", async () => {
+    const base = sandboxBaseName("session", "ses_1");
+    for (const [replicas, expected] of [
+      [undefined, "absent"],
+      [0, "stopped"],
+      [1, "running"],
+    ] as const) {
+      const gateway = fakeGateway(
+        replicas === undefined ? new Map() : new Map([[base, replicas]]),
+      );
+      const driver = newKubernetesSandboxProvisionerOverGateway(
+        gateway,
+        config,
+        silentLogger,
+      );
+      expect(await driver.probe("session", "ses_1")).toBe(expected);
+    }
+  });
+});
+
+describe("the manifest shapes (the Java SandboxManifestFactory pins)", () => {
+  it("the Deployment carries Recreate, the runner command, and the env contract", () => {
+    const deployment = buildSandboxDeployment("session", "ses_1", env, config);
+    expect(deployment.spec?.strategy?.type).toBe("Recreate");
+    const container = deployment.spec?.template.spec?.containers[0];
+    expect(container?.command).toEqual(["node", "/runner/dist/main.js"]);
+    const envByName = new Map(
+      (container?.env ?? []).map((entry) => [entry.name, entry]),
+    );
+    expect(envByName.get("MODE")?.value).toBe("local");
+    expect(envByName.get("STIGMER_TASK_QUEUE")?.value).toBe("session:ses_1");
+    expect(envByName.get("STIGMER_BACKEND_ENDPOINT")?.value).toBe(
+      config.backendEndpoint,
+    );
+    expect(envByName.get("TEMPORAL_SERVICE_ADDRESS")?.value).toBe(
+      config.temporalAddress,
+    );
+    expect(envByName.get("WORKSPACE_ROOT_DIR")?.value).toBe("/workspace");
+    expect(envByName.get("STIGMER_TOKEN")?.valueFrom?.secretKeyRef?.name).toBe(
+      `${sandboxBaseName("session", "ses_1")}-env`,
+    );
+    expect(deployment.spec?.template.spec?.automountServiceAccountToken).toBe(
+      false,
+    );
+  });
+
+  it("a token-less sandbox omits the token env but keeps the (empty) Secret", () => {
+    const tokenless = { taskQueue: "session:ses_1", stigmerToken: "" };
+    const deployment = buildSandboxDeployment(
+      "session",
+      "ses_1",
+      tokenless,
+      config,
+    );
+    const names = (
+      deployment.spec?.template.spec?.containers[0]?.env ?? []
+    ).map((entry) => entry.name);
+    expect(names).not.toContain("STIGMER_TOKEN");
+    const secret = buildSandboxSecret("session", "ses_1", "");
+    expect(secret.stringData).toEqual({});
+  });
+});

--- a/backend/services/stigmer-server/src/sandbox/__tests__/local-process.integration.test.ts
+++ b/backend/services/stigmer-server/src/sandbox/__tests__/local-process.integration.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration smoke for the local-process driver (§6d, O6): real child
+ * processes, the full ensure → fast-path → probe → deprovision cycle,
+ * and the env contract the runner reads (config.ts's variables) —
+ * proven by a stand-in script that dumps its environment where the test
+ * can read it, so no real runner install is needed.
+ *
+ * Unix-only like the runner itself; deterministic (poll with timeout,
+ * never sleep).
+ */
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterAll, describe, expect, it, vi } from "vitest";
+
+import { createLogger } from "../../boot/logger.js";
+import { newLocalProcessSandboxProvisioner } from "../local-process.js";
+import type { SandboxDriverConfig } from "../provisioner.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+describe.skipIf(process.platform === "win32")(
+  "local-process driver (integration)",
+  () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "sbx-localproc-"));
+    // The stand-in runner: records its environment, then stays alive
+    // polling like a worker would (the driver kills it on deprovision).
+    const script = path.join(dir, "fake-runner.sh");
+    writeFileSync(
+      script,
+      `#!/bin/sh\nenv > "${dir}/env-$$.dump"\necho "$$" >> "${dir}/spawns.log"\nwhile true; do sleep 1; done\n`,
+    );
+    chmodSync(script, 0o755);
+
+    const config: SandboxDriverConfig = {
+      backendEndpoint: "http://127.0.0.1:7234",
+      temporalAddress: "127.0.0.1:7233",
+      runnerImage: "unused-by-this-driver",
+      runnerCommand: script,
+      kubernetesNamespace: "unused-by-this-driver",
+    };
+    const driver = newLocalProcessSandboxProvisioner({
+      config,
+      logger: silentLogger,
+    });
+
+    afterAll(async () => {
+      await driver.deprovisionSessionSandbox("ses_smoke");
+      rmSync(dir, { recursive: true, force: true });
+    });
+
+    function spawnCount(): number {
+      const log = path.join(dir, "spawns.log");
+      if (!existsSync(log)) {
+        return 0;
+      }
+      return readFileSync(log, "utf8").trim().split("\n").filter(Boolean)
+        .length;
+    }
+
+    it("ensure spawns once, injects the runner env contract, and is idempotent", async () => {
+      await driver.ensureSessionSandbox("ses_smoke", {
+        taskQueue: "session:ses_smoke",
+        stigmerToken: "tok-smoke",
+      });
+      await vi.waitFor(() => expect(spawnCount()).toBe(1));
+      expect(await driver.probe("session", "ses_smoke")).toBe("running");
+
+      // Fast path: a second ensure must not spawn a second process.
+      await driver.ensureSessionSandbox("ses_smoke", {
+        taskQueue: "session:ses_smoke",
+        stigmerToken: "tok-smoke",
+      });
+      expect(spawnCount()).toBe(1);
+
+      // The env dump carries the contract the runner's config.ts reads.
+      const dumpName = readFileSync(path.join(dir, "spawns.log"), "utf8")
+        .trim()
+        .split("\n")[0];
+      const dump = readFileSync(path.join(dir, `env-${dumpName}.dump`), "utf8");
+      expect(dump).toContain("MODE=local");
+      expect(dump).toContain("STIGMER_TASK_QUEUE=session:ses_smoke");
+      expect(dump).toContain("STIGMER_TOKEN=tok-smoke");
+      expect(dump).toContain(
+        `STIGMER_BACKEND_ENDPOINT=${config.backendEndpoint}`,
+      );
+      expect(dump).toContain(
+        `TEMPORAL_SERVICE_ADDRESS=${config.temporalAddress}`,
+      );
+      expect(dump).toMatch(/WORKSPACE_ROOT_DIR=.+session-ses_smoke/);
+    });
+
+    it("deprovision kills the child; probe reports absent; re-ensure respawns", async () => {
+      await driver.deprovisionSessionSandbox("ses_smoke");
+      await vi.waitFor(async () => {
+        expect(await driver.probe("session", "ses_smoke")).toBe("absent");
+      });
+
+      // The repair arm without stored state: a fresh ensure respawns.
+      await driver.ensureSessionSandbox("ses_smoke", {
+        taskQueue: "session:ses_smoke",
+        stigmerToken: "",
+      });
+      await vi.waitFor(() => expect(spawnCount()).toBe(2));
+      expect(await driver.probe("session", "ses_smoke")).toBe("running");
+    });
+
+    it("deprovision of an absent sandbox is success (idempotent)", async () => {
+      await driver.deprovisionWorkflowSandbox("wfx_never_existed");
+    });
+  },
+);

--- a/backend/services/stigmer-server/src/sandbox/__tests__/provisioner.test.ts
+++ b/backend/services/stigmer-server/src/sandbox/__tests__/provisioner.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Pins the sandbox driver seam's selection and naming contracts (§6d,
+ * O6):
+ *
+ *   - "" selects NO provisioner — the external-runner default whose
+ *     byte-identity the conformance rosters ride;
+ *   - unknown names are loud boot throws listing every known type;
+ *   - extension-registered factories are reachable behind the knob but
+ *     can never shadow a built-in name;
+ *   - sandboxBaseName is the Java SandboxObjectNaming derivation
+ *     (sbx-<code>-<12-hex-sha256>), deterministic and DNS-1123-safe for
+ *     resource-id alphabets.
+ */
+import { describe, expect, it } from "vitest";
+
+import { createLogger } from "../../boot/logger.js";
+import { sandboxBaseName } from "../naming.js";
+import type {
+  SandboxDriverConfig,
+  SandboxProvisioner,
+  SandboxProvisionerFactory,
+} from "../provisioner.js";
+import {
+  BUILT_IN_SANDBOX_PROVISIONER_TYPES,
+  newSandboxProvisioner,
+} from "../provisioner.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const driverConfig: SandboxDriverConfig = {
+  backendEndpoint: "http://host.docker.internal:7234",
+  temporalAddress: "host.docker.internal:7233",
+  runnerImage: "ghcr.io/stigmer/runner:latest",
+  runnerCommand: "stigmer-runner",
+  kubernetesNamespace: "stigmer-sandboxes",
+};
+
+function fakeFactory(marker: {
+  constructed: number;
+}): SandboxProvisionerFactory {
+  return () => {
+    marker.constructed += 1;
+    return {} as SandboxProvisioner;
+  };
+}
+
+describe("newSandboxProvisioner selection", () => {
+  it("empty type selects nothing — the external-runner default", () => {
+    const provisioner = newSandboxProvisioner(
+      "",
+      { config: driverConfig, logger: silentLogger },
+      new Map(),
+      new Map(),
+    );
+    expect(provisioner).toBeUndefined();
+  });
+
+  it("an unknown type is a loud boot throw naming the known set", () => {
+    const marker = { constructed: 0 };
+    expect(() =>
+      newSandboxProvisioner(
+        "daytona",
+        { config: driverConfig, logger: silentLogger },
+        new Map([["docker", fakeFactory(marker)]]),
+        new Map([["fly-machines", fakeFactory(marker)]]),
+      ),
+    ).toThrowError(
+      "unknown sandbox provisioner type 'daytona' — known types: 'docker', 'fly-machines'",
+    );
+    expect(marker.constructed, "no factory may run on a failed selection").toBe(
+      0,
+    );
+  });
+
+  it("selects a built-in factory and constructs it exactly once", () => {
+    const marker = { constructed: 0 };
+    const provisioner = newSandboxProvisioner(
+      "docker",
+      { config: driverConfig, logger: silentLogger },
+      new Map([["docker", fakeFactory(marker)]]),
+      new Map(),
+    );
+    expect(provisioner).toBeDefined();
+    expect(marker.constructed).toBe(1);
+  });
+
+  it("selects an extension-registered factory beyond the built-ins", () => {
+    const marker = { constructed: 0 };
+    const provisioner = newSandboxProvisioner(
+      "fly-machines",
+      { config: driverConfig, logger: silentLogger },
+      new Map(),
+      new Map([["fly-machines", fakeFactory(marker)]]),
+    );
+    expect(provisioner).toBeDefined();
+    expect(marker.constructed).toBe(1);
+  });
+
+  it("an unselected driver constructs nothing (§6b's factory discipline)", () => {
+    const selected = { constructed: 0 };
+    const bystander = { constructed: 0 };
+    newSandboxProvisioner(
+      "docker",
+      { config: driverConfig, logger: silentLogger },
+      new Map([
+        ["docker", fakeFactory(selected)],
+        ["kubernetes", fakeFactory(bystander)],
+      ]),
+      new Map(),
+    );
+    expect(bystander.constructed).toBe(0);
+  });
+
+  it("the built-in name set is DD-002's isolation ladder", () => {
+    expect([...BUILT_IN_SANDBOX_PROVISIONER_TYPES]).toEqual([
+      "local-process",
+      "docker",
+      "kubernetes",
+    ]);
+  });
+});
+
+describe("sandboxBaseName (the Java SandboxObjectNaming derivation)", () => {
+  it("is deterministic per scope+id and distinct across scopes", () => {
+    const a = sandboxBaseName("session", "ses_01ABC");
+    expect(a).toBe(sandboxBaseName("session", "ses_01ABC"));
+    expect(a).not.toBe(sandboxBaseName("workflow", "ses_01ABC"));
+    expect(a).not.toBe(sandboxBaseName("session", "ses_01ABD"));
+  });
+
+  it("emits the sbx-<code>-<12-hex> shape, DNS-safe for id alphabets", () => {
+    for (const [scope, code] of [
+      ["session", "ses"],
+      ["workflow", "wfx"],
+      ["connect", "mcp"],
+    ] as const) {
+      const name = sandboxBaseName(scope, "wfx_01J_UNDERSCORED.id");
+      expect(name).toMatch(new RegExp(`^sbx-${code}-[0-9a-f]{12}$`));
+    }
+  });
+});

--- a/backend/services/stigmer-server/src/sandbox/__tests__/steps.test.ts
+++ b/backend/services/stigmer-server/src/sandbox/__tests__/steps.test.ts
@@ -1,0 +1,524 @@
+/**
+ * Pins the sandbox invocation surface's per-lane postures (§6d, O6 —
+ * the T01 gate rulings Q1/Q2/Q3/Q6):
+ *
+ *   - the session lane fires ONLY on resolved CLOUD target with
+ *     per-session routing, is NON-critical (a provisioning failure never
+ *     throws), and PRE-STAMPS the root cause onto status.error
+ *     first-non-empty-wins — the 2026-07 quota-outage contract;
+ *   - the workflow lane fires only on CLOUD + per-execution routing and
+ *     is CRITICAL (Unavailable on failure);
+ *   - the terminal observer deprovisions exactly on transitions INTO a
+ *     terminal phase, fire-and-forget, and swallows (logs) teardown
+ *     failures;
+ *   - a disabled mint lane launches token-less rather than failing.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { ExecutionTarget } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase as WorkflowExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../boot/logger.js";
+import {
+  AgentExecutionTemporalConfig,
+  ROUTING_GLOBAL,
+  ROUTING_SESSION,
+} from "../../domain/agentexecution/temporal/config.js";
+import {
+  WORKFLOW_ROUTING_EXECUTION,
+  WORKFLOW_ROUTING_GLOBAL,
+  WorkflowExecutionTemporalConfig,
+} from "../../domain/workflowexecution/temporal/config.js";
+import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
+import { SqliteStore } from "../../store/sqlite/store.js";
+import type { SandboxLane } from "../lane.js";
+import type { SandboxEnvironment, SandboxProvisioner } from "../provisioner.js";
+import {
+  deprovisionSessionSandboxBestEffort,
+  ensureSessionSandboxForExecution,
+  ensureWorkflowSandboxForExecution,
+  newWorkflowSandboxTerminalObserver,
+  SANDBOX_PROVISIONING_FAILED_PREFIX,
+} from "../steps.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+/** Records every provisioner call; ensure/deprovision failures injectable. */
+function fakeProvisioner(overrides?: {
+  ensureError?: Error;
+  deprovisionError?: Error;
+}): SandboxProvisioner & {
+  ensured: Array<{ scope: string; id: string; env: SandboxEnvironment }>;
+  deprovisioned: Array<{ scope: string; id: string }>;
+} {
+  const ensured: Array<{ scope: string; id: string; env: SandboxEnvironment }> =
+    [];
+  const deprovisioned: Array<{ scope: string; id: string }> = [];
+  const ensure = async (scope: string, id: string, env: SandboxEnvironment) => {
+    if (overrides?.ensureError) {
+      throw overrides.ensureError;
+    }
+    ensured.push({ scope, id, env });
+  };
+  const deprovision = async (scope: string, id: string) => {
+    if (overrides?.deprovisionError) {
+      throw overrides.deprovisionError;
+    }
+    deprovisioned.push({ scope, id });
+  };
+  return {
+    ensured,
+    deprovisioned,
+    ensureSessionSandbox: (id, env) => ensure("session", id, env),
+    deprovisionSessionSandbox: (id) => deprovision("session", id),
+    ensureWorkflowSandbox: (id, env) => ensure("workflow", id, env),
+    deprovisionWorkflowSandbox: (id) => deprovision("workflow", id),
+    createConnectSandbox: async (id, env) => {
+      await ensure("connect", id, env);
+      return id;
+    },
+    deprovisionConnectSandbox: (id) => deprovision("connect", id),
+    probe: async () => "absent" as const,
+  };
+}
+
+const mintingCredentials: RunnerCredentialProvider = {
+  isEnabled: (lane) => lane === "execution_scoped",
+  mint: (_lane, binding, ttlSeconds) => ({
+    token: `tok-${binding}`,
+    ttlSeconds,
+  }),
+  verify: () => {
+    throw new Error("verify is not under test");
+  },
+};
+
+const disabledCredentials: RunnerCredentialProvider = {
+  isEnabled: () => false,
+  mint: () => {
+    throw new Error("mint must not be called when the lane is disabled");
+  },
+  verify: () => {
+    throw new Error("verify is not under test");
+  },
+};
+
+function lane(
+  provisioner: SandboxProvisioner,
+  credentials: RunnerCredentialProvider = mintingCredentials,
+): SandboxLane {
+  return { enabled: true, provisioner, credentials };
+}
+
+const sessionRoutingCloudDefault = new AgentExecutionTemporalConfig(
+  "agent_execution_stigmer",
+  "stigmer_runner",
+  ROUTING_SESSION,
+  "cloud",
+);
+
+const executionRoutingConfig = new WorkflowExecutionTemporalConfig(
+  "workflow_execution_stigmer",
+  "stigmer_runner",
+  WORKFLOW_ROUTING_EXECUTION,
+  "local",
+);
+
+describe("the session lane (ensureSessionSandboxForExecution)", () => {
+  let dir: string;
+  let store: SqliteStore;
+  let counter = 0;
+
+  beforeAll(() => {
+    dir = mkdtempSync(path.join(tmpdir(), "sandbox-steps-"));
+    store = SqliteStore.open(path.join(dir, "test.db"));
+  });
+  afterAll(async () => {
+    await store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function seed(target: ExecutionTarget): Promise<{
+    sessionId: string;
+    execution: AgentExecution;
+  }> {
+    counter += 1;
+    const sessionId = `ses_sbx_${counter}`;
+    const executionId = `axr_sbx_${counter}`;
+    await store.saveResource(
+      ApiResourceKind.session,
+      sessionId,
+      SessionSchema,
+      create(SessionSchema, {
+        metadata: { id: sessionId, name: sessionId },
+        spec: { executionTarget: target },
+      }),
+    );
+    const execution = create(AgentExecutionSchema, {
+      metadata: { id: executionId, name: executionId },
+      spec: { sessionId },
+    });
+    await store.saveResource(
+      ApiResourceKind.agent_execution,
+      executionId,
+      AgentExecutionSchema,
+      execution,
+    );
+    return { sessionId, execution };
+  }
+
+  it("fires on CLOUD target with the per-session queue and the minted token", async () => {
+    const provisioner = fakeProvisioner();
+    const { sessionId, execution } = await seed(ExecutionTarget.CLOUD);
+    await ensureSessionSandboxForExecution(
+      {
+        store,
+        logger: silentLogger,
+        lane: lane(provisioner),
+        temporalConfig: sessionRoutingCloudDefault,
+      },
+      execution,
+    );
+    expect(provisioner.ensured).toEqual([
+      {
+        scope: "session",
+        id: sessionId,
+        env: {
+          taskQueue: `session:${sessionId}`,
+          stigmerToken: `tok-${execution.metadata?.id ?? ""}`,
+        },
+      },
+    ]);
+  });
+
+  it("skips on resolved LOCAL target — the roster fast path", async () => {
+    const provisioner = fakeProvisioner();
+    const { execution } = await seed(ExecutionTarget.LOCAL);
+    await ensureSessionSandboxForExecution(
+      {
+        store,
+        logger: silentLogger,
+        lane: lane(provisioner),
+        temporalConfig: sessionRoutingCloudDefault,
+      },
+      execution,
+    );
+    expect(provisioner.ensured).toEqual([]);
+  });
+
+  it("skips when the lane is disabled without touching the store", async () => {
+    const execution = create(AgentExecutionSchema, {
+      metadata: { id: "axr_disabled" },
+      spec: { sessionId: "ses_never_loaded" },
+    });
+    // A store that fails every read proves the disabled arm never reads.
+    const explodingStore = new Proxy(store, {
+      get() {
+        throw new Error("the disabled lane must not touch the store");
+      },
+    });
+    await ensureSessionSandboxForExecution(
+      {
+        store: explodingStore,
+        logger: silentLogger,
+        lane: { enabled: false },
+        temporalConfig: sessionRoutingCloudDefault,
+      },
+      execution,
+    );
+  });
+
+  it("skips on the wfexec: queue-override lane (child sandbox affinity)", async () => {
+    const provisioner = fakeProvisioner();
+    const { execution } = await seed(ExecutionTarget.CLOUD);
+    if (execution.spec !== undefined) {
+      execution.spec.activityTaskQueue = "wfexec:wfx_parent";
+    }
+    await ensureSessionSandboxForExecution(
+      {
+        store,
+        logger: silentLogger,
+        lane: lane(provisioner),
+        temporalConfig: sessionRoutingCloudDefault,
+      },
+      execution,
+    );
+    expect(provisioner.ensured).toEqual([]);
+  });
+
+  it("skips (warn) on CLOUD target under global routing — the dark-config belt", async () => {
+    const provisioner = fakeProvisioner();
+    const { execution } = await seed(ExecutionTarget.CLOUD);
+    await ensureSessionSandboxForExecution(
+      {
+        store,
+        logger: silentLogger,
+        lane: lane(provisioner),
+        temporalConfig: new AgentExecutionTemporalConfig(
+          "agent_execution_stigmer",
+          "stigmer_runner",
+          ROUTING_GLOBAL,
+          "cloud",
+        ),
+      },
+      execution,
+    );
+    expect(provisioner.ensured).toEqual([]);
+  });
+
+  it("launches token-less when the mint lane is disabled (redaction posture)", async () => {
+    const provisioner = fakeProvisioner();
+    const { execution } = await seed(ExecutionTarget.CLOUD);
+    await ensureSessionSandboxForExecution(
+      {
+        store,
+        logger: silentLogger,
+        lane: lane(provisioner, disabledCredentials),
+        temporalConfig: sessionRoutingCloudDefault,
+      },
+      execution,
+    );
+    expect(provisioner.ensured[0]?.env.stigmerToken).toBe("");
+  });
+
+  it("a provisioning failure never throws and pre-stamps status.error", async () => {
+    const provisioner = fakeProvisioner({
+      ensureError: new Error("quota exhausted: count/secrets"),
+    });
+    const { execution } = await seed(ExecutionTarget.CLOUD);
+    const executionId = execution.metadata?.id ?? "";
+    await ensureSessionSandboxForExecution(
+      {
+        store,
+        logger: silentLogger,
+        lane: lane(provisioner),
+        temporalConfig: sessionRoutingCloudDefault,
+      },
+      execution,
+    );
+    const stamped = await store.getResource(
+      ApiResourceKind.agent_execution,
+      executionId,
+      AgentExecutionSchema,
+    );
+    expect(stamped.status?.error).toBe(
+      `${SANDBOX_PROVISIONING_FAILED_PREFIX}quota exhausted: count/secrets`,
+    );
+  });
+
+  it("the pre-stamp is first-non-empty-wins — an existing error survives", async () => {
+    const provisioner = fakeProvisioner({
+      ensureError: new Error("second failure"),
+    });
+    const { sessionId, execution } = await seed(ExecutionTarget.CLOUD);
+    const executionId = execution.metadata?.id ?? "";
+    // Re-seed WITH a status already carrying the first error — the state
+    // a concurrent runner write (or an earlier stamp) leaves behind.
+    await store.saveResource(
+      ApiResourceKind.agent_execution,
+      executionId,
+      AgentExecutionSchema,
+      create(AgentExecutionSchema, {
+        metadata: { id: executionId, name: executionId },
+        spec: { sessionId },
+        status: { error: "the real root cause" },
+      }),
+    );
+    await ensureSessionSandboxForExecution(
+      {
+        store,
+        logger: silentLogger,
+        lane: lane(provisioner),
+        temporalConfig: sessionRoutingCloudDefault,
+      },
+      execution,
+    );
+    const after = await store.getResource(
+      ApiResourceKind.agent_execution,
+      executionId,
+      AgentExecutionSchema,
+    );
+    expect(after.status?.error).toBe("the real root cause");
+  });
+});
+
+describe("the workflow lane (ensureWorkflowSandboxForExecution)", () => {
+  function workflowExecution(target: ExecutionTarget) {
+    return create(WorkflowExecutionSchema, {
+      metadata: { id: "wfx_sbx_1", name: "wfx_sbx_1" },
+      spec: { executionTarget: target },
+    });
+  }
+
+  it("fires on CLOUD + per-execution routing with the wfexec queue", async () => {
+    const provisioner = fakeProvisioner();
+    await ensureWorkflowSandboxForExecution(
+      {
+        logger: silentLogger,
+        lane: lane(provisioner),
+        temporalConfig: executionRoutingConfig,
+      },
+      workflowExecution(ExecutionTarget.CLOUD),
+    );
+    expect(provisioner.ensured).toEqual([
+      {
+        scope: "workflow",
+        id: "wfx_sbx_1",
+        env: { taskQueue: "wfexec:wfx_sbx_1", stigmerToken: "tok-wfx_sbx_1" },
+      },
+    ]);
+  });
+
+  it("skips on LOCAL target and on global routing", async () => {
+    const provisioner = fakeProvisioner();
+    await ensureWorkflowSandboxForExecution(
+      {
+        logger: silentLogger,
+        lane: lane(provisioner),
+        temporalConfig: executionRoutingConfig,
+      },
+      workflowExecution(ExecutionTarget.LOCAL),
+    );
+    await ensureWorkflowSandboxForExecution(
+      {
+        logger: silentLogger,
+        lane: lane(provisioner),
+        temporalConfig: new WorkflowExecutionTemporalConfig(
+          "workflow_execution_stigmer",
+          "stigmer_runner",
+          WORKFLOW_ROUTING_GLOBAL,
+          "cloud",
+        ),
+      },
+      workflowExecution(ExecutionTarget.CLOUD),
+    );
+    expect(provisioner.ensured).toEqual([]);
+  });
+
+  it("a provisioning failure is CRITICAL — Unavailable, the create refused", async () => {
+    const provisioner = fakeProvisioner({
+      ensureError: new Error("no capacity"),
+    });
+    try {
+      await ensureWorkflowSandboxForExecution(
+        {
+          logger: silentLogger,
+          lane: lane(provisioner),
+          temporalConfig: executionRoutingConfig,
+        },
+        workflowExecution(ExecutionTarget.CLOUD),
+      );
+      expect.unreachable("the workflow lane must throw on failure");
+    } catch (error) {
+      const connectError = ConnectError.from(error);
+      expect(connectError.code).toBe(Code.Unavailable);
+      expect(connectError.rawMessage).toBe(
+        "failed to provision workflow sandbox",
+      );
+    }
+  });
+});
+
+describe("the terminal observer (newWorkflowSandboxTerminalObserver)", () => {
+  const P = WorkflowExecutionPhase;
+
+  it("deprovisions on every transition INTO a terminal phase", async () => {
+    const provisioner = fakeProvisioner();
+    const observe = newWorkflowSandboxTerminalObserver(
+      lane(provisioner),
+      silentLogger,
+    );
+    observe("wfx_1", P.EXECUTION_IN_PROGRESS, P.EXECUTION_COMPLETED);
+    observe("wfx_2", P.EXECUTION_IN_PROGRESS, P.EXECUTION_FAILED);
+    observe("wfx_3", P.EXECUTION_PENDING, P.EXECUTION_CANCELLED);
+    observe("wfx_4", P.EXECUTION_PAUSED, P.EXECUTION_TERMINATED);
+    await vi.waitFor(() => {
+      expect(provisioner.deprovisioned.map((d) => d.id)).toEqual([
+        "wfx_1",
+        "wfx_2",
+        "wfx_3",
+        "wfx_4",
+      ]);
+    });
+    expect(provisioner.deprovisioned.every((d) => d.scope === "workflow")).toBe(
+      true,
+    );
+  });
+
+  it("ignores non-terminal phases, non-transitions, and the disabled lane", async () => {
+    const provisioner = fakeProvisioner();
+    const observe = newWorkflowSandboxTerminalObserver(
+      lane(provisioner),
+      silentLogger,
+    );
+    observe("wfx_a", P.EXECUTION_PENDING, P.EXECUTION_IN_PROGRESS);
+    observe("wfx_b", P.EXECUTION_FAILED, P.EXECUTION_FAILED);
+    const disabledObserve = newWorkflowSandboxTerminalObserver(
+      { enabled: false },
+      silentLogger,
+    );
+    disabledObserve("wfx_c", P.EXECUTION_IN_PROGRESS, P.EXECUTION_COMPLETED);
+    // Give any wrongly-fired teardown a chance to surface.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(provisioner.deprovisioned).toEqual([]);
+  });
+
+  it("a teardown failure is logged, never thrown (fire-and-forget)", async () => {
+    const failures: string[] = [];
+    const loggingLogger = createLogger({
+      level: "error",
+      pretty: false,
+      write: (line) => failures.push(line),
+    });
+    const provisioner = fakeProvisioner({
+      deprovisionError: new Error("api unreachable"),
+    });
+    const observe = newWorkflowSandboxTerminalObserver(
+      lane(provisioner),
+      loggingLogger,
+    );
+    observe("wfx_leak", P.EXECUTION_IN_PROGRESS, P.EXECUTION_FAILED);
+    await vi.waitFor(() => {
+      expect(failures.join("")).toContain("sandbox may be leaked");
+    });
+  });
+});
+
+describe("deprovisionSessionSandboxBestEffort", () => {
+  it("tears down through the lane and swallows failures", async () => {
+    const ok = fakeProvisioner();
+    await deprovisionSessionSandboxBestEffort(lane(ok), silentLogger, "ses_1");
+    expect(ok.deprovisioned).toEqual([{ scope: "session", id: "ses_1" }]);
+
+    const failing = fakeProvisioner({
+      deprovisionError: new Error("gone wrong"),
+    });
+    await deprovisionSessionSandboxBestEffort(
+      lane(failing),
+      silentLogger,
+      "ses_2",
+    );
+    // Reaching here IS the assertion: the failure was swallowed.
+
+    await deprovisionSessionSandboxBestEffort(
+      { enabled: false },
+      silentLogger,
+      "ses_3",
+    );
+  });
+});

--- a/backend/services/stigmer-server/src/sandbox/builtins.ts
+++ b/backend/services/stigmer-server/src/sandbox/builtins.ts
@@ -1,0 +1,22 @@
+/**
+ * The built-in sandbox driver assembly — the name → factory table the
+ * composition root hands to newSandboxProvisioner, one entry per tier of
+ * DD-002's isolation ladder. Kept separate from provisioner.ts so the
+ * contract module never imports driver implementations (extensions
+ * compile against the contract alone through the exports map).
+ */
+import { newDockerSandboxProvisioner } from "./docker.js";
+import { newKubernetesSandboxProvisioner } from "./kubernetes.js";
+import { newLocalProcessSandboxProvisioner } from "./local-process.js";
+import type { SandboxProvisionerFactory } from "./provisioner.js";
+
+export function builtInSandboxProvisionerFactories(): ReadonlyMap<
+  string,
+  SandboxProvisionerFactory
+> {
+  return new Map<string, SandboxProvisionerFactory>([
+    ["local-process", newLocalProcessSandboxProvisioner],
+    ["docker", newDockerSandboxProvisioner],
+    ["kubernetes", newKubernetesSandboxProvisioner],
+  ]);
+}

--- a/backend/services/stigmer-server/src/sandbox/docker.ts
+++ b/backend/services/stigmer-server/src/sandbox/docker.ts
@@ -1,0 +1,206 @@
+/**
+ * The Docker sandbox driver — DD-002's second isolation tier, built by
+ * O6 (20260827.05). Each sandbox is one container running the published
+ * runner image, polling exactly one task queue. Mechanism per the
+ * mid-session owner ruling: the docker CLI via child_process — zero new
+ * dependencies, present wherever this tier's audience (dev and small
+ * self-host boxes) already has Docker; the driver seam keeps an
+ * Engine-API swap mechanical if demand appears.
+ *
+ * The ensure state machine (the Java KubernetesSandboxProvisioner's
+ * arms, minus the cloud-only archive ladder): container absent → run;
+ * exists but stopped → start; running → fast path. State is derived
+ * from the container itself — name + labels — never a store table (gate
+ * ruling Q4).
+ *
+ * Deliberate divergences from the cloud manifest, named:
+ *
+ *   - MODE=local, not cloud: the runner's MODE distinguishes
+ *     proxy-transport posture (cloud routes LLM/artifact traffic through
+ *     the proxy and REQUIRES a token), not isolation. An OSS container
+ *     talks to the backend directly, exactly like the compose stack's
+ *     runner container.
+ *   - The token rides `docker run -e STIGMER_TOKEN` with the VALUE
+ *     supplied through the CLI's environment (never argv — argv is
+ *     world-readable in the host process table). It remains visible in
+ *     `docker inspect`, the same trust boundary as the cloud's
+ *     per-sandbox Secret (cluster admins can read those too).
+ *
+ * Both endpoints are construct-time REQUIRED: a container cannot reach
+ * the server or Temporal on this process's localhost, and a driver that
+ * launched sandboxes pointing nowhere would fail as activity timeouts
+ * minutes later — the loud-fail doctrine puts the error at boot instead.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import type {
+  SandboxEnvironment,
+  SandboxProbeState,
+  SandboxProvisioner,
+  SandboxProvisionerFactory,
+  SandboxScope,
+} from "./provisioner.js";
+import {
+  SANDBOX_ID_LABEL,
+  SANDBOX_MANAGED_BY_LABEL,
+  SANDBOX_MANAGED_BY_VALUE,
+  SANDBOX_SCOPE_LABEL,
+  sandboxBaseName,
+} from "./naming.js";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * The runner entrypoint inside the sandbox image — the image's CMD is
+ * /bin/bash by design (Dockerfile.sandbox: the provisioner sets the
+ * command, exactly as the cloud pod spec does).
+ */
+const RUNNER_CONTAINER_COMMAND = ["node", "/runner/dist/main.js"];
+
+/** The in-container workspace mount point (the cloud manifest's value). */
+const CONTAINER_WORKSPACE_DIR = "/workspace";
+
+export const newDockerSandboxProvisioner: SandboxProvisionerFactory = ({
+  config,
+  logger,
+}) => {
+  if (config.backendEndpoint === "") {
+    throw new Error(
+      "sandbox provisioner 'docker' requires STIGMER_SANDBOX_BACKEND_ENDPOINT — a container cannot reach the server on this process's localhost",
+    );
+  }
+  if (config.temporalAddress === "") {
+    throw new Error(
+      "sandbox provisioner 'docker' requires STIGMER_SANDBOX_TEMPORAL_ADDRESS (or TEMPORAL_HOST_PORT) reachable from inside a container",
+    );
+  }
+
+  async function docker(
+    args: string[],
+    env?: NodeJS.ProcessEnv,
+  ): Promise<string> {
+    const { stdout } = await execFileAsync("docker", args, {
+      env: env ?? process.env,
+    });
+    return stdout.trim();
+  }
+
+  /** Live container state by name: absent | stopped | running (Q5's probe). */
+  async function inspectState(name: string): Promise<SandboxProbeState> {
+    try {
+      const running = await docker([
+        "inspect",
+        "--format",
+        "{{.State.Running}}",
+        name,
+      ]);
+      return running === "true" ? "running" : "stopped";
+    } catch (error) {
+      if (isNoSuchContainer(error)) {
+        return "absent";
+      }
+      throw error;
+    }
+  }
+
+  async function ensure(
+    scope: SandboxScope,
+    id: string,
+    env: SandboxEnvironment,
+  ): Promise<void> {
+    const name = sandboxBaseName(scope, id);
+    const state = await inspectState(name);
+    if (state === "running") {
+      return; // The fast path.
+    }
+    if (state === "stopped") {
+      // The scale-up arm: the container keeps its original env (token
+      // included) — the cloud's defer-restart posture for a stale token
+      // degenerates here to "the next full recreate re-mints" (Q6).
+      await docker(["start", name]);
+      logger.info("Docker sandbox restarted", { scope, id, container: name });
+      return;
+    }
+    const runArgs = [
+      "run",
+      "--detach",
+      "--name",
+      name,
+      "--label",
+      `${SANDBOX_MANAGED_BY_LABEL}=${SANDBOX_MANAGED_BY_VALUE}`,
+      "--label",
+      `${SANDBOX_SCOPE_LABEL}=${scope}`,
+      "--label",
+      `${SANDBOX_ID_LABEL}=${id}`,
+      "--env",
+      "MODE=local",
+      "--env",
+      `STIGMER_TASK_QUEUE=${env.taskQueue}`,
+      "--env",
+      `STIGMER_BACKEND_ENDPOINT=${config.backendEndpoint}`,
+      "--env",
+      `TEMPORAL_SERVICE_ADDRESS=${config.temporalAddress}`,
+      "--env",
+      `WORKSPACE_ROOT_DIR=${CONTAINER_WORKSPACE_DIR}`,
+    ];
+    let runEnv: NodeJS.ProcessEnv | undefined;
+    if (env.stigmerToken !== "") {
+      // Value-less --env inherits from the CLI's environment (module
+      // header: the token must never appear in argv).
+      runArgs.push("--env", "STIGMER_TOKEN");
+      runEnv = { ...process.env, STIGMER_TOKEN: env.stigmerToken };
+    }
+    runArgs.push(config.runnerImage, ...RUNNER_CONTAINER_COMMAND);
+    await docker(runArgs, runEnv);
+    logger.info("Docker sandbox provisioned", {
+      scope,
+      id,
+      container: name,
+      taskQueue: env.taskQueue,
+      image: config.runnerImage,
+    });
+  }
+
+  async function deprovision(scope: SandboxScope, id: string): Promise<void> {
+    const name = sandboxBaseName(scope, id);
+    try {
+      await docker(["rm", "--force", name]);
+      logger.info("Docker sandbox deprovisioned", {
+        scope,
+        id,
+        container: name,
+      });
+    } catch (error) {
+      if (isNoSuchContainer(error)) {
+        return; // Missing is success — idempotent teardown.
+      }
+      throw error;
+    }
+  }
+
+  const provisioner: SandboxProvisioner = {
+    ensureSessionSandbox: (sessionId, env) => ensure("session", sessionId, env),
+    deprovisionSessionSandbox: (sessionId) => deprovision("session", sessionId),
+    ensureWorkflowSandbox: (executionId, env) =>
+      ensure("workflow", executionId, env),
+    deprovisionWorkflowSandbox: (executionId) =>
+      deprovision("workflow", executionId),
+    async createConnectSandbox(connectRequestId, env) {
+      await ensure("connect", connectRequestId, env);
+      return connectRequestId;
+    },
+    deprovisionConnectSandbox: (sandboxId) => deprovision("connect", sandboxId),
+    probe: (scope, id) => inspectState(sandboxBaseName(scope, id)),
+  };
+  return provisioner;
+};
+
+/** Docker CLI's not-found shapes ("No such container"/"No such object"). */
+function isNoSuchContainer(error: unknown): boolean {
+  const text =
+    error instanceof Error
+      ? `${error.message} ${(error as { stderr?: string }).stderr ?? ""}`
+      : String(error);
+  return text.includes("No such container") || text.includes("No such object");
+}

--- a/backend/services/stigmer-server/src/sandbox/kubernetes.ts
+++ b/backend/services/stigmer-server/src/sandbox/kubernetes.ts
@@ -1,0 +1,478 @@
+/**
+ * The Kubernetes sandbox driver — DD-002's third isolation tier, the
+ * cloud edition's production provisioner GENERALIZED (stigmer-cloud
+ * KubernetesSandboxProvisioner.java + SandboxManifestFactory.java, built
+ * by O6 20260827.05; mechanism per the mid-session owner ruling:
+ * @kubernetes/client-node, the official client — this driver is the one
+ * the cloud composition will eventually run in production, C4).
+ *
+ * Each sandbox = a per-sandbox Secret (STIGMER_TOKEN) + a single-replica
+ * Deployment (strategy Recreate) + a PVC-backed /workspace for the
+ * persistent scopes (session, workflow — the Java persistent-scope
+ * split; connect rides emptyDir). One shared namespace, never
+ * per-sandbox namespaces. Naming and labels ride naming.ts (the Java
+ * SandboxObjectNaming derivation).
+ *
+ * The ensure state machine (the Java arms, minus the cloud-only
+ * archive/restore ladder and pool claim): Deployment absent → apply
+ * Secret + PVC + Deployment (the repair arm — a surviving PVC is reused
+ * by name); replicas 0 → scale to 1; replicas ≥ 1 → fast path. State is
+ * the cluster's, never a store table (gate ruling Q4). NO readiness
+ * probes and no post-apply wait, deliberately (gate ruling Q5): the boot
+ * window is covered by Temporal's ScheduleToStartTimeout, and the ensure
+ * step's error pre-stamp names provisioning failures.
+ *
+ * Stale-token posture (gate ruling Q6): OSS tokens are per-execution
+ * re-mints — a running sandbox keeps the Secret it booted with (the
+ * cloud's defer-restart discipline, cloud#485: never SIGTERM the
+ * triggering turn); the repair and provision arms always write the
+ * freshest token.
+ *
+ * Deliberate divergence from the cloud manifest, named: MODE=local, not
+ * cloud — MODE selects the runner's proxy-transport posture (cloud-only
+ * lanes), not isolation. OSS sandboxes talk to the backend directly.
+ */
+import {
+  ApiException,
+  AppsV1Api,
+  CoreV1Api,
+  KubeConfig,
+} from "@kubernetes/client-node";
+import type {
+  V1Deployment,
+  V1PersistentVolumeClaim,
+  V1Secret,
+} from "@kubernetes/client-node";
+
+import type {
+  SandboxDriverConfig,
+  SandboxEnvironment,
+  SandboxProbeState,
+  SandboxProvisioner,
+  SandboxProvisionerFactory,
+  SandboxScope,
+} from "./provisioner.js";
+import {
+  SANDBOX_ID_LABEL,
+  SANDBOX_MANAGED_BY_LABEL,
+  SANDBOX_MANAGED_BY_VALUE,
+  SANDBOX_SCOPE_LABEL,
+  sandboxBaseName,
+} from "./naming.js";
+
+// ---------------------------------------------------------------------------
+// Manifest constants — the Java SandboxManifestFactory values, kept
+// identical so a sandbox looks the same whichever edition provisioned it.
+// ---------------------------------------------------------------------------
+
+/** The runner container name (SandboxManifestFactory). */
+const RUNNER_CONTAINER_NAME = "runner";
+/** The image CMD is /bin/bash by design — the provisioner sets the command. */
+const RUNNER_COMMAND = ["node", "/runner/dist/main.js"];
+/** The in-pod workspace mount (SandboxManifestFactory WORKSPACE mount). */
+const WORKSPACE_MOUNT_PATH = "/workspace";
+/** Persistent-scope workspace claim size (the Java default). */
+const WORKSPACE_PVC_SIZE = "10Gi";
+/**
+ * Drain window for a full runner turn (SandboxManifestFactory's
+ * terminationGracePeriodSeconds — a SIGTERM'd runner finishes streaming
+ * before the kill).
+ */
+const TERMINATION_GRACE_PERIOD_SECONDS = 600;
+/** The Java resource shape: requests 500m/512Mi, limits 2 CPU / 2Gi. */
+const RUNNER_RESOURCES = {
+  requests: { cpu: "500m", memory: "512Mi" },
+  limits: { cpu: "2", memory: "2Gi" },
+} as const;
+
+/** The persistent-workspace scopes (SandboxScope.persistentWorkspace). */
+const PERSISTENT_SCOPES: ReadonlySet<SandboxScope> = new Set([
+  "session",
+  "workflow",
+]);
+
+// ---------------------------------------------------------------------------
+// The gateway seam — the ONLY surface touching the client (the Java
+// SandboxKubernetesGateway shape): manifest logic stays pure above it,
+// and a client swap (or a test fake) never touches ensure semantics.
+// ---------------------------------------------------------------------------
+
+export interface KubernetesSandboxGateway {
+  /** Replicas of the named Deployment; undefined when it does not exist. */
+  deploymentReplicas(name: string): Promise<number | undefined>;
+  applySecret(secret: V1Secret): Promise<void>;
+  applyPvc(pvc: V1PersistentVolumeClaim): Promise<void>;
+  applyDeployment(deployment: V1Deployment): Promise<void>;
+  scaleDeployment(name: string, replicas: number): Promise<void>;
+  /** Deletes are idempotent — missing objects are success. */
+  deleteDeployment(name: string): Promise<void>;
+  deleteSecret(name: string): Promise<void>;
+  deletePvc(name: string): Promise<void>;
+}
+
+function newClientGateway(namespace: string): KubernetesSandboxGateway {
+  const kubeConfig = new KubeConfig();
+  // In-cluster service account or the operator's kubeconfig — the client's
+  // standard resolution order, exactly what kubectl would use.
+  kubeConfig.loadFromDefault();
+  const apps = kubeConfig.makeApiClient(AppsV1Api);
+  const core = kubeConfig.makeApiClient(CoreV1Api);
+
+  function isNotFound(error: unknown): boolean {
+    return error instanceof ApiException && error.code === 404;
+  }
+  function isConflict(error: unknown): boolean {
+    return error instanceof ApiException && error.code === 409;
+  }
+
+  return {
+    async deploymentReplicas(name) {
+      try {
+        const deployment = await apps.readNamespacedDeployment({
+          name,
+          namespace,
+        });
+        return deployment.spec?.replicas ?? 0;
+      } catch (error) {
+        if (isNotFound(error)) {
+          return undefined;
+        }
+        throw error;
+      }
+    },
+    async applySecret(secret) {
+      try {
+        await core.createNamespacedSecret({ namespace, body: secret });
+      } catch (error) {
+        if (!isConflict(error)) {
+          throw error;
+        }
+        await core.replaceNamespacedSecret({
+          name: secret.metadata?.name ?? "",
+          namespace,
+          body: secret,
+        });
+      }
+    },
+    async applyPvc(pvc) {
+      try {
+        await core.createNamespacedPersistentVolumeClaim({
+          namespace,
+          body: pvc,
+        });
+      } catch (error) {
+        // An existing claim is REUSED, never replaced — PVC specs are
+        // mostly immutable and the surviving workspace is the point of
+        // the repair arm.
+        if (!isConflict(error)) {
+          throw error;
+        }
+      }
+    },
+    async applyDeployment(deployment) {
+      try {
+        await apps.createNamespacedDeployment({ namespace, body: deployment });
+      } catch (error) {
+        if (!isConflict(error)) {
+          throw error;
+        }
+        await apps.replaceNamespacedDeployment({
+          name: deployment.metadata?.name ?? "",
+          namespace,
+          body: deployment,
+        });
+      }
+    },
+    async scaleDeployment(name, replicas) {
+      // Read-then-replace of the Scale subresource: the client's patch
+      // call defaults to JSON-Patch encoding, which rejects a plain
+      // merge body (proven live on kind, 2026-08-27) — replace is
+      // explicit and stable across client versions.
+      const scale = await apps.readNamespacedDeploymentScale({
+        name,
+        namespace,
+      });
+      scale.spec = { ...(scale.spec ?? {}), replicas };
+      await apps.replaceNamespacedDeploymentScale({
+        name,
+        namespace,
+        body: scale,
+      });
+    },
+    async deleteDeployment(name) {
+      try {
+        await apps.deleteNamespacedDeployment({ name, namespace });
+      } catch (error) {
+        if (!isNotFound(error)) {
+          throw error;
+        }
+      }
+    },
+    async deleteSecret(name) {
+      try {
+        await core.deleteNamespacedSecret({ name, namespace });
+      } catch (error) {
+        if (!isNotFound(error)) {
+          throw error;
+        }
+      }
+    },
+    async deletePvc(name) {
+      try {
+        await core.deleteNamespacedPersistentVolumeClaim({ name, namespace });
+      } catch (error) {
+        if (!isNotFound(error)) {
+          throw error;
+        }
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure manifest builders (the SandboxManifestFactory half).
+// ---------------------------------------------------------------------------
+
+function sandboxLabels(
+  scope: SandboxScope,
+  id: string,
+): Record<string, string> {
+  return {
+    [SANDBOX_MANAGED_BY_LABEL]: SANDBOX_MANAGED_BY_VALUE,
+    [SANDBOX_SCOPE_LABEL]: scope,
+    [SANDBOX_ID_LABEL]: id,
+  };
+}
+
+export function buildSandboxSecret(
+  scope: SandboxScope,
+  id: string,
+  stigmerToken: string,
+): V1Secret {
+  return {
+    metadata: {
+      name: `${sandboxBaseName(scope, id)}-env`,
+      labels: sandboxLabels(scope, id),
+    },
+    type: "Opaque",
+    // A token-less sandbox still gets its (empty) Secret — the object
+    // must exist for uniform cleanup (the Java posture).
+    stringData: stigmerToken !== "" ? { STIGMER_TOKEN: stigmerToken } : {},
+  };
+}
+
+export function buildWorkspacePvc(
+  scope: SandboxScope,
+  id: string,
+): V1PersistentVolumeClaim {
+  return {
+    metadata: {
+      name: `${sandboxBaseName(scope, id)}-workspace`,
+      labels: sandboxLabels(scope, id),
+    },
+    spec: {
+      accessModes: ["ReadWriteOnce"],
+      // No storageClassName: the cluster default. Self-host clusters vary
+      // too much to pin the cloud's class here; an operator overrides at
+      // the cluster level.
+      resources: { requests: { storage: WORKSPACE_PVC_SIZE } },
+    },
+  };
+}
+
+export function buildSandboxDeployment(
+  scope: SandboxScope,
+  id: string,
+  env: SandboxEnvironment,
+  config: SandboxDriverConfig,
+): V1Deployment {
+  const baseName = sandboxBaseName(scope, id);
+  const labels = sandboxLabels(scope, id);
+  const persistent = PERSISTENT_SCOPES.has(scope);
+
+  const containerEnv: Array<{
+    name: string;
+    value?: string;
+    valueFrom?: {
+      secretKeyRef: { name: string; key: string; optional?: boolean };
+    };
+  }> = [
+    { name: "MODE", value: "local" },
+    { name: "STIGMER_TASK_QUEUE", value: env.taskQueue },
+    { name: "STIGMER_BACKEND_ENDPOINT", value: config.backendEndpoint },
+    { name: "TEMPORAL_SERVICE_ADDRESS", value: config.temporalAddress },
+    { name: "WORKSPACE_ROOT_DIR", value: WORKSPACE_MOUNT_PATH },
+  ];
+  if (env.stigmerToken !== "") {
+    containerEnv.push({
+      name: "STIGMER_TOKEN",
+      valueFrom: {
+        secretKeyRef: { name: `${baseName}-env`, key: "STIGMER_TOKEN" },
+      },
+    });
+  }
+
+  return {
+    metadata: { name: baseName, labels },
+    spec: {
+      replicas: 1,
+      // Recreate, never RollingUpdate: two runners polling one sandbox
+      // queue mid-rollout would race the workspace (the Java strategy).
+      strategy: { type: "Recreate" },
+      selector: {
+        matchLabels: {
+          [SANDBOX_MANAGED_BY_LABEL]: SANDBOX_MANAGED_BY_VALUE,
+          [SANDBOX_ID_LABEL]: id,
+        },
+      },
+      template: {
+        metadata: { labels },
+        spec: {
+          terminationGracePeriodSeconds: TERMINATION_GRACE_PERIOD_SECONDS,
+          automountServiceAccountToken: false,
+          securityContext: { seccompProfile: { type: "RuntimeDefault" } },
+          containers: [
+            {
+              name: RUNNER_CONTAINER_NAME,
+              image: config.runnerImage,
+              command: [...RUNNER_COMMAND],
+              env: containerEnv,
+              resources: {
+                requests: { ...RUNNER_RESOURCES.requests },
+                limits: { ...RUNNER_RESOURCES.limits },
+              },
+              securityContext: {
+                allowPrivilegeEscalation: false,
+                capabilities: { drop: ["ALL"] },
+              },
+              volumeMounts: [
+                { name: "workspace", mountPath: WORKSPACE_MOUNT_PATH },
+              ],
+            },
+          ],
+          volumes: [
+            persistent
+              ? {
+                  name: "workspace",
+                  persistentVolumeClaim: { claimName: `${baseName}-workspace` },
+                }
+              : { name: "workspace", emptyDir: {} },
+          ],
+        },
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The driver.
+// ---------------------------------------------------------------------------
+
+export const newKubernetesSandboxProvisioner: SandboxProvisionerFactory = ({
+  config,
+  logger,
+}) => {
+  if (config.backendEndpoint === "") {
+    throw new Error(
+      "sandbox provisioner 'kubernetes' requires STIGMER_SANDBOX_BACKEND_ENDPOINT — a pod cannot reach the server on this process's localhost",
+    );
+  }
+  if (config.temporalAddress === "") {
+    throw new Error(
+      "sandbox provisioner 'kubernetes' requires STIGMER_SANDBOX_TEMPORAL_ADDRESS (or TEMPORAL_HOST_PORT) reachable from inside the cluster",
+    );
+  }
+  const gateway = newClientGateway(config.kubernetesNamespace);
+  return newKubernetesSandboxProvisionerOverGateway(gateway, config, logger);
+};
+
+/**
+ * The driver over an injected gateway — the unit-test seam (the live
+ * factory above builds the client gateway; tests inject a fake and pin
+ * the ensure arms without a cluster).
+ */
+export function newKubernetesSandboxProvisionerOverGateway(
+  gateway: KubernetesSandboxGateway,
+  config: SandboxDriverConfig,
+  logger: {
+    info: (msg: string, fields?: Record<string, unknown>) => void;
+  },
+): SandboxProvisioner {
+  async function ensure(
+    scope: SandboxScope,
+    id: string,
+    env: SandboxEnvironment,
+  ): Promise<void> {
+    const baseName = sandboxBaseName(scope, id);
+    const replicas = await gateway.deploymentReplicas(baseName);
+    if (replicas === undefined) {
+      // Absent → provision/repair: Secret first (the Deployment's env
+      // references it), claim (reused when it survived a repair), then
+      // the Deployment. No readiness wait (module header).
+      await gateway.applySecret(
+        buildSandboxSecret(scope, id, env.stigmerToken),
+      );
+      if (PERSISTENT_SCOPES.has(scope)) {
+        await gateway.applyPvc(buildWorkspacePvc(scope, id));
+      }
+      await gateway.applyDeployment(
+        buildSandboxDeployment(scope, id, env, config),
+      );
+      logger.info("Kubernetes sandbox provisioned", {
+        scope,
+        id,
+        deployment: baseName,
+        taskQueue: env.taskQueue,
+      });
+      return;
+    }
+    if (replicas === 0) {
+      await gateway.scaleDeployment(baseName, 1);
+      logger.info("Kubernetes sandbox scaled up", {
+        scope,
+        id,
+        deployment: baseName,
+      });
+      return;
+    }
+    // Running → fast path (the Java ~1-2s arm): the pod keeps the token
+    // it booted with (defer-restart, module header).
+  }
+
+  async function deprovision(scope: SandboxScope, id: string): Promise<void> {
+    const baseName = sandboxBaseName(scope, id);
+    await gateway.deleteDeployment(baseName);
+    await gateway.deleteSecret(`${baseName}-env`);
+    if (PERSISTENT_SCOPES.has(scope)) {
+      await gateway.deletePvc(`${baseName}-workspace`);
+    }
+    logger.info("Kubernetes sandbox deprovisioned", {
+      scope,
+      id,
+      deployment: baseName,
+    });
+  }
+
+  return {
+    ensureSessionSandbox: (sessionId, env) => ensure("session", sessionId, env),
+    deprovisionSessionSandbox: (sessionId) => deprovision("session", sessionId),
+    ensureWorkflowSandbox: (executionId, env) =>
+      ensure("workflow", executionId, env),
+    deprovisionWorkflowSandbox: (executionId) =>
+      deprovision("workflow", executionId),
+    async createConnectSandbox(connectRequestId, env) {
+      await ensure("connect", connectRequestId, env);
+      return connectRequestId;
+    },
+    deprovisionConnectSandbox: (sandboxId) => deprovision("connect", sandboxId),
+    async probe(scope, id): Promise<SandboxProbeState> {
+      const replicas = await gateway.deploymentReplicas(
+        sandboxBaseName(scope, id),
+      );
+      if (replicas === undefined) {
+        return "absent";
+      }
+      return replicas === 0 ? "stopped" : "running";
+    },
+  };
+}

--- a/backend/services/stigmer-server/src/sandbox/lane.ts
+++ b/backend/services/stigmer-server/src/sandbox/lane.ts
@@ -1,0 +1,72 @@
+/**
+ * The composed sandbox lane — the explicit modeled state the invocation
+ * steps consume (never a nullable provisioner threaded through deps; the
+ * composition doctrine's "optional infrastructure is a modeled state").
+ * Disabled IS the OSS default: SANDBOX_PROVISIONER_TYPE unset means the
+ * external-runner posture (gate ruling Q1) and every step below
+ * short-circuits on its fast path — byte-identical wire behavior, pinned
+ * by the conformance rosters.
+ *
+ * Credential minting (gate ruling Q6): sandboxes authenticate on the ONE
+ * OSS credential lane — execution-scoped (runnerauth §6c). The token is
+ * minted per execution at ensure time, so the cloud's stale-token refresh
+ * arm degenerates to per-execution re-mint here; a disabled mint lane
+ * launches the sandbox with no token and ExecutionContext decrypt falls
+ * back to redaction (oss#535's posture), degraded but never dark.
+ */
+import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
+import { TOKEN_TYPE_EXECUTION_SCOPED } from "../runnerauth/runnerauth.js";
+import type { Logger } from "../boot/logger.js";
+import type { SandboxProvisioner } from "./provisioner.js";
+
+/**
+ * Sandbox credential TTL: 4 hours — the cloud edition's
+ * SandboxTokenService TTL, kept identical so a sandbox outliving its
+ * token behaves the same on both editions (the runner renews via
+ * getRunnerScopedToken either way).
+ */
+export const SANDBOX_TOKEN_TTL_SECONDS = 4 * 60 * 60;
+
+/** The lane: either disabled (the default) or a provisioner + its credential mint. */
+export type SandboxLane =
+  | { readonly enabled: false }
+  | {
+      readonly enabled: true;
+      readonly provisioner: SandboxProvisioner;
+      readonly credentials: RunnerCredentialProvider;
+    };
+
+export function newSandboxLane(
+  provisioner: SandboxProvisioner | undefined,
+  credentials: RunnerCredentialProvider,
+): SandboxLane {
+  if (provisioner === undefined) {
+    return { enabled: false };
+  }
+  return { enabled: true, provisioner, credentials };
+}
+
+/**
+ * Mints the sandbox's STIGMER_TOKEN on the execution-scoped lane, or ""
+ * when minting is disabled (module header). A mint FAILURE on an enabled
+ * lane is a real fault and propagates to the caller's failure posture —
+ * never swallowed into the no-token arm.
+ */
+export function mintSandboxToken(
+  lane: Extract<SandboxLane, { enabled: true }>,
+  executionId: string,
+  logger: Logger,
+): string {
+  if (!lane.credentials.isEnabled(TOKEN_TYPE_EXECUTION_SCOPED)) {
+    logger.warn(
+      "Sandbox launching without a runner token (credential lane disabled) — ExecutionContext reads will be redacted",
+      { executionId },
+    );
+    return "";
+  }
+  return lane.credentials.mint(
+    TOKEN_TYPE_EXECUTION_SCOPED,
+    executionId,
+    SANDBOX_TOKEN_TTL_SECONDS,
+  ).token;
+}

--- a/backend/services/stigmer-server/src/sandbox/local-process.ts
+++ b/backend/services/stigmer-server/src/sandbox/local-process.ts
@@ -1,0 +1,188 @@
+/**
+ * The local-process sandbox driver — DD-002's first isolation tier
+ * (process → Docker → Kubernetes), built by O6 (20260827.05, gate ruling
+ * Q1: a REAL driver, not a named no-op). Each sandbox is a managed
+ * runner child process polling exactly one task queue, with its own
+ * isolated workspace directory — today's implicit "the runner is a local
+ * process" posture made explicit and per-execution.
+ *
+ * The child's env is the runner's verified contract
+ * (backend/services/runner/src/config.ts): MODE=local,
+ * STIGMER_TASK_QUEUE (the one queue this sandbox serves),
+ * STIGMER_BACKEND_ENDPOINT / TEMPORAL_SERVICE_ADDRESS (empty values fall
+ * back to the runner's own local defaults and Temporal self-discovery),
+ * STIGMER_TOKEN when minted ("" stays unset — optional in local mode),
+ * and a per-sandbox WORKSPACE_ROOT_DIR so concurrent sandboxes never
+ * share a workspace.
+ *
+ * Process lifecycle facts this driver leans on deliberately:
+ *
+ *   - The check-spawn-record section of ensure has NO awaits, so
+ *     concurrent ensures for one id cannot double-spawn (single-threaded
+ *     atomicity — the same reason the map needs no lock).
+ *   - An exited child removes itself from the table, so the next ensure
+ *     observes "absent" and respawns — the state machine's repair arm
+ *     without stored state (gate ruling Q4: runtime-derived).
+ *   - Children are killed on server-process exit (the exit hook below):
+ *     a process-tier sandbox must not outlive the server that provisions
+ *     it — unlike the container tiers, nothing could ever re-adopt it.
+ */
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+
+import type { Logger } from "../boot/logger.js";
+import type {
+  SandboxEnvironment,
+  SandboxProbeState,
+  SandboxProvisioner,
+  SandboxProvisionerFactory,
+  SandboxScope,
+} from "./provisioner.js";
+
+/** SIGTERM-first teardown; the runner's Temporal worker drains on it. */
+const DEPROVISION_SIGNAL: NodeJS.Signals = "SIGTERM";
+
+export const newLocalProcessSandboxProvisioner: SandboxProvisionerFactory = ({
+  config,
+  logger,
+}) => {
+  const children = new Map<string, ChildProcess>();
+
+  // A process-tier sandbox dies with the server (module header). "exit"
+  // allows only synchronous work — kill() is.
+  process.once("exit", () => {
+    for (const child of children.values()) {
+      child.kill(DEPROVISION_SIGNAL);
+    }
+  });
+
+  function key(scope: SandboxScope, id: string): string {
+    return `${scope}:${id}`;
+  }
+
+  function ensure(
+    scope: SandboxScope,
+    id: string,
+    env: SandboxEnvironment,
+  ): void {
+    // No awaits from here to children.set — the double-spawn guard.
+    const existing = children.get(key(scope, id));
+    if (
+      existing !== undefined &&
+      existing.exitCode === null &&
+      !existing.killed
+    ) {
+      return; // Running — the fast path.
+    }
+
+    const workspaceRoot = path.join(
+      homedir(),
+      ".stigmer",
+      "sandboxes",
+      `${scope}-${id}`,
+    );
+    mkdirSync(workspaceRoot, { recursive: true });
+
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      MODE: "local",
+      STIGMER_TASK_QUEUE: env.taskQueue,
+      WORKSPACE_ROOT_DIR: workspaceRoot,
+    };
+    if (config.backendEndpoint !== "") {
+      childEnv["STIGMER_BACKEND_ENDPOINT"] = config.backendEndpoint;
+    }
+    if (config.temporalAddress !== "") {
+      childEnv["TEMPORAL_SERVICE_ADDRESS"] = config.temporalAddress;
+    }
+    if (env.stigmerToken !== "") {
+      childEnv["STIGMER_TOKEN"] = env.stigmerToken;
+    }
+
+    // stdio inherits: the process tier's sandbox logs belong in the
+    // server's own stream (the container tiers get per-container logs).
+    const child = spawn(config.runnerCommand, [], {
+      env: childEnv,
+      stdio: "inherit",
+    });
+    children.set(key(scope, id), child);
+    logger.info("Local-process sandbox started", {
+      scope,
+      id,
+      pid: child.pid ?? -1,
+      taskQueue: env.taskQueue,
+    });
+    child.once("exit", (code, signal) => {
+      // Self-removal IS the repair arm: the next ensure sees absent.
+      // Guarded to THIS child — a deprovisioned child's late exit event
+      // must never clobber a replacement ensured under the same key.
+      if (children.get(key(scope, id)) === child) {
+        children.delete(key(scope, id));
+      }
+      logger.info("Local-process sandbox exited", {
+        scope,
+        id,
+        code: code ?? -1,
+        signal: signal ?? "",
+      });
+    });
+    child.once("error", (error) => {
+      // Spawn failures (command not found) surface here asynchronously;
+      // the exit handler above never fires for them. Same self-guard.
+      if (children.get(key(scope, id)) === child) {
+        children.delete(key(scope, id));
+      }
+      logger.error("Local-process sandbox failed to start", {
+        scope,
+        id,
+        command: config.runnerCommand,
+        error: error.message,
+      });
+    });
+  }
+
+  function deprovision(scope: SandboxScope, id: string): void {
+    const child = children.get(key(scope, id));
+    if (child === undefined) {
+      return; // Missing is success — idempotent teardown.
+    }
+    children.delete(key(scope, id));
+    child.kill(DEPROVISION_SIGNAL);
+    logger.info("Local-process sandbox deprovisioned", { scope, id });
+  }
+
+  const provisioner: SandboxProvisioner = {
+    async ensureSessionSandbox(sessionId, env) {
+      ensure("session", sessionId, env);
+    },
+    async deprovisionSessionSandbox(sessionId) {
+      deprovision("session", sessionId);
+    },
+    async ensureWorkflowSandbox(executionId, env) {
+      ensure("workflow", executionId, env);
+    },
+    async deprovisionWorkflowSandbox(executionId) {
+      deprovision("workflow", executionId);
+    },
+    async createConnectSandbox(connectRequestId, env) {
+      ensure("connect", connectRequestId, env);
+      return connectRequestId;
+    },
+    async deprovisionConnectSandbox(sandboxId) {
+      deprovision("connect", sandboxId);
+    },
+    async probe(scope, id): Promise<SandboxProbeState> {
+      const child = children.get(key(scope, id));
+      if (child === undefined || child.exitCode !== null || child.killed) {
+        // An exited child self-removed (or is mid-removal): a process has
+        // no "stopped but resumable" state — absent covers both.
+        return "absent";
+      }
+      return "running";
+    },
+  };
+  return provisioner;
+};

--- a/backend/services/stigmer-server/src/sandbox/naming.ts
+++ b/backend/services/stigmer-server/src/sandbox/naming.ts
@@ -1,0 +1,38 @@
+/**
+ * Deterministic sandbox object naming — generalized from the cloud
+ * edition's SandboxObjectNaming.java so both container drivers (and the
+ * cloud's own provisioner) name sandboxes identically: an operator
+ * moving between tiers sees one vocabulary.
+ *
+ * Base name: sbx-<scope-code>-<first 12 hex chars of SHA-256(id)> —
+ * DNS-1123-safe regardless of the id's alphabet or length (resource ids
+ * carry prefixes like ses_ that DNS labels reject; hashing sidesteps
+ * every alphabet/length edge). The full id travels in a label so the
+ * mapping is recoverable from the runtime object alone (gate ruling Q4:
+ * runtime-derived state, no store tables).
+ */
+import { createHash } from "node:crypto";
+
+import type { SandboxScope } from "./provisioner.js";
+
+/** The Java SandboxScope codes, byte-identical. */
+const SCOPE_CODES: Record<SandboxScope, string> = {
+  session: "ses",
+  workflow: "wfx",
+  connect: "mcp",
+};
+
+/** Label carrying the owning driver ("stigmer-server") — the reap/list filter. */
+export const SANDBOX_MANAGED_BY_LABEL = "stigmer.ai/managed-by";
+/** Label carrying the scope ("session" | "workflow" | "connect"). */
+export const SANDBOX_SCOPE_LABEL = "stigmer.ai/scope";
+/** Label carrying the full owning resource id (the Q4 runtime-derived link). */
+export const SANDBOX_ID_LABEL = "stigmer.ai/sandbox-id";
+
+export const SANDBOX_MANAGED_BY_VALUE = "stigmer-server";
+
+/** sbx-<code>-<12-hex> (SandboxObjectNaming.java's derivation, kept exactly). */
+export function sandboxBaseName(scope: SandboxScope, id: string): string {
+  const digest = createHash("sha256").update(id).digest("hex").slice(0, 12);
+  return `sbx-${SCOPE_CODES[scope]}-${digest}`;
+}

--- a/backend/services/stigmer-server/src/sandbox/provisioner.ts
+++ b/backend/services/stigmer-server/src/sandbox/provisioner.ts
@@ -1,0 +1,175 @@
+/**
+ * The sandbox-provisioner driver seam — convergence program 20260826.02,
+ * blueprint/03 §6d and DD-002, built by sub-project 20260827.05 (O6). The
+ * contract generalizes the cloud edition's production-proven Java
+ * strategy interface (stigmer-cloud
+ * domain/agentic/sandbox/SandboxProvisioner.java) so execution isolation
+ * is an OSS capability: a provisioner creates, repairs, and tears down
+ * the isolated runner that polls one execution-scoped Temporal task
+ * queue.
+ *
+ * Scope vocabulary (the Java interface's three variants, kept exactly):
+ *
+ *   - SESSION: long-lived, one sandbox per session, ensure is IDEMPOTENT
+ *     ensure-as-state-machine (absent → provision; stopped → start;
+ *     running → fast path). Invoked non-critically after the execution's
+ *     workflow starts (see steps.ts).
+ *   - WORKFLOW: ephemeral, one sandbox per workflow execution (shared by
+ *     the workflow AND its nested child agent executions via the wfexec:
+ *     queue-override lane — dispatch.ts). Ensured critically BEFORE the
+ *     execution persists; deprovisioned on the terminal phase transition.
+ *   - CONNECT: request-scoped, NOT idempotent; the caller must
+ *     deprovision in a finally block. Carried in the contract for the
+ *     cloud implementation (its MCP connect lane) — OSS does not invoke
+ *     it today because OSS connect runs on the shared runner queue (a
+ *     named non-goal, T01 gate ruling Q7).
+ *
+ * The probe is ensure-time LIVE-STATE inspection, never a boot-readiness
+ * wait (gate ruling Q5): the verified cloud design has NO readiness
+ * probes — a sandbox that never polls its queue surfaces as the
+ * activity's ScheduleToStartTimeout, with the ensure step's error
+ * pre-stamp naming the root cause.
+ *
+ * Selection follows the artifact-storage precedent (§6b): built-in
+ * drivers by name behind the SANDBOX_PROVISIONER_TYPE config knob,
+ * extension-registered names beyond them (extensions/drivers.ts), an
+ * unknown name a loud boot throw. The DEFAULT ("") is the external-runner
+ * posture — no provisioner constructed, ensure never invoked — which IS
+ * today's OSS behavior, named (gate ruling Q1): an operator-managed
+ * runner process polls the queues.
+ */
+import type { Logger } from "../boot/logger.js";
+
+/**
+ * The runtime handed to a provisioner for one sandbox: which queue the
+ * sandboxed runner must poll and the credential it authenticates with.
+ * Deliberately minimal (the Java SandboxEnvironment carries the same two
+ * load-bearing fields plus cloud-only accounting) — endpoints, images,
+ * and resource shapes are DRIVER configuration, not per-sandbox state.
+ */
+export interface SandboxEnvironment {
+  /** The Temporal task queue the sandboxed runner polls (session:{id} / wfexec:{id}). */
+  readonly taskQueue: string;
+  /**
+   * The runner credential injected as STIGMER_TOKEN. "" means none was
+   * minted (the provider's lane is disabled) — the sandbox still launches
+   * and EC decrypt falls back to redaction, the oss#535 posture.
+   */
+  readonly stigmerToken: string;
+}
+
+/** One sandbox's observed live state (the Q5 probe result). */
+export type SandboxProbeState = "absent" | "stopped" | "running";
+
+/** The scope discriminant, shared by probe and the drivers' naming. */
+export type SandboxScope = "session" | "workflow" | "connect";
+
+/**
+ * The driver contract. Implementations must be safe for concurrent use —
+ * ensure calls for the same id may race (the cloud accepts check-then-act
+ * overshoot, DD-002) and every arm must be idempotent except connect
+ * creation, which is documented one-shot.
+ */
+export interface SandboxProvisioner {
+  /**
+   * Ensure-as-state-machine for a session sandbox: absent → provision;
+   * stopped → start; running → fast path. Idempotent; safe to invoke on
+   * every execution create/recover for the session.
+   */
+  ensureSessionSandbox(
+    sessionId: string,
+    env: SandboxEnvironment,
+  ): Promise<void>;
+  /** Tears down the session sandbox; missing is success (idempotent). */
+  deprovisionSessionSandbox(sessionId: string): Promise<void>;
+  /**
+   * Ensures the per-execution workflow sandbox. Same state-machine
+   * semantics; the sandbox lives exactly as long as the execution runs.
+   */
+  ensureWorkflowSandbox(
+    executionId: string,
+    env: SandboxEnvironment,
+  ): Promise<void>;
+  /** Tears down the workflow sandbox; missing is success (idempotent). */
+  deprovisionWorkflowSandbox(executionId: string): Promise<void>;
+  /**
+   * Creates a request-scoped connect sandbox and returns the provider's
+   * sandbox id. NOT idempotent — the caller owns deprovision in a
+   * finally block. Unused by OSS wiring today (module header).
+   */
+  createConnectSandbox(
+    connectRequestId: string,
+    env: SandboxEnvironment,
+  ): Promise<string>;
+  /** Tears down a connect sandbox by provider id; missing is success. */
+  deprovisionConnectSandbox(sandboxId: string): Promise<void>;
+  /** Live-state inspection (Q5) — consumed by ensure arms and diagnostics. */
+  probe(scope: SandboxScope, id: string): Promise<SandboxProbeState>;
+}
+
+/**
+ * Driver configuration resolved from ServerConfig — what every built-in
+ * needs to launch a runner that can reach this server. Extension drivers
+ * receive the same bag and may read their own env beyond it.
+ */
+export interface SandboxDriverConfig {
+  /**
+   * The server endpoint AS REACHABLE FROM INSIDE a sandbox (a container
+   * cannot use this process's localhost). Injected as
+   * STIGMER_BACKEND_ENDPOINT.
+   */
+  readonly backendEndpoint: string;
+  /** Temporal address as reachable from inside a sandbox (TEMPORAL_SERVICE_ADDRESS). */
+  readonly temporalAddress: string;
+  /** The runner image for container-based drivers (docker/kubernetes). */
+  readonly runnerImage: string;
+  /** The runner executable for the local-process driver. */
+  readonly runnerCommand: string;
+  /** The namespace the kubernetes driver provisions into. */
+  readonly kubernetesNamespace: string;
+}
+
+/** Constructs a driver. Factories, not instances — an unselected driver constructs nothing (§6b). */
+export type SandboxProvisionerFactory = (options: {
+  readonly config: SandboxDriverConfig;
+  readonly logger: Logger;
+}) => SandboxProvisioner;
+
+/**
+ * The built-in driver names — reserved: an extension registering one of
+ * these is a boot throw (the registry's shadow rule, extensions/
+ * registry.ts). DD-002's isolation ladder: process → Docker → Kubernetes.
+ */
+export const BUILT_IN_SANDBOX_PROVISIONER_TYPES = [
+  "local-process",
+  "docker",
+  "kubernetes",
+] as const;
+
+/**
+ * Selects and constructs the configured provisioner, or undefined for
+ * the default external-runner posture (type ""). Unknown names are a
+ * loud boot throw — a typo'd knob must never silently run unisolated
+ * (the validateR2Config precedent).
+ */
+export function newSandboxProvisioner(
+  type: string,
+  options: { readonly config: SandboxDriverConfig; readonly logger: Logger },
+  builtInFactories: ReadonlyMap<string, SandboxProvisionerFactory>,
+  registeredFactories: ReadonlyMap<string, SandboxProvisionerFactory>,
+): SandboxProvisioner | undefined {
+  if (type === "") {
+    return undefined;
+  }
+  const factory = builtInFactories.get(type) ?? registeredFactories.get(type);
+  if (factory === undefined) {
+    const known = [
+      ...builtInFactories.keys(),
+      ...registeredFactories.keys(),
+    ].sort();
+    throw new Error(
+      `unknown sandbox provisioner type '${type}' — known types: '${known.join("', '")}'`,
+    );
+  }
+  return factory(options);
+}

--- a/backend/services/stigmer-server/src/sandbox/steps.ts
+++ b/backend/services/stigmer-server/src/sandbox/steps.ts
@@ -1,0 +1,359 @@
+/**
+ * The sandbox invocation surface — the per-lane postures the cloud
+ * edition proved in production (T01 gate ruling Q2: ONE shared
+ * implementation, per-lane postures — the blueprint §6d "one shared step"
+ * names the session-lane shape, the Java workflow lane is deliberately
+ * its opposite):
+ *
+ *   - EnsureSessionSandbox (agent executions): AFTER StartWorkflow,
+ *     NON-critical. A provisioning failure never fails the launch, but it
+ *     is never silent either — ERROR-logged and PRE-STAMPED onto
+ *     status.error first-non-empty-wins, so when the agent activity dies
+ *     at its ScheduleToStartTimeout minutes later the user sees the root
+ *     cause instead of a generic timeout. The 2026-07 cloud quota outage
+ *     hid for two days behind this step's former WARN-and-swallow — the
+ *     pre-stamp posture is contract (DD-002).
+ *   - EnsureWorkflowSandbox (workflow executions): BEFORE Persist,
+ *     CRITICAL and synchronous — a refusal orphans nothing (no row, no
+ *     Temporal workflow), the verified Java ordering.
+ *   - Workflow-sandbox terminal deprovision: server-side at the three
+ *     status write sites (gate ruling Q3b — the invoke workflow's history
+ *     shape is pinned contract, so no new workflow activity). KNOWN
+ *     WINDOW, ruled acceptable: the orchestrator's terminal persists are
+ *     best-effort, so a persist that never lands leaks the sandbox — OSS
+ *     has no orphan reaper (the cloud's rides its C4 extension workers).
+ *     Deprovision is idempotent, so multiple sites firing is harmless.
+ *   - DeprovisionSessionSandbox (session delete): best-effort teardown,
+ *     ERROR-logged on failure, never fails the delete (the Java
+ *     SessionDeleteHandler posture).
+ *
+ * The pre-stamp rides Store.updateResource (atomic read-modify-write) —
+ * a whole-resource save here would race the runner's concurrent
+ * UpdateStatus writes; load-then-save stays banned in status paths.
+ *
+ * Every step short-circuits when the lane is disabled or the execution's
+ * resolved target is LOCAL — the conformance rosters run entirely on
+ * those fast paths (byte-identity by construction).
+ */
+import { create } from "@bufbuild/protobuf";
+
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  AgentExecutionSchema,
+  AgentExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionTarget } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase as WorkflowExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { Logger } from "../boot/logger.js";
+import type { AgentExecutionTemporalConfig } from "../domain/agentexecution/temporal/config.js";
+import {
+  WORKFLOW_ROUTING_EXECUTION,
+  type WorkflowExecutionTemporalConfig,
+} from "../domain/workflowexecution/temporal/config.js";
+import { unavailableError } from "../pipeline/errors.js";
+import type { PipelineStep } from "../pipeline/pipeline.js";
+import {
+  formatSessionTaskQueue,
+  resolveActivityTaskQueue,
+} from "../temporal/agentexecution/dispatch.js";
+import { resolveWorkflowTaskQueue } from "../temporal/workflowexecution/dispatch.js";
+import type { Store } from "../store/interface.js";
+import { mintSandboxToken, type SandboxLane } from "./lane.js";
+
+/**
+ * The pre-stamped root-cause prefix — the cloud edition's
+ * stampProvisioningFailure copy, kept identical (the same failure must
+ * read the same on both editions).
+ */
+export const SANDBOX_PROVISIONING_FAILED_PREFIX =
+  "Sandbox provisioning failed: ";
+
+type AgentExecutionCreateDesc = typeof AgentExecutionSchema;
+
+export interface EnsureSessionSandboxDeps {
+  readonly store: Store;
+  readonly logger: Logger;
+  readonly lane: SandboxLane;
+  readonly temporalConfig: AgentExecutionTemporalConfig;
+}
+
+/**
+ * The session-lane ensure step (module header posture #1). Placed after
+ * StartWorkflow in the agent-execution create chain and after
+ * StartFreshWorkflow in recover — the sandbox boots concurrently with the
+ * workflow's first activity ScheduleToStart window.
+ *
+ * Dispatch is re-resolved here (one extra session read, on the
+ * enabled+CLOUD arm only) so the step stays self-contained — the same
+ * choice the Java step makes rather than threading dispatch results
+ * through the chain.
+ */
+export function newEnsureSessionSandboxStep(
+  deps: EnsureSessionSandboxDeps,
+): PipelineStep<AgentExecutionCreateDesc> {
+  return {
+    name: "EnsureSessionSandbox",
+    async execute(ctx) {
+      await ensureSessionSandboxForExecution(deps, ctx.newState);
+    },
+  };
+}
+
+/**
+ * The session-lane body, shared by the create step above and the recover
+ * chain's post-StartFreshWorkflow invocation (lifecycle.ts) — the Java
+ * precedent wires ONE step bean into both pipelines; here the two
+ * chains' differing context shapes (newState vs loaded execution) meet
+ * at this seam instead.
+ */
+export async function ensureSessionSandboxForExecution(
+  deps: EnsureSessionSandboxDeps,
+  execution: AgentExecution,
+): Promise<void> {
+  if (!deps.lane.enabled) {
+    return;
+  }
+  const lane = deps.lane;
+  const executionId = execution.metadata?.id ?? "";
+  const sessionId = execution.spec?.sessionId ?? "";
+  // The wfexec: override lane shares the parent workflow's sandbox —
+  // dispatch forces LOCAL there, but skipping before the store read
+  // keeps the child-execution hot path free of it.
+  if (sessionId === "" || (execution.spec?.activityTaskQueue ?? "") !== "") {
+    return;
+  }
+  try {
+    const dispatch = await resolveActivityTaskQueue(
+      deps.store,
+      sessionId,
+      deps.temporalConfig,
+      "",
+      deps.logger,
+    );
+    if (dispatch.executionTarget !== ExecutionTarget.CLOUD) {
+      return;
+    }
+    if (dispatch.taskQueue !== formatSessionTaskQueue(sessionId)) {
+      // CLOUD target under global routing: the sandbox would have to
+      // poll the shared queue, which is the external-runner posture —
+      // boot coherence validation forbids the combination; this arm is
+      // the belt-and-braces skip.
+      deps.logger.warn(
+        "Sandbox provisioning skipped: session routing is not per-session",
+        { executionId, sessionId, taskQueue: dispatch.taskQueue },
+      );
+      return;
+    }
+    await lane.provisioner.ensureSessionSandbox(sessionId, {
+      taskQueue: dispatch.taskQueue,
+      stigmerToken: mintSandboxToken(lane, executionId, deps.logger),
+    });
+  } catch (error) {
+    // Non-critical: never fail the launch — but never silent either
+    // (module header). The real error goes to the log; the sanitized
+    // root cause is pre-stamped for the timeout the user will see.
+    deps.logger.error(
+      "Session sandbox provisioning failed - execution will time out unless a runner polls its queue",
+      {
+        executionId,
+        sessionId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    await stampProvisioningFailure(deps.store, deps.logger, executionId, error);
+  }
+}
+
+/**
+ * First-non-empty-wins stamp of the provisioning root cause onto
+ * status.error (the Java setStatusErrorIfEmpty semantic) via the store's
+ * atomic read-modify-write. Touches ONLY the error field — phase stays
+ * the runner-owned lane. Best-effort: a stamp failure is logged, never
+ * thrown (the execution is already launched).
+ */
+async function stampProvisioningFailure(
+  store: Store,
+  logger: Logger,
+  executionId: string,
+  cause: unknown,
+): Promise<void> {
+  const message =
+    SANDBOX_PROVISIONING_FAILED_PREFIX +
+    (cause instanceof Error ? cause.message : String(cause));
+  try {
+    await store.updateResource(
+      ApiResourceKind.agent_execution,
+      executionId,
+      AgentExecutionSchema,
+      (execution: AgentExecution) => {
+        execution.status ??= create(AgentExecutionStatusSchema);
+        if (execution.status.error === "") {
+          execution.status.error = message;
+        }
+      },
+    );
+  } catch (error) {
+    logger.error("Failed to pre-stamp sandbox provisioning failure", {
+      executionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+export interface EnsureWorkflowSandboxDeps {
+  readonly logger: Logger;
+  readonly lane: SandboxLane;
+  readonly temporalConfig: WorkflowExecutionTemporalConfig;
+}
+
+/**
+ * The workflow-lane ensure step (module header posture #2): CRITICAL,
+ * placed before Persist in the workflow-execution create chain — a
+ * provisioning failure answers Unavailable with zero orphaned state.
+ * Only reachable with a provisioner composed AND per-execution routing
+ * resolved to CLOUD, so the copy is new O6 surface, not ported wire
+ * contract.
+ */
+export function newEnsureWorkflowSandboxStep(
+  deps: EnsureWorkflowSandboxDeps,
+): PipelineStep<typeof WorkflowExecutionSchema> {
+  return {
+    name: "EnsureWorkflowSandbox",
+    async execute(ctx) {
+      await ensureWorkflowSandboxForExecution(deps, ctx.newState);
+    },
+  };
+}
+
+/**
+ * The workflow-lane body, shared by the create step above and recover's
+ * re-provision (lifecycle.ts — the previous sandbox was deprovisioned at
+ * the terminal FAILED, so a recovered execution needs a fresh one before
+ * its fresh workflow starts). Throws Unavailable on provisioning failure
+ * — the critical posture in both chains.
+ */
+export async function ensureWorkflowSandboxForExecution(
+  deps: EnsureWorkflowSandboxDeps,
+  execution: WorkflowExecution,
+): Promise<void> {
+  if (!deps.lane.enabled) {
+    return;
+  }
+  const lane = deps.lane;
+  const executionId = execution.metadata?.id ?? "";
+  if (
+    executionId === "" ||
+    deps.temporalConfig.workflowActivityRouting !== WORKFLOW_ROUTING_EXECUTION
+  ) {
+    return;
+  }
+  const dispatch = resolveWorkflowTaskQueue(
+    executionId,
+    execution.spec?.executionTarget ?? ExecutionTarget.UNSPECIFIED,
+    deps.temporalConfig,
+    deps.logger,
+  );
+  if (dispatch.executionTarget !== ExecutionTarget.CLOUD) {
+    return;
+  }
+  try {
+    await lane.provisioner.ensureWorkflowSandbox(executionId, {
+      taskQueue: dispatch.taskQueue,
+      stigmerToken: mintSandboxToken(lane, executionId, deps.logger),
+    });
+  } catch (error) {
+    deps.logger.error(
+      "Workflow sandbox provisioning failed - refusing the request",
+      {
+        executionId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
+    throw unavailableError("failed to provision workflow sandbox");
+  }
+}
+
+/** The workflow-execution phases after which the per-execution sandbox has no work left. */
+const TERMINAL_WORKFLOW_PHASES: ReadonlySet<WorkflowExecutionPhase> = new Set([
+  WorkflowExecutionPhase.EXECUTION_COMPLETED,
+  WorkflowExecutionPhase.EXECUTION_FAILED,
+  WorkflowExecutionPhase.EXECUTION_CANCELLED,
+  WorkflowExecutionPhase.EXECUTION_TERMINATED,
+]);
+
+/**
+ * Observes one persisted status write and fires the workflow-sandbox
+ * teardown on a transition INTO a terminal phase — fire-and-forget
+ * (module header posture #3). Invoked from the three status write sites
+ * (the UpdateStatus RPC, the orchestrator's persist activity, the
+ * lifecycle cancel/terminate persists); idempotent deprovision makes the
+ * multi-site wiring safe.
+ */
+export type WorkflowSandboxTerminalObserver = (
+  executionId: string,
+  previousPhase: WorkflowExecutionPhase,
+  currentPhase: WorkflowExecutionPhase,
+) => void;
+
+export function newWorkflowSandboxTerminalObserver(
+  lane: SandboxLane,
+  logger: Logger,
+): WorkflowSandboxTerminalObserver {
+  return (executionId, previousPhase, currentPhase) => {
+    if (
+      !lane.enabled ||
+      previousPhase === currentPhase ||
+      !TERMINAL_WORKFLOW_PHASES.has(currentPhase)
+    ) {
+      return;
+    }
+    void lane.provisioner.deprovisionWorkflowSandbox(executionId).then(
+      () => {
+        logger.info("Workflow sandbox deprovisioned on terminal phase", {
+          executionId,
+          phase: WorkflowExecutionPhase[currentPhase],
+        });
+      },
+      (error: unknown) => {
+        // ERROR, not warn: nothing retries this and no reaper exists —
+        // the log line is the operator's only signal of the leak.
+        logger.error(
+          "Workflow sandbox deprovision failed - sandbox may be leaked",
+          {
+            executionId,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      },
+    );
+  };
+}
+
+/**
+ * Best-effort session-sandbox teardown for the session delete handler
+ * (module header posture #4; the Java SessionDeleteHandler shape — a
+ * handler call after the delete pipeline, not a pipeline step). A
+ * failure never fails the delete (the row is already gone) but is
+ * ERROR-logged — no reaper exists to catch a leak.
+ */
+export async function deprovisionSessionSandboxBestEffort(
+  lane: SandboxLane,
+  logger: Logger,
+  sessionId: string,
+): Promise<void> {
+  if (!lane.enabled || sessionId === "") {
+    return;
+  }
+  try {
+    await lane.provisioner.deprovisionSessionSandbox(sessionId);
+  } catch (error) {
+    logger.error("Session sandbox deprovision failed - sandbox may be leaked", {
+      sessionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/backend/services/stigmer-server/src/temporal/workflowexecution/__tests__/activities.test.ts
+++ b/backend/services/stigmer-server/src/temporal/workflowexecution/__tests__/activities.test.ts
@@ -164,6 +164,7 @@ describe("UpdateWorkflowExecutionStatus activity (real store)", () => {
       store,
       logger: silentLogger,
       broker,
+      sandboxTerminalObserver: () => {},
     });
     return activities[UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME] as (
       executionId: string,

--- a/backend/services/stigmer-server/src/temporal/workflowexecution/activities.ts
+++ b/backend/services/stigmer-server/src/temporal/workflowexecution/activities.ts
@@ -51,6 +51,7 @@ import {
   DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME,
   deleteExecutionContextForExecution,
 } from "../../domain/executioncontext/temporal/delete-execution-context.js";
+import type { WorkflowSandboxTerminalObserver } from "../../sandbox/steps.js";
 import type { Store } from "../../store/interface.js";
 import { UPDATE_WORKFLOW_EXECUTION_STATUS_ACTIVITY_NAME } from "./names.js";
 
@@ -58,6 +59,13 @@ export interface WorkflowExecutionActivityDeps {
   readonly store: Store;
   readonly logger: Logger;
   readonly broker: StreamBroker;
+  /**
+   * Fires the workflow-sandbox teardown on terminal transitions (§6d,
+   * O6) — this activity is the orchestrator's failure/cancellation
+   * persist site, one of the three status write sites the Q3b ruling
+   * wires.
+   */
+  readonly sandboxTerminalObserver: WorkflowSandboxTerminalObserver;
 }
 
 /**
@@ -69,7 +77,7 @@ export interface WorkflowExecutionActivityDeps {
 export function createWorkflowExecutionActivities(
   deps: WorkflowExecutionActivityDeps,
 ): Record<string, (...args: never[]) => Promise<unknown>> {
-  const { store, logger, broker } = deps;
+  const { store, logger, broker, sandboxTerminalObserver } = deps;
 
   return {
     /**
@@ -86,12 +94,18 @@ export function createWorkflowExecutionActivities(
       const statusUpdates = fromJson(WorkflowExecutionStatusSchema, statusJson);
 
       let updated: WorkflowExecution;
+      // The phase BEFORE this merge, read under the write lock — the
+      // sandbox observer below keys on the transition (§6d, O6).
+      let previousPhase = ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
       try {
         updated = await store.updateResource(
           ApiResourceKind.workflow_execution,
           executionId,
           WorkflowExecutionSchema,
           (execution) => {
+            previousPhase =
+              execution.status?.phase ??
+              ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
             applyActivityStatusMerge(execution, statusUpdates);
           },
         );
@@ -118,6 +132,13 @@ export function createWorkflowExecutionActivities(
       // (ADR 011 write path) — failure recovery updates must be
       // immediately visible to externally-connected subscribe streams.
       broker.broadcast(updated);
+      // A terminal transition (the orchestrator's FAILED/CANCELLED
+      // persists) tears the per-execution sandbox down, fire-and-forget.
+      sandboxTerminalObserver(
+        executionId,
+        previousPhase,
+        updated.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED,
+      );
     },
 
     /** #15's seam, shared with the agent-execution worker exactly as in Go. */

--- a/backend/services/stigmer-server/src/temporal/workflowexecution/worker.ts
+++ b/backend/services/stigmer-server/src/temporal/workflowexecution/worker.ts
@@ -27,6 +27,7 @@ import { Worker } from "@temporalio/worker";
 import type { Logger } from "../../boot/logger.js";
 import type { WorkflowExecutionTemporalConfig } from "../../domain/workflowexecution/temporal/config.js";
 import type { StreamBroker } from "../../domain/workflowexecution/stream-broker.js";
+import type { WorkflowSandboxTerminalObserver } from "../../sandbox/steps.js";
 import type { Store } from "../../store/interface.js";
 import type { WorkerFactory } from "../manager.js";
 import { resolveWorkflowSource } from "../workflow-source.js";
@@ -37,6 +38,8 @@ export interface WorkflowExecutionWorkerDeps {
   readonly logger: Logger;
   readonly broker: StreamBroker;
   readonly temporalConfig: WorkflowExecutionTemporalConfig;
+  /** The activity persist site's sandbox teardown observer (§6d, O6). */
+  readonly sandboxTerminalObserver: WorkflowSandboxTerminalObserver;
 }
 
 export function newWorkflowExecutionWorkerFactory(
@@ -47,6 +50,7 @@ export function newWorkflowExecutionWorkerFactory(
       store: deps.store,
       logger: deps.logger,
       broker: deps.broker,
+      sandboxTerminalObserver: deps.sandboxTerminalObserver,
     });
 
     const workflowSource = resolveWorkflowSource({

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -51,6 +51,8 @@ import type {
   PipelineStep,
   PresignedUpload,
   RunnerCredentialProvider,
+  SandboxProvisioner,
+  SandboxProvisionerFactory,
   ServerExtension,
   Store,
   WorkerFactory,
@@ -184,6 +186,35 @@ const consumerBlobDriver: ArtifactStorageDriverFactory =
     health: () => Promise.resolve(),
   });
 
+/**
+ * A consumer-registered sandbox driver (the O6 §6d registration shape) —
+ * the full scoped contract: ensure-as-state-machine per scope, idempotent
+ * teardown, the Q5 live-state probe. Selected at runtime through
+ * SANDBOX_PROVISIONER_TYPE naming the registered key.
+ */
+const consumerSandboxDriver: SandboxProvisionerFactory = ({
+  config,
+  logger,
+}): SandboxProvisioner => {
+  void config.backendEndpoint;
+  void logger;
+  return {
+    ensureSessionSandbox: (sessionId, env) => {
+      void sessionId;
+      void env.taskQueue;
+      void env.stigmerToken;
+      return Promise.resolve();
+    },
+    deprovisionSessionSandbox: () => Promise.resolve(),
+    ensureWorkflowSandbox: () => Promise.resolve(),
+    deprovisionWorkflowSandbox: () => Promise.resolve(),
+    createConnectSandbox: (connectRequestId) =>
+      Promise.resolve(connectRequestId),
+    deprovisionConnectSandbox: () => Promise.resolve(),
+    probe: () => Promise.resolve("absent" as const),
+  };
+};
+
 const registerBillingService = (router: ConnectRouter): void => {
   router.service(BillingQueryController, {
     getBillingAccount: (input) =>
@@ -205,6 +236,9 @@ export const fakeExtension: ServerExtension = {
     modelCatalogProvider: catalogProvider,
     runnerCredentialProvider: credentialProvider,
     artifactStorageDrivers: new Map([["consumer-blob", consumerBlobDriver]]),
+    sandboxProvisionerDrivers: new Map([
+      ["consumer-sandbox", consumerSandboxDriver],
+    ]),
   },
   services: [registerBillingService],
   workers: [workerFactory],


### PR DESCRIPTION
## Summary
O6 of the convergence program (20260826.02, blueprint 03 §6d, DD-002): sandbox execution isolation becomes an OSS capability behind a `SandboxProvisioner` driver seam — the contract generalized from the cloud edition's production Kubernetes provisioner, three built-in isolation tiers (local-process, Docker, Kubernetes), and a registry-driven extension point so compositions register their own drivers.

## Context
DD-002 ruled that sandbox provisioning is generic infrastructure, not cloud business logic: self-hosted production without isolation contradicts the self-host tier's promise. The cloud keeps exactly its two ruled extensions (the capacity decorator at O4's `sandbox-acquisition:gate` slot and its runner-credential provider); everything else lands here, maintained once in OSS.

## Changes
- **The seam** (`src/sandbox/provisioner.ts`): session/workflow/connect scoped variants with ensure-as-state-machine semantics and the live-state probe (T01 gate ruling Q5: ensure-time inspection, never a boot-readiness wait — the verified cloud posture). Selection follows the artifact-storage precedent: built-in factories + extension-registered names behind `SANDBOX_PROVISIONER_TYPE`, unknown names a loud boot throw, routing coherence validated at compose (a provisioner no dispatch can reach is a boot fault).
- **The default is the external-runner posture** (Q1): no driver constructed, ensure steps short-circuit on resolved LOCAL targets — today's behavior, named. Byte-identity holds structurally: the conformance rosters set neither routing knob.
- **Per-lane postures, the verified Java shapes** (Q2): the session lane ensures post-StartWorkflow, NON-critical, with failures ERROR-logged and pre-stamped onto `status.error` first-non-empty-wins via the atomic `updateResource` (the 2026-07 quota-outage lesson); the workflow lane ensures CRITICALLY before Persist (a refusal orphans nothing); recover chains re-ensure in both domains.
- **Terminal deprovision server-side** (Q3b): one observer wired at all three workflow-execution status write sites (the UpdateStatus RPC, the orchestrator's persist activity, the lifecycle persists) — the invoke workflow's pinned history shape stays untouched; the best-effort-persist leak window is documented in `sandbox/steps.ts`. Session sandboxes tear down on session delete.
- **Drivers**: local-process (managed runner child processes, per-sandbox workspaces); Docker via the docker CLI (owner-ruled: zero new dependency); Kubernetes via `@kubernetes/client-node` (owner-ruled: the production path — this driver is what the cloud composition will run) with the Java manifest shapes (per-sandbox Secret + Recreate Deployment + PVC for persistent scopes, `sbx-<scope>-<12-hex>` naming) behind a gateway seam.
- **Extension surface**: `sandboxProvisionerDrivers` on `ExtensionDrivers` with the shadow/duplicate merge rules; exports map + `test/extension-consumer` compile proof extended.
- Credentials (Q6): minted per execution on the existing execution-scoped lane; a disabled mint lane launches token-less (EC reads fall back to redaction). Connect lane (Q7): contract-complete, OSS wiring a named non-goal until per-connect dispatch exists.

## Test plan
- Unit: 1,876 passed (140 files) including the new sandbox suites (selection/naming, per-lane postures, pre-stamp semantics, terminal observer, K8s state machine over a fake gateway).
- All four conformance rosters green at the recorded counts: `local` 492, `local-execution` 160, `local-postgres` 492, `local-postgres-execution` 160 (one flaky first run of the postgres-execution roster passed clean on rerun, identical code).
- Local-process integration smoke (always-on): real child processes, env contract, respawn/teardown — it caught and fixed a late-exit-handler race.
- Docker integration smoke (opt-in `STIGMER_SANDBOX_DOCKER_SMOKE=1`): run green on this machine against `ghcr.io/stigmer/stigmer-runner:latest` (the multi-arch tag; the amd64-only `ghcr.io/stigmer/runner` default is documented in the smoke header).
- Kubernetes proven live against a disposable kind cluster (kind v0.24.0, `kind-stigmer-o6-proof`, deleted after): all ensure/deprovision/probe arms plus stopped→scale-up; the live proof caught a Scale-subresource patch-encoding bug, fixed as read-then-replace.
- `test/extension-consumer` compile proof green; typecheck clean.

## Risks
- The seam is dormant by default (no provisioner composed → no behavior change; rosters pin it). The known leak window on the server-side terminal deprovision is owner-ruled (Q3b) and documented in the module header.
- Rollback: revert the PR; no schema, proto, or wire-identifier changes.

Made with [Cursor](https://cursor.com)