### PR TITLE
feat(backend/stigmer-server): open the C4 runner-credential seams — provider capability methods + the sandbox-acquisition gate slot

### DIFF
--- a/.cursor/rules/backend/ts-server-guidelines.mdc
+++ b/.cursor/rules/backend/ts-server-guidelines.mdc
@@ -62,10 +62,10 @@ eventually violate creatively.
 - **Gate-slot names are PROTECTED VOCABULARY** (convergence blueprint
   20260826.02/03 §3a; declared in `src/extensions/gate-slots.ts`, spliced
   where the table says, empty when no extension is composed). Never rename
-  a slot; adding one is an owner-visible act (the deferred
-  `sandbox-acquisition:gate` arrives with the entry that builds the gated
-  provisioning splice — O4 ruling Q1). The ratified table — the code must
-  match it exactly:
+  a slot; adding one is an owner-visible act (all six ratified names are
+  now declared — `sandbox-acquisition:gate` landed with the C4 wave's
+  OSS-side seam work, closing O4 ruling Q1's deferral). The ratified
+  table — the code must match it exactly:
 
   | Slot | Position |
   |---|---|
@@ -74,6 +74,7 @@ eventually violate creatively.
   | `agent-execution-submit-approval:gate` | after `ValidateApproval`, before `RecordApprovalDecision` |
   | `session-create:pre-side-effect-gate` | after `NormalizeReferences`, before `Persist` (Q2 ruling: mirrors Java's post-resolution position; the pre-validation default-instance resolution side-effects pre-gate in BOTH editions) |
   | `org-create:post-persist` | after `Persist`, before `IndexSearch` (non-transactional in BOTH editions: a slot failure fails the request, the row survives, idempotent retry heals) |
+  | `sandbox-acquisition:gate` | workflow-execution CREATE: after `NormalizeReferences`, before `SetInitialPhase`; workflow-execution RECOVER: after `ValidateRecoverable`, before `TerminateExistingWorkflow` (the Java capacity-gate positions, cloud#355/#290 — post-authorize, pre-side-effect, pre-provision; the default instance side-effects pre-gate in BOTH editions, inherited orphan-on-refusal semantics; the SESSION lane's capacity gates ride the two agent-execution slots above, whose positions coincide with Java's session gate) |
 
   Facts gate AUTHORS inherit (recorded, not mechanisms): slots run
   wherever their chain runs, INCLUDING in-process invocations (the Java

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -818,6 +818,7 @@ export async function composeServer(
       store,
       logger,
       authorizer,
+      gateSteps: extensions.gateSteps,
       engineState: workflowExecutionEngineState,
       broker: workflowExecutionStreamBroker,
       sandboxLane,

--- a/backend/services/stigmer-server/src/domain/agentexecution/lifecycle.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/lifecycle.ts
@@ -716,6 +716,7 @@ export async function recoverExecution(
               temporalConfig: deps.temporalConfig,
             },
             loadedExecution(ctx),
+            ctx.callerIdentity.identityId,
           );
         },
       },

--- a/backend/services/stigmer-server/src/domain/executioncontext/__tests__/resolve-values-capability.test.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/__tests__/resolve-values-capability.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Pins the C4 authorizeExecutionContextRead capability arm of
+ * resolveValuesForCaller (gate ruling Q1): when the composed provider
+ * defines it, the capability IS the entire decrypt trust decision —
+ * true decrypts, false redacts, and a THROWING capability falls closed
+ * to redaction (redaction-as-success must survive a policy fault). The
+ * OSS fallback arm (execution-scoped verify + binding equality) is
+ * pinned by executioncontext.test.ts and the conformance suites; this
+ * file covers only the delegation.
+ */
+import type { HandlerContext } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import { SecretService } from "../../../encryption/encryption.js";
+import { InvalidTokenError } from "../../../runnerauth/runnerauth.js";
+import type { RunnerCredentialProvider } from "../../../runnerauth/runner-credential-provider.js";
+import { resolveValuesForCaller } from "../resolve-values-for-caller.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const secretService = SecretService.create(Buffer.alloc(32, 7));
+
+/** A minimal HandlerContext: the resolve path reads only the auth header. */
+function ctxWithBearer(token: string): HandlerContext {
+  const headers = new Headers();
+  if (token !== "") {
+    headers.set("authorization", `Bearer ${token}`);
+  }
+  return { requestHeader: headers } as unknown as HandlerContext;
+}
+
+function providerWith(
+  authorize: (rawToken: string, executionId: string) => Promise<boolean>,
+): RunnerCredentialProvider & { asked: Array<[string, string]> } {
+  const asked: Array<[string, string]> = [];
+  return {
+    asked,
+    isEnabled: () => false,
+    mint: () => {
+      throw new Error("mint is not under test");
+    },
+    verify: () => {
+      // The capability path must never consult the primitive verify —
+      // throwing here turns an accidental fallback into a test failure.
+      throw new InvalidTokenError();
+    },
+    authorizeExecutionContextRead: (rawToken, executionId) => {
+      asked.push([rawToken, executionId]);
+      return authorize(rawToken, executionId);
+    },
+  };
+}
+
+function executionContext() {
+  return create(ExecutionContextSchema, {
+    spec: {
+      executionId: "aexec_cap1",
+      data: {
+        API_KEY: {
+          value: secretService.encrypt("s3cret"),
+          isSecret: true,
+        },
+      },
+    },
+  });
+}
+
+describe("resolveValuesForCaller (capability delegation — C4)", () => {
+  it("decrypts when the capability answers true, passing token and execution id", async () => {
+    const provider = providerWith(async () => true);
+    const ec = executionContext();
+    await resolveValuesForCaller(
+      { logger: silentLogger, secretService, runnerAuthService: provider },
+      ctxWithBearer("sandbox-token"),
+      ec,
+    );
+    expect(ec.spec?.data["API_KEY"]?.value).toBe("s3cret");
+    expect(provider.asked).toEqual([["sandbox-token", "aexec_cap1"]]);
+  });
+
+  it("redacts when the capability answers false", async () => {
+    const provider = providerWith(async () => false);
+    const ec = executionContext();
+    await resolveValuesForCaller(
+      { logger: silentLogger, secretService, runnerAuthService: provider },
+      ctxWithBearer("someone-elses-token"),
+      ec,
+    );
+    expect(ec.spec?.data["API_KEY"]?.value).toBe("***REDACTED***");
+  });
+
+  it("redacts without consulting the capability when no bearer token is presented", async () => {
+    const provider = providerWith(async () => true);
+    const ec = executionContext();
+    await resolveValuesForCaller(
+      { logger: silentLogger, secretService, runnerAuthService: provider },
+      ctxWithBearer(""),
+      ec,
+    );
+    expect(ec.spec?.data["API_KEY"]?.value).toBe("***REDACTED***");
+    expect(provider.asked).toEqual([]);
+  });
+
+  it("a THROWING capability falls closed to redaction — never a failed read", async () => {
+    const provider = providerWith(async () => {
+      throw new Error("policy backend unavailable");
+    });
+    const ec = executionContext();
+    await resolveValuesForCaller(
+      { logger: silentLogger, secretService, runnerAuthService: provider },
+      ctxWithBearer("sandbox-token"),
+      ec,
+    );
+    expect(ec.spec?.data["API_KEY"]?.value).toBe("***REDACTED***");
+  });
+});

--- a/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
@@ -387,6 +387,6 @@ async function getByExecutionId(
   // scope-bound runner token, redact for everyone else. Both transforms
   // mutate the fresh store unmarshal, never the stored row.
   const ec = reqCtx.get(TARGET_RESOURCE_KEY) as ExecutionContext;
-  resolveValuesForCaller(deps, ctx, ec);
+  await resolveValuesForCaller(deps, ctx, ec);
   return ec;
 }

--- a/backend/services/stigmer-server/src/domain/executioncontext/resolve-values-for-caller.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/resolve-values-for-caller.ts
@@ -66,22 +66,67 @@ export interface ResolveValuesDeps {
  * Applies the credential-dispatched transform in place: decrypt for a
  * scope-bound runner token, redact for everyone else. Both transforms
  * mutate the fresh store unmarshal, never the stored row.
+ *
+ * With the authorizeExecutionContextRead capability composed (C4, gate
+ * ruling Q1), the provider owns the ENTIRE trust decision — its lane set
+ * and scope bindings (the cloud's session/workflow/connect rules) replace
+ * the OSS execution-scoped check below. Redaction-as-success stays the
+ * contract on every arm.
  */
-export function resolveValuesForCaller(
+export async function resolveValuesForCaller(
   deps: ResolveValuesDeps,
   ctx: HandlerContext,
   ec: ExecutionContext,
-): void {
+): Promise<void> {
+  if (await runnerMayDecrypt(deps, ctx, ec)) {
+    decryptSecretValues(deps, ec);
+    return;
+  }
+  redactExecutionContextSecrets(ec);
+}
+
+/**
+ * The trust decision: the composed capability when present, the OSS
+ * execution-scoped verify otherwise. A capability that THROWS is a bug in
+ * the composition, not a credential failure — it still falls closed to
+ * redaction, WARN-logged, because a read that would have redacted must
+ * never start failing outright on a policy fault (the
+ * redaction-as-success contract).
+ */
+async function runnerMayDecrypt(
+  deps: ResolveValuesDeps,
+  ctx: HandlerContext,
+  ec: ExecutionContext,
+): Promise<boolean> {
+  const authorizeRead =
+    deps.runnerAuthService.authorizeExecutionContextRead?.bind(
+      deps.runnerAuthService,
+    );
+  if (authorizeRead !== undefined) {
+    const token = bearerToken(ctx);
+    if (token === "") {
+      return false;
+    }
+    try {
+      return await authorizeRead(token, ec.spec?.executionId ?? "");
+    } catch (error) {
+      deps.logger.warn(
+        "ExecutionContext read authorization failed — redacting secrets",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      return false;
+    }
+  }
+
   const executionId = verifyRunnerToken(deps, ctx, ec);
   if (executionId !== undefined) {
     deps.logger.debug(
       "Scope-bound runner token presented - decrypting execution context secrets",
       { executionId },
     );
-    decryptSecretValues(deps, ec);
-    return;
+    return true;
   }
-  redactExecutionContextSecrets(ec);
+  return false;
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/platform/__tests__/platform.test.ts
+++ b/backend/services/stigmer-server/src/domain/platform/__tests__/platform.test.ts
@@ -20,7 +20,12 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { Code, ConnectError, createClient, createRouterTransport } from "@connectrpc/connect";
+import {
+  Code,
+  ConnectError,
+  createClient,
+  createRouterTransport,
+} from "@connectrpc/connect";
 import type { Client, Transport } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
@@ -37,10 +42,21 @@ import { composeServer } from "../../../boot/compose.js";
 import type { ComposedServer } from "../../../boot/compose.js";
 import { createLogger } from "../../../boot/logger.js";
 import { newExecutionScopedRunnerCredentialProvider } from "../../../runnerauth/runner-credential-provider.js";
-import { RunnerAuthService } from "../../../runnerauth/runnerauth.js";
+import type {
+  RunnerCredentialProvider,
+  RunnerScopedTokenRequest,
+} from "../../../runnerauth/runner-credential-provider.js";
+import {
+  InvalidTokenError,
+  RunnerAuthService,
+} from "../../../runnerauth/runnerauth.js";
 import { registerPlatformServices } from "../controller.js";
 
-const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
 
 const RUNNER_KEY = Buffer.alloc(32, 5);
 const ENC_KEY = Buffer.alloc(32, 6);
@@ -183,5 +199,179 @@ describe("platform domain (keyless runner-token service)", () => {
     expect(out.runnerScopedToken).toBe("");
     expect(out.tokenType).toBe("");
     expect(out.expiresInSeconds).toBe(0);
+  });
+});
+
+/**
+ * The C4 capability delegation (gate ruling Q1), proven through the FULL
+ * stack: a provider registered via the extension registry, the identity
+ * interceptor stamping the trusted-local caller, and the platform
+ * controller delegating every arm. This is the seam the cloud
+ * composition's exchange rides — the fakes record exactly what crossed
+ * it.
+ */
+describe("platform domain (capability-delegating provider — C4)", () => {
+  let server: ComposedServer;
+  let client: PlatformClient;
+  let dir: string;
+  const exchanged: {
+    request: RunnerScopedTokenRequest;
+    callerIdentityId: string;
+    callerClass: string;
+  }[] = [];
+  let bootstrapCallerIds: string[] = [];
+  let bootstrapThrows = false;
+
+  const capabilityProvider: RunnerCredentialProvider = {
+    isEnabled: () => false,
+    mint: () => {
+      throw new Error("primitive mint is not under test here");
+    },
+    verify: () => {
+      throw new InvalidTokenError();
+    },
+    async exchangeScopedToken(request, caller) {
+      exchanged.push({
+        request,
+        callerIdentityId: caller.identityId,
+        callerClass: caller.callerClass,
+      });
+      if (request.arm === "pool-claim" && request.sessionId === "ses_denied") {
+        throw new ConnectError(
+          "pool member holds no claim for session ses_denied",
+          Code.PermissionDenied,
+        );
+      }
+      if (request.arm === "renewal") {
+        return { minted: false };
+      }
+      return { minted: true, token: "cloud-token", expiresInSeconds: 14400 };
+    },
+    async bootstrapCredentials(caller) {
+      if (bootstrapThrows) {
+        throw new Error("payload key store unavailable");
+      }
+      bootstrapCallerIds.push(caller.identityId);
+      return {
+        accessToken: { token: "cloud-bootstrap-token", expiresInSeconds: 900 },
+        payloadKeys: {
+          keyId: "rpk_test1",
+          keyBase64: "a2V5",
+          secondaryKeyId: "rpk_test0",
+          secondaryKeyBase64: "b2xk",
+        },
+      };
+    },
+  };
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "platform-capability-test-"));
+    vi.stubEnv("STIGMER_ENCRYPTION_KEY", ENC_KEY.toString("base64"));
+    server = await composeServer({
+      config: loadConfig({
+        STIGMER_MODEL_REGISTRY_REFRESH: "off",
+        DB_PATH: path.join(dir, "stigmer.db"),
+        ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+        TEMPORAL_HOST_PORT: "127.0.0.1:7777",
+        TEMPORAL_NAMESPACE: "conformance-ns",
+      }),
+      logger: silentLogger,
+      portOverride: 0,
+      host: "127.0.0.1",
+      extensions: [
+        {
+          name: "fake-cloud-credentials",
+          drivers: { runnerCredentialProvider: capabilityProvider },
+        },
+      ],
+    });
+    const port = await server.start();
+    client = createClient(
+      PlatformQueryController,
+      createGrpcTransport({ baseUrl: `http://127.0.0.1:${port}` }),
+    );
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("delegates every exchange arm with the stamped caller identity", async () => {
+    exchanged.length = 0;
+
+    const minted = await client.getRunnerScopedToken({
+      scope: { case: "agentExecutionId", value: "aexec_cap1" },
+    });
+    expect(minted.runnerScopedToken).toBe("cloud-token");
+    expect(minted.tokenType).toBe("Bearer");
+    expect(minted.expiresInSeconds).toBe(14400);
+
+    await client.getRunnerScopedToken({
+      scope: { case: "workflowExecutionId", value: "wexec_cap1" },
+    });
+    const renewal = await client.getRunnerScopedToken({
+      scope: { case: "renewal", value: {} },
+    });
+    // The implementation's not-minted degrade rides the presence-based
+    // empty output — same wire shape as the OSS pool/renewal answer.
+    expect(renewal.runnerScopedToken).toBe("");
+    expect(renewal.tokenType).toBe("");
+    expect(renewal.expiresInSeconds).toBe(0);
+
+    expect(exchanged.map((e) => e.request)).toEqual([
+      { arm: "agent-execution", executionId: "aexec_cap1" },
+      { arm: "workflow-execution", executionId: "wexec_cap1" },
+      { arm: "renewal" },
+    ]);
+    // The trusted-local identity the chain stamped is what crossed the
+    // seam — the cloud implementation gates its arms on exactly this.
+    for (const call of exchanged) {
+      expect(call.callerIdentityId).not.toBe("");
+      expect(call.callerClass).toBe("user");
+    }
+  });
+
+  it("a refusal thrown by the implementation propagates as the gRPC error", async () => {
+    try {
+      await client.getRunnerScopedToken({
+        scope: { case: "poolClaim", value: { sessionId: "ses_denied" } },
+      });
+      throw new Error("expected the call to fail");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ConnectError);
+      expect((error as ConnectError).code).toBe(Code.PermissionDenied);
+      expect((error as ConnectError).rawMessage).toBe(
+        "pool member holds no claim for session ses_denied",
+      );
+    }
+  });
+
+  it("merges bootstrap credentials into the coordinate response", async () => {
+    bootstrapCallerIds = [];
+    const config = await client.getRunnerBootstrapConfig({});
+    expect(config.temporalAddress).toBe("127.0.0.1:7777");
+    expect(config.runnerAccessToken).toBe("cloud-bootstrap-token");
+    expect(config.tokenType).toBe("Bearer");
+    expect(config.runnerAccessTokenExpiresInSeconds).toBe(900);
+    expect(config.payloadEncryptionKeyId).toBe("rpk_test1");
+    expect(config.payloadEncryptionKey).toBe("a2V5");
+    expect(config.payloadEncryptionSecondaryKeyId).toBe("rpk_test0");
+    expect(config.payloadEncryptionSecondaryKey).toBe("b2xk");
+    expect(bootstrapCallerIds).toHaveLength(1);
+  });
+
+  it("a bootstrap-credentials failure degrades to coordinates-only, never an error", async () => {
+    bootstrapThrows = true;
+    try {
+      const config = await client.getRunnerBootstrapConfig({});
+      expect(config.temporalAddress).toBe("127.0.0.1:7777");
+      expect(config.runnerAccessToken).toBe("");
+      expect(config.tokenType).toBe("");
+      expect(config.payloadEncryptionKey).toBe("");
+    } finally {
+      bootstrapThrows = false;
+    }
   });
 });

--- a/backend/services/stigmer-server/src/domain/platform/controller.ts
+++ b/backend/services/stigmer-server/src/domain/platform/controller.ts
@@ -16,8 +16,17 @@
  * for it. On a single-user server the token is the LANE DISCRIMINATOR that
  * lets the EC read RPCs redact by default without breaking the runner, not
  * a trust boundary (DD-004).
+ *
+ * The C4 capability delegation (20260827.09, gate ruling Q1): when the
+ * composed provider defines exchangeScopedToken / bootstrapCredentials,
+ * this controller delegates the exchange arms and the bootstrap
+ * credential fields to it wholesale — the cloud's per-arm caller-class
+ * gating, row authorization, and multi-lane minting are POLICY, not
+ * contract, and live behind the seam. With neither defined (the OSS
+ * default), every arm below behaves exactly as before; the conformance
+ * suites pin that byte-identity.
  */
-import type { ConnectRouter } from "@connectrpc/connect";
+import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
 import { create } from "@bufbuild/protobuf";
 
 import {
@@ -35,7 +44,11 @@ import type {
 } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
 
 import type { Logger } from "../../boot/logger.js";
-import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
+import type {
+  RunnerCredentialProvider,
+  RunnerScopedTokenRequest,
+} from "../../runnerauth/runner-credential-provider.js";
 import { TOKEN_TYPE_EXECUTION_SCOPED } from "../../runnerauth/runnerauth.js";
 import { SERVER_VERSION } from "./version.js";
 
@@ -72,8 +85,10 @@ export function registerPlatformServices(
 ): void {
   router.service(PlatformQueryController, {
     getServerInfo: () => getServerInfo(deps),
-    getRunnerBootstrapConfig: () => getRunnerBootstrapConfig(deps),
-    getRunnerScopedToken: (input) => getRunnerScopedToken(deps, input),
+    getRunnerBootstrapConfig: (_input, ctx) =>
+      getRunnerBootstrapConfig(deps, ctx),
+    getRunnerScopedToken: (input, ctx) =>
+      getRunnerScopedToken(deps, input, ctx),
   });
 }
 
@@ -89,18 +104,54 @@ function getServerInfo(deps: PlatformControllerDeps): GetServerInfoOutput {
  * Go GetRunnerBootstrapConfig: the Temporal coordinates an embedded runner
  * should connect to so it can self-bootstrap from a token alone. The
  * RunnerAccessToken / TokenType / RunnerAccessTokenExpiresInSeconds fields
- * are intentionally left empty: minting an iss=stigmer proxy token is a
- * cloud-only capability (OSS has no Cursor BiDi proxy to authenticate
+ * are intentionally left empty in OSS: minting an iss=stigmer proxy token
+ * is a cloud-only capability (OSS has no Cursor BiDi proxy to authenticate
  * against), so OSS runners keep using the token they already hold. The
  * suite pins the presence-based all-or-nothing coupling of those fields.
+ *
+ * A composed provider with the bootstrapCredentials capability populates
+ * the token and payload-key fields (module header); the coordinates are
+ * OSS-owned either way — they describe THIS deployment's Temporal, not a
+ * credential policy. Capability failures degrade to the empty fields and
+ * never fail the bootstrap the coordinates ride on (the Java handler's
+ * best-effort contract).
  */
-function getRunnerBootstrapConfig(
+async function getRunnerBootstrapConfig(
   deps: PlatformControllerDeps,
-): GetRunnerBootstrapConfigOutput {
-  return create(GetRunnerBootstrapConfigOutputSchema, {
+  ctx: HandlerContext,
+): Promise<GetRunnerBootstrapConfigOutput> {
+  const output = create(GetRunnerBootstrapConfigOutputSchema, {
     temporalAddress: deps.temporalHostPort,
     temporalNamespace: deps.temporalNamespace,
   });
+  const bootstrapCredentials =
+    deps.runnerAuthService.bootstrapCredentials?.bind(deps.runnerAuthService);
+  if (bootstrapCredentials === undefined) {
+    return output;
+  }
+  try {
+    const credentials = await bootstrapCredentials(callerIdentityOf(ctx));
+    if (credentials.accessToken !== undefined) {
+      output.runnerAccessToken = credentials.accessToken.token;
+      output.tokenType = "Bearer";
+      output.runnerAccessTokenExpiresInSeconds =
+        credentials.accessToken.expiresInSeconds;
+    }
+    if (credentials.payloadKeys !== undefined) {
+      output.payloadEncryptionKey = credentials.payloadKeys.keyBase64;
+      output.payloadEncryptionKeyId = credentials.payloadKeys.keyId;
+      output.payloadEncryptionSecondaryKey =
+        credentials.payloadKeys.secondaryKeyBase64 ?? "";
+      output.payloadEncryptionSecondaryKeyId =
+        credentials.payloadKeys.secondaryKeyId ?? "";
+    }
+  } catch (error) {
+    deps.logger.warn(
+      "Bootstrap credentials unavailable — answering coordinates without them",
+      { error: error instanceof Error ? error.message : String(error) },
+    );
+  }
+  return output;
 }
 
 /**
@@ -124,11 +175,36 @@ function getRunnerBootstrapConfig(
  * no-credential path treats absence as "proceed tokenless", which degrades
  * to redacted values (a clear downstream signal), while an error here
  * would abort the activity.
+ *
+ * With the exchangeScopedToken capability composed, EVERY arm delegates
+ * to the provider (module header): its refusals (wrong credential class,
+ * failed authorization) propagate as the gRPC errors it throws — the
+ * cloud exchange's contract — while its keyless degrade keeps the
+ * presence-based empty output.
  */
-function getRunnerScopedToken(
+async function getRunnerScopedToken(
   deps: PlatformControllerDeps,
   input: GetRunnerScopedTokenInput,
-): GetRunnerScopedTokenOutput {
+  ctx: HandlerContext,
+): Promise<GetRunnerScopedTokenOutput> {
+  const exchange = deps.runnerAuthService.exchangeScopedToken?.bind(
+    deps.runnerAuthService,
+  );
+  if (exchange !== undefined) {
+    const minted = await exchange(
+      exchangeRequestOf(input),
+      callerIdentityOf(ctx),
+    );
+    if (!minted.minted) {
+      return create(GetRunnerScopedTokenOutputSchema);
+    }
+    return create(GetRunnerScopedTokenOutputSchema, {
+      runnerScopedToken: minted.token,
+      tokenType: "Bearer",
+      expiresInSeconds: minted.expiresInSeconds,
+    });
+  }
+
   let executionId: string;
   switch (input.scope.case) {
     case "agentExecutionId":
@@ -175,5 +251,33 @@ function getRunnerScopedToken(
       },
     );
     return create(GetRunnerScopedTokenOutputSchema);
+  }
+}
+
+/**
+ * The proto oneof, transcribed to the seam's domain shape (the provider
+ * contract deliberately imports no wire types). Every arm maps
+ * one-to-one, INCLUDING unset — the implementation owns the unset
+ * refusal (Java answers INVALID_ARGUMENT there), so this mapping must
+ * never collapse it into a real arm.
+ */
+function exchangeRequestOf(
+  input: GetRunnerScopedTokenInput,
+): RunnerScopedTokenRequest {
+  switch (input.scope.case) {
+    case "agentExecutionId":
+      return { arm: "agent-execution", executionId: input.scope.value };
+    case "workflowExecutionId":
+      return { arm: "workflow-execution", executionId: input.scope.value };
+    case "poolClaim":
+      return { arm: "pool-claim", sessionId: input.scope.value.sessionId };
+    case "renewal":
+      return { arm: "renewal" };
+    case undefined:
+      return { arm: "unset" };
+    default: {
+      const exhaustive: never = input.scope;
+      throw new Error(`unhandled scope arm: ${JSON.stringify(exhaustive)}`);
+    }
   }
 }

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/lifecycle.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/lifecycle.test.ts
@@ -126,6 +126,9 @@ function deps(engineStub?: EngineStub): LifecycleDeps {
     sandboxLane: { enabled: false },
     temporalConfig: newWorkflowExecutionConfigFromEnv(),
     sandboxTerminalObserver: () => {},
+    // Empty slots — the OSS shape; the recover chain's
+    // sandbox-acquisition:gate splice contributes nothing here (C4).
+    gateSteps: new Map(),
   };
 }
 

--- a/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
@@ -37,6 +37,8 @@ import { create } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
+import { stepsForSlot } from "../../extensions/gate-slots.js";
 import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -121,6 +123,13 @@ export interface WorkflowExecutionControllerDeps {
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
   /**
+   * The merged slot registrations (O1/O4; DD-006 §2). This domain
+   * carries `sandbox-acquisition:gate` on the create and recover chains
+   * at the Java-verified capacity-gate position (C4, 20260827.09) —
+   * empty in OSS.
+   */
+  readonly gateSteps: ResolvedGateSteps;
+  /**
    * The workflow-execution engine seam (engine.ts): permanently
    * disconnected until #21's TemporalManager flips it. Consumed by the
    * create gate, the lifecycle RPCs, sendSignal, and
@@ -177,6 +186,7 @@ export function registerWorkflowExecutionServices(
     sandboxLane: deps.sandboxLane,
     temporalConfig: deps.temporalConfig,
     sandboxTerminalObserver: deps.sandboxTerminalObserver,
+    gateSteps: deps.gateSteps,
   };
   router.service(WorkflowExecutionCommandController, {
     create: (execution, ctx) => createExecution(deps, execution, ctx),
@@ -237,7 +247,7 @@ async function createExecution(
     callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof WorkflowExecutionSchema>(
+  const builder = newPipeline<typeof WorkflowExecutionSchema>(
     "workflowexecution-create",
     deps.logger,
   )
@@ -261,7 +271,19 @@ async function createExecution(
     )
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
-    .addStep(newNormalizeReferencesStep())
+    .addStep(newNormalizeReferencesStep());
+  // The ratified sandbox-acquisition gate slot (blueprint 03 §3a; C4):
+  // the Java-verified capacity-gate position — after Authorize and every
+  // resolution step (the default instance, like Java's, side-effects
+  // pre-gate: orphan-on-refusal is inherited semantics), before the
+  // phase stamp and every later side effect, pre-provision. Empty in OSS.
+  for (const step of stepsForSlot<typeof WorkflowExecutionSchema>(
+    deps.gateSteps,
+    "sandbox-acquisition:gate",
+  )) {
+    builder.addStep(step);
+  }
+  await builder
     .addStep(newSetInitialPhaseStep())
     .addStep(newNormalizeWorkflowRefStep(deps.store, deps.logger))
     .addStep(newPinWorkflowVersionStep(deps.store, deps.logger))

--- a/backend/services/stigmer-server/src/domain/workflowexecution/lifecycle.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/lifecycle.ts
@@ -46,6 +46,8 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
+import { stepsForSlot } from "../../extensions/gate-slots.js";
 import {
   filterByDeclaredKeys,
   mergeEnvironmentLayers,
@@ -101,6 +103,13 @@ export interface LifecycleDeps {
   readonly temporalConfig: WorkflowExecutionTemporalConfig;
   /** Fires the workflow-sandbox teardown on terminal transitions (§6d, O6). */
   readonly sandboxTerminalObserver: WorkflowSandboxTerminalObserver;
+  /**
+   * The merged slot registrations (O1/O4; DD-006 §2) — recover carries
+   * `sandbox-acquisition:gate` at the Java-verified position (C4):
+   * recover re-provisions a deprovisioned sandbox, which is capacity
+   * growth (cloud#355's recover-parity shape). Empty in OSS.
+   */
+  readonly gateSteps: ResolvedGateSteps;
 }
 
 // ---------------------------------------------------------------------------
@@ -894,6 +903,12 @@ export async function recoverExecution(
         (phase) =>
           `cannot recover execution in phase ${phase}; only FAILED executions can be recovered`,
       ),
+      // The ratified sandbox-acquisition gate slot (blueprint 03 §3a;
+      // C4): after load/authorize/phase validation, before the first
+      // side effect (the terminate) — recover re-provisions a
+      // deprovisioned sandbox, which is capacity growth (the Java
+      // recover chain's verified 3b position, cloud#355). Empty in OSS.
+      ...stepsForSlot<Desc>(deps.gateSteps, "sandbox-acquisition:gate"),
       newTerminateExistingWorkflowStep(deps),
       newRecreateExecutionContextStep(deps),
       // The workflow-lane sandbox re-ensure (§6d, O6): the terminal
@@ -914,6 +929,7 @@ export async function recoverExecution(
               temporalConfig: deps.temporalConfig,
             },
             loadedExecution(ctx),
+            ctx.callerIdentity.identityId,
           );
         },
       },

--- a/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
@@ -319,6 +319,7 @@ describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
       "agent-execution-recover:pre-side-effect-gate",
       "agent-execution-submit-approval:gate",
       "org-create:post-persist",
+      "sandbox-acquisition:gate",
       "session-create:pre-side-effect-gate",
     ]);
   });

--- a/backend/services/stigmer-server/src/extensions/gate-slots.ts
+++ b/backend/services/stigmer-server/src/extensions/gate-slots.ts
@@ -6,15 +6,18 @@
  * composition. Slot names are PROTECTED VOCABULARY (never renamed,
  * byte-stable), scoped `<chain-name>:<position>`.
  *
- * O1 (20260826.09) shipped the mechanism; O4 (20260827.07) declares the
- * ratified slots at their Java-verified semantic positions. FIVE of the
- * six ratified names are declared here — `sandbox-acquisition:gate` is
- * deferred to the entry that builds the gated provisioning position (O4
- * plan-gate ruling Q1: a declared slot whose steps can never run would be
- * a silent no-op, the exact failure §2b exists to prevent; O6 shipped the
- * SandboxProvisioner as a driver seam with its own chain steps, so the
- * capacity-gate splice site — and with it the sixth name — arrives with
- * the C4 wave's OSS-side seam work).
+ * O1 (20260826.09) shipped the mechanism; O4 (20260827.07) declared the
+ * first five ratified slots at their Java-verified semantic positions,
+ * deferring `sandbox-acquisition:gate` to the entry that builds its
+ * splice sites (ruling Q1: a declared slot whose steps can never run
+ * would be a silent no-op, the exact failure §2b exists to prevent). C4
+ * (20260827.09) declares it: the workflow-execution chains have no
+ * generic pre-side-effect slot, and their Java-verified capacity-gate
+ * position (post-authorize, before any side effect, pre-provision —
+ * cloud#355's 7c/3b) is where the cloud's sandbox-capacity gate rides on
+ * BOTH the create and recover chains. The session lane needs no sixth
+ * splice — its capacity gates ride the two declared agent-execution
+ * slots, whose positions coincide exactly with the Java session gate.
  *
  * Two enforcement layers, deliberately redundant, both derived from the
  * ONE literal tuple below (lockstep by construction):
@@ -51,6 +54,7 @@ export const GATE_SLOT_NAMES = [
   "agent-execution-submit-approval:gate",
   "session-create:pre-side-effect-gate",
   "org-create:post-persist",
+  "sandbox-acquisition:gate",
 ] as const;
 
 /** The declared slot-name union — a registration outside it fails tsc. */

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -111,7 +111,17 @@ export type { ModelCatalogProvider } from "./domain/workflow/registry/model-cata
 // baseline) builds providers from documents with the SAME interpretation
 // ModelRegistryStore uses — the semantics live exactly once in OSS.
 export { newModelCatalogProviderFromDocument } from "./domain/workflow/registry/document-catalog.js";
-export type { RunnerCredentialProvider } from "./runnerauth/runner-credential-provider.js";
+export type {
+  RunnerCredentialProvider,
+  // The C4 capability shapes (gate ruling Q1): the optional methods'
+  // domain-shaped request/result types — a composition implementing the
+  // exchange, bootstrap, sandbox-mint, or EC-read capabilities types
+  // against these, never against wire messages.
+  RunnerBootstrapCredentials,
+  RunnerScopedTokenExchange,
+  RunnerScopedTokenRequest,
+  SandboxCredentialRequest,
+} from "./runnerauth/runner-credential-provider.js";
 export type { MintedToken } from "./runnerauth/runnerauth.js";
 export {
   InvalidTokenError,

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -129,6 +129,19 @@ export {
   TOKEN_TYPE_EXECUTION_SCOPED,
 } from "./runnerauth/runnerauth.js";
 
+// The cross-edition secret envelope (enc:v1 — AES-256-GCM, the format the
+// Java SecretEncryptionService shares): compositions building extension
+// domains with secret-bearing columns seal under the SAME envelope the
+// OSS store uses (C4 gate ruling Q4's interim posture; C2/C3 inherit the
+// seam). The service, not the primitives — the format stays defined
+// exactly once.
+export {
+  DecryptionFailedError,
+  EncryptionDisabledError,
+  InvalidCiphertextError,
+  SecretService,
+} from "./encryption/encryption.js";
+
 // The O6 driver seam (§6d): the sandbox-provisioner contract an extension
 // implements to register its own isolation driver (selected through the
 // SANDBOX_PROVISIONER_TYPE knob), plus the reserved built-in names its

--- a/backend/services/stigmer-server/src/runnerauth/runner-credential-provider.ts
+++ b/backend/services/stigmer-server/src/runnerauth/runner-credential-provider.ts
@@ -32,13 +32,101 @@
  * substitute an implementation through the drivers registry point
  * (extensions/drivers.ts); with none composed, behavior is byte-identical
  * to the direct-service wiring this seam replaced.
+ *
+ * # The optional capability methods (C4, 20260827.09 — gate ruling Q1)
+ *
+ * Beyond the mint/verify primitives, an edition's runner credentials
+ * surface at four OSS-owned touchpoints whose POLICY is edition-specific:
+ * the platform scoped-token exchange, the bootstrap credential response,
+ * the token baked into a provisioned sandbox, and the ExecutionContext
+ * decrypt trust decision. Each is an OPTIONAL method here; each OSS call
+ * site falls back to today's exact behavior when the method is absent,
+ * and the OSS default provider defines none — empty-composition behavior
+ * is byte-identical by construction (the local conformance rosters pin
+ * it). One provider object carries the edition's whole credential story;
+ * the rejected alternative (a second single-instance driver for the
+ * exchange) split that story across two objects whose only consumer is
+ * the same composition.
+ *
+ * Capability implementations REFUSE by throwing (a ConnectError with the
+ * implementation's own byte-pinned copy — the gate-step refusal shape)
+ * and DEGRADE by returning their not-minted/empty results. The
+ * distinction is contract: a refusal fails the RPC, a degrade rides the
+ * presence-based response the runner already handles.
  */
+import type { CallerIdentity } from "../extensions/identity.js";
 import type { MintedToken } from "./runnerauth.js";
 import {
   InvalidTokenError,
   RunnerAuthService,
   TOKEN_TYPE_EXECUTION_SCOPED,
 } from "./runnerauth.js";
+
+/**
+ * The domain shape of a getRunnerScopedToken request — one arm per proto
+ * scope (server_info.proto), transcribed so implementations never import
+ * wire types. The renewal arm is deliberately empty: every renewal
+ * parameter comes from the CALLER's verified credential, never the
+ * request (the Java exchange's ruled posture).
+ */
+export type RunnerScopedTokenRequest =
+  | { readonly arm: "agent-execution"; readonly executionId: string }
+  | { readonly arm: "workflow-execution"; readonly executionId: string }
+  | { readonly arm: "pool-claim"; readonly sessionId: string }
+  | { readonly arm: "renewal" }
+  // The proto oneof left unset — carried so implementations own the
+  // refusal (the Java exchange answers INVALID_ARGUMENT; OSS's
+  // capability-less fallback answers not-minted). Erasing this arm into
+  // any other would let a malformed request impersonate that arm's
+  // semantics.
+  | { readonly arm: "unset" };
+
+/**
+ * An exchange outcome: minted, or the presence-based "not minted" shape
+ * (empty output on the wire — the runner's degrade contract). Refusals
+ * are NOT an arm of this type: implementations throw them.
+ */
+export type RunnerScopedTokenExchange =
+  | { readonly minted: false }
+  | {
+      readonly minted: true;
+      readonly token: string;
+      readonly expiresInSeconds: number;
+    };
+
+/**
+ * The credential portion of a getRunnerBootstrapConfig response. Both
+ * arms are independently optional — the Java contract's presence-based
+ * coupling (token fields all-or-nothing, key fields all-or-nothing) is
+ * expressed structurally.
+ */
+export interface RunnerBootstrapCredentials {
+  readonly accessToken?: {
+    readonly token: string;
+    readonly expiresInSeconds: number;
+  };
+  readonly payloadKeys?: {
+    readonly keyId: string;
+    readonly keyBase64: string;
+    readonly secondaryKeyId?: string;
+    readonly secondaryKeyBase64?: string;
+  };
+}
+
+/**
+ * What the sandbox ensure steps know when they mint the credential baked
+ * into a provisioned sandbox (steps.ts). `sessionId` is empty on the
+ * workflow scope; `callerIdentityId` is empty when the invocation site
+ * has no caller (the Java ensure step's null-identity arm, which mints
+ * nothing rather than minting unattributed).
+ */
+export interface SandboxCredentialRequest {
+  readonly scope: "session" | "workflow";
+  readonly sessionId: string;
+  readonly executionId: string;
+  readonly org: string;
+  readonly callerIdentityId: string;
+}
 
 /**
  * Mints and verifies runner credentials per lane. Implementations must be
@@ -65,6 +153,57 @@ export interface RunnerCredentialProvider {
    * returns the binding. ANY failure throws InvalidTokenError.
    */
   verify(lane: string, token: string): string;
+
+  /**
+   * The whole getRunnerScopedToken policy: per-arm caller-class gating,
+   * authorization, and mint (the cloud edition's four-arm exchange).
+   * When present, the platform controller delegates EVERY arm here;
+   * absent, the controller keeps the OSS behavior (execution arms mint
+   * on the execution_scoped lane; pool-claim/renewal answer not-minted).
+   * Refusals throw; keyless degrade returns `{ minted: false }`.
+   */
+  exchangeScopedToken?(
+    request: RunnerScopedTokenRequest,
+    caller: CallerIdentity,
+  ): Promise<RunnerScopedTokenExchange>;
+
+  /**
+   * The credential portion of getRunnerBootstrapConfig (the runner access
+   * token and per-identity payload-encryption keys). When present, the
+   * platform controller merges the result into the response; absent, the
+   * fields stay empty (the OSS posture — minting a proxy credential is a
+   * cloud capability). Both arms are best-effort by contract: a failure
+   * inside an arm degrades that arm to absent, never fails the bootstrap
+   * the Temporal coordinates ride on.
+   */
+  bootstrapCredentials?(
+    caller: CallerIdentity,
+  ): Promise<RunnerBootstrapCredentials>;
+
+  /**
+   * The credential baked into a provisioned sandbox (SandboxEnvironment.
+   * stigmerToken). When present, the ensure steps delegate here with the
+   * full provisioning context; absent, they mint on the execution_scoped
+   * lane exactly as before. Returns "" to launch tokenless (the
+   * redaction-fallback contract lane.ts documents); a thrown error
+   * propagates to the invoking step's own failure posture.
+   */
+  mintSandboxCredential?(request: SandboxCredentialRequest): string;
+
+  /**
+   * The ExecutionContext decrypt trust decision for getByExecutionId
+   * (`executionId` is the EC's spec.execution_id). When present, it IS
+   * the entire decision — the implementation owns its lane set and scope
+   * bindings (the cloud's session/workflow/connect scope rules, including
+   * any resource loads through its own clients); absent, the decrypt gate
+   * keeps the OSS decision (execution_scoped verify + binding equality).
+   * True decrypts; false redacts; never throws for an unrecognized or
+   * invalid token — redaction-as-success is the pinned contract.
+   */
+  authorizeExecutionContextRead?(
+    rawToken: string,
+    executionId: string,
+  ): Promise<boolean>;
 }
 
 /**

--- a/backend/services/stigmer-server/src/sandbox/__tests__/steps.test.ts
+++ b/backend/services/stigmer-server/src/sandbox/__tests__/steps.test.ts
@@ -40,7 +40,10 @@ import {
   WORKFLOW_ROUTING_GLOBAL,
   WorkflowExecutionTemporalConfig,
 } from "../../domain/workflowexecution/temporal/config.js";
-import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
+import type {
+  RunnerCredentialProvider,
+  SandboxCredentialRequest,
+} from "../../runnerauth/runner-credential-provider.js";
 import { SqliteStore } from "../../store/sqlite/store.js";
 import type { SandboxLane } from "../lane.js";
 import type { SandboxEnvironment, SandboxProvisioner } from "../provisioner.js";
@@ -51,6 +54,13 @@ import {
   newWorkflowSandboxTerminalObserver,
   SANDBOX_PROVISIONING_FAILED_PREFIX,
 } from "../steps.js";
+
+/**
+ * The caller identity the ensure bodies thread into the credential mint
+ * (C4): the OSS execution-scoped mint ignores it, so these tests pass a
+ * fixed value and the token assertions stay binding-shaped.
+ */
+const TEST_CALLER_IDENTITY_ID = "ida_test_caller";
 
 const silentLogger = createLogger({
   level: "error",
@@ -117,6 +127,38 @@ const disabledCredentials: RunnerCredentialProvider = {
     throw new Error("verify is not under test");
   },
 };
+
+/**
+ * A provider with the C4 mintSandboxCredential capability: records the
+ * full provisioning context it received and returns a distinguishable
+ * token — proving the ensure steps delegate the WHOLE mint decision
+ * (the primitives must never be consulted on this path).
+ */
+function capabilityCredentials(): RunnerCredentialProvider & {
+  minted: SandboxCredentialRequest[];
+} {
+  const minted: SandboxCredentialRequest[] = [];
+  return {
+    minted,
+    isEnabled: () => {
+      throw new Error(
+        "primitives must not be consulted on the capability path",
+      );
+    },
+    mint: () => {
+      throw new Error(
+        "primitives must not be consulted on the capability path",
+      );
+    },
+    verify: () => {
+      throw new Error("verify is not under test");
+    },
+    mintSandboxCredential: (request) => {
+      minted.push(request);
+      return `cloud-tok-${request.scope}`;
+    },
+  };
+}
 
 function lane(
   provisioner: SandboxProvisioner,
@@ -193,6 +235,7 @@ describe("the session lane (ensureSessionSandboxForExecution)", () => {
         temporalConfig: sessionRoutingCloudDefault,
       },
       execution,
+      TEST_CALLER_IDENTITY_ID,
     );
     expect(provisioner.ensured).toEqual([
       {
@@ -206,6 +249,49 @@ describe("the session lane (ensureSessionSandboxForExecution)", () => {
     ]);
   });
 
+  it("delegates the mint to the capability provider with the full provisioning context (C4)", async () => {
+    const provisioner = fakeProvisioner();
+    const credentials = capabilityCredentials();
+    counter += 1;
+    const sessionId = `ses_sbx_${counter}`;
+    const executionId = `axr_sbx_${counter}`;
+    await store.saveResource(
+      ApiResourceKind.session,
+      sessionId,
+      SessionSchema,
+      create(SessionSchema, {
+        metadata: { id: sessionId, name: sessionId },
+        spec: { executionTarget: ExecutionTarget.CLOUD },
+      }),
+    );
+    const execution = create(AgentExecutionSchema, {
+      metadata: { id: executionId, name: executionId, org: "org-test" },
+      spec: { sessionId },
+    });
+
+    await ensureSessionSandboxForExecution(
+      {
+        store,
+        logger: silentLogger,
+        lane: lane(provisioner, credentials),
+        temporalConfig: sessionRoutingCloudDefault,
+      },
+      execution,
+      TEST_CALLER_IDENTITY_ID,
+    );
+
+    expect(credentials.minted).toEqual([
+      {
+        scope: "session",
+        sessionId,
+        executionId,
+        org: "org-test",
+        callerIdentityId: TEST_CALLER_IDENTITY_ID,
+      },
+    ]);
+    expect(provisioner.ensured[0]?.env.stigmerToken).toBe("cloud-tok-session");
+  });
+
   it("skips on resolved LOCAL target — the roster fast path", async () => {
     const provisioner = fakeProvisioner();
     const { execution } = await seed(ExecutionTarget.LOCAL);
@@ -217,6 +303,7 @@ describe("the session lane (ensureSessionSandboxForExecution)", () => {
         temporalConfig: sessionRoutingCloudDefault,
       },
       execution,
+      TEST_CALLER_IDENTITY_ID,
     );
     expect(provisioner.ensured).toEqual([]);
   });
@@ -240,6 +327,7 @@ describe("the session lane (ensureSessionSandboxForExecution)", () => {
         temporalConfig: sessionRoutingCloudDefault,
       },
       execution,
+      TEST_CALLER_IDENTITY_ID,
     );
   });
 
@@ -257,6 +345,7 @@ describe("the session lane (ensureSessionSandboxForExecution)", () => {
         temporalConfig: sessionRoutingCloudDefault,
       },
       execution,
+      TEST_CALLER_IDENTITY_ID,
     );
     expect(provisioner.ensured).toEqual([]);
   });
@@ -277,6 +366,7 @@ describe("the session lane (ensureSessionSandboxForExecution)", () => {
         ),
       },
       execution,
+      TEST_CALLER_IDENTITY_ID,
     );
     expect(provisioner.ensured).toEqual([]);
   });
@@ -292,6 +382,7 @@ describe("the session lane (ensureSessionSandboxForExecution)", () => {
         temporalConfig: sessionRoutingCloudDefault,
       },
       execution,
+      TEST_CALLER_IDENTITY_ID,
     );
     expect(provisioner.ensured[0]?.env.stigmerToken).toBe("");
   });
@@ -310,6 +401,7 @@ describe("the session lane (ensureSessionSandboxForExecution)", () => {
         temporalConfig: sessionRoutingCloudDefault,
       },
       execution,
+      TEST_CALLER_IDENTITY_ID,
     );
     const stamped = await store.getResource(
       ApiResourceKind.agent_execution,
@@ -347,6 +439,7 @@ describe("the session lane (ensureSessionSandboxForExecution)", () => {
         temporalConfig: sessionRoutingCloudDefault,
       },
       execution,
+      TEST_CALLER_IDENTITY_ID,
     );
     const after = await store.getResource(
       ApiResourceKind.agent_execution,
@@ -374,6 +467,7 @@ describe("the workflow lane (ensureWorkflowSandboxForExecution)", () => {
         temporalConfig: executionRoutingConfig,
       },
       workflowExecution(ExecutionTarget.CLOUD),
+      TEST_CALLER_IDENTITY_ID,
     );
     expect(provisioner.ensured).toEqual([
       {
@@ -382,6 +476,33 @@ describe("the workflow lane (ensureWorkflowSandboxForExecution)", () => {
         env: { taskQueue: "wfexec:wfx_sbx_1", stigmerToken: "tok-wfx_sbx_1" },
       },
     ]);
+  });
+
+  it("delegates the mint to the capability provider on the workflow scope (C4)", async () => {
+    const provisioner = fakeProvisioner();
+    const credentials = capabilityCredentials();
+    await ensureWorkflowSandboxForExecution(
+      {
+        logger: silentLogger,
+        lane: lane(provisioner, credentials),
+        temporalConfig: executionRoutingConfig,
+      },
+      create(WorkflowExecutionSchema, {
+        metadata: { id: "wfx_sbx_cap", name: "wfx_sbx_cap", org: "org-test" },
+        spec: { executionTarget: ExecutionTarget.CLOUD },
+      }),
+      TEST_CALLER_IDENTITY_ID,
+    );
+    expect(credentials.minted).toEqual([
+      {
+        scope: "workflow",
+        sessionId: "",
+        executionId: "wfx_sbx_cap",
+        org: "org-test",
+        callerIdentityId: TEST_CALLER_IDENTITY_ID,
+      },
+    ]);
+    expect(provisioner.ensured[0]?.env.stigmerToken).toBe("cloud-tok-workflow");
   });
 
   it("skips on LOCAL target and on global routing", async () => {
@@ -393,6 +514,7 @@ describe("the workflow lane (ensureWorkflowSandboxForExecution)", () => {
         temporalConfig: executionRoutingConfig,
       },
       workflowExecution(ExecutionTarget.LOCAL),
+      TEST_CALLER_IDENTITY_ID,
     );
     await ensureWorkflowSandboxForExecution(
       {
@@ -406,6 +528,7 @@ describe("the workflow lane (ensureWorkflowSandboxForExecution)", () => {
         ),
       },
       workflowExecution(ExecutionTarget.CLOUD),
+      TEST_CALLER_IDENTITY_ID,
     );
     expect(provisioner.ensured).toEqual([]);
   });
@@ -422,6 +545,7 @@ describe("the workflow lane (ensureWorkflowSandboxForExecution)", () => {
           temporalConfig: executionRoutingConfig,
         },
         workflowExecution(ExecutionTarget.CLOUD),
+        TEST_CALLER_IDENTITY_ID,
       );
       expect.unreachable("the workflow lane must throw on failure");
     } catch (error) {

--- a/backend/services/stigmer-server/src/sandbox/lane.ts
+++ b/backend/services/stigmer-server/src/sandbox/lane.ts
@@ -13,8 +13,17 @@
  * arm degenerates to per-execution re-mint here; a disabled mint lane
  * launches the sandbox with no token and ExecutionContext decrypt falls
  * back to redaction (oss#535's posture), degraded but never dark.
+ *
+ * A provider with the mintSandboxCredential capability (C4, gate ruling
+ * Q1) owns the mint instead: the ensure steps hand it the full
+ * provisioning context and bake whatever it returns — the cloud's
+ * session/workflow-scoped tokens ride this without the steps knowing any
+ * lane vocabulary beyond their own identifiers.
  */
-import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
+import type {
+  RunnerCredentialProvider,
+  SandboxCredentialRequest,
+} from "../runnerauth/runner-credential-provider.js";
 import { TOKEN_TYPE_EXECUTION_SCOPED } from "../runnerauth/runnerauth.js";
 import type { Logger } from "../boot/logger.js";
 import type { SandboxProvisioner } from "./provisioner.js";
@@ -47,26 +56,34 @@ export function newSandboxLane(
 }
 
 /**
- * Mints the sandbox's STIGMER_TOKEN on the execution-scoped lane, or ""
- * when minting is disabled (module header). A mint FAILURE on an enabled
- * lane is a real fault and propagates to the caller's failure posture —
- * never swallowed into the no-token arm.
+ * Mints the sandbox's STIGMER_TOKEN, or "" to launch tokenless (module
+ * header). With the mintSandboxCredential capability composed, the
+ * provider owns the whole decision from the provisioning context;
+ * otherwise the OSS execution-scoped mint runs exactly as before. A mint
+ * FAILURE on an enabled lane is a real fault and propagates to the
+ * caller's failure posture — never swallowed into the no-token arm.
  */
 export function mintSandboxToken(
   lane: Extract<SandboxLane, { enabled: true }>,
-  executionId: string,
+  request: SandboxCredentialRequest,
   logger: Logger,
 ): string {
+  const mintSandboxCredential = lane.credentials.mintSandboxCredential?.bind(
+    lane.credentials,
+  );
+  if (mintSandboxCredential !== undefined) {
+    return mintSandboxCredential(request);
+  }
   if (!lane.credentials.isEnabled(TOKEN_TYPE_EXECUTION_SCOPED)) {
     logger.warn(
       "Sandbox launching without a runner token (credential lane disabled) — ExecutionContext reads will be redacted",
-      { executionId },
+      { executionId: request.executionId },
     );
     return "";
   }
   return lane.credentials.mint(
     TOKEN_TYPE_EXECUTION_SCOPED,
-    executionId,
+    request.executionId,
     SANDBOX_TOKEN_TTL_SECONDS,
   ).token;
 }

--- a/backend/services/stigmer-server/src/sandbox/steps.ts
+++ b/backend/services/stigmer-server/src/sandbox/steps.ts
@@ -98,7 +98,11 @@ export function newEnsureSessionSandboxStep(
   return {
     name: "EnsureSessionSandbox",
     async execute(ctx) {
-      await ensureSessionSandboxForExecution(deps, ctx.newState);
+      await ensureSessionSandboxForExecution(
+        deps,
+        ctx.newState,
+        ctx.callerIdentity.identityId,
+      );
     },
   };
 }
@@ -109,10 +113,16 @@ export function newEnsureSessionSandboxStep(
  * precedent wires ONE step bean into both pipelines; here the two
  * chains' differing context shapes (newState vs loaded execution) meet
  * at this seam instead.
+ *
+ * `callerIdentityId` rides into the credential mint (lane.ts): the Java
+ * ensure step mints session tokens FOR the requesting caller, so the
+ * capability mint needs the identity the OSS execution-scoped mint never
+ * did. Empty when the invoking site has no caller.
  */
 export async function ensureSessionSandboxForExecution(
   deps: EnsureSessionSandboxDeps,
   execution: AgentExecution,
+  callerIdentityId: string,
 ): Promise<void> {
   if (!deps.lane.enabled) {
     return;
@@ -150,7 +160,17 @@ export async function ensureSessionSandboxForExecution(
     }
     await lane.provisioner.ensureSessionSandbox(sessionId, {
       taskQueue: dispatch.taskQueue,
-      stigmerToken: mintSandboxToken(lane, executionId, deps.logger),
+      stigmerToken: mintSandboxToken(
+        lane,
+        {
+          scope: "session",
+          sessionId,
+          executionId,
+          org: execution.metadata?.org ?? "",
+          callerIdentityId,
+        },
+        deps.logger,
+      ),
     });
   } catch (error) {
     // Non-critical: never fail the launch — but never silent either
@@ -224,7 +244,11 @@ export function newEnsureWorkflowSandboxStep(
   return {
     name: "EnsureWorkflowSandbox",
     async execute(ctx) {
-      await ensureWorkflowSandboxForExecution(deps, ctx.newState);
+      await ensureWorkflowSandboxForExecution(
+        deps,
+        ctx.newState,
+        ctx.callerIdentity.identityId,
+      );
     },
   };
 }
@@ -234,11 +258,13 @@ export function newEnsureWorkflowSandboxStep(
  * re-provision (lifecycle.ts — the previous sandbox was deprovisioned at
  * the terminal FAILED, so a recovered execution needs a fresh one before
  * its fresh workflow starts). Throws Unavailable on provisioning failure
- * — the critical posture in both chains.
+ * — the critical posture in both chains. `callerIdentityId` rides into
+ * the credential mint exactly as on the session body.
  */
 export async function ensureWorkflowSandboxForExecution(
   deps: EnsureWorkflowSandboxDeps,
   execution: WorkflowExecution,
+  callerIdentityId: string,
 ): Promise<void> {
   if (!deps.lane.enabled) {
     return;
@@ -263,7 +289,17 @@ export async function ensureWorkflowSandboxForExecution(
   try {
     await lane.provisioner.ensureWorkflowSandbox(executionId, {
       taskQueue: dispatch.taskQueue,
-      stigmerToken: mintSandboxToken(lane, executionId, deps.logger),
+      stigmerToken: mintSandboxToken(
+        lane,
+        {
+          scope: "workflow",
+          sessionId: "",
+          executionId,
+          org: execution.metadata?.org ?? "",
+          callerIdentityId,
+        },
+        deps.logger,
+      ),
     });
   } catch (error) {
     deps.logger.error(

--- a/test/extension-consumer/package-lock.json
+++ b/test/extension-consumer/package-lock.json
@@ -43,6 +43,7 @@
         "@bufbuild/protovalidate": "^1.1.1",
         "@connectrpc/connect": "^2.0.0",
         "@connectrpc/connect-node": "^2.0.0",
+        "@kubernetes/client-node": "2.0.0",
         "@stigmer/protos": "file:../../../apis/stubs/ts",
         "@stigmer/temporal-codecs": "file:../../libs/ts/temporal-codecs",
         "@stigmer/zip-structure": "file:../../libs/ts/zip-structure",
@@ -53,6 +54,7 @@
         "@temporalio/worker": "1.16.2",
         "@temporalio/workflow": "1.16.2",
         "fflate": "^0.8.3",
+        "jose": "6.2.10",
         "js-yaml": "^4.3.1",
         "pg": "8.23.0",
         "ulidx": "2.4.1"

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -54,7 +54,11 @@ import type {
   ModelCatalogProvider,
   PipelineStep,
   PresignedUpload,
+  RunnerBootstrapCredentials,
   RunnerCredentialProvider,
+  RunnerScopedTokenExchange,
+  RunnerScopedTokenRequest,
+  SandboxCredentialRequest,
   SandboxProvisioner,
   SandboxProvisionerFactory,
   ServerExtension,
@@ -159,6 +163,26 @@ const credentialProvider: RunnerCredentialProvider = {
   verify: (): string => {
     throw new InvalidTokenError();
   },
+  // The C4 capability methods (gate ruling Q1): the four edition-policy
+  // touchpoints a composition may take over — the platform exchange, the
+  // bootstrap credential fields, the sandbox-provisioning mint, and the
+  // ExecutionContext decrypt trust decision. All optional; this consumer
+  // proves the shapes compile against the exports map alone.
+  exchangeScopedToken: async (
+    request: RunnerScopedTokenRequest,
+  ): Promise<RunnerScopedTokenExchange> => {
+    if (request.arm === "unset") {
+      return { minted: false };
+    }
+    return { minted: true, token: "fake-scoped-token", expiresInSeconds: 60 };
+  },
+  bootstrapCredentials: async (): Promise<RunnerBootstrapCredentials> => ({
+    accessToken: { token: "fake-bootstrap-token", expiresInSeconds: 60 },
+    payloadKeys: { keyId: "rpk_fake", keyBase64: "a2V5" },
+  }),
+  mintSandboxCredential: (request: SandboxCredentialRequest): string =>
+    `fake-${request.scope}-token`,
+  authorizeExecutionContextRead: async (): Promise<boolean> => false,
 };
 
 /**
@@ -243,6 +267,9 @@ export const fakeExtension: ServerExtension = {
   gateSteps: new Map<GateSlotName, ReadonlyArray<PipelineStep<DescMessage>>>([
     ["agent-execution-create:pre-side-effect-gate", [consumerGateStep()]],
     ["org-create:post-persist", [consumerGateStep()]],
+    // The sixth ratified slot (C4): the workflow-execution chains'
+    // capacity-gate position.
+    ["sandbox-acquisition:gate", [consumerGateStep()]],
   ]),
   statusTransitionHooks: {
     observers: [statusObserver],


### PR DESCRIPTION
## Summary
The OSS-side seam work of the convergence program's C4 entry (`20260827.09.sp.fleet-ops-and-runner-credentials`, cross-repo per O4 ruling Q1): the `RunnerCredentialProvider` gains four OPTIONAL capability methods carrying the edition-specific runner-credential policy, and the sixth ratified gate slot `sandbox-acquisition:gate` is declared and spliced in the workflow-execution chains. With no extension composed, every touched path behaves byte-identically to main — proven by all four local conformance rosters.

## Context
The cloud edition's runner credentials surface at four OSS-owned touchpoints whose policy is edition-specific: the platform scoped-token exchange (four arms with per-arm credential classes and row-level authorization), the bootstrap credential/payload-key response, the token baked into a provisioned sandbox, and the ExecutionContext decrypt trust decision. The proto (`server_info.proto`) already documents the full contract — only the handlers hard-coded the OSS-only arms. Separately, O4's plan gate deferred the sixth ratified slot to "the entry that builds the gated provisioning splice" (recorded in `gate-slots.ts`); the Java-verified position is the workflow-execution create/recover chains' post-authorize pre-side-effect point (cloud#355's 7c/3b), which had no slot.

## Changes
- `runnerauth/runner-credential-provider.ts`: four optional, domain-shaped capability methods — `exchangeScopedToken` (the whole four-arm exchange policy, including the honest `unset` arm), `bootstrapCredentials` (token + payload-key fields), `mintSandboxCredential` (the provisioning-time mint with full context), `authorizeExecutionContextRead` (the decrypt trust decision) — with per-method fallback contracts documented at each call site.
- `domain/platform/controller.ts`: delegates the exchange and bootstrap-credential portions to the capability methods when present; byte-identical fallback otherwise; bootstrap capability failures degrade to coordinates-only (the Java handler's best-effort contract).
- `sandbox/lane.ts` + `sandbox/steps.ts`: the ensure steps hand the full provisioning context (`scope`, session/execution ids, org, caller identity) to `mintSandboxCredential` when present; the OSS execution-scoped mint is the unchanged fallback. `SandboxEnvironment` itself is untouched.
- `domain/executioncontext/resolve-values-for-caller.ts`: the capability, when present, IS the decrypt trust decision; a throwing capability falls closed to redaction (redaction-as-success survives policy faults). Now async; single call site awaited.
- `extensions/gate-slots.ts`: declares `sandbox-acquisition:gate` (all six ratified names now live); the header records the arrival, closing O4 ruling Q1's deferral.
- `domain/workflowexecution/controller.ts` + `lifecycle.ts`: the slot spliced at the Java-verified positions — create: after `NormalizeReferences`, before `SetInitialPhase`; recover: after `ValidateRecoverable`, before `TerminateExistingWorkflow`. `gateSteps` wired through compose.
- ts-server guidelines: the slot table gains its sixth row (code and table match exactly).
- `test/extension-consumer`: the fake extension exercises every new surface (compile proof against the exports map alone).

## Implementation notes
- Capability methods on the ONE provider seam rather than a second single-instance driver: one cloud object owns the edition's whole credential story (C4 plan-gate ruling Q1; the alternative split it across two objects with the same single consumer).
- The exchange request union carries an explicit `unset` arm rather than collapsing it into `renewal` — the implementation owns the unset refusal (Java answers INVALID_ARGUMENT), and protovalidate refuses it upstream on both editions anyway.
- The session lane's capacity gates need no new slot: the Java session capacity-gate position coincides exactly with the already-declared `agent-execution-create/recover:pre-side-effect-gate` positions.

## Breaking changes
- None on the wire. Two internal signatures widened (`mintSandboxToken` takes the credential request; the ensure bodies take the caller identity id) — both module-internal to the server package.

## Test plan
- All four local conformance rosters byte-identical to main: local 498, local-execution 160, local-postgres 498, local-postgres-execution 160 (Node 22.22.1).
- Server units: 1942 passed (new: full-stack capability-delegation suite on a composed server with an extension-registered provider — arm mapping, caller-identity threading, refusal propagation, bootstrap merge + degrade; sandbox-mint delegation with full-context assertions; EC decrypt capability matrix incl. fail-closed-on-throw).
- `tsc --noEmit` clean on the server and the extension-consumer compile proof.

## Risks
- Low: every new path is behind optional methods the OSS default never defines; the rosters pin the fallback arms. Rollback is a revert — no schema, no wire, no workflow changes.

## Checklist
- [x] Docs updated (guidelines slot table; module intent headers)
- [x] Tests added/updated
- [x] Backward compatible

Made with [Cursor](https://cursor.com)