### PR TITLE
feat(backend/stigmer-server): declare the gate slots and wire the status-transition hooks (O4)

### DIFF
--- a/.cursor/rules/backend/ts-server-guidelines.mdc
+++ b/.cursor/rules/backend/ts-server-guidelines.mdc
@@ -59,6 +59,37 @@ eventually violate creatively.
   introduce a synonym; the domain inventory and the ported chains read
   straight onto the code. Domain-specific steps stay domain-local; promote
   to shared only when a second domain needs the identical step.
+- **Gate-slot names are PROTECTED VOCABULARY** (convergence blueprint
+  20260826.02/03 §3a; declared in `src/extensions/gate-slots.ts`, spliced
+  where the table says, empty when no extension is composed). Never rename
+  a slot; adding one is an owner-visible act (O6 adds
+  `sandbox-acquisition:gate` with the provisioner invocation step). The
+  ratified table — the code must match it exactly:
+
+  | Slot | Position |
+  |---|---|
+  | `agent-execution-create:pre-side-effect-gate` | after `EnsureEngineAvailable`, before `CreateDefaultInstanceIfNeeded` |
+  | `agent-execution-recover:pre-side-effect-gate` | after `TerminateExistingWorkflow`, before `RecreateExecutionContext` |
+  | `agent-execution-submit-approval:gate` | after `ValidateApproval`, before `RecordApprovalDecision` |
+  | `session-create:pre-side-effect-gate` | after `NormalizeReferences`, before `Persist` (Q2 ruling: mirrors Java's post-resolution position; the pre-validation default-instance resolution side-effects pre-gate in BOTH editions) |
+  | `org-create:post-persist` | after `Persist`, before `IndexSearch` (non-transactional in BOTH editions: a slot failure fails the request, the row survives, idempotent retry heals) |
+
+  Facts gate AUTHORS inherit (recorded, not mechanisms): slots run
+  wherever their chain runs, INCLUDING in-process invocations (the Java
+  baseline) — but in-process callers carry `callerClass: "internal"`
+  where Java propagated the original caller; slots do not honor
+  chain-internal skip shortcuts (idempotent-replay flags) — a gate owns
+  its own idempotency; a gate refuses by throwing a `ConnectError` with
+  the correct code and byte-pinned copy, exactly as OSS steps do.
+- **Status-transition hooks fire from EVERY phase-transition persist
+  site**, not one chokepoint (O4 ruling Q3) — the five sites are
+  enumerated in `src/domain/agentexecution/status-observers.ts`, and a
+  NEW phase write MUST call `notifyStatusObservers` and extend that list.
+  Observers fire only on actual phase changes (ruling Q4), post-persist,
+  before any broadcast; observer failure is logged, never a failed
+  transition; decorators contribute only fields the shared reply schema
+  carries, clone-committed per decorator. Workflowexecution deliberately
+  has NO hooks (unmetered in cloud; nothing built ahead of need).
 - **The composition root is staged plain functions** (config → storage →
   temporal → controllers → routes → listen). No DI framework. A missing
   dependency is a compile error or a loud boot throw, never a silent no-op.

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -377,6 +377,10 @@ export async function composeServer(
         logger,
         broker: agentExecutionStreamBroker,
         authorizer,
+        // O4: the worker's status-merge activity reuses updateStatus, so
+        // the workflow's terminal writes notify the same composed hooks.
+        statusObservers: extensions.statusObservers,
+        responseDecorators: extensions.responseDecorators,
         temporalConfig,
       }),
       newWorkflowExecutionWorkerFactory({
@@ -611,7 +615,16 @@ export async function composeServer(
   }
   const routes = (router: ConnectRouter): void => {
     registerHealthService(router, healthState);
-    registerOrganizationServices(router, { store, logger, authorizer });
+    // The O4 extension points ride the same explicit-deps pattern the
+    // authorizer established: the three slot-hosting domains receive the
+    // merged gateSteps; agentexecution additionally receives the
+    // status-transition hooks (both empty in the no-extension composition).
+    registerOrganizationServices(router, {
+      store,
+      logger,
+      authorizer,
+      gateSteps: extensions.gateSteps,
+    });
     registerEnvironmentServices(router, {
       store,
       logger,
@@ -651,6 +664,7 @@ export async function composeServer(
       authorizer,
       temporalConfig,
       agentInstanceCreator: () => requireInProcess().agentInstanceCreator,
+      gateSteps: extensions.gateSteps,
     });
     // The sharing/channel family registers after the agent family, as in
     // Go server.go (agent 378 → agentshare 384 → agentchannel 391 →
@@ -697,6 +711,9 @@ export async function composeServer(
       engineState: executionEngineState,
       modelRegistry: modelCatalog,
       artifactStorage,
+      gateSteps: extensions.gateSteps,
+      statusObservers: extensions.statusObservers,
+      responseDecorators: extensions.responseDecorators,
       agentLoader: () => requireInProcess().executionAgentLoader,
       agentInstanceCreator: () =>
         requireInProcess().executionAgentInstanceCreator,

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/agentexecution.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/agentexecution.test.ts
@@ -52,7 +52,10 @@ import {
   ToolCallStatus,
 } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { CapturedFileChangeSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/filereview_pb";
-import { SubmitApprovalInputSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import {
+  SubmitApprovalInputSchema,
+  SubmitFileDecisionInputSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
 import { AgentExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/query_pb";
 import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
@@ -62,6 +65,7 @@ import { composeServer } from "../../../boot/compose.js";
 import type { ComposedServer } from "../../../boot/compose.js";
 import { createLogger } from "../../../boot/logger.js";
 import { executionUsageReportNotFoundMessage } from "../constants.js";
+import type { AgentExecutionStatusTransition } from "../../../extensions/status-hooks.js";
 import type {
   ConnectedExecutionEngine,
   ExecutionEngineState,
@@ -69,6 +73,7 @@ import type {
 import { EngineWorkflowNotFoundError } from "../engine.js";
 import { aggregateDigest, fileDigest } from "../filereview/digest.js";
 import { submitApproval } from "../submit-approval.js";
+import { submitFileDecision } from "../submit-file-decision.js";
 import { stubConnectedEngine } from "./engine-stub.js";
 
 const silentLogger = createLogger({
@@ -1109,6 +1114,8 @@ describe("the engine-connected signal arms (stubbed engine, direct calls)", () =
       authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: server.agentExecutionStreamBroker,
       engineState: () => ({ connected: true, engine }) as ExecutionEngineState,
+      gateSteps: new Map(),
+      statusObservers: [],
     };
   }
 
@@ -1203,6 +1210,48 @@ describe("the engine-connected signal arms (stubbed engine, direct calls)", () =
       (final.status?.approvalEventStream?.events ?? []).length,
     ).toBeGreaterThan(0);
     expect(final.status?.pendingApprovals).toHaveLength(0);
+  });
+
+  // O4 (20260827.07, ruling Q3): the reconcile's →FAILED stamp is notify
+  // site 4 of 5 — a terminal transition the update-status chokepoint
+  // never sees.
+  it("the stale-workflow reconcile notifies the composed status observers", async () => {
+    const id = await seed(
+      gatedSeed({ toolCalls: [{ id: "tc-obs", name: "Write" }] }),
+    );
+    const observed: AgentExecutionStatusTransition[] = [];
+    const deps = {
+      ...stubDeps(
+        stubConnectedEngine({
+          signalApprovalGateResolved: async (executionId) => {
+            throw new EngineWorkflowNotFoundError(executionId);
+          },
+        }),
+      ),
+      statusObservers: [
+        (t: AgentExecutionStatusTransition): void => void observed.push(t),
+      ],
+    };
+
+    await expectCode(
+      () =>
+        submitApproval(
+          deps,
+          create(SubmitApprovalInputSchema, {
+            agentExecutionId: id,
+            toolCallId: "tc-obs",
+            action: ApprovalAction.APPROVE,
+          }),
+          testCallerIdentity(),
+        ),
+      Code.FailedPrecondition,
+    );
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.oldPhase).toBe(
+      ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+    );
+    expect(observed[0]?.newPhase).toBe(ExecutionPhase.EXECUTION_FAILED);
+    expect(observed[0]?.execution.metadata?.id).toBe(id);
   });
 });
 
@@ -1309,6 +1358,55 @@ describe("submitFileDecision over the wire", () => {
       (c) => c.id === changeSetId,
     );
     expect(csRepeat?.decisions).toHaveLength(1);
+  });
+
+  // O4 (20260827.07, ruling Q3): the file-review reconcile twin is notify
+  // site 5 of 5.
+  it("the workflow-gone reconcile notifies the composed status observers", async () => {
+    const { init, changeSetId, aggregate } = ledgerSeed();
+    const id = await seed(init);
+    const observed: AgentExecutionStatusTransition[] = [];
+    const deps = {
+      store: server.store,
+      logger: silentLogger,
+      authorizer: newPermissiveSingleTeamAuthorizer(),
+      broker: server.agentExecutionStreamBroker,
+      engineState: () =>
+        ({
+          connected: true,
+          engine: stubConnectedEngine({
+            signalApprovalGateResolved: async (executionId: string) => {
+              throw new EngineWorkflowNotFoundError(executionId);
+            },
+          }),
+        }) as ExecutionEngineState,
+      statusObservers: [
+        (t: AgentExecutionStatusTransition): void => void observed.push(t),
+      ],
+    };
+
+    // A CHANGE_SET decision resolves the whole gate, so the signal fires
+    // and the vanished workflow triggers the reconcile.
+    await expectCode(
+      () =>
+        submitFileDecision(
+          deps,
+          create(SubmitFileDecisionInputSchema, {
+            agentExecutionId: id,
+            changeSetId,
+            scope: FileDecisionScope.CHANGE_SET,
+            action: FileDecisionAction.APPROVE,
+            expectedDigest: aggregate,
+          }),
+          testCallerIdentity(),
+        ),
+      Code.FailedPrecondition,
+    );
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.oldPhase).toBe(
+      ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+    );
+    expect(observed[0]?.newPhase).toBe(ExecutionPhase.EXECUTION_FAILED);
   });
 
   it("refuses a stale digest, an unknown change set, and FILE scope without an id", async () => {

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/create-steps.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/create-steps.test.ts
@@ -21,7 +21,11 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
-import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  AgentExecutionSchema,
+  AgentExecutionStatusSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import {
   DeclaredPreferencesSchema,
   RecalledMemoriesSchema,
@@ -57,7 +61,11 @@ import {
   newCreateSessionIfNeededStep,
   newEnsureSessionOrAgentResolvedStep,
   newResolveDefaultAgentStep,
+  newStartWorkflowStep,
 } from "../create-steps.js";
+import type { AgentExecutionStatusTransition } from "../../../extensions/status-hooks.js";
+import type { ExecutionEngineState } from "../engine.js";
+import { stubConnectedEngine } from "./engine-stub.js";
 
 const silentLogger = createLogger({
   level: "error",
@@ -921,5 +929,56 @@ describe("agentCallTaskEnvironmentRefs", () => {
     expect(
       agentCallTaskEnvironmentRefs(silentLogger, workflow, "review"),
     ).toHaveLength(0);
+  });
+});
+
+// O4 (20260827.07, ruling Q3): the StartWorkflow failure arm's
+// PENDING→FAILED stamp is notify site 3 of 5 — an execution that consumed
+// its create-gate side effects and then never started still reaches the
+// composed observers (the cloud settles its reservation on exactly this).
+describe("newStartWorkflowStep — start-failure FAILED stamp", () => {
+  it("persists FAILED and notifies the observers before surfacing Internal", async () => {
+    const observed: AgentExecutionStatusTransition[] = [];
+    const step = newStartWorkflowStep({
+      store,
+      logger: silentLogger,
+      engineState: () =>
+        ({
+          connected: true,
+          engine: stubConnectedEngine({
+            startInvokeWorkflow: async () => {
+              throw new Error("temporal exploded");
+            },
+          }),
+        }) as ExecutionEngineState,
+      statusObservers: [
+        (t: AgentExecutionStatusTransition): void => void observed.push(t),
+      ],
+    });
+
+    const execution = newExecution("ses_sw", "agt_sw");
+    execution.metadata!.id = "aexec_sw_fail";
+    // The chain stamps PENDING at SetInitialPhase before this step runs.
+    execution.status = create(AgentExecutionStatusSchema, {
+      phase: ExecutionPhase.EXECUTION_PENDING,
+    });
+
+    const err = await expectCode(
+      () => step.execute(newContext(execution)),
+      Code.Internal,
+    );
+    expect(err.rawMessage).toBe("failed to start workflow");
+
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.oldPhase).toBe(ExecutionPhase.EXECUTION_PENDING);
+    expect(observed[0]?.newPhase).toBe(ExecutionPhase.EXECUTION_FAILED);
+
+    const persisted = await store.getResource(
+      ApiResourceKind.agent_execution,
+      "aexec_sw_fail",
+      AgentExecutionSchema,
+    );
+    expect(persisted.status?.phase).toBe(ExecutionPhase.EXECUTION_FAILED);
+    expect(persisted.status?.error).toContain("temporal exploded");
   });
 });

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/lifecycle.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/lifecycle.test.ts
@@ -57,6 +57,7 @@ import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import { createLogger } from "../../../boot/logger.js";
+import type { AgentExecutionStatusTransition } from "../../../extensions/status-hooks.js";
 import { SqliteStore } from "../../../store/sqlite/store.js";
 import type { Store } from "../../../store/interface.js";
 import type { ManagedEnvironmentService } from "../../mcpserver/oauth/managed-env.js";
@@ -443,6 +444,8 @@ function lifecycleDeps(engineState: ExecutionEngineState): LifecycleDeps {
     broker: new StreamBroker(silentLogger),
     engineState: () => engineState,
     executionContextBuilder: stubBuilderDeps(),
+    gateSteps: new Map(),
+    statusObservers: [],
   };
 }
 
@@ -647,6 +650,118 @@ describe("lifecycle pipelines", () => {
     expect(result.status?.error).toBe("Terminated: disk full");
   });
 
+  // O4 (20260827.07, ruling Q3): the lifecycle persist step is notify
+  // site 2 of 5 — the user-initiated terminal transitions the update-status
+  // chokepoint never sees MUST reach the composed observers (the cloud's
+  // billing finalize settles on exactly these).
+  it("cancel notifies the composed status observers with the persisted transition", async () => {
+    const observed: AgentExecutionStatusTransition[] = [];
+    const deps: LifecycleDeps = {
+      ...lifecycleDeps(connected(stubConnectedEngine())),
+      statusObservers: [(t) => void observed.push(t)],
+    };
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+    });
+    await cancelExecution(deps, cancelInput(id), testCallerIdentity());
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.oldPhase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    expect(observed[0]?.newPhase).toBe(ExecutionPhase.EXECUTION_CANCELLED);
+    expect(observed[0]?.execution.metadata?.id).toBe(id);
+    // The observer sees the PERSISTED snapshot (post-merge contract).
+    expect(observed[0]?.execution.status?.completedAt).not.toBe("");
+  });
+
+  it("terminate notifies the composed status observers", async () => {
+    const observed: AgentExecutionStatusTransition[] = [];
+    const deps: LifecycleDeps = {
+      ...lifecycleDeps(connected(stubConnectedEngine())),
+      statusObservers: [(t) => void observed.push(t)],
+    };
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_IN_PROGRESS,
+    });
+    await terminateExecution(
+      deps,
+      terminateInput(id, "disk full"),
+      testCallerIdentity(),
+    );
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.newPhase).toBe(ExecutionPhase.EXECUTION_TERMINATED);
+  });
+
+  it("an idempotent already-in-target cancel notifies nothing (no write, no transition)", async () => {
+    const observed: AgentExecutionStatusTransition[] = [];
+    const deps: LifecycleDeps = {
+      ...lifecycleDeps(connected(stubConnectedEngine())),
+      statusObservers: [(t) => void observed.push(t)],
+    };
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_CANCELLED,
+    });
+    await cancelExecution(deps, cancelInput(id), testCallerIdentity());
+    expect(observed).toHaveLength(0);
+  });
+
+  // O4: the recover chain's ratified slot position — after workflow
+  // termination, before re-launch side effects (the RearmBillingStep
+  // ordering, blueprint 03 §3a).
+  it("a recover slot gate refuses after termination and before any re-launch side effect", async () => {
+    const terminations: string[] = [];
+    const starts: string[] = [];
+    const deps: LifecycleDeps = {
+      ...lifecycleDeps(
+        connected(
+          stubConnectedEngine({
+            terminateWorkflow: async (executionId) => {
+              terminations.push(executionId);
+            },
+            startInvokeWorkflow: async (params) => {
+              starts.push(params.executionId);
+            },
+          }),
+        ),
+      ),
+      gateSteps: new Map([
+        [
+          "agent-execution-recover:pre-side-effect-gate",
+          [
+            {
+              name: "FakeRearmGate",
+              execute: (): void => {
+                throw new ConnectError(
+                  "fake rearm refused",
+                  Code.FailedPrecondition,
+                );
+              },
+            },
+          ],
+        ],
+      ]),
+    };
+    const id = await seedExecution({
+      phase: ExecutionPhase.EXECUTION_FAILED,
+      sessionId: "ses_lc",
+      error: "runner exploded",
+    });
+
+    const err = await expectCode(
+      () => recoverExecution(deps, recoverInput(id), testCallerIdentity()),
+      Code.FailedPrecondition,
+    );
+    expect(err.rawMessage).toBe("fake rearm refused");
+    // Position proof: the terminated-workflow side of the boundary ran,
+    // the re-launch side did not, and the phase write never happened.
+    expect(terminations).toEqual([id]);
+    expect(starts).toEqual([]);
+    const persisted = await store.getResource(
+      ApiResourceKind.agent_execution,
+      id,
+      AgentExecutionSchema,
+    );
+    expect(persisted.status?.phase).toBe(ExecutionPhase.EXECUTION_FAILED);
+  });
+
   it("resume from PAUSED clears completed_at and returns IN_PROGRESS", async () => {
     const resumed: string[] = [];
     const deps = lifecycleDeps(
@@ -678,6 +793,8 @@ describe("lifecycle pipelines", () => {
       logger: silentLogger,
       authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
+      gateSteps: new Map(),
+      statusObservers: [],
       engineState: () =>
         connected(
           stubConnectedEngine({
@@ -731,6 +848,8 @@ describe("lifecycle pipelines", () => {
       logger: silentLogger,
       authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
+      gateSteps: new Map(),
+      statusObservers: [],
       engineState: () =>
         connected(
           stubConnectedEngine({
@@ -772,6 +891,8 @@ describe("lifecycle pipelines", () => {
       logger: silentLogger,
       authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
+      gateSteps: new Map(),
+      statusObservers: [],
       engineState: () =>
         connected(
           stubConnectedEngine({
@@ -820,6 +941,8 @@ describe("lifecycle pipelines", () => {
       logger: silentLogger,
       authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
+      gateSteps: new Map(),
+      statusObservers: [],
       engineState: () =>
         connected(
           stubConnectedEngine({
@@ -861,6 +984,8 @@ describe("lifecycle pipelines", () => {
       logger: silentLogger,
       authorizer: newPermissiveSingleTeamAuthorizer(),
       broker: new StreamBroker(silentLogger),
+      gateSteps: new Map(),
+      statusObservers: [],
       engineState: () => connected(stubConnectedEngine()),
       executionContextBuilder: {
         ...builderDeps,
@@ -974,6 +1099,8 @@ describe("lifecycle persist uses the atomic updateResource", () => {
         broker: new StreamBroker(silentLogger),
         engineState: () => connected(stubConnectedEngine()),
         executionContextBuilder: stubBuilderDeps(),
+        gateSteps: new Map(),
+        statusObservers: [],
       };
 
       // Seed through the RAW store so the seed write is not counted.

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/status-observers.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/status-observers.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Pins the status-hook consumption contract (O4, 20260827.07; DD-006 §3):
+ * the Q4 firing rule (phase change only), observer ordering and isolation
+ * (a throwing/rejecting observer is logged and never fails the caller),
+ * and the decorator clone-commit posture (a throwing decorator degrades
+ * exactly ITS contribution — earlier contributions survive, the RPC never
+ * fails). The per-site wiring is pinned by the lifecycle/approval/
+ * composition suites; this file pins the shared notifier itself.
+ */
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  ExecutionControlSignal,
+  ExecutionPhase,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { UpdateStatusResponseSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+
+import type { Logger } from "../../../boot/logger.js";
+import type { AgentExecutionStatusTransition } from "../../../extensions/status-hooks.js";
+import {
+  applyResponseDecorators,
+  notifyStatusObservers,
+} from "../status-observers.js";
+
+function silentLoggerWithCapture(): { logger: Logger; warnings: string[] } {
+  const warnings: string[] = [];
+  const logger = {
+    debug: () => {},
+    info: () => {},
+    warn: (msg: string) => {
+      warnings.push(msg);
+    },
+    error: () => {},
+  } as unknown as Logger;
+  return { logger, warnings };
+}
+
+function execution(id: string) {
+  return create(AgentExecutionSchema, { metadata: { id, name: id } });
+}
+
+describe("notifyStatusObservers", () => {
+  it("fires only when the phase actually changed (ruling Q4)", async () => {
+    const seen: AgentExecutionStatusTransition[] = [];
+    const { logger } = silentLoggerWithCapture();
+    const deps = {
+      statusObservers: [
+        (t: AgentExecutionStatusTransition) => void seen.push(t),
+      ],
+      logger,
+    };
+
+    await notifyStatusObservers(
+      deps,
+      execution("aexec_same"),
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+    );
+    expect(seen).toHaveLength(0);
+
+    await notifyStatusObservers(
+      deps,
+      execution("aexec_changed"),
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_COMPLETED,
+    );
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.oldPhase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    expect(seen[0]?.newPhase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+    expect(seen[0]?.execution.metadata?.id).toBe("aexec_changed");
+  });
+
+  it("runs observers in registration order, awaiting each", async () => {
+    const order: string[] = [];
+    const { logger } = silentLoggerWithCapture();
+    await notifyStatusObservers(
+      {
+        statusObservers: [
+          async () => {
+            // A microtask delay: were observers not awaited in order, the
+            // second (synchronous) observer would record first.
+            await Promise.resolve();
+            order.push("first");
+          },
+          () => void order.push("second"),
+        ],
+        logger,
+      },
+      execution("aexec_order"),
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_FAILED,
+    );
+    expect(order).toEqual(["first", "second"]);
+  });
+
+  it("logs a throwing or rejecting observer and keeps going — never a failed transition", async () => {
+    const seen: string[] = [];
+    const { logger, warnings } = silentLoggerWithCapture();
+    await expect(
+      notifyStatusObservers(
+        {
+          statusObservers: [
+            () => {
+              throw new Error("sync extension bug");
+            },
+            () => Promise.reject(new Error("async extension bug")),
+            () => void seen.push("healthy"),
+          ],
+          logger,
+        },
+        execution("aexec_faulty"),
+        ExecutionPhase.EXECUTION_IN_PROGRESS,
+        ExecutionPhase.EXECUTION_CANCELLED,
+      ),
+    ).resolves.toBeUndefined();
+    expect(seen).toEqual(["healthy"]);
+    expect(warnings).toHaveLength(2);
+  });
+});
+
+describe("applyResponseDecorators", () => {
+  it("commits each successful decorator's contribution to the reply", async () => {
+    const { logger } = silentLoggerWithCapture();
+    const decorated = await applyResponseDecorators(
+      [
+        (_execution, response) => {
+          response.signal = ExecutionControlSignal.STOP;
+        },
+      ],
+      logger,
+      execution("aexec_dec"),
+      create(UpdateStatusResponseSchema, {
+        signal: ExecutionControlSignal.UNSPECIFIED,
+      }),
+    );
+    expect(decorated.signal).toBe(ExecutionControlSignal.STOP);
+  });
+
+  it("degrades exactly the throwing decorator's contribution, keeping earlier ones", async () => {
+    const { logger, warnings } = silentLoggerWithCapture();
+    const decorated = await applyResponseDecorators(
+      [
+        (_execution, response) => {
+          response.signal = ExecutionControlSignal.STOP;
+        },
+        (_execution, response) => {
+          // Writes before throwing — the clone-commit posture must
+          // discard this partial write, not ship it.
+          response.signal = ExecutionControlSignal.UNSPECIFIED;
+          throw new Error("decorator bug");
+        },
+      ],
+      logger,
+      execution("aexec_partial"),
+      create(UpdateStatusResponseSchema, {
+        signal: ExecutionControlSignal.UNSPECIFIED,
+      }),
+    );
+    expect(decorated.signal).toBe(ExecutionControlSignal.STOP);
+    expect(warnings).toHaveLength(1);
+  });
+});

--- a/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
@@ -30,6 +30,12 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
+import { stepsForSlot } from "../../extensions/gate-slots.js";
+import type {
+  AgentExecutionResponseDecorator,
+  AgentExecutionStatusObserver,
+} from "../../extensions/status-hooks.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -158,6 +164,17 @@ export interface AgentExecutionControllerDeps {
   readonly sessionCreator: SessionCreatorProvider;
   /** The shared EC-builder deps (create's step 16 + recover's recreate). */
   readonly executionContextBuilder: ExecutionContextBuilderDeps;
+  /**
+   * The composed slot registrations (O4, blueprint 03 §3a) — this domain
+   * splices the create, recover, and submit-approval slots.
+   */
+  readonly gateSteps: ResolvedGateSteps;
+  /**
+   * The composed status-transition hooks (O4, DD-006 §3) — consumed at
+   * the five phase-transition persist sites (status-observers.ts).
+   */
+  readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
+  readonly responseDecorators: ReadonlyArray<AgentExecutionResponseDecorator>;
 }
 
 /** Registers both agentexecution services on the router (routes stage). */
@@ -172,6 +189,8 @@ export function registerAgentExecutionServices(
     broker: deps.broker,
     engineState: deps.engineState,
     executionContextBuilder: deps.executionContextBuilder,
+    gateSteps: deps.gateSteps,
+    statusObservers: deps.statusObservers,
   };
   const artifactDeps = {
     store: deps.store,
@@ -224,11 +243,12 @@ export function registerAgentExecutionServices(
  * (proto → visibility → tier #357 → thinking #772) → target resolution
  * (default agent → invariant guard) → the standard build → the engine
  * gate (fail fast BEFORE the first side effect, so a down engine orphans
- * nothing) → the side-effecting steps (default instance, session
- * bootstrap, preference/memory snapshots, initial phase, the
- * ExecutionContext with merged env, attachment validation) → Persist →
- * IndexSearch → StartWorkflow (after persist; a start failure marks the
- * execution FAILED, recoverable via Recover).
+ * nothing) → the pre-side-effect gate slot (O4; empty in OSS) → the
+ * side-effecting steps (default instance, session bootstrap,
+ * preference/memory snapshots, initial phase, the ExecutionContext with
+ * merged env, attachment validation) → Persist → IndexSearch →
+ * StartWorkflow (after persist; a start failure marks the execution
+ * FAILED, recoverable via Recover).
  */
 async function createExecution(
   deps: AgentExecutionControllerDeps,
@@ -241,7 +261,7 @@ async function createExecution(
     callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof AgentExecutionSchema>(
+  const builder = newPipeline<typeof AgentExecutionSchema>(
     "agent-execution-create",
     deps.logger,
   )
@@ -260,7 +280,17 @@ async function createExecution(
     .addStep(newResolveSlugStep())
     .addStep(newBuildNewStateStep())
     .addStep(newNormalizeReferencesStep())
-    .addStep(newEnsureEngineAvailableStep(deps.engineState))
+    .addStep(newEnsureEngineAvailableStep(deps.engineState));
+  // The ratified pre-side-effect gate slot (blueprint 03 §3a; O4): after
+  // every pure validation/resolution step, before the first side-effecting
+  // step — a refusal orphans nothing. Empty in OSS.
+  for (const step of stepsForSlot<typeof AgentExecutionSchema>(
+    deps.gateSteps,
+    "agent-execution-create:pre-side-effect-gate",
+  )) {
+    builder.addStep(step);
+  }
+  await builder
     .addStep(
       newCreateDefaultInstanceIfNeededStep({
         store: deps.store,
@@ -293,6 +323,7 @@ async function createExecution(
         store: deps.store,
         logger: deps.logger,
         engineState: deps.engineState,
+        statusObservers: deps.statusObservers,
       }),
     )
     .build()

--- a/backend/services/stigmer-server/src/domain/agentexecution/create-steps.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/create-steps.ts
@@ -52,11 +52,12 @@ import {
 } from "../agent/defaultagent.js";
 import { buildDefaultInstanceRequest } from "../agentinstance/defaultinstance.js";
 
-import type {
-  ExecutionEngineStateProvider,
-} from "./engine.js";
+import type { AgentExecutionStatusObserver } from "../../extensions/status-hooks.js";
+
+import type { ExecutionEngineStateProvider } from "./engine.js";
 import { EngineDispatchError } from "./engine.js";
 import { ENGINE_UNAVAILABLE_MESSAGE } from "./constants.js";
+import { notifyStatusObservers } from "./status-observers.js";
 import { unavailableError } from "../../pipeline/errors.js";
 
 type CreateDesc = typeof AgentExecutionSchema;
@@ -227,14 +228,12 @@ export type ExecutionAgentInstanceCreatorProvider =
  * (matching Go/Java: repo save, not the Update pipeline), and stores the
  * instance id in the context for the next step.
  */
-export function newCreateDefaultInstanceIfNeededStep(
-  deps: {
-    store: Store;
-    logger: Logger;
-    agentLoader: AgentLoaderProvider;
-    agentInstanceCreator: ExecutionAgentInstanceCreatorProvider;
-  },
-): PipelineStep<CreateDesc> {
+export function newCreateDefaultInstanceIfNeededStep(deps: {
+  store: Store;
+  logger: Logger;
+  agentLoader: AgentLoaderProvider;
+  agentInstanceCreator: ExecutionAgentInstanceCreatorProvider;
+}): PipelineStep<CreateDesc> {
   return {
     name: "CreateDefaultInstanceIfNeeded",
     async execute(ctx) {
@@ -313,7 +312,10 @@ export function newCreateDefaultInstanceIfNeededStep(
         createdId = created.metadata?.id ?? "";
       } catch (error) {
         if (error instanceof ConnectError) {
-          throw goWrappedStatusError("failed to create default instance", error);
+          throw goWrappedStatusError(
+            "failed to create default instance",
+            error,
+          );
         }
         throw new Error(
           `failed to create default instance: ${error instanceof Error ? error.message : String(error)}`,
@@ -388,12 +390,10 @@ export function buildAutoCreateSessionSpec(
  * resource is the single source of truth; the persisted execution never
  * carries a second copy that could drift).
  */
-export function newCreateSessionIfNeededStep(
-  deps: {
-    logger: Logger;
-    sessionCreator: SessionCreatorProvider;
-  },
-): PipelineStep<CreateDesc> {
+export function newCreateSessionIfNeededStep(deps: {
+  logger: Logger;
+  sessionCreator: SessionCreatorProvider;
+}): PipelineStep<CreateDesc> {
   return {
     name: "CreateSessionIfNeeded",
     async execute(ctx) {
@@ -402,9 +402,12 @@ export function newCreateSessionIfNeededStep(
       const agentId = execution.spec?.agentId ?? "";
 
       if (sessionId !== "") {
-        deps.logger.debug("Session ID already provided, skipping auto-creation", {
-          sessionId,
-        });
+        deps.logger.debug(
+          "Session ID already provided, skipping auto-creation",
+          {
+            sessionId,
+          },
+        );
         return;
       }
 
@@ -783,13 +786,13 @@ export function newProcessAttachmentsStep(
  * existed, so there is no event stream to preserve and no concurrent
  * appender to lose a write to), then answers Internal.
  */
-export function newStartWorkflowStep(
-  deps: {
-    store: Store;
-    logger: Logger;
-    engineState: ExecutionEngineStateProvider;
-  },
-): PipelineStep<CreateDesc> {
+export function newStartWorkflowStep(deps: {
+  store: Store;
+  logger: Logger;
+  engineState: ExecutionEngineStateProvider;
+  /** O4: the failure arm's PENDING→FAILED stamp is a notified transition. */
+  statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
+}): PipelineStep<CreateDesc> {
   return {
     name: "StartWorkflow",
     async execute(ctx) {
@@ -849,6 +852,7 @@ export function newStartWorkflowStep(
           },
         );
         execution.status ??= create(AgentExecutionStatusSchema);
+        const oldPhase = execution.status.phase;
         execution.status.phase = ExecutionPhase.EXECUTION_FAILED;
         execution.status.error = `Failed to start Temporal workflow: ${error instanceof Error ? error.message : String(error)}`;
 
@@ -865,6 +869,15 @@ export function newStartWorkflowStep(
             "failed to start workflow and failed to update status",
           );
         }
+        // O4 site 3 of 5 (status-observers.ts): the PENDING→FAILED stamp
+        // is a persisted terminal transition — notified before the
+        // refusal surfaces.
+        await notifyStatusObservers(
+          deps,
+          execution as AgentExecution,
+          oldPhase,
+          ExecutionPhase.EXECUTION_FAILED,
+        );
         throw internalError(error, "failed to start workflow");
       }
 

--- a/backend/services/stigmer-server/src/domain/agentexecution/lifecycle.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/lifecycle.ts
@@ -46,6 +46,9 @@ import { enumToJson } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
+import { stepsForSlot } from "../../extensions/gate-slots.js";
+import type { AgentExecutionStatusObserver } from "../../extensions/status-hooks.js";
 import {
   failedPreconditionError,
   internalError,
@@ -64,6 +67,7 @@ import type { ExecutionContextBuilderDeps } from "./create-execution-context-ste
 import { buildAndPersistExecutionContext } from "./create-execution-context-step.js";
 import type { ExecutionEngineStateProvider } from "./engine.js";
 import { EngineDispatchError, EngineWorkflowNotFoundError } from "./engine.js";
+import { notifyStatusObservers } from "./status-observers.js";
 import { settleInterruptedToolCalls } from "./tool-call-settle.js";
 import type { StreamBroker } from "./stream-broker.js";
 
@@ -84,6 +88,10 @@ export interface LifecycleDeps {
   readonly engineState: ExecutionEngineStateProvider;
   /** The shared EC-builder deps, consumed by recover's recreate step. */
   readonly executionContextBuilder: ExecutionContextBuilderDeps;
+  /** The composed slot registrations — recover's pre-side-effect slot (O4). */
+  readonly gateSteps: ResolvedGateSteps;
+  /** The composed status-transition observers (O4, DD-006 §3). */
+  readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
 }
 
 /** Inputs that carry an execution id (Go LifecycleInput). */
@@ -330,12 +338,16 @@ function newUpdateExecutionPhaseAndPersistStep<Desc extends DescMessage>(
       const reason = typeof reasonValue === "string" ? reasonValue : "";
 
       let updated: AgentExecution;
+      let oldPhase = ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
       try {
         updated = await deps.store.updateResource(
           ApiResourceKind.agent_execution,
           executionId,
           AgentExecutionSchema,
           (loaded) => {
+            oldPhase =
+              loaded.status?.phase ??
+              ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
             applyLifecyclePhaseTransition(
               loaded,
               targetPhase,
@@ -351,6 +363,9 @@ function newUpdateExecutionPhaseAndPersistStep<Desc extends DescMessage>(
         }
         throw internalError(error, "failed to persist execution");
       }
+      // O4 site 2 of 5 (status-observers.ts): observers see the persisted
+      // transition before LifecycleBroadcast runs — broadcast stays last.
+      await notifyStatusObservers(deps, updated, oldPhase, targetPhase);
       // Hand the persisted result to the broadcast step and the handler's
       // return value (both read the same key).
       ctx.set(LOADED_EXECUTION_KEY, updated);
@@ -666,6 +681,14 @@ export async function recoverExecution(
           ),
         failureMessage: "failed to terminate previous workflow during recovery",
       }),
+      // The ratified pre-side-effect gate slot (blueprint 03 §3a; O4):
+      // after workflow termination, before re-launch side effects — the
+      // verified RearmBillingStep ordering (a terminated workflow issues
+      // no new settles). Empty in OSS.
+      ...stepsForSlot<Desc>(
+        deps.gateSteps,
+        "agent-execution-recover:pre-side-effect-gate",
+      ),
       newRecreateExecutionContextStep(deps),
       newStartFreshWorkflowStep(deps),
       newUpdateExecutionPhaseAndPersistStep(

--- a/backend/services/stigmer-server/src/domain/agentexecution/status-observers.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/status-observers.ts
@@ -1,0 +1,108 @@
+/**
+ * Status-observer notification — the domain-owned consumer of the
+ * extension registry's status-transition hooks (blueprint 03 §7, DD-006
+ * §3; O4 plan-gate ruling Q3, 20260827.07).
+ *
+ * The blueprint drafted the hook "at the updateStatus chokepoint", but
+ * the verified reality is FIVE phase-transition persist sites, and a
+ * finalize observer that misses any of them misses exactly what it
+ * exists to settle (user cancels/terminations, start-failure FAILED,
+ * workflow-gone FAILED). The ruled design: this ONE notifier is invoked
+ * from every site — the site list below is the exhaustive contract,
+ * re-verified whenever a new phase write appears:
+ *   1. update-status.ts       — the runner's merge chokepoint;
+ *   2. lifecycle.ts           — the phase-transition persist step
+ *                               (cancel/terminate/pause/resume/recover);
+ *   3. create-steps.ts        — the StartWorkflow failure arm (FAILED);
+ *   4. submit-approval.ts     — reconcileStaleExecution (FAILED);
+ *   5. submit-file-decision.ts — the file-review reconcile twin (FAILED).
+ * Initial-phase stamping at creation (SetInitialPhase → PENDING) is by
+ * definition not a transition and does not notify.
+ *
+ * Contract rendered here (status-hooks.ts carries the ratified text):
+ *   - fires only when the phase actually changed (ruling Q4 — runner
+ *     progress reports repeat the phase many times per execution; the
+ *     terminal-vs-not filter stays with the observer);
+ *   - observers run in registration order and are awaited, so every
+ *     observer completes before the caller proceeds to broadcast —
+ *     "StreamBroker.broadcast stays last" holds for async observers too;
+ *   - a throwing/rejecting observer is an extension bug logged here,
+ *     NEVER a failed transition (the cloud's expiry sweep remains the
+ *     reconciliation backstop).
+ */
+import { clone } from "@bufbuild/protobuf";
+
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { UpdateStatusResponse } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { UpdateStatusResponseSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type {
+  AgentExecutionResponseDecorator,
+  AgentExecutionStatusObserver,
+} from "../../extensions/status-hooks.js";
+
+/** The deps every notifying site threads (a slice of its own deps). */
+export interface StatusObserverDeps {
+  readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
+  readonly logger: Logger;
+}
+
+/**
+ * Notifies the composed observers of one persisted phase transition.
+ * Call AFTER the store write commits and BEFORE any broadcast, with the
+ * persisted snapshot and the phase read from the pre-merge state.
+ */
+export async function notifyStatusObservers(
+  deps: StatusObserverDeps,
+  execution: AgentExecution,
+  oldPhase: ExecutionPhase,
+  newPhase: ExecutionPhase,
+): Promise<void> {
+  if (oldPhase === newPhase) {
+    return;
+  }
+  for (const observer of deps.statusObservers) {
+    try {
+      await observer({ execution, oldPhase, newPhase });
+    } catch (error) {
+      deps.logger.warn("status observer failed (extension bug, ignored)", {
+        executionId: execution.metadata?.id ?? "",
+        oldPhase,
+        newPhase,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+/**
+ * Applies the composed response decorators to the UpdateStatus reply
+ * (blueprint 03 §7 — the querySignal seam: after the merge, before the
+ * reply). Each decorator works on a clone and commits only on success, so
+ * a throwing decorator degrades exactly ITS contribution to the defaults
+ * (the verified non-fatal posture) — never a partial write, never the
+ * RPC. Returns the decorated reply.
+ */
+export async function applyResponseDecorators(
+  decorators: ReadonlyArray<AgentExecutionResponseDecorator>,
+  logger: Logger,
+  execution: AgentExecution,
+  response: UpdateStatusResponse,
+): Promise<UpdateStatusResponse> {
+  let decorated = response;
+  for (const decorator of decorators) {
+    const candidate = clone(UpdateStatusResponseSchema, decorated);
+    try {
+      await decorator(execution, candidate);
+      decorated = candidate;
+    } catch (error) {
+      logger.warn("response decorator failed (extension bug, ignored)", {
+        executionId: execution.metadata?.id ?? "",
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+  return decorated;
+}

--- a/backend/services/stigmer-server/src/domain/agentexecution/submit-approval.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/submit-approval.ts
@@ -47,6 +47,9 @@ import { enumToJson } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
+import { stepsForSlot } from "../../extensions/gate-slots.js";
+import type { AgentExecutionStatusObserver } from "../../extensions/status-hooks.js";
 import {
   failedPreconditionError,
   internalError,
@@ -71,6 +74,7 @@ import { projectPendingApprovals } from "./approval/project.js";
 import type { ExecutionEngineStateProvider } from "./engine.js";
 import { EngineWorkflowNotFoundError } from "./engine.js";
 import { countAwaitingReview } from "./filereview/gate.js";
+import { notifyStatusObservers } from "./status-observers.js";
 import { settleInterruptedToolCalls } from "./tool-call-settle.js";
 import type { StreamBroker } from "./stream-broker.js";
 
@@ -81,6 +85,10 @@ export interface SubmitApprovalDeps {
   readonly authorizer: Authorizer;
   readonly broker: StreamBroker;
   readonly engineState: ExecutionEngineStateProvider;
+  /** The composed slot registrations — this chain's approval gate slot (O4). */
+  readonly gateSteps: ResolvedGateSteps;
+  /** O4: the stale-workflow reconcile's →FAILED stamp is a notified transition. */
+  readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
 }
 
 type SubmitApprovalDesc =
@@ -101,7 +109,7 @@ export async function submitApproval(
     identity,
     ApiResourceKind.agent_execution,
   );
-  await newPipeline<SubmitApprovalDesc>(
+  const builder = newPipeline<SubmitApprovalDesc>(
     "agent-execution-submit-approval",
     deps.logger,
   )
@@ -190,7 +198,17 @@ export async function submitApproval(
           );
         }
       },
-    })
+    });
+  // The ratified approval gate slot (blueprint 03 §3a; O4): after
+  // ValidateApproval, before the approval side effects (the record is the
+  // atomic read-modify-write). Empty in OSS.
+  for (const step of stepsForSlot<SubmitApprovalDesc>(
+    deps.gateSteps,
+    "agent-execution-submit-approval:gate",
+  )) {
+    builder.addStep(step);
+  }
+  await builder
     .addStep({
       name: "RecordApprovalDecision",
       async execute(ctx) {
@@ -455,6 +473,15 @@ async function reconcileStaleExecution(
   deps.logger.info("RECONCILIATION: Updated stale execution status to FAILED", {
     executionId,
   });
+
+  // O4 site 4 of 5 (status-observers.ts): the reconcile's →FAILED stamp
+  // is a persisted terminal transition.
+  await notifyStatusObservers(
+    deps,
+    reconciled,
+    execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED,
+    ExecutionPhase.EXECUTION_FAILED,
+  );
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/agentexecution/submit-file-decision.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/submit-file-decision.ts
@@ -46,6 +46,7 @@ import { enumToJson } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { AgentExecutionStatusObserver } from "../../extensions/status-hooks.js";
 import {
   failedPreconditionError,
   internalError,
@@ -74,6 +75,7 @@ import {
 } from "./filereview/author.js";
 import { countAwaitingReview, gateResolved } from "./filereview/gate.js";
 import { projectFileChangeSets } from "./filereview/project.js";
+import { notifyStatusObservers } from "./status-observers.js";
 import { settleInterruptedToolCalls } from "./tool-call-settle.js";
 import type { StreamBroker } from "./stream-broker.js";
 
@@ -84,6 +86,8 @@ export interface SubmitFileDecisionDeps {
   readonly authorizer: Authorizer;
   readonly broker: StreamBroker;
   readonly engineState: ExecutionEngineStateProvider;
+  /** O4: the stale-workflow reconcile's →FAILED stamp is a notified transition. */
+  readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
 }
 
 type SubmitFileDecisionDesc =
@@ -460,5 +464,14 @@ async function reconcileStaleFileReviewExecution(
   deps.logger.info(
     "RECONCILIATION: Updated stale file-review execution status to FAILED",
     { executionId },
+  );
+
+  // O4 site 5 of 5 (status-observers.ts): the reconcile's →FAILED stamp
+  // is a persisted terminal transition.
+  await notifyStatusObservers(
+    deps,
+    reconciled,
+    execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED,
+    ExecutionPhase.EXECUTION_FAILED,
   );
 }

--- a/backend/services/stigmer-server/src/domain/agentexecution/update-status.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/update-status.ts
@@ -3,13 +3,20 @@
  * progressive status-update RPC and the domain's single merge chokepoint.
  *
  * Chain per Go: ValidateUpdateStatusInput → MergeAndPersistExecution →
- * BroadcastToStreams. The merge+persist is ONE atomic read-modify-write
- * under the store's per-resource write lock (store.updateResource) — the
- * same discipline SubmitApproval uses, load-bearing now that the
- * append-only approval_event_stream is the source of truth for
- * pending_approvals: a non-atomic load-then-save could drop an approval
- * event a concurrent SubmitApproval appended in the window between the
- * load and the save.
+ * NotifyStatusObservers → BroadcastToStreams. The merge+persist is ONE
+ * atomic read-modify-write under the store's per-resource write lock
+ * (store.updateResource) — the same discipline SubmitApproval uses,
+ * load-bearing now that the append-only approval_event_stream is the
+ * source of truth for pending_approvals: a non-atomic load-then-save
+ * could drop an approval event a concurrent SubmitApproval appended in
+ * the window between the load and the save.
+ *
+ * O4 (20260827.07) consumes the status-transition hooks here — one of
+ * the five notifying sites (the exhaustive list: status-observers.ts):
+ * observers fire post-persist and before broadcast; the response
+ * decorators run on the reply (the §7 querySignal seam — the cloud
+ * piggybacks its control signal on this response; OSS answers
+ * UNSPECIFIED).
  *
  * applyUpdateStatusMerge is the merge body run inside the updateResource
  * closure (and exercised directly by the guard tests), mirroring the Java
@@ -44,6 +51,10 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type {
+  AgentExecutionResponseDecorator,
+  AgentExecutionStatusObserver,
+} from "../../extensions/status-hooks.js";
 import {
   internalError,
   invalidArgumentError,
@@ -67,6 +78,10 @@ import {
   isTerminalExecutionPhase,
   isTranscriptTerminalPhase,
 } from "./phases.js";
+import {
+  applyResponseDecorators,
+  notifyStatusObservers,
+} from "./status-observers.js";
 import { settleInterruptedToolCalls } from "./tool-call-settle.js";
 import type { StreamBroker } from "./stream-broker.js";
 
@@ -76,12 +91,19 @@ export interface UpdateStatusDeps {
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
   readonly broker: StreamBroker;
+  /** The composed status-transition observers (O4, DD-006 §3). */
+  readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
+  /** The composed reply decorators — the §7 querySignal seam (O4). */
+  readonly responseDecorators: ReadonlyArray<AgentExecutionResponseDecorator>;
 }
 
 type UpdateStatusDesc =
   typeof AgentExecutionCommandController.method.updateStatus.input;
 
 const EXECUTION_KEY = "execution";
+// O4-internal handoff (not a ported Go key): the phase read inside the
+// updateResource closure BEFORE the merge mutates, for the observer step.
+const OLD_PHASE_KEY = "o4OldPhase";
 
 export async function updateStatus(
   deps: UpdateStatusDeps,
@@ -119,12 +141,16 @@ export async function updateStatus(
       name: "MergeAndPersistExecution",
       async execute(ctx) {
         let updated: AgentExecution;
+        let oldPhase = ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
         try {
           updated = await deps.store.updateResource(
             ApiResourceKind.agent_execution,
             ctx.input.executionId,
             AgentExecutionSchema,
             (execution) => {
+              oldPhase =
+                execution.status?.phase ??
+                ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED;
               applyUpdateStatusMerge(execution, ctx.input, deps.logger);
             },
           );
@@ -134,8 +160,24 @@ export async function updateStatus(
           }
           throw internalError(error, "failed to update execution status");
         }
-        // Hand the merged result to the broadcast step.
+        // Hand the merged result to the observer + broadcast steps.
         ctx.set(EXECUTION_KEY, updated);
+        ctx.set(OLD_PHASE_KEY, oldPhase);
+      },
+    })
+    .addStep({
+      name: "NotifyStatusObservers",
+      async execute(ctx) {
+        const execution = ctx.get(EXECUTION_KEY) as AgentExecution | undefined;
+        if (execution === undefined) {
+          return; // BroadcastToStreams answers the missing-key fault below.
+        }
+        await notifyStatusObservers(
+          deps,
+          execution,
+          ctx.get(OLD_PHASE_KEY) as ExecutionPhase,
+          execution.status?.phase ?? ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED,
+        );
       },
     })
     .addStep({
@@ -157,9 +199,17 @@ export async function updateStatus(
     .build()
     .execute(reqCtx);
 
-  return create(UpdateStatusResponseSchema, {
-    signal: ExecutionControlSignal.UNSPECIFIED,
-  });
+  // The §7 decorator seam: the cloud contributes its control signal to
+  // fields the shared reply schema already carries; the OSS baseline
+  // (UNSPECIFIED) is byte-identical when no decorator is composed.
+  return applyResponseDecorators(
+    deps.responseDecorators,
+    deps.logger,
+    reqCtx.get(EXECUTION_KEY) as AgentExecution,
+    create(UpdateStatusResponseSchema, {
+      signal: ExecutionControlSignal.UNSPECIFIED,
+    }),
+  );
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/organization/controller.ts
+++ b/backend/services/stigmer-server/src/domain/organization/controller.ts
@@ -40,6 +40,8 @@ import type {
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
+import { stepsForSlot } from "../../extensions/gate-slots.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -83,6 +85,8 @@ export interface OrganizationControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed slot registrations — this domain's post-persist slot (O4). */
+  readonly gateSteps: ResolvedGateSteps;
 }
 
 /** Registers both organization services on the router (routes stage). */
@@ -113,6 +117,13 @@ function kindOf(ctx: HandlerContext): ApiResourceKind {
  * Create — chain per Go buildCreatePipeline: ResolveSlug runs before
  * ValidateProto so clients can omit the slug and have it derived before
  * field constraints (slug pattern, 2–15 chars) are checked.
+ *
+ * The post-persist gate slot splices after Persist, before IndexSearch —
+ * the verified Java OrganizationCreateHandler ordering (FGA tuple
+ * seeding, billing account getOrCreate: synchronous, a failure fails the
+ * request). Java runs these with NO transactional envelope: a slot-step
+ * failure leaves the org row persisted while the request fails, healed by
+ * idempotent retry — inherited semantics (O4 verification V1).
  */
 async function createOrganization(
   deps: OrganizationControllerDeps,
@@ -125,7 +136,7 @@ async function createOrganization(
     callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof OrganizationSchema>(
+  const builder = newPipeline<typeof OrganizationSchema>(
     "organization-create",
     deps.logger,
   )
@@ -141,7 +152,16 @@ async function createOrganization(
     .addStep(newCheckOrgDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
     .addStep(newCopySlugToIdStep())
-    .addStep(newPersistStep(deps.store))
+    .addStep(newPersistStep(deps.store));
+  // The ratified post-persist gate slot (blueprint 03 §3a; O4 — see the
+  // doc comment above for the inherited failure semantics). Empty in OSS.
+  for (const step of stepsForSlot<typeof OrganizationSchema>(
+    deps.gateSteps,
+    "org-create:post-persist",
+  )) {
+    builder.addStep(step);
+  }
+  await builder
     .addStep(
       newIndexSearchStep(deps.store, organizationSearchExtractor, deps.logger),
     )

--- a/backend/services/stigmer-server/src/domain/session/controller.ts
+++ b/backend/services/stigmer-server/src/domain/session/controller.ts
@@ -37,6 +37,8 @@ import { create } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
+import { stepsForSlot } from "../../extensions/gate-slots.js";
 import type { AgentExecutionTemporalConfig } from "../agentexecution/temporal/config.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
@@ -115,6 +117,8 @@ export interface SessionControllerDeps {
    * DI story, DD-002).
    */
   readonly agentInstanceCreator: AgentInstanceCreatorProvider;
+  /** The composed slot registrations — this domain's create slot (O4). */
+  readonly gateSteps: ResolvedGateSteps;
 }
 
 /** Registers both session services on the router (routes stage). */
@@ -146,6 +150,13 @@ function kindOf(ctx: HandlerContext): ApiResourceKind {
  * Create — chain per Go buildCreatePipeline. ResolveDefaultAgentInstance
  * runs BEFORE ValidateProto: when agent_instance_id is omitted, the
  * resolution fills it in before validation sees the spec.
+ *
+ * The pre-side-effect gate slot splices before Persist, after the last
+ * pure step (O4 plan-gate ruling Q2, mirroring the Java baseline's
+ * post-resolution gate position). The default-instance resolution above
+ * it side-effects PRE-gate in BOTH editions — a gate refusal can leave a
+ * created default instance behind; inherited Java semantics, not a new
+ * compromise.
  */
 async function createSession(
   deps: SessionControllerDeps,
@@ -158,7 +169,10 @@ async function createSession(
     callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof SessionSchema>("session-create", deps.logger)
+  const builder = newPipeline<typeof SessionSchema>(
+    "session-create",
+    deps.logger,
+  )
     .addStep(
       newAuthorizeStep(SessionCommandController.method.create, deps.authorizer),
     )
@@ -174,7 +188,16 @@ async function createSession(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
-    .addStep(newNormalizeReferencesStep())
+    .addStep(newNormalizeReferencesStep());
+  // The ratified pre-side-effect gate slot (blueprint 03 §3a; O4; Q2
+  // ruling — see the create doc comment). Empty in OSS.
+  for (const step of stepsForSlot<typeof SessionSchema>(
+    deps.gateSteps,
+    "session-create:pre-side-effect-gate",
+  )) {
+    builder.addStep(step);
+  }
+  await builder
     .addStep(newPersistStep(deps.store))
     .addStep(
       newIndexSearchStep(deps.store, sessionSearchExtractor, deps.logger),

--- a/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
@@ -16,23 +16,40 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { create } from "@bufbuild/protobuf";
-import { createClient } from "@connectrpc/connect";
+import type { DescMessage } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
 import type { Transport } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
+import {
+  ExecutionControlSignal,
+  ExecutionPhase,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { SessionCommandController } from "@stigmer/protos/ai/stigmer/agentic/session/v1/command_pb";
+import { SessionQueryController } from "@stigmer/protos/ai/stigmer/agentic/session/v1/query_pb";
 import { BillingQueryController } from "@stigmer/protos/ai/stigmer/billing/v1/query_pb";
 import { BillingAccountSchema } from "@stigmer/protos/ai/stigmer/billing/v1/billing_account_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import {
   PlatformQueryController,
   ServerEdition,
 } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+import { OrganizationSchema } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+import { OrganizationCommandController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/command_pb";
+import { OrganizationQueryController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/query_pb";
 
 import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
 import { loadConfig } from "../../boot/config.js";
 import { composeServer } from "../../boot/compose.js";
 import type { ComposedServer } from "../../boot/compose.js";
 import { createLogger } from "../../boot/logger.js";
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { GateSlotName } from "../gate-slots.js";
+import type { AgentExecutionStatusTransition } from "../status-hooks.js";
 import type { ServerExtension } from "../registry.js";
 
 const BILLING_PROCEDURE =
@@ -79,7 +96,9 @@ describe("extension composition (composed server)", () => {
       host: "127.0.0.1",
     });
     const port = await server.start();
-    portTransport = createGrpcTransport({ baseUrl: `http://127.0.0.1:${port}` });
+    portTransport = createGrpcTransport({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
   });
 
   afterAll(async () => {
@@ -192,8 +211,7 @@ describe("extension composition (O5 driver substitution)", () => {
               download: (key) =>
                 Promise.resolve(blobs.get(key) ?? new Uint8Array()),
               size: (key) => Promise.resolve(blobs.get(key)?.length ?? 0),
-              presignPut: () =>
-                Promise.reject(new Error("not exercised here")),
+              presignPut: () => Promise.reject(new Error("not exercised here")),
               getSignedUrl: () => Promise.resolve("https://blob.invalid"),
               delete: () => Promise.resolve(),
               exists: (key) => Promise.resolve(blobs.has(key)),
@@ -239,7 +257,10 @@ describe("extension composition (O5 driver substitution)", () => {
   });
 
   it("the platform exchange mints through the substituted credential provider", async () => {
-    const client = createClient(PlatformQueryController, server.inProcessTransport);
+    const client = createClient(
+      PlatformQueryController,
+      server.inProcessTransport,
+    );
     const out = await client.getRunnerScopedToken({
       scope: { case: "agentExecutionId", value: "aex_substituted" },
     });
@@ -249,5 +270,213 @@ describe("extension composition (O5 driver substitution)", () => {
 
   it("the artifact factory constructed the registered blob driver exactly once", () => {
     expect(blobDriverConstructed).toBe(1);
+  });
+});
+
+/**
+ * The O4 gate-slot + status-hook arms: an extension gate spliced into a
+ * declared slot refuses with its own ConnectError code and copy — before
+ * the side effect on the pre-side-effect slot (nothing persisted), after
+ * it on the post-persist slot (the row survives the failed request, the
+ * inherited Java semantics — O4 verification V1); the status observers
+ * see the terminal updateStatus transition exactly once (the Q4
+ * phase-change rule) and the response decorator contributes the control
+ * signal on the shared reply schema.
+ */
+describe("extension composition (O4 gate slots + status hooks)", () => {
+  const REFUSED_SESSION = "o4-refused-session";
+  const REFUSED_ORG_SLUG = "o4refusedorg";
+  let server: ComposedServer;
+  let dir: string;
+  let portTransport: Transport;
+  const observed: AgentExecutionStatusTransition[] = [];
+
+  const sessionGate: PipelineStep<DescMessage> = {
+    name: "FakeSessionGate",
+    execute: (ctx) => {
+      const session = ctx.newState as { metadata?: { name?: string } };
+      if (session.metadata?.name === REFUSED_SESSION) {
+        throw new ConnectError(
+          "fake session gate refuses this session",
+          Code.PermissionDenied,
+        );
+      }
+    },
+  };
+
+  const orgPostPersistGate: PipelineStep<DescMessage> = {
+    name: "FakeOrgPostPersistGate",
+    execute: (ctx) => {
+      const org = ctx.newState as { metadata?: { slug?: string } };
+      if (org.metadata?.slug === REFUSED_ORG_SLUG) {
+        throw new ConnectError(
+          "fake tuple seeding failed",
+          Code.FailedPrecondition,
+        );
+      }
+    },
+  };
+
+  const gateExtension: ServerExtension = {
+    name: "fake-gates-and-hooks",
+    gateSteps: new Map<GateSlotName, ReadonlyArray<PipelineStep<DescMessage>>>([
+      ["session-create:pre-side-effect-gate", [sessionGate]],
+      ["org-create:post-persist", [orgPostPersistGate]],
+    ]),
+    statusTransitionHooks: {
+      observers: [
+        (transition): void => {
+          observed.push(transition);
+        },
+      ],
+      responseDecorators: [
+        (_execution, response): void => {
+          response.signal = ExecutionControlSignal.STOP;
+        },
+      ],
+    },
+  };
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "gate-slot-hook-test-"));
+    server = await composeServer({
+      config: loadConfig({
+        STIGMER_MODEL_REGISTRY_REFRESH: "off",
+        DB_PATH: path.join(dir, "stigmer.db"),
+        STORAGE_PATH: path.join(dir, "storage"),
+        ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      }),
+      logger: createLogger({ level: "error", pretty: false, write: () => {} }),
+      extensions: [gateExtension],
+      portOverride: 0,
+      host: "127.0.0.1",
+    });
+    const port = await server.start();
+    portTransport = createGrpcTransport({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("a pre-side-effect gate refusal aborts session create with nothing persisted", async () => {
+    const command = createClient(SessionCommandController, portTransport);
+    const query = createClient(SessionQueryController, portTransport);
+
+    let refused: ConnectError | undefined;
+    try {
+      await command.create(
+        create(SessionSchema, {
+          apiVersion: "agentic.stigmer.ai/v1",
+          kind: "Session",
+          metadata: { name: REFUSED_SESSION, org: "acme" },
+          spec: { agentInstanceId: "agi_gate_test" },
+        }),
+      );
+    } catch (error) {
+      refused = ConnectError.from(error);
+    }
+    // The gate's own code and copy reach the wire (the §3b refusal
+    // contract: a gate refuses exactly as OSS steps do).
+    expect(refused?.code).toBe(Code.PermissionDenied);
+    expect(refused?.rawMessage).toBe("fake session gate refuses this session");
+
+    // Pre-side-effect means pre-persist: no session row exists.
+    let getError: ConnectError | undefined;
+    try {
+      await query.get({ value: `ses_${REFUSED_SESSION}` });
+    } catch (error) {
+      getError = ConnectError.from(error);
+    }
+    expect(getError?.code).toBe(Code.NotFound);
+  });
+
+  it("a passing gate is invisible: session create succeeds through the slot", async () => {
+    const command = createClient(SessionCommandController, portTransport);
+    const session = await command.create(
+      create(SessionSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Session",
+        metadata: { name: "o4-allowed-session", org: "acme" },
+        spec: { agentInstanceId: "agi_gate_test" },
+      }),
+    );
+    expect(session.metadata?.id).not.toBe("");
+  });
+
+  it("a post-persist gate failure fails the request but the org row survives (inherited Java semantics)", async () => {
+    const command = createClient(OrganizationCommandController, portTransport);
+    const query = createClient(OrganizationQueryController, portTransport);
+
+    let refused: ConnectError | undefined;
+    try {
+      await command.create(
+        create(OrganizationSchema, {
+          apiVersion: "tenancy.stigmer.ai/v1",
+          kind: "Organization",
+          metadata: { name: "O4 Refused Org", slug: REFUSED_ORG_SLUG },
+        }),
+      );
+    } catch (error) {
+      refused = ConnectError.from(error);
+    }
+    expect(refused?.code).toBe(Code.FailedPrecondition);
+    expect(refused?.rawMessage).toBe("fake tuple seeding failed");
+
+    // The slot sits AFTER Persist: the row was committed before the gate
+    // refused — healed by idempotent retry, never rolled back (V1).
+    const org = await query.get({ value: REFUSED_ORG_SLUG });
+    expect(org.metadata?.slug).toBe(REFUSED_ORG_SLUG);
+  });
+
+  it("observers see the terminal updateStatus transition once and the decorator contributes the signal", async () => {
+    const executionId = "aexec_o4_hooks";
+    await server.store.saveResource(
+      ApiResourceKind.agent_execution,
+      executionId,
+      AgentExecutionSchema,
+      create(AgentExecutionSchema, {
+        metadata: { id: executionId, name: executionId, org: "acme" },
+        spec: { message: "hook test" },
+        status: { phase: ExecutionPhase.EXECUTION_IN_PROGRESS },
+      }),
+    );
+    const command = createClient(
+      AgentExecutionCommandController,
+      portTransport,
+    );
+
+    observed.length = 0;
+    const reply = await command.updateStatus({
+      executionId,
+      status: {
+        phase: ExecutionPhase.EXECUTION_COMPLETED,
+        completedAt: "2026-08-27T10:00:00Z",
+        messages: [{ content: "done" }],
+      },
+    });
+    // The decorator's contribution rides the field the shared reply
+    // schema already carries (§7 — the cloud's control-signal seam).
+    expect(reply.signal).toBe(ExecutionControlSignal.STOP);
+    expect(observed).toHaveLength(1);
+    expect(observed[0]?.oldPhase).toBe(ExecutionPhase.EXECUTION_IN_PROGRESS);
+    expect(observed[0]?.newPhase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
+    expect(observed[0]?.execution.metadata?.id).toBe(executionId);
+
+    // A repeat report with the phase unchanged decorates the reply but
+    // does NOT re-notify (the Q4 phase-change rule).
+    const repeat = await command.updateStatus({
+      executionId,
+      status: {
+        phase: ExecutionPhase.EXECUTION_COMPLETED,
+        completedAt: "2026-08-27T10:00:00Z",
+        messages: [{ content: "done" }],
+      },
+    });
+    expect(repeat.signal).toBe(ExecutionControlSignal.STOP);
+    expect(observed).toHaveLength(1);
   });
 });

--- a/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
@@ -21,6 +21,7 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
 import type { WorkerFactory } from "../../temporal/manager.js";
 import type { Authorizer } from "../authorizer.js";
+import { DECLARED_GATE_SLOTS, GATE_SLOT_NAMES } from "../gate-slots.js";
 import type { GateSlotName } from "../gate-slots.js";
 import type { IdentityVerifier } from "../identity.js";
 import { resolveExtensions } from "../registry.js";
@@ -151,7 +152,9 @@ describe("resolveExtensions — merge semantics", () => {
         name: "credential-unit",
         drivers: {
           runnerCredentialProvider: credentials,
-          artifactStorageDrivers: new Map([["r2-artifacts", fakeStorageDriver]]),
+          artifactStorageDrivers: new Map([
+            ["r2-artifacts", fakeStorageDriver],
+          ]),
         },
       },
     ]);
@@ -169,9 +172,7 @@ describe("resolveExtensions — merge semantics", () => {
 
 describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
   it("throws on an empty unit name", () => {
-    expect(() => resolveExtensions([{ name: "" }])).toThrowError(
-      /empty name/,
-    );
+    expect(() => resolveExtensions([{ name: "" }])).toThrowError(/empty name/);
   });
 
   it("throws on a duplicate unit name, naming it", () => {
@@ -210,33 +211,96 @@ describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
     ).toThrowError(/edition 'server_edition_unspecified'/);
   });
 
-  it("throws on a registration into an unknown gate slot, naming the slot", () => {
+  it("throws on a registration into an unknown gate slot, listing the declared slots", () => {
     const step: PipelineStep<DescMessage> = {
       name: "UnitTestGate",
       execute: () => {},
     };
-    // GateSlotName is the empty union until O4 declares the ratified
-    // slots, so no registration typechecks — the cast exercises the
-    // runtime arm of the two-layer contract (a JS consumer, or a
-    // composition built against a pin where a slot has moved, must throw
-    // at boot, never no-op).
+    // A misspelled slot cannot typecheck against GateSlotName — the cast
+    // exercises the runtime arm of the two-layer contract (a JS consumer,
+    // or a composition built against a pin where a slot has moved, must
+    // throw at boot, never no-op).
     const gateSteps = new Map([
-      ["agent-execution-create:pre-side-effect-gate", [step]],
+      ["agent-execution-create:pre-side-effect", [step]],
     ]) as unknown as ReadonlyMap<
       GateSlotName,
       ReadonlyArray<PipelineStep<DescMessage>>
     >;
-    const unit: ServerExtension = { name: "early-gate", gateSteps };
+    const unit: ServerExtension = { name: "typo-gate", gateSteps };
     expect(() => resolveExtensions([unit])).toThrowError(
-      /extension 'early-gate' registered gate steps into unknown slot 'agent-execution-create:pre-side-effect-gate'.*none in this build/,
+      /extension 'typo-gate' registered gate steps into unknown slot 'agent-execution-create:pre-side-effect' — declared slots: 'agent-execution-create:pre-side-effect-gate'/,
     );
+  });
+
+  it("accepts registrations into declared slots, concatenating in unit order", () => {
+    const stepNamed = (name: string): PipelineStep<DescMessage> => ({
+      name,
+      execute: () => {},
+    });
+    const resolved = resolveExtensions([
+      {
+        name: "billing",
+        gateSteps: new Map<
+          GateSlotName,
+          ReadonlyArray<PipelineStep<DescMessage>>
+        >([
+          [
+            "agent-execution-create:pre-side-effect-gate",
+            [stepNamed("BillingPreflight")],
+          ],
+          ["org-create:post-persist", [stepNamed("SeedTuples")]],
+        ]),
+      },
+      {
+        name: "capacity",
+        gateSteps: new Map<
+          GateSlotName,
+          ReadonlyArray<PipelineStep<DescMessage>>
+        >([
+          [
+            "agent-execution-create:pre-side-effect-gate",
+            [stepNamed("CapacityGate")],
+          ],
+        ]),
+      },
+    ]);
+    expect(
+      resolved.gateSteps
+        .get("agent-execution-create:pre-side-effect-gate")
+        ?.map((s) => s.name),
+    ).toEqual(["BillingPreflight", "CapacityGate"]);
+    expect(
+      resolved.gateSteps.get("org-create:post-persist")?.map((s) => s.name),
+    ).toEqual(["SeedTuples"]);
+  });
+
+  it("keeps DECLARED_GATE_SLOTS in lockstep with the ratified slot names", () => {
+    // The boot-time set derives from the one literal tuple; this pin
+    // catches an accidental edit to either the tuple or the derivation
+    // (the names are protected vocabulary — blueprint 03 §3a).
+    expect([...DECLARED_GATE_SLOTS].sort()).toEqual(
+      [...GATE_SLOT_NAMES].sort(),
+    );
+    expect([...GATE_SLOT_NAMES].sort()).toEqual([
+      "agent-execution-create:pre-side-effect-gate",
+      "agent-execution-recover:pre-side-effect-gate",
+      "agent-execution-submit-approval:gate",
+      "org-create:post-persist",
+      "session-create:pre-side-effect-gate",
+    ]);
   });
 
   it("throws on a second ModelCatalogProvider, naming both units", () => {
     expect(() =>
       resolveExtensions([
-        { name: "first-catalog", drivers: { modelCatalogProvider: fakeCatalog() } },
-        { name: "second-catalog", drivers: { modelCatalogProvider: fakeCatalog() } },
+        {
+          name: "first-catalog",
+          drivers: { modelCatalogProvider: fakeCatalog() },
+        },
+        {
+          name: "second-catalog",
+          drivers: { modelCatalogProvider: fakeCatalog() },
+        },
       ]),
     ).toThrowError(
       /extension 'second-catalog' registers a ModelCatalogProvider, but 'first-catalog' already did/,
@@ -265,11 +329,15 @@ describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
       resolveExtensions([
         {
           name: "first-blob",
-          drivers: { artifactStorageDrivers: new Map([["gcs", fakeStorageDriver]]) },
+          drivers: {
+            artifactStorageDrivers: new Map([["gcs", fakeStorageDriver]]),
+          },
         },
         {
           name: "second-blob",
-          drivers: { artifactStorageDrivers: new Map([["gcs", fakeStorageDriver]]) },
+          drivers: {
+            artifactStorageDrivers: new Map([["gcs", fakeStorageDriver]]),
+          },
         },
       ]),
     ).toThrowError(
@@ -283,7 +351,9 @@ describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
         resolveExtensions([
           {
             name: "shadowing",
-            drivers: { artifactStorageDrivers: new Map([[name, fakeStorageDriver]]) },
+            drivers: {
+              artifactStorageDrivers: new Map([[name, fakeStorageDriver]]),
+            },
           },
         ]),
       ).toThrowError(

--- a/backend/services/stigmer-server/src/extensions/gate-slots.ts
+++ b/backend/services/stigmer-server/src/extensions/gate-slots.ts
@@ -6,30 +6,83 @@
  * composition. Slot names are PROTECTED VOCABULARY (never renamed,
  * byte-stable), scoped `<chain-name>:<position>`.
  *
- * O1 (20260826.09) ships the mechanism; O4 declares the six ratified slots
- * at their Java-verified semantic positions and adds each name to BOTH
- * layers below. Until then no slot exists, so every registration is the
- * §2b unknown-slot boot throw — proven by the extension test suite.
+ * O1 (20260826.09) shipped the mechanism; O4 (20260827.07) declares the
+ * ratified slots at their Java-verified semantic positions. FIVE of the
+ * six ratified names are declared here — `sandbox-acquisition:gate` is
+ * declared by O6 together with the provisioner invocation step it gates
+ * (O4 plan-gate ruling Q1: a declared slot whose steps can never run
+ * would be a silent no-op, the exact failure §2b exists to prevent).
  *
- * Two enforcement layers, deliberately redundant:
+ * Two enforcement layers, deliberately redundant, both derived from the
+ * ONE literal tuple below (lockstep by construction):
  *   - GateSlotName (compile time): the union of declared slot literals.
- *     Empty today, so a TS consumer cannot even express a registration.
+ *     A TS consumer cannot express a registration into an unknown slot.
  *   - DECLARED_GATE_SLOTS (boot time): the load-bearing §2b contract. A JS
  *     consumer, or a composition built against a pin where a slot has
  *     since moved, must throw loudly at boot — never no-op silently.
+ *
+ * Slot semantics for gate authors (recorded facts, not mechanisms —
+ * details in the ts-server guidelines' slot table):
+ *   - Slots run wherever their chain runs, INCLUDING in-process
+ *     invocations (the Java baseline: internal creations traverse the
+ *     full nested handler chains). In-process callers carry
+ *     `callerClass: "internal"` (O2's ratified identity semantics), where
+ *     the Java edition propagated the original caller — gates keying on
+ *     caller class must account for the `internal` arm.
+ *   - Slots do not honor chain-internal skip shortcuts (e.g. the
+ *     lifecycle already-in-target idempotent flag): a gate runs on every
+ *     traversal of its position and owns its own idempotency.
  */
+import type { DescMessage } from "@bufbuild/protobuf";
+
+import type { PipelineStep } from "../pipeline/pipeline.js";
 
 /**
- * The declared slot-name union. Grows only with owner-visible slot
- * additions (a slot table change in the blueprint's successor docs — O4
- * declares the first six). `never` is the honest empty union: no slot
- * exists, so no registration typechecks.
+ * The ratified slot names (blueprint 03 §3a). Grows only with
+ * owner-visible slot additions — each entry cites its chain position in
+ * the guidelines' slot table, which must match the splice sites exactly.
  */
-export type GateSlotName = never;
+export const GATE_SLOT_NAMES = [
+  "agent-execution-create:pre-side-effect-gate",
+  "agent-execution-recover:pre-side-effect-gate",
+  "agent-execution-submit-approval:gate",
+  "session-create:pre-side-effect-gate",
+  "org-create:post-persist",
+] as const;
+
+/** The declared slot-name union — a registration outside it fails tsc. */
+export type GateSlotName = (typeof GATE_SLOT_NAMES)[number];
 
 /**
  * The boot-time declared-slot set — resolveExtensions validates every
- * registration against it. Kept in lockstep with GateSlotName by hand;
- * the extension suite pins the correspondence once slots exist.
+ * registration against it (the §2b unknown-slot throw).
  */
-export const DECLARED_GATE_SLOTS: ReadonlySet<string> = new Set<string>();
+export const DECLARED_GATE_SLOTS: ReadonlySet<string> = new Set<string>(
+  GATE_SLOT_NAMES,
+);
+
+/**
+ * The merged slot registrations the chains consume — slot name → steps in
+ * unit order (registry.ts builds it; keys are validated slot names).
+ */
+export type ResolvedGateSteps = ReadonlyMap<
+  string,
+  ReadonlyArray<PipelineStep<DescMessage>>
+>;
+
+/**
+ * The steps registered into one slot, typed for the consuming chain — the
+ * ONE place the empty-slot default lives, so splice sites never scatter
+ * `?? []` and a slot-name typo is a compile error.
+ */
+export function stepsForSlot<Desc extends DescMessage>(
+  gateSteps: ResolvedGateSteps,
+  slot: GateSlotName,
+): ReadonlyArray<PipelineStep<Desc>> {
+  const steps = gateSteps.get(slot) ?? [];
+  // Sound narrowing: a gate step is written against
+  // RequestContext<DescMessage> and consumes only the context surface
+  // every specialization shares. Centralized here so no chain carries a
+  // local cast.
+  return steps as ReadonlyArray<PipelineStep<Desc>>;
+}

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -23,7 +23,9 @@
  *
  * Consumption map (each point's consumer entry): services + workers +
  * edition are consumed here in O1; identity verifiers + authorizer land
- * with O2; gate steps + status hooks with O4; the O5 driver kinds
+ * with O2; gate steps are consumed at the chain splice sites (the
+ * gate-slots.ts slot table) and status hooks at the agentexecution
+ * transition sites (status-observers.ts), both O4; the O5 driver kinds
  * (catalog provider, artifact-storage registration, runner-credential
  * provider) are consumed at their compose.ts construction sites; sandbox
  * provisioners land with O6.
@@ -42,7 +44,7 @@ import type { WorkerFactory } from "../temporal/manager.js";
 import type { Authorizer } from "./authorizer.js";
 import type { ExtensionDrivers } from "./drivers.js";
 import { DECLARED_GATE_SLOTS } from "./gate-slots.js";
-import type { GateSlotName } from "./gate-slots.js";
+import type { GateSlotName, ResolvedGateSteps } from "./gate-slots.js";
 import type { IdentityVerifier } from "./identity.js";
 import type {
   AgentExecutionResponseDecorator,
@@ -119,10 +121,7 @@ export interface ResolvedExtensions {
   readonly authorizer: Authorizer | undefined;
   readonly identityVerifiers: ReadonlyArray<IdentityVerifier>;
   /** Slot name → steps, validated against DECLARED_GATE_SLOTS. */
-  readonly gateSteps: ReadonlyMap<
-    string,
-    ReadonlyArray<PipelineStep<DescMessage>>
-  >;
+  readonly gateSteps: ResolvedGateSteps;
   readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
   readonly responseDecorators: ReadonlyArray<AgentExecutionResponseDecorator>;
   readonly drivers: ResolvedExtensionDrivers;

--- a/backend/services/stigmer-server/src/temporal/agentexecution/__tests__/activities.test.ts
+++ b/backend/services/stigmer-server/src/temporal/agentexecution/__tests__/activities.test.ts
@@ -94,6 +94,8 @@ function newFixture() {
     logger: silentLogger,
     broker,
     authorizer: newPermissiveSingleTeamAuthorizer(),
+    statusObservers: [],
+    responseDecorators: [],
     client: () => stubClient,
   });
   return { store, broker, activities, completions };

--- a/backend/services/stigmer-server/src/temporal/agentexecution/activities.ts
+++ b/backend/services/stigmer-server/src/temporal/agentexecution/activities.ts
@@ -42,6 +42,10 @@ import type { Logger } from "../../boot/logger.js";
 import type { StreamBroker } from "../../domain/agentexecution/stream-broker.js";
 import { updateStatus } from "../../domain/agentexecution/update-status.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type {
+  AgentExecutionResponseDecorator,
+  AgentExecutionStatusObserver,
+} from "../../extensions/status-hooks.js";
 import { trustedLocalIdentity } from "../../pipeline/interceptors/auth.js";
 import {
   DELETE_EXECUTION_CONTEXT_ACTIVITY_NAME,
@@ -61,6 +65,14 @@ export interface AgentExecutionActivityDeps {
   readonly broker: StreamBroker;
   /** The composed Authorizer, required by the status-merge updateStatus pipeline (O2). */
   readonly authorizer: Authorizer;
+  /**
+   * The composed status hooks (O4): the activity reuses updateStatus
+   * wholesale, so the workflow's terminal writes (persistFinalStatus,
+   * failure/cancellation paths) notify observers exactly like the
+   * runner's gRPC path — one implementation, no divergence.
+   */
+  readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
+  readonly responseDecorators: ReadonlyArray<AgentExecutionResponseDecorator>;
   /** Live Temporal client (reads the manager's CURRENT client). */
   readonly client: () => Client;
 }
@@ -85,7 +97,14 @@ export interface CompleteExternalActivityInput {
 export function createAgentExecutionActivities(
   deps: AgentExecutionActivityDeps,
 ): Record<string, (...args: never[]) => Promise<unknown>> {
-  const { store, logger, broker, authorizer } = deps;
+  const {
+    store,
+    logger,
+    broker,
+    authorizer,
+    statusObservers,
+    responseDecorators,
+  } = deps;
 
   return {
     /**
@@ -104,7 +123,14 @@ export function createAgentExecutionActivities(
       // the one honest principal (O2; audit bytes unchanged: the derived
       // actor equals the pre-O2 process-global operator actor).
       await updateStatus(
-        { store, logger, broker, authorizer },
+        {
+          store,
+          logger,
+          broker,
+          authorizer,
+          statusObservers,
+          responseDecorators,
+        },
         create(AgentExecutionUpdateStatusInputSchema, {
           executionId,
           status,

--- a/backend/services/stigmer-server/src/temporal/agentexecution/worker.ts
+++ b/backend/services/stigmer-server/src/temporal/agentexecution/worker.ts
@@ -26,6 +26,10 @@ import type { AgentExecutionTemporalConfig } from "../../domain/agentexecution/t
 import type { StreamBroker } from "../../domain/agentexecution/stream-broker.js";
 import type { Store } from "../../store/interface.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type {
+  AgentExecutionResponseDecorator,
+  AgentExecutionStatusObserver,
+} from "../../extensions/status-hooks.js";
 import type { WorkerFactory } from "../manager.js";
 import { resolveWorkflowSource } from "../workflow-source.js";
 import { createAgentExecutionActivities } from "./activities.js";
@@ -36,6 +40,9 @@ export interface AgentExecutionWorkerDeps {
   readonly broker: StreamBroker;
   /** The composed Authorizer — the status-merge activity's updateStatus pipeline carries the Authorize step like every chain (O2). */
   readonly authorizer: Authorizer;
+  /** The composed status hooks — the activity's updateStatus reuse (O4). */
+  readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
+  readonly responseDecorators: ReadonlyArray<AgentExecutionResponseDecorator>;
   readonly temporalConfig: AgentExecutionTemporalConfig;
 }
 
@@ -48,6 +55,8 @@ export function newAgentExecutionWorkerFactory(
       logger: deps.logger,
       broker: deps.broker,
       authorizer: deps.authorizer,
+      statusObservers: deps.statusObservers,
+      responseDecorators: deps.responseDecorators,
       client,
     });
 

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -11,12 +11,13 @@
  *
  * It exercises every extension point a consumer can touch today: the
  * seven-point unit shape (services, workers, edition, authorizer,
- * verifiers, status hooks, the O5 driver kinds; gate slots are
- * compile-closed until O4 declares the ratified names), a gate-step body
- * built from the pipeline primitives, the store-fault idiom, and the
- * compose entry itself. It is never executed — the runtime behavior is
- * pinned by the server's own extension suite; execution here would need
- * real infrastructure for no additional proof.
+ * verifiers, status hooks, the O5 driver kinds, and gate-step
+ * registrations into the O4-declared slot names — a misspelled slot fails
+ * THIS compile via the GateSlotName union), a gate-step body built from
+ * the pipeline primitives, the store-fault idiom, and the compose entry
+ * itself. It is never executed — the runtime behavior is pinned by the
+ * server's own extension suite; execution here would need real
+ * infrastructure for no additional proof.
  */
 import { create } from "@bufbuild/protobuf";
 import type { DescMessage } from "@bufbuild/protobuf";
@@ -47,6 +48,7 @@ import type {
   Authorizer,
   CallerIdentity,
   ComposedServer,
+  GateSlotName,
   IdentityVerifier,
   MintedToken,
   ModelCatalogProvider,
@@ -132,9 +134,10 @@ const workerFactory: WorkerFactory = () =>
  * so the semantics stay OSS-owned. The interface remains implementable by
  * hand (ConsumerDriverBundle below keeps the type position covered).
  */
-const catalogProvider: ModelCatalogProvider = newModelCatalogProviderFromDocument(
-  `{"models":[{"id":"consumer-model","harness":"native"}]}`,
-);
+const catalogProvider: ModelCatalogProvider =
+  newModelCatalogProviderFromDocument(
+    `{"models":[{"id":"consumer-model","harness":"native"}]}`,
+  );
 
 /**
  * A consumer-shaped runner-credential provider (the O5 §6c shape). The
@@ -204,6 +207,12 @@ export const fakeExtension: ServerExtension = {
   edition: ServerEdition.cloud,
   authorizer,
   identityVerifiers: [verifier],
+  // The O4 slot vocabulary is typed: registering into a slot name outside
+  // GateSlotName fails this compile (the §2b contract's compile-time layer).
+  gateSteps: new Map<GateSlotName, ReadonlyArray<PipelineStep<DescMessage>>>([
+    ["agent-execution-create:pre-side-effect-gate", [consumerGateStep()]],
+    ["org-create:post-persist", [consumerGateStep()]],
+  ]),
   statusTransitionHooks: {
     observers: [statusObserver],
     responseDecorators: [responseDecorator],


### PR DESCRIPTION
## Summary

O4 of the convergence program (blueprint 03 §11 items 2+9, parent `20260826.02`, sub-project `20260827.07`): the named gate slots are declared and spliced at the Java-verified positions of the ratified chains, and the status-transition hooks (observers + response decorators) are consumed at every agent-execution phase-transition persist site. OSS behavior with no extensions composed is byte-identical — all four conformance rosters pin it.

## Context

O1 shipped the registry sockets hollow (`gateSteps`, `statusTransitionHooks`) and O2 threaded identity; this entry is the consumption half, unblocking C2 (IAM lifecycle) and C3 (channel delivery) together with C1. Four plan-gate rulings bind the shape: **Q1** — five slots declared here; `sandbox-acquisition:gate` is declared by O6 with the provisioner invocation step it gates (a registered gate that can never run would be a silent no-op, contradicting DD-006 §2b). **Q2** — the session-create slot mirrors Java's post-resolution gate position (Java also resolves the default instance pre-validation with nested side effects pre-gate; orphan-on-refusal is inherited baseline semantics). **Q3** — the blueprint's "single updateStatus chokepoint" premise is not literally true: FIVE production sites write phase transitions, and the hooks fire from every one of them. **Q4** — observers fire only on actual phase changes.

## Changes

- `extensions/gate-slots.ts`: the five ratified slot names as one literal tuple; `GateSlotName` (compile layer) and `DECLARED_GATE_SLOTS` (boot layer) both derived from it; new `ResolvedGateSteps` type and `stepsForSlot` helper (the one home of the empty-slot default and the documented covariant widening — chains carry no casts, a slot typo is a compile error).
- Slot splices, threaded through controller deps exactly as O2 threaded `authorizer`:
  - `agent-execution-create:pre-side-effect-gate` — after `EnsureEngineAvailable`, before `CreateDefaultInstanceIfNeeded`
  - `agent-execution-recover:pre-side-effect-gate` — after `TerminateExistingWorkflow`, before `RecreateExecutionContext` (the RearmBillingStep ordering)
  - `agent-execution-submit-approval:gate` — after `ValidateApproval`, before `RecordApprovalDecision`
  - `session-create:pre-side-effect-gate` — after `NormalizeReferences`, before `Persist`
  - `org-create:post-persist` — after `Persist`, before `IndexSearch` (non-transactional in BOTH editions: the row survives a slot refusal, healed by idempotent retry — verified against the Java handler)
- New `domain/agentexecution/status-observers.ts`: one domain-owned notifier (phase-change-only firing; observers awaited in order; a throwing observer is logged, never a failed transition) + `applyResponseDecorators` (clone-committed per decorator). Invoked from all five transition-persist sites: the updateStatus merge, the lifecycle persist step (cancel/terminate/pause/resume/recover), the StartWorkflow failure arm, and both stale-workflow reconciles (approval + file review). The updateStatus reply now runs the decorators — the §7 control-signal seam; OSS answers UNSPECIFIED byte-identically.
- The Temporal activity path (`temporal/agentexecution/activities.ts`/`worker.ts`) threads the hooks through its updateStatus reuse — workflow terminal writes notify identically to the runner RPC.
- `test/extension-consumer`: the compile-closed gate registration opens against the real slot names (a misspelled slot fails the consumer's tsc).
- `ts-server-guidelines.mdc`: the slot table + hook rules recorded as protected vocabulary, including the gate-author facts (slots run on in-process invocations per the Java baseline, with O2's `internal` caller class; no chain-internal skip shortcuts; ConnectError refusal contract) and the rule that a NEW phase write must call the notifier.

## Implementation notes

- Workflowexecution deliberately gets no hooks (ratified scope note: unmetered in cloud, nothing built ahead of need); the workflow `stigmer/agent-execution/invoke` is untouched.
- `pipeline.ts` (a Go-parity port) is untouched: `PipelineStep<DescMessage>` is soundly assignable to the specialized chains, so slot steps splice via plain `addStep`.
- Discovered en route (within ruling Q3's letter): a FIFTH transition-write site, `submit-approval.ts`'s `reconcileStaleExecution` — the plan had counted four. All five are enumerated in the notifier's intent header and pinned by tests.

## Breaking changes

- None on the wire. Internal deps interfaces gain required fields (`gateSteps`, `statusObservers`, `responseDecorators`) — construction sites updated in-repo.

## Test plan

- All four conformance rosters green and byte-identical to the baselines: `local` 492, `local-postgres` 492, `local-execution` 160, `local-postgres-execution` 160.
- Server unit suite 1857 passed / 0 failed; `tsc --noEmit` + Prettier clean; extension-consumer typecheck green.
- New arms: slot-refusal pre-side-effect (nothing persisted) and post-persist row-survival over the composed server; observer + decorator at a terminal updateStatus transition with the Q4 same-phase no-refire; cancel/terminate/idempotent lanes; the recover slot's position proof (terminate ran, no fresh start); the StartWorkflow failure arm; both reconcile arms; registry loud-fail + lockstep pins; notifier/decorator contracts in isolation.

## Risks

- All hook/slot machinery is inert with an empty extension set (the roster proof); the residual risk is the deps-threading churn, covered by the compile gate and the full suite. Rollback is a clean revert.

## Checklist

- [x] Docs updated (ts-server guidelines slot table + hook rules)
- [x] Tests added/updated
- [x] Backward compatible (empty-set byte-identity, roster-proven)

Made with [Cursor](https://cursor.com)