### PR TITLE
feat(backend/stigmer-server): add the resource-authorization lifecycle and organization-directory seams (C2)

### DIFF
--- a/.cursor/rules/backend/ts-server-guidelines.mdc
+++ b/.cursor/rules/backend/ts-server-guidelines.mdc
@@ -82,6 +82,27 @@ eventually violate creatively.
   chain-internal skip shortcuts (idempotent-replay flags) — a gate owns
   its own idempotency; a gate refuses by throwing a `ConnectError` with
   the correct code and byte-pinned copy, exactly as OSS steps do.
+- **The tuple-lifecycle steps are part of every resource chain** (C2,
+  20260827.10 ruling Q2 — the config-driven port of the cloud's
+  CreateAuthorizationTuplesStepV2 machinery). Three shared steps in
+  `src/pipeline/steps/authorization-tuples.ts`, no-ops unless a
+  composition registers `drivers.resourceAuthorizationLifecycle`:
+  `CreateAuthorizationTuples` (post-Persist in EVERY create chain — in
+  the org chain BEFORE the `org-create:post-persist` slot, the verified
+  Java order; a driver failure fails the request, the row survives),
+  `CleanupIamPolicies` (after the store delete, best-effort — never
+  fails the delete), and `UpdateVisibilityTuples` (post-persist in every
+  updateVisibility chain, paired with `RecordVisibilityBeforeUpdate`
+  after the load). A NEW create/delete/updateVisibility chain MUST
+  splice the matching step; the skill push lane has a domain-local
+  adapter (`SkillPushAuthorizationTuples` — push is an upsert whose
+  message is the request, not the resource). All resolution (kind
+  config from `kind_meta`, parent ids from `spec_field` reflection, the
+  visibility shape diff with its org floor) is OSS-owned and
+  edition-neutral; drivers receive resolved events and write tuples.
+  The organization query forks (enumeration refusal, my-orgs filtering,
+  `getByExternalOrgId`) ride the `drivers.organizationDirectory` point —
+  never a second registration of an OSS-served RPC.
 - **Status-transition hooks fire from EVERY phase-transition persist
   site**, not one chokepoint (O4 ruling Q3) — the five sites are
   enumerated in `src/domain/agentexecution/status-observers.ts`, and a

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -226,6 +226,13 @@ export async function composeServer(
   // position 1 of every chain calls it (O2).
   const authorizer =
     extensions.authorizer ?? newPermissiveSingleTeamAuthorizer();
+  // The C2 tuple-lifecycle driver (ruling Q2): undefined = the three
+  // shared tuple steps (CreateAuthorizationTuples / CleanupIamPolicies /
+  // UpdateVisibilityTuples) no-op — OSS behavior byte-identical. Handed
+  // to every resource controller as an explicit dependency, the same
+  // threading as the authorizer.
+  const authorizationLifecycle =
+    extensions.drivers.resourceAuthorizationLifecycle;
 
   // Stage: storage — the driver selection seam (DD-010): DATABASE_URL
   // present → Postgres (async connect + advisory-locked migrations), else
@@ -684,18 +691,26 @@ export async function composeServer(
       logger,
       authorizer,
       gateSteps: extensions.gateSteps,
+      authorizationLifecycle,
+      organizationDirectory: extensions.drivers.organizationDirectory,
     });
     // ApiKey is the first domain born AFTER the Go port (O3, 20260827.06 —
     // DD-003: the apikey contract is wholly OSS), so it has no Go
     // registration order to mirror; it registers with the tenancy/IAM
     // family at the top. The chassis's apikey VERIFIER shares this
     // domain's lookup module — not the RPC (domain/apikey/lookup.ts).
-    registerApiKeyServices(router, { store, logger, authorizer });
+    registerApiKeyServices(router, {
+      store,
+      logger,
+      authorizer,
+      authorizationLifecycle,
+    });
     registerEnvironmentServices(router, {
       store,
       logger,
       authorizer,
       secretService,
+      authorizationLifecycle,
     });
     // OAuthApp reuses the environment's SecretService instance — Go wires
     // ONE encryption service for both (server.go 302–307).
@@ -704,6 +719,7 @@ export async function composeServer(
       secretService,
       logger,
       authorizer,
+      authorizationLifecycle,
     });
     registerExecutionContextServices(router, {
       store,
@@ -711,17 +727,20 @@ export async function composeServer(
       authorizer,
       secretService,
       runnerAuthService: runnerCredentials,
+      authorizationLifecycle,
     });
     registerAgentServices(router, {
       store,
       logger,
       authorizer,
+      authorizationLifecycle,
       agentInstanceApplier: () => requireInProcess().agentInstanceApplier,
     });
     registerAgentInstanceServices(router, {
       store,
       logger,
       authorizer,
+      authorizationLifecycle,
       parentAgentLoader: () => requireInProcess().parentAgentLoader,
     });
     registerSessionServices(router, {
@@ -732,17 +751,24 @@ export async function composeServer(
       agentInstanceCreator: () => requireInProcess().agentInstanceCreator,
       gateSteps: extensions.gateSteps,
       sandboxLane,
+      authorizationLifecycle,
     });
     // The sharing/channel family registers after the agent family, as in
     // Go server.go (agent 378 → agentshare 384 → agentchannel 391 →
     // channelmessage 399 → channelconversation 408 → channelapp 416).
     // ChannelApp shares the ONE SecretService instance with Environment —
     // one key, one enc:v1: format (Go wires the same pointer).
-    registerAgentShareServices(router, { store, logger, authorizer });
+    registerAgentShareServices(router, {
+      store,
+      logger,
+      authorizer,
+      authorizationLifecycle,
+    });
     registerAgentChannelServices(router, {
       store,
       logger,
       authorizer,
+      authorizationLifecycle,
       // The SAME domain-owned registry instance the workflow validator
       // and the registry lanes read — the channel model-pin rule
       // (stigmer/stigmer#774) can never drift from the served pickers.
@@ -755,6 +781,7 @@ export async function composeServer(
       logger,
       authorizer,
       secretService,
+      authorizationLifecycle,
     });
     // Schedule registers between channelapp and memory (Go server.go
     // 417 → 426 → 436). The clock and runner ride constant providers —
@@ -768,12 +795,19 @@ export async function composeServer(
       modelRegistry: modelCatalog,
       clock: () => scheduleSyncer,
       runner: () => scheduleRunStarter,
+      authorizationLifecycle,
     });
-    registerMemoryServices(router, { store, logger, authorizer });
+    registerMemoryServices(router, {
+      store,
+      logger,
+      authorizer,
+      authorizationLifecycle,
+    });
     registerAgentExecutionServices(router, {
       store,
       logger,
       authorizer,
+      authorizationLifecycle,
       broker: agentExecutionStreamBroker,
       engineState: executionEngineState,
       modelRegistry: modelCatalog,
@@ -805,6 +839,7 @@ export async function composeServer(
       store,
       logger,
       authorizer,
+      authorizationLifecycle,
       validator: workflowValidator,
       workflowInstanceCreator: () => requireInProcess().workflowInstanceCreator,
     });
@@ -812,12 +847,14 @@ export async function composeServer(
       store,
       logger,
       authorizer,
+      authorizationLifecycle,
       parentWorkflowLoader: () => requireInProcess().parentWorkflowLoader,
     });
     registerWorkflowExecutionServices(router, {
       store,
       logger,
       authorizer,
+      authorizationLifecycle,
       engineState: workflowExecutionEngineState,
       broker: workflowExecutionStreamBroker,
       sandboxLane,
@@ -848,6 +885,7 @@ export async function composeServer(
       store,
       logger,
       authorizer,
+      authorizationLifecycle,
       connect: {
         store,
         logger,
@@ -878,6 +916,7 @@ export async function composeServer(
       store,
       logger,
       authorizer,
+      authorizationLifecycle,
       artifactStorage: skillArtifactStorage,
       // The agentexecution blob store (server.go:362-363) — read side of
       // pushFromExecutionArtifact.
@@ -904,6 +943,7 @@ export async function composeServer(
       store,
       logger,
       authorizer,
+      authorizationLifecycle,
       orphanDeleter: () => requireInProcess().projectOrphanDeleter,
     });
     // The two CQRS query services register between the domains and the

--- a/backend/services/stigmer-server/src/domain/agent/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agent/controller.ts
@@ -62,6 +62,7 @@ import {
 import {
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
+  withResolvedApplyId,
 } from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
 import {
@@ -219,7 +220,8 @@ async function update(
 /**
  * Apply — kubectl-style create-or-update: a minimal probe pipeline decides
  * existence, then delegates to Create or Update with the ORIGINAL request
- * message (Go delegates `agent`, not the pipeline's mutated clone).
+ * message (Go delegates `agent`, not the pipeline's mutated clone);
+ * the update arm carries the resolved id via withResolvedApplyId.
  */
 async function apply(
   deps: AgentControllerDeps,
@@ -251,7 +253,7 @@ async function apply(
   }
   return shouldCreate
     ? createAgent(deps, agent, ctx)
-    : update(deps, agent, ctx);
+    : update(deps, withResolvedApplyId(AgentSchema, agent, reqCtx), ctx);
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/agent/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agent/controller.ts
@@ -32,6 +32,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError, notFoundError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -71,6 +72,12 @@ import {
   newNormalizeReferencesStep,
   newValidateReferencesStep,
 } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+  newRecordVisibilityBeforeUpdateStep,
+  newUpdateVisibilityTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -96,6 +103,8 @@ export interface AgentControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   /**
    * The agentinstance in-process edge — a lazy provider because
    * agent↔agentinstance is a true dependency cycle (DD-002; the ratified
@@ -158,6 +167,12 @@ async function createAgent(
     .addStep(newValidateEnabledToolsStep(deps.store))
     .addStep(newMergeMcpServerEnvSpecsStep(deps.store, deps.logger))
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(
       newCreateDefaultInstanceStep(deps.agentInstanceApplier, deps.logger),
     )
@@ -268,6 +283,9 @@ async function deleteAgent(
     .addStep(newCascadeDeleteInstancesStep(deps.store, deps.logger))
     .addStep(newCascadeDeleteSharesStep(deps.store, deps.logger))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);
@@ -317,9 +335,16 @@ async function updateVisibility(
     )
     .addStep(newValidateProtoStep())
     .addStep(newLoadAgentForVisibilityUpdateStep(deps.store))
+    .addStep(newRecordVisibilityBeforeUpdateStep(UPDATE_VISIBILITY_AGENT_KEY))
     .addStep(newValidateVisibilityUpdateStep())
     .addStep(newSetAgentVisibilityStep())
     .addStep(newPersistAgentForVisibilityUpdateStep(deps.store))
+    .addStep(
+      newUpdateVisibilityTuplesStep(
+        deps.authorizationLifecycle,
+        UPDATE_VISIBILITY_AGENT_KEY,
+      ),
+    )
     .addStep(newIndexAgentAfterVisibilityUpdateStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
@@ -46,6 +46,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
   failedPreconditionError,
@@ -83,6 +84,10 @@ import {
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -101,6 +106,8 @@ export interface AgentChannelControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   readonly modelRegistry: ModelCatalogProvider;
 }
 
@@ -164,6 +171,12 @@ async function createChannel(
     .addStep(newInitInstallStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -336,6 +349,9 @@ async function deleteChannel(
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, AgentChannelSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .build()
     .execute(reqCtx);
 

--- a/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
@@ -30,6 +30,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
 import { stepsForSlot } from "../../extensions/gate-slots.js";
 import type {
@@ -61,6 +62,10 @@ import {
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -136,6 +141,8 @@ export interface AgentExecutionControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   /**
    * The shared broadcast fabric for subscribe streams. ONE instance spans
    * both routers (serving + in-process) — see stream-broker.ts; the
@@ -325,6 +332,12 @@ async function createExecution(
     .addStep(newProcessAttachmentsStep(deps.logger))
     .addStep(newPersistStep(deps.store))
     .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
+    .addStep(
       newIndexSearchStep(
         deps.store,
         agentExecutionSearchExtractor,
@@ -433,6 +446,9 @@ async function deleteExecution(
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, AgentExecutionSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/agentinstance/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentinstance/controller.ts
@@ -38,6 +38,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError, notFoundError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -74,6 +75,12 @@ import {
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+  newRecordVisibilityBeforeUpdateStep,
+  newUpdateVisibilityTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -100,6 +107,8 @@ export interface AgentInstanceControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   /**
    * The agent in-process edge — a lazy provider because
    * agent↔agentinstance is a true dependency cycle (DD-002; the ratified
@@ -167,6 +176,12 @@ async function createInstance(
     .addStep(newBuildNewStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(
       newIndexSearchStep(deps.store, agentInstanceSearchExtractor, deps.logger),
     )
@@ -283,6 +298,9 @@ async function deleteInstance(
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, AgentInstanceSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);
@@ -330,10 +348,19 @@ async function updateVisibility(
     )
     .addStep(newValidateProtoStep())
     .addStep(newLoadInstanceForVisibilityUpdateStep(deps.store))
+    .addStep(
+      newRecordVisibilityBeforeUpdateStep(UPDATE_VISIBILITY_INSTANCE_KEY),
+    )
     .addStep(newRejectDefaultInstanceVisibilityUpdateStep(deps.store))
     .addStep(newValidateVisibilityUpdateStep())
     .addStep(newSetInstanceVisibilityStep())
     .addStep(newPersistInstanceForVisibilityUpdateStep(deps.store))
+    .addStep(
+      newUpdateVisibilityTuplesStep(
+        deps.authorizationLifecycle,
+        UPDATE_VISIBILITY_INSTANCE_KEY,
+      ),
+    )
     .addStep(newIndexInstanceAfterVisibilityUpdateStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/agentinstance/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentinstance/controller.ts
@@ -68,6 +68,7 @@ import {
 import {
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
+  withResolvedApplyId,
 } from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
 import {
@@ -229,7 +230,8 @@ async function update(
 
 /**
  * Apply — kubectl-style create-or-update; delegates with the ORIGINAL
- * request message. The create route is the default-instance path (the
+ * request message (the update arm carries the resolved id via
+ * withResolvedApplyId). The create route is the default-instance path (the
  * agent controller's CreateDefaultInstance applies through here); the
  * update route is the self-heal for pre-cascade legacy orphans.
  */
@@ -269,7 +271,11 @@ async function apply(
   }
   return shouldCreate
     ? createInstance(deps, instance, ctx)
-    : update(deps, instance, ctx);
+    : update(
+        deps,
+        withResolvedApplyId(AgentInstanceSchema, instance, reqCtx),
+        ctx,
+      );
 }
 
 /** Delete — no cascade of its own; returns the deleted instance. */

--- a/backend/services/stigmer-server/src/domain/agentshare/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentshare/controller.ts
@@ -46,6 +46,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
   internalError,
@@ -86,6 +87,10 @@ import {
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -108,6 +113,8 @@ export interface AgentShareControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
 }
 
 /** Registers both agentshare services on the router (routes stage). */
@@ -170,6 +177,12 @@ async function createShare(
     .addStep(newStampAgentPinStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -406,6 +419,9 @@ async function deleteShare(
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, AgentShareSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .build()
     .execute(reqCtx);
 

--- a/backend/services/stigmer-server/src/domain/apikey/controller.ts
+++ b/backend/services/stigmer-server/src/domain/apikey/controller.ts
@@ -40,6 +40,7 @@ import type {
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { internalError } from "../../pipeline/errors.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
@@ -62,6 +63,10 @@ import {
   TARGET_RESOURCE_KEY,
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
@@ -79,6 +84,8 @@ export interface ApiKeyControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
 }
 
 /** Registers both apikey services on the router (routes stage). */
@@ -129,6 +136,12 @@ async function createApiKey(
     .addStep(newBuildNewStateStep())
     .addStep(newGenerateApiKeyStep())
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(newReplaceHashWithPlainTextStep())
     .build()
     .execute(reqCtx);
@@ -188,6 +201,9 @@ async function deleteApiKey(
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, ApiKeySchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .build()
     .execute(reqCtx);
 

--- a/backend/services/stigmer-server/src/domain/channelapp/controller.ts
+++ b/backend/services/stigmer-server/src/domain/channelapp/controller.ts
@@ -42,6 +42,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError } from "../../pipeline/errors.js";
@@ -72,6 +73,10 @@ import {
   TARGET_RESOURCE_KEY,
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -90,6 +95,8 @@ export interface ChannelAppControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   readonly secretService: SecretService;
 }
 
@@ -149,6 +156,12 @@ async function createChannelApp(
     )
     .addStep(newBuildNewStateStep())
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .build()
     .execute(reqCtx);
   redactChannelApp(reqCtx.newState);
@@ -274,6 +287,9 @@ async function deleteChannelApp(
     .addStep(newLoadExistingForDeleteStep(deps.store, ChannelAppSchema))
     .addStep(newCheckNoReferencingChannelsStep(deps.store, deps.logger))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .build()
     .execute(reqCtx);
 

--- a/backend/services/stigmer-server/src/domain/channelapp/controller.ts
+++ b/backend/services/stigmer-server/src/domain/channelapp/controller.ts
@@ -67,6 +67,7 @@ import {
 import {
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
+  withResolvedApplyId,
 } from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
 import {
@@ -213,7 +214,8 @@ async function update(
  * minimal probe pipeline decides existence, then delegates to Create or
  * Update with the ORIGINAL request message (Go delegates `app`, not the
  * pipeline's clone — unlike agentshare/agentchannel, whose defaults live
- * on the clone; channelapp's Update re-resolves the slug itself). Sending
+ * on the clone; channelapp's Update re-resolves the slug itself); the
+ * update arm carries the resolved id via withResolvedApplyId. Sending
  * the marker for a secret field on an apply that resolves to update
  * preserves the stored value; on an apply that resolves to create it is
  * refused — there is nothing to preserve.
@@ -251,7 +253,7 @@ async function apply(
   }
   return shouldCreate
     ? createChannelApp(deps, app, ctx)
-    : update(deps, app, ctx);
+    : update(deps, withResolvedApplyId(ChannelAppSchema, app, reqCtx), ctx);
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/environment/controller.ts
+++ b/backend/services/stigmer-server/src/domain/environment/controller.ts
@@ -43,6 +43,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
@@ -88,6 +89,12 @@ import {
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+  newRecordVisibilityBeforeUpdateStep,
+  newUpdateVisibilityTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -116,6 +123,8 @@ export interface EnvironmentControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   readonly secretService: SecretService;
 }
 
@@ -178,6 +187,12 @@ async function createEnvironment(
     .addStep(newPreserveRedactedSecretsStep())
     .addStep(newEncryptSecretValuesStep(deps.secretService, deps.logger))
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(
       newIndexSearchStep(deps.store, environmentSearchExtractor, deps.logger),
     )
@@ -296,6 +311,9 @@ async function deleteEnvironment(
     .addStep(newValidateProtoStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, EnvironmentSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);
@@ -348,12 +366,21 @@ async function updateVisibility(
     )
     .addStep(newValidateProtoStep())
     .addStep(newLoadEnvironmentForVisibilityUpdateStep(deps.store))
+    .addStep(
+      newRecordVisibilityBeforeUpdateStep(UPDATE_VISIBILITY_ENVIRONMENT_KEY),
+    )
     // After load, per the cross-edition error precedence: unknown id +
     // bad level = NOT_FOUND on both editions.
     .addStep(newValidateVisibilityUpdateStep())
     .addStep(newValidateEnvironmentShareRestrictionStep())
     .addStep(newSetEnvironmentVisibilityStep())
     .addStep(newPersistEnvironmentForVisibilityUpdateStep(deps.store))
+    .addStep(
+      newUpdateVisibilityTuplesStep(
+        deps.authorizationLifecycle,
+        UPDATE_VISIBILITY_ENVIRONMENT_KEY,
+      ),
+    )
     .addStep(
       newIndexEnvironmentAfterVisibilityUpdateStep(deps.store, deps.logger),
     )

--- a/backend/services/stigmer-server/src/domain/environment/controller.ts
+++ b/backend/services/stigmer-server/src/domain/environment/controller.ts
@@ -82,6 +82,7 @@ import {
 import {
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
+  withResolvedApplyId,
 } from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
 import {
@@ -241,7 +242,8 @@ async function update(
 /**
  * Apply — kubectl-style create-or-update: a minimal probe pipeline decides
  * existence, then delegates to Create or Update with the ORIGINAL request
- * message (Go delegates `environment`, not the pipeline's mutated clone).
+ * message (Go delegates `environment`, not the pipeline's mutated clone);
+ * the update arm carries the resolved id via withResolvedApplyId.
  */
 async function apply(
   deps: EnvironmentControllerDeps,
@@ -276,7 +278,7 @@ async function apply(
   }
   return shouldCreate
     ? createEnvironment(deps, env, ctx)
-    : update(deps, env, ctx);
+    : update(deps, withResolvedApplyId(EnvironmentSchema, env, reqCtx), ctx);
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
@@ -48,6 +48,7 @@ import type {
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { alreadyExistsError, internalError } from "../../pipeline/errors.js";
@@ -77,6 +78,10 @@ import {
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -97,6 +102,8 @@ export interface ExecutionContextControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   /**
    * Shared with the Environment/OAuthApp controllers so the
    * encrypt-on-write / decrypt-on-read key pair always matches.
@@ -171,6 +178,12 @@ async function createExecutionContext(
     .addStep(newNormalizeReferencesStep())
     .addStep(newEncryptSecretValuesStep(deps.secretService, deps.logger))
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(
       newIndexSearchStep(
         deps.store,
@@ -269,6 +282,9 @@ async function deleteExecutionContext(
     .addStep(newValidateProtoStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, ExecutionContextSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/mcpserver/controller.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/controller.ts
@@ -75,6 +75,7 @@ import {
 import {
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
+  withResolvedApplyId,
 } from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
 import {
@@ -269,7 +270,8 @@ async function update(
 
 /**
  * Apply — kubectl-style create-or-update: a minimal probe pipeline
- * decides existence, then delegates with the ORIGINAL request message.
+ * decides existence, then delegates with the ORIGINAL request message
+ * (the update arm carries the resolved id via withResolvedApplyId).
  *
  * The tail fires startBestEffortConnect on the result — Go's
  * `go StartBestEffortConnect(result)` (apply.go:76), auto discovery
@@ -310,7 +312,11 @@ async function apply(
   }
   const result = shouldCreate
     ? await createMcpServer(deps, server, ctx)
-    : await update(deps, server, ctx);
+    : await update(
+        deps,
+        withResolvedApplyId(McpServerSchema, server, reqCtx),
+        ctx,
+      );
 
   // startBestEffortConnect's arms never throw by design; the catch is
   // the process-safety net an unhandled rejection would pierce.

--- a/backend/services/stigmer-server/src/domain/mcpserver/controller.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/controller.ts
@@ -45,6 +45,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError, notFoundError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -81,6 +82,12 @@ import {
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+  newRecordVisibilityBeforeUpdateStep,
+  newUpdateVisibilityTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -107,6 +114,8 @@ export interface McpServerControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   /** The connect/OAuth slice's dependencies (D4 #19). */
   readonly connect: McpServerConnectDeps;
 }
@@ -206,6 +215,12 @@ async function createMcpServer(
     .addStep(newBuildNewStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(
       newIndexSearchStep(deps.store, mcpServerSearchExtractor, deps.logger),
     )
@@ -340,6 +355,9 @@ async function deleteMcpServer(
     .addStep(newValidateProtoStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, McpServerSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);
@@ -388,9 +406,18 @@ async function updateVisibility(
     )
     .addStep(newValidateProtoStep())
     .addStep(newLoadMcpServerForVisibilityUpdateStep(deps.store))
+    .addStep(
+      newRecordVisibilityBeforeUpdateStep(UPDATE_VISIBILITY_MCP_SERVER_KEY),
+    )
     .addStep(newValidateVisibilityUpdateStep())
     .addStep(newSetMcpServerVisibilityStep())
     .addStep(newPersistMcpServerForVisibilityUpdateStep(deps.store))
+    .addStep(
+      newUpdateVisibilityTuplesStep(
+        deps.authorizationLifecycle,
+        UPDATE_VISIBILITY_MCP_SERVER_KEY,
+      ),
+    )
     .addStep(
       newIndexMcpServerAfterVisibilityUpdateStep(deps.store, deps.logger),
     )

--- a/backend/services/stigmer-server/src/domain/memory/controller.ts
+++ b/backend/services/stigmer-server/src/domain/memory/controller.ts
@@ -68,6 +68,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -90,6 +91,10 @@ import {
   TARGET_RESOURCE_KEY,
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -116,6 +121,8 @@ export interface MemoryControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
 }
 
 /** Registers both memory services on the router (routes stage). */
@@ -180,6 +187,12 @@ async function createMemory(
     .addStep(newBuildNewStateStep())
     .addStep(newInitializeMemoryLifecycleStep())
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .build()
     .execute(reqCtx);
   return reqCtx.newState;
@@ -366,6 +379,9 @@ async function deleteMemory(
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, MemorySchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .build()
     .execute(reqCtx);
 

--- a/backend/services/stigmer-server/src/domain/oauthapp/controller.ts
+++ b/backend/services/stigmer-server/src/domain/oauthapp/controller.ts
@@ -43,6 +43,7 @@ import { OAuthAppQueryController } from "@stigmer/protos/ai/stigmer/iam/oauthapp
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import { internalError } from "../../pipeline/errors.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
@@ -73,6 +74,10 @@ import {
   TARGET_RESOURCE_KEY,
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -91,6 +96,8 @@ export interface OAuthAppControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
 }
 
 /** Registers both OAuthApp services on the router (routes stage). */
@@ -149,6 +156,12 @@ async function createOAuthApp(
     )
     .addStep(newBuildNewStateStep())
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .build()
     .execute(reqCtx);
   const result = reqCtx.newState;
@@ -265,6 +278,9 @@ async function deleteOAuthApp(
     .addStep(newLoadExistingForDeleteStep(deps.store, OAuthAppSchema))
     .addStep(newCheckNoReferencingMcpServersStep(deps.store, deps.logger))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .build()
     .execute(reqCtx);
 

--- a/backend/services/stigmer-server/src/domain/oauthapp/controller.ts
+++ b/backend/services/stigmer-server/src/domain/oauthapp/controller.ts
@@ -68,6 +68,7 @@ import {
 import {
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
+  withResolvedApplyId,
 } from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
 import {
@@ -211,7 +212,8 @@ async function update(
 /**
  * Apply — kubectl-style idempotent create-or-update: a minimal pipeline
  * decides existence, then delegates to Create or Update with the ORIGINAL
- * request message (Go delegates `app`, not the pipeline's mutated clone).
+ * request message (Go delegates `app`, not the pipeline's mutated clone);
+ * the update arm carries the resolved id via withResolvedApplyId.
  */
 async function apply(
   deps: OAuthAppControllerDeps,
@@ -241,7 +243,9 @@ async function apply(
       "apply operation failed to determine create vs update",
     );
   }
-  return shouldCreate ? createOAuthApp(deps, app, ctx) : update(deps, app, ctx);
+  return shouldCreate
+    ? createOAuthApp(deps, app, ctx)
+    : update(deps, withResolvedApplyId(OAuthAppSchema, app, reqCtx), ctx);
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/organization/controller.ts
+++ b/backend/services/stigmer-server/src/domain/organization/controller.ts
@@ -80,6 +80,7 @@ import {
 import {
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
+  withResolvedApplyId,
 } from "../../pipeline/steps/load-for-apply.js";
 import {
   newLoadTargetStep,
@@ -253,7 +254,8 @@ async function update(
 /**
  * Apply — kubectl-style idempotent create-or-update: a minimal pipeline
  * decides existence, then delegates to Create or Update with the ORIGINAL
- * request message (Go delegates `org`, not the pipeline's mutated clone).
+ * request message (Go delegates `org`, not the pipeline's mutated clone);
+ * the update arm carries the resolved id via withResolvedApplyId.
  */
 async function apply(
   deps: OrganizationControllerDeps,
@@ -291,7 +293,7 @@ async function apply(
   }
   return shouldCreate
     ? createOrganization(deps, org, ctx)
-    : update(deps, org, ctx);
+    : update(deps, withResolvedApplyId(OrganizationSchema, org, reqCtx), ctx);
 }
 
 /** Delete — returns the deleted organization (gRPC audit-trail convention). */

--- a/backend/services/stigmer-server/src/domain/organization/controller.ts
+++ b/backend/services/stigmer-server/src/domain/organization/controller.ts
@@ -8,17 +8,22 @@
  * organization.conformance.test.ts (CONFORMANCE_TARGET=local) and
  * __tests__/organization.test.ts.
  *
- * getByExternalOrgId is DELIBERATELY not implemented: it is the single
- * genuinely Unimplemented RPC across all registered domains (Go falls to
- * the embedded Unimplemented struct; here the method is simply absent from
- * the partial service implementation, and ConnectRPC answers Unimplemented)
- * — the SDK capability-probes this and must see UNIMPLEMENTED, not
- * NotFound (conformance pins it via externalOrgLookup=false).
+ * getByExternalOrgId is implemented ONLY when the composed
+ * OrganizationDirectory provides the lookup (C2, ruling Q7) — with no
+ * directory the method stays absent from the partial service
+ * implementation and ConnectRPC answers Unimplemented (the SDK
+ * capability-probes this and must see UNIMPLEMENTED, not NotFound;
+ * conformance pins it via externalOrgLookup=false). The directory also
+ * carries the other two edition forks: find's enumeration posture and
+ * findMyOrganizations' filtering (see organization-directory.ts).
  *
- * Versus Stigmer Cloud, OSS excludes the Authorize, CreateIamPolicies, and
- * Publish steps (no multi-tenant auth, IAM/FGA, or event publishing here).
+ * Versus Stigmer Cloud's Java service, plain OSS excludes the
+ * CreateIamPolicies and Publish steps; with the C2 seam composed, the
+ * CreateAuthorizationTuples/CleanupIamPolicies steps deliver the same
+ * lifecycle through the resourceAuthorizationLifecycle driver.
  */
 import type { ConnectRouter, HandlerContext } from "@connectrpc/connect";
+import { Code, ConnectError } from "@connectrpc/connect";
 import { fromBinary } from "@bufbuild/protobuf";
 import { create } from "@bufbuild/protobuf";
 
@@ -33,6 +38,7 @@ import {
   OrganizationsSchema,
 } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/io_pb";
 import type {
+  OrganizationExternalLookup,
   OrganizationId,
   OrganizationList,
   Organizations,
@@ -42,8 +48,15 @@ import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
 import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
 import { stepsForSlot } from "../../extensions/gate-slots.js";
+import { ALL_ORGANIZATIONS } from "../../extensions/organization-directory.js";
+import type { OrganizationDirectory } from "../../extensions/organization-directory.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
-import { internalError } from "../../pipeline/errors.js";
+import {
+  internalError,
+  invalidArgumentError,
+  notFoundError,
+} from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
@@ -72,10 +85,15 @@ import {
   newLoadTargetStep,
   TARGET_RESOURCE_KEY,
 } from "../../pipeline/steps/load-target.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
 import { organizationSearchExtractor } from "./search-extractor.js";
 import { newCheckOrgDuplicateStep, newCopySlugToIdStep } from "./steps.js";
@@ -87,6 +105,10 @@ export interface OrganizationControllerDeps {
   readonly authorizer: Authorizer;
   /** The composed slot registrations — this domain's post-persist slot (O4). */
   readonly gateSteps: ResolvedGateSteps;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
+  /** The composed query directory — undefined = OSS single-tenant behavior (C2). */
+  readonly organizationDirectory: OrganizationDirectory | undefined;
 }
 
 /** Registers both organization services on the router (routes stage). */
@@ -100,12 +122,26 @@ export function registerOrganizationServices(
     update: (org, ctx) => update(deps, org, ctx),
     delete: (orgId, ctx) => deleteOrganization(deps, orgId, ctx),
   });
-  // getByExternalOrgId deliberately absent → ConnectRPC answers
-  // Unimplemented (the capability-probed pin; see the module header).
+  // getByExternalOrgId registers ONLY when the composed directory carries
+  // the lookup (ruling Q7); otherwise the method stays absent from the
+  // partial implementation and ConnectRPC answers Unimplemented (the
+  // capability-probed pin; see the module header).
+  const externalLookup =
+    deps.organizationDirectory?.getOrganizationIdByExternalOrgId?.bind(
+      deps.organizationDirectory,
+    );
   router.service(OrganizationQueryController, {
     get: (orgId, ctx) => get(deps, orgId, ctx),
     find: (req, ctx) => find(deps, req, ctx),
-    findMyOrganizations: () => findMyOrganizations(deps),
+    findMyOrganizations: (_, ctx) => findMyOrganizations(deps, ctx),
+    ...(externalLookup === undefined
+      ? {}
+      : {
+          getByExternalOrgId: (
+            lookup: OrganizationExternalLookup,
+            ctx: HandlerContext,
+          ) => getByExternalOrgId(deps, externalLookup, lookup, ctx),
+        }),
   });
 }
 
@@ -152,7 +188,16 @@ async function createOrganization(
     .addStep(newCheckOrgDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
     .addStep(newCopySlugToIdStep())
-    .addStep(newPersistStep(deps.store));
+    .addStep(newPersistStep(deps.store))
+    // The C2 tuple step runs BEFORE the slot — the verified Java order
+    // (createAuthorizationTuples → linkManagedOrgToIdentityProvider →
+    // provisionBillingAccount). No-op with no driver composed.
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    );
   // The ratified post-persist gate slot (blueprint 03 §3a; O4 — see the
   // doc comment above for the inherited failure semantics). Empty in OSS.
   for (const step of stepsForSlot<typeof OrganizationSchema>(
@@ -275,6 +320,9 @@ async function deleteOrganization(
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, OrganizationSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);
@@ -321,14 +369,22 @@ const FIND_RESULT_KEY = "findResult";
  * Find — enumerates ALL organizations with manual pagination (page size
  * default 20, cap 100). The request's org field is accepted but IGNORED
  * for filtering: organizations are the top-level scope and belong to no
- * org. Single-tenant OSS enumerates freely; cloud gates this behind
- * admin access (the organizationEnumeration capability fork).
+ * org. Single-tenant OSS enumerates freely; a composed directory with
+ * refusesEnumeration answers UNIMPLEMENTED before any work — the
+ * organizationEnumeration capability fork, byte-matching the
+ * absent-method semantics the cloud edition pins.
  */
 async function find(
   deps: OrganizationControllerDeps,
   req: FindApiResourcesRequest,
   ctx: HandlerContext,
 ): Promise<OrganizationList> {
+  if (deps.organizationDirectory?.refusesEnumeration === true) {
+    throw new ConnectError(
+      "ai.stigmer.tenancy.organization.v1.OrganizationQueryController.find is not implemented",
+      Code.Unimplemented,
+    );
+  }
   const reqCtx = new RequestContext(
     OrganizationQueryController.method.find.input,
     req,
@@ -419,12 +475,42 @@ function newListAllOrganizationsStep(
 /**
  * FindMyOrganizations — deliberately pipeline-less (Go): the input is
  * Empty, there is nothing to validate, and single-user OSS applies no IAM
- * filtering — ALL organizations are "mine". Cloud filters by the caller's
- * IAM policies instead (the multiTenant capability fork).
+ * filtering — ALL organizations are "mine". A composed directory filters
+ * to the caller's authorized set instead (the multiTenant capability
+ * fork, ruling Q7): the directory answers ids, the controller loads
+ * them, and ids whose rows are gone are skipped (grants can outlive
+ * rows).
  */
 async function findMyOrganizations(
   deps: OrganizationControllerDeps,
+  ctx: HandlerContext,
 ): Promise<Organizations> {
+  const directory = deps.organizationDirectory;
+  if (directory !== undefined) {
+    const authorized = await directory.listMyOrganizationIds(
+      callerIdentityOf(ctx),
+    );
+    if (authorized !== ALL_ORGANIZATIONS) {
+      const entries: Organization[] = [];
+      for (const id of authorized) {
+        try {
+          entries.push(
+            await deps.store.getResource(
+              ApiResourceKind.organization,
+              id,
+              OrganizationSchema,
+            ),
+          );
+        } catch (error) {
+          if (error instanceof ResourceNotFoundError) {
+            continue;
+          }
+          throw internalError(error, "failed to list organizations");
+        }
+      }
+      return create(OrganizationsSchema, { entries });
+    }
+  }
   let data: Uint8Array[];
   try {
     data = await deps.store.listResources(ApiResourceKind.organization);
@@ -440,4 +526,58 @@ async function findMyOrganizations(
     }
   }
   return create(OrganizationsSchema, { entries });
+}
+
+/**
+ * GetByExternalOrgId — registered only with a directory lookup composed
+ * (ruling Q7). The chain stays controller-owned: Authorize → validate →
+ * directory resolves the external id → LoadTarget-shaped store read.
+ * Both miss arms (no mapping, mapped row gone) answer the same NotFound
+ * — an external caller cannot distinguish a stale mapping from a
+ * missing org.
+ */
+async function getByExternalOrgId(
+  deps: OrganizationControllerDeps,
+  lookup: (externalOrgId: string) => Promise<string | undefined>,
+  input: OrganizationExternalLookup,
+  ctx: HandlerContext,
+): Promise<Organization> {
+  const reqCtx = new RequestContext(
+    OrganizationQueryController.method.getByExternalOrgId.input,
+    input,
+    callerIdentityOf(ctx),
+    kindOf(ctx),
+  );
+  await newPipeline<
+    typeof OrganizationQueryController.method.getByExternalOrgId.input
+  >("organization-get-by-external-org-id", deps.logger)
+    .addStep(
+      newAuthorizeStep(
+        OrganizationQueryController.method.getByExternalOrgId,
+        deps.authorizer,
+      ),
+    )
+    .addStep(newValidateProtoStep())
+    .build()
+    .execute(reqCtx);
+
+  if (input.externalOrgId === "") {
+    throw invalidArgumentError("external_org_id is required");
+  }
+  const orgId = await lookup(input.externalOrgId);
+  if (orgId === undefined) {
+    throw notFoundError("Organization", input.externalOrgId);
+  }
+  try {
+    return await deps.store.getResource(
+      ApiResourceKind.organization,
+      orgId,
+      OrganizationSchema,
+    );
+  } catch (error) {
+    if (error instanceof ResourceNotFoundError) {
+      throw notFoundError("Organization", input.externalOrgId);
+    }
+    throw internalError(error, "failed to load organization");
+  }
 }

--- a/backend/services/stigmer-server/src/domain/project/controller.ts
+++ b/backend/services/stigmer-server/src/domain/project/controller.ts
@@ -37,6 +37,7 @@ import { ProjectStatusSchema } from "@stigmer/protos/ai/stigmer/tenancy/project/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { internalError } from "../../pipeline/errors.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -68,6 +69,10 @@ import {
   TARGET_RESOURCE_KEY,
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
@@ -87,6 +92,8 @@ export interface ProjectControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   /**
    * The four downstream delete edges (agent/workflow/mcp_server/skill),
    * lazy per the compose root's boot-ordering idiom — the TS replacement
@@ -144,6 +151,12 @@ async function createProject(
     .addStep(newBuildNewStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(
       newIndexSearchStep(deps.store, projectSearchExtractor, deps.logger),
     )
@@ -286,6 +299,9 @@ async function deleteProject(
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, ProjectSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/project/controller.ts
+++ b/backend/services/stigmer-server/src/domain/project/controller.ts
@@ -64,6 +64,7 @@ import {
 import {
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
+  withResolvedApplyId,
 } from "../../pipeline/steps/load-for-apply.js";
 import {
   TARGET_RESOURCE_KEY,
@@ -252,7 +253,11 @@ async function apply(
 
   const persisted = shouldCreate
     ? await createProject(deps, project, ctx)
-    : await update(deps, project, ctx);
+    : await update(
+        deps,
+        withResolvedApplyId(ProjectSchema, project, reqCtx),
+        ctx,
+      );
 
   const currentMembers = persisted.spec?.members ?? [];
 

--- a/backend/services/stigmer-server/src/domain/schedule/controller.ts
+++ b/backend/services/stigmer-server/src/domain/schedule/controller.ts
@@ -52,6 +52,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -84,6 +85,10 @@ import {
   newLoadTargetStep,
   TARGET_RESOURCE_KEY,
 } from "../../pipeline/steps/load-target.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
@@ -121,6 +126,8 @@ export interface ScheduleControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   readonly modelRegistry: ModelCatalogProvider;
   /**
    * The scheduling runtime (clock.ts), resolved at call time so the
@@ -194,6 +201,12 @@ async function createSchedule(
     .addStep(newBuildNewStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(newArmScheduleStep(deps.clock, deps.logger))
     .build()
     .execute(reqCtx);
@@ -311,6 +324,9 @@ async function deleteSchedule(
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, ScheduleSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newTeardownScheduleArtifactStep(deps.clock, deps.logger))
     .addStep(newDeleteScheduleRunsStep(deps.store, deps.logger))
     .build()

--- a/backend/services/stigmer-server/src/domain/session/controller.ts
+++ b/backend/services/stigmer-server/src/domain/session/controller.ts
@@ -37,6 +37,7 @@ import { create } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
 import { stepsForSlot } from "../../extensions/gate-slots.js";
 import type { AgentExecutionTemporalConfig } from "../agentexecution/temporal/config.js";
@@ -79,6 +80,10 @@ import {
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -107,6 +112,8 @@ export interface SessionControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   /**
    * The agent-execution temporal config — the update pipeline's
    * execution-target immutability step resolves UNSPECIFIED through the
@@ -206,6 +213,12 @@ async function createSession(
   }
   await builder
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(
       newIndexSearchStep(deps.store, sessionSearchExtractor, deps.logger),
     )
@@ -318,6 +331,9 @@ async function deleteSession(
     .addStep(newRejectDeleteWithActiveExecutionsStep(deps.store, deps.logger))
     .addStep(newCascadeDeleteAgentExecutionsStep(deps.store, deps.logger))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/session/controller.ts
+++ b/backend/services/stigmer-server/src/domain/session/controller.ts
@@ -74,6 +74,7 @@ import {
 import {
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
+  withResolvedApplyId,
 } from "../../pipeline/steps/load-for-apply.js";
 import {
   TARGET_RESOURCE_KEY,
@@ -266,7 +267,8 @@ async function update(
 /**
  * Apply — kubectl-style create-or-update: a minimal probe pipeline decides
  * existence, then delegates to Create or Update with the ORIGINAL request
- * message (Go delegates `session`, not the pipeline's mutated clone).
+ * message (Go delegates `session`, not the pipeline's mutated clone);
+ * the update arm carries the resolved id via withResolvedApplyId.
  */
 async function apply(
   deps: SessionControllerDeps,
@@ -298,7 +300,7 @@ async function apply(
   }
   return shouldCreate
     ? createSession(deps, session, ctx)
-    : update(deps, session, ctx);
+    : update(deps, withResolvedApplyId(SessionSchema, session, reqCtx), ctx);
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/skill/controller.ts
+++ b/backend/services/stigmer-server/src/domain/skill/controller.ts
@@ -57,6 +57,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
   failedPreconditionError,
@@ -69,6 +70,11 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import {
+  newCleanupIamPoliciesStep,
+  newRecordVisibilityBeforeUpdateStep,
+  newUpdateVisibilityTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
 import {
   RESOURCE_ID_KEY,
@@ -98,6 +104,7 @@ import {
   newPopulateSkillFieldsStep,
   newResolveArtifactSourceStep,
   newResolveSlugForPushStep,
+  newSkillPushAuthorizationTuplesStep,
   newStoreSkillStep,
 } from "./push.js";
 import { skillSearchExtractor } from "./search-extractor.js";
@@ -131,6 +138,8 @@ export interface SkillControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   readonly artifactStorage: SkillArtifactStorage;
   /**
    * Execution artifact storage for pushFromExecutionArtifact (Go
@@ -212,6 +221,12 @@ async function push(
     .addStep(newPopulateSkillFieldsStep())
     .addStep(newArchiveCurrentSkillStep(deps.store, deps.logger))
     .addStep(newStoreSkillStep(deps.store))
+    .addStep(
+      newSkillPushAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(newIndexSkillSearchStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);
@@ -396,9 +411,16 @@ async function updateVisibility(
     )
     .addStep(newValidateProtoStep())
     .addStep(newLoadSkillForVisibilityUpdateStep(deps.store))
+    .addStep(newRecordVisibilityBeforeUpdateStep(UPDATE_VISIBILITY_SKILL_KEY))
     .addStep(newValidateVisibilityUpdateStep())
     .addStep(newSetVisibilityStep())
     .addStep(newPersistSkillForVisibilityUpdateStep(deps.store))
+    .addStep(
+      newUpdateVisibilityTuplesStep(
+        deps.authorizationLifecycle,
+        UPDATE_VISIBILITY_SKILL_KEY,
+      ),
+    )
     .addStep(newIndexSkillAfterVisibilityUpdateStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);
@@ -532,6 +554,9 @@ async function deleteSkill(
     .addStep(newLoadExistingForDeleteStep(deps.store, SkillSchema))
     .addStep(newDeleteSkillArchivesStep(deps.store, deps.logger))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/skill/push.ts
+++ b/backend/services/stigmer-server/src/domain/skill/push.ts
@@ -47,6 +47,7 @@ import { ApiResourceAuditSchema } from "@stigmer/protos/ai/stigmer/commons/apire
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import {
   defaultVisibilityFor,
   getIdPrefix,
@@ -58,6 +59,10 @@ import {
 } from "../../pipeline/errors.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import type { RequestContext } from "../../pipeline/request-context.js";
+import {
+  diffVisibilityShapes,
+  resolveResourceCreatedEvent,
+} from "../../pipeline/steps/authorization-tuples.js";
 import {
   generateId,
   setAuditFieldsForCreate,
@@ -492,6 +497,78 @@ export function newStoreSkillStep(store: Store): PipelineStep<PushDesc> {
         );
       } catch (error) {
         throw internalError(error, "failed to save skill");
+      }
+    },
+  };
+}
+
+/**
+ * SkillPushAuthorizationTuples — the C2 tuple-lifecycle splice for the
+ * push lane. Domain-local for the same reason as IndexSkillSearch (the
+ * skill rides SKILL_KEY, not newState), and push is an UPSERT, so the
+ * lane has both arms:
+ *   - a genuine create (SHOULD_CREATE_SKILL_KEY) fires the full creation
+ *     event — the Java SkillPushHandler runs the same create-tuples path;
+ *   - a re-push diffs the existing skill's visibility against the pushed
+ *     head and fires a visibility transition only when it changed (the
+ *     reconciler's same-level no-op, preserved).
+ * Failure semantics match the shared create step: a driver throw fails
+ * the push (post-persist; retry converges).
+ */
+export function newSkillPushAuthorizationTuplesStep(
+  lifecycle: ResourceAuthorizationLifecycle | undefined,
+  logger: Logger,
+): PipelineStep<PushDesc> {
+  return {
+    name: "SkillPushAuthorizationTuples",
+    async execute(ctx: RequestContext<PushDesc>): Promise<void> {
+      if (lifecycle === undefined) {
+        return;
+      }
+      const skill = ctx.get(SKILL_KEY) as Skill;
+      const shouldCreate = ctx.get(SHOULD_CREATE_SKILL_KEY) as boolean;
+      if (shouldCreate) {
+        const event = resolveResourceCreatedEvent(
+          ctx.apiResourceKind,
+          skill,
+          ctx.callerIdentity,
+          logger,
+        );
+        if (event === undefined) {
+          return;
+        }
+        try {
+          await lifecycle.onResourceCreated(event);
+        } catch (error) {
+          throw internalError(error, "failed to create authorization tuples");
+        }
+        return;
+      }
+      const existing = ctx.get(EXISTING_SKILL_KEY) as Skill | undefined;
+      const oldLevel =
+        existing?.metadata?.visibility ??
+        ApiResourceVisibility.api_resource_visibility_unspecified;
+      const newLevel =
+        skill.metadata?.visibility ??
+        ApiResourceVisibility.api_resource_visibility_unspecified;
+      const { shapesToCreate, shapesToDelete } = diffVisibilityShapes(
+        ctx.apiResourceKind,
+        oldLevel,
+        newLevel,
+      );
+      if (shapesToCreate.length === 0 && shapesToDelete.length === 0) {
+        return;
+      }
+      try {
+        await lifecycle.onVisibilityChanged({
+          kind: ctx.apiResourceKind,
+          resourceId: skill.metadata?.id ?? "",
+          orgId: skill.metadata?.org ?? "",
+          shapesToCreate,
+          shapesToDelete,
+        });
+      } catch (error) {
+        throw internalError(error, "failed to update visibility tuples");
       }
     },
   };

--- a/backend/services/stigmer-server/src/domain/workflow/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/controller.ts
@@ -94,6 +94,7 @@ import {
 import {
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
+  withResolvedApplyId,
 } from "../../pipeline/steps/load-for-apply.js";
 import {
   TARGET_RESOURCE_KEY,
@@ -291,7 +292,8 @@ async function update(
 /**
  * Apply — kubectl-style create-or-update: a minimal probe pipeline decides
  * existence, then delegates to Create or Update with the ORIGINAL request
- * message (Go delegates `workflow`, not the pipeline's mutated clone).
+ * message (Go delegates `workflow`, not the pipeline's mutated clone);
+ * the update arm carries the resolved id via withResolvedApplyId.
  */
 async function apply(
   deps: WorkflowControllerDeps,
@@ -323,7 +325,7 @@ async function apply(
   }
   return shouldCreate
     ? createWorkflow(deps, workflow, ctx)
-    : update(deps, workflow, ctx);
+    : update(deps, withResolvedApplyId(WorkflowSchema, workflow, reqCtx), ctx);
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/workflow/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/controller.ts
@@ -56,6 +56,7 @@ import {
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import {
   internalError,
@@ -99,6 +100,12 @@ import {
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+  newRecordVisibilityBeforeUpdateStep,
+  newUpdateVisibilityTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import {
@@ -137,6 +144,8 @@ export interface WorkflowControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   /** The Layer-2 validator (converter + structural checks + registry). */
   readonly validator: InProcessValidator;
   /**
@@ -214,6 +223,12 @@ async function createWorkflow(
     .addStep(newComputeVersionHashStep(deps.logger))
     .addStep(newPopulateVersionHashStep(true))
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(
       newCreateDefaultInstanceStep(deps.workflowInstanceCreator, deps.logger),
     )
@@ -342,6 +357,9 @@ async function deleteWorkflow(
     .addStep(newLoadExistingForDeleteStep(deps.store, WorkflowSchema))
     .addStep(newCascadeDeleteWorkflowInstancesStep(deps.store, deps.logger))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);
@@ -392,9 +410,18 @@ async function updateVisibility(
     )
     .addStep(newValidateProtoStep())
     .addStep(newLoadWorkflowForVisibilityUpdateStep(deps.store))
+    .addStep(
+      newRecordVisibilityBeforeUpdateStep(UPDATE_VISIBILITY_WORKFLOW_KEY),
+    )
     .addStep(newValidateVisibilityUpdateStep())
     .addStep(newSetWorkflowVisibilityStep())
     .addStep(newPersistWorkflowForVisibilityUpdateStep(deps.store))
+    .addStep(
+      newUpdateVisibilityTuplesStep(
+        deps.authorizationLifecycle,
+        UPDATE_VISIBILITY_WORKFLOW_KEY,
+      ),
+    )
     .addStep(newIndexWorkflowAfterVisibilityUpdateStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
@@ -37,6 +37,7 @@ import { create } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -65,6 +66,10 @@ import {
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -120,6 +125,8 @@ export interface WorkflowExecutionControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   /**
    * The workflow-execution engine seam (engine.ts): permanently
    * disconnected until #21's TemporalManager flips it. Consumed by the
@@ -279,6 +286,12 @@ async function createExecution(
     )
     .addStep(newPersistStep(deps.store))
     .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
+    .addStep(
       newIndexSearchStep(
         deps.store,
         workflowExecutionSearchExtractor,
@@ -375,6 +388,9 @@ async function deleteExecution(
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, WorkflowExecutionSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/workflowinstance/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowinstance/controller.ts
@@ -43,6 +43,7 @@ import type {
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
 import { internalError, notFoundError } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -79,6 +80,12 @@ import {
   newLoadTargetStep,
 } from "../../pipeline/steps/load-target.js";
 import { newNormalizeReferencesStep } from "../../pipeline/steps/references.js";
+import {
+  newCleanupIamPoliciesStep,
+  newCreateAuthorizationTuplesStep,
+  newRecordVisibilityBeforeUpdateStep,
+  newUpdateVisibilityTuplesStep,
+} from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
@@ -101,6 +108,8 @@ export interface WorkflowInstanceControllerDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
+  readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   /**
    * The workflow in-process edge — a lazy provider because
    * workflow↔workflowinstance is a true dependency cycle (DD-002).
@@ -168,6 +177,12 @@ async function createInstance(
     .addStep(newBuildNewStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
+    .addStep(
+      newCreateAuthorizationTuplesStep(
+        deps.authorizationLifecycle,
+        deps.logger,
+      ),
+    )
     .addStep(
       newIndexSearchStep(
         deps.store,
@@ -290,6 +305,9 @@ async function deleteInstance(
     .addStep(newExtractResourceIdStep())
     .addStep(newLoadExistingForDeleteStep(deps.store, WorkflowInstanceSchema))
     .addStep(newDeleteResourceStep(deps.store))
+    .addStep(
+      newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
     .execute(reqCtx);
@@ -347,6 +365,9 @@ async function updateVisibility(
       ),
     )
     .addStep(
+      newRecordVisibilityBeforeUpdateStep(UPDATE_VISIBILITY_INSTANCE_KEY),
+    )
+    .addStep(
       newRejectDefaultWorkflowInstanceVisibilityUpdateStep(
         deps.store,
         UPDATE_VISIBILITY_INSTANCE_KEY,
@@ -359,6 +380,12 @@ async function updateVisibility(
         deps.store,
         UPDATE_VISIBILITY_INSTANCE_KEY,
         "PersistInstanceForVisibilityUpdate",
+      ),
+    )
+    .addStep(
+      newUpdateVisibilityTuplesStep(
+        deps.authorizationLifecycle,
+        UPDATE_VISIBILITY_INSTANCE_KEY,
       ),
     )
     .addStep(

--- a/backend/services/stigmer-server/src/domain/workflowinstance/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowinstance/controller.ts
@@ -73,6 +73,7 @@ import {
 import {
   SHOULD_CREATE_KEY,
   newLoadForApplyStep,
+  withResolvedApplyId,
 } from "../../pipeline/steps/load-for-apply.js";
 import { newLoadByReferenceStep } from "../../pipeline/steps/load-by-reference.js";
 import {
@@ -236,7 +237,10 @@ async function update(
   return reqCtx.newState;
 }
 
-/** Apply — kubectl-style create-or-update, delegating the ORIGINAL request. */
+/**
+ * Apply — kubectl-style create-or-update, delegating the ORIGINAL request;
+ * the update arm carries the resolved id via withResolvedApplyId.
+ */
 async function apply(
   deps: WorkflowInstanceControllerDeps,
   instance: WorkflowInstance,
@@ -273,7 +277,11 @@ async function apply(
   }
   return shouldCreate
     ? createInstance(deps, instance, ctx)
-    : update(deps, instance, ctx);
+    : update(
+        deps,
+        withResolvedApplyId(WorkflowInstanceSchema, instance, reqCtx),
+        ctx,
+      );
 }
 
 /**

--- a/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
@@ -22,6 +22,9 @@ import type { Transport } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import { AgentQueryController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/query_pb";
 import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
 import {
@@ -34,6 +37,7 @@ import { SessionQueryController } from "@stigmer/protos/ai/stigmer/agentic/sessi
 import { BillingQueryController } from "@stigmer/protos/ai/stigmer/billing/v1/query_pb";
 import { BillingAccountSchema } from "@stigmer/protos/ai/stigmer/billing/v1/billing_account_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
 import {
   PlatformQueryController,
   ServerEdition,
@@ -49,6 +53,13 @@ import type { ComposedServer } from "../../boot/compose.js";
 import { createLogger } from "../../boot/logger.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import type { GateSlotName } from "../gate-slots.js";
+import type { OrganizationDirectory } from "../organization-directory.js";
+import type {
+  ResourceAuthorizationLifecycle,
+  ResourceCreatedEvent,
+  ResourceDeletedEvent,
+  VisibilityChangedEvent,
+} from "../resource-authorization.js";
 import type { AgentExecutionStatusTransition } from "../status-hooks.js";
 import type { ServerExtension } from "../registry.js";
 
@@ -478,5 +489,278 @@ describe("extension composition (O4 gate slots + status hooks)", () => {
     });
     expect(repeat.signal).toBe(ExecutionControlSignal.STOP);
     expect(observed).toHaveLength(1);
+  });
+});
+
+describe("extension composition (C2 tuple lifecycle + organization directory)", () => {
+  let server: ComposedServer;
+  let dir: string;
+  let portTransport: Transport;
+
+  const createdEvents: ResourceCreatedEvent[] = [];
+  const deletedEvents: ResourceDeletedEvent[] = [];
+  const visibilityEvents: VisibilityChangedEvent[] = [];
+  let failCreates = false;
+  let failDeletes = false;
+
+  const fakeLifecycle: ResourceAuthorizationLifecycle = {
+    async onResourceCreated(event): Promise<void> {
+      if (failCreates) {
+        throw new Error("fga is down");
+      }
+      createdEvents.push(event);
+    },
+    async onResourceDeleted(event): Promise<void> {
+      if (failDeletes) {
+        throw new Error("fga is down");
+      }
+      deletedEvents.push(event);
+    },
+    async onVisibilityChanged(event): Promise<void> {
+      visibilityEvents.push(event);
+    },
+  };
+
+  // The directory answers are test-mutable so each case can stage its
+  // own world without a second composed server.
+  const myOrgIds: string[] = [];
+  const externalOrgMap = new Map<string, string>();
+  const fakeDirectory: OrganizationDirectory = {
+    refusesEnumeration: true,
+    listMyOrganizationIds: async () => [...myOrgIds],
+    getOrganizationIdByExternalOrgId: async (externalOrgId) =>
+      externalOrgMap.get(externalOrgId),
+  };
+
+  const iamExtension: ServerExtension = {
+    name: "fake-iam",
+    drivers: {
+      resourceAuthorizationLifecycle: fakeLifecycle,
+      organizationDirectory: fakeDirectory,
+    },
+  };
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "tuple-lifecycle-test-"));
+    server = await composeServer({
+      config: loadConfig({
+        STIGMER_MODEL_REGISTRY_REFRESH: "off",
+        DB_PATH: path.join(dir, "stigmer.db"),
+        STORAGE_PATH: path.join(dir, "storage"),
+        ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      }),
+      logger: createLogger({ level: "error", pretty: false, write: () => {} }),
+      extensions: [iamExtension],
+      portOverride: 0,
+      host: "127.0.0.1",
+    });
+    const port = await server.start();
+    portTransport = createGrpcTransport({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("org create fires the creation event: OWNER_ONLY — direct owner, no scope link", async () => {
+    const command = createClient(OrganizationCommandController, portTransport);
+    createdEvents.length = 0;
+    const org = await command.create(
+      create(OrganizationSchema, {
+        apiVersion: "tenancy.stigmer.ai/v1",
+        kind: "Organization",
+        metadata: { name: "C2 Seeded Org", slug: "c2seededorg" },
+      }),
+    );
+    expect(createdEvents).toHaveLength(1);
+    const event = createdEvents[0]!;
+    expect(event.kind).toBe(ApiResourceKind.organization);
+    expect(event.resourceId).toBe(org.metadata?.id);
+    expect(event.parentLinks).toEqual([]);
+    expect(event.caller.identityId).not.toBe("");
+    myOrgIds.push(org.metadata?.id ?? "");
+    externalOrgMap.set("ext-org-42", org.metadata?.id ?? "");
+  });
+
+  it("agent create fires creation events for the agent AND its in-process default instance", async () => {
+    const command = createClient(AgentCommandController, portTransport);
+    createdEvents.length = 0;
+    const agent = await command.create(
+      create(AgentSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Agent",
+        metadata: {
+          name: "c2-seeded-agent",
+          org: "c2seededorg",
+          visibility: ApiResourceVisibility.visibility_org,
+        },
+        spec: { instructions: "a conformant instruction body" },
+      }),
+    );
+    // TWO events: the agent, and the default AgentInstance the create
+    // chain applies through the in-process client — the seam runs
+    // wherever its chain runs, including in-process invocations (the
+    // same inherited fact the gate slots record).
+    expect(createdEvents).toHaveLength(2);
+    const agentEvent = createdEvents.find(
+      (event) => event.kind === ApiResourceKind.agent,
+    );
+    expect(agentEvent?.parentLinks).toEqual([
+      {
+        relation: "organization",
+        parentKind: ApiResourceKind.organization,
+        parentId: "c2seededorg",
+      },
+    ]);
+    expect(agentEvent?.visibilityShapes).toEqual(["org-viewer"]);
+    const instanceEvent = createdEvents.find(
+      (event) => event.kind === ApiResourceKind.agent_instance,
+    );
+    expect(instanceEvent?.parentLinks).toContainEqual({
+      relation: "agent",
+      parentKind: ApiResourceKind.agent,
+      parentId: agent.metadata?.id,
+    });
+  });
+
+  it("updateVisibility fires the set-diff transition (org→public keeps the floor)", async () => {
+    const command = createClient(AgentCommandController, portTransport);
+    const agent = await command.create(
+      create(AgentSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Agent",
+        metadata: {
+          name: "c2-visibility-agent",
+          org: "c2seededorg",
+          visibility: ApiResourceVisibility.visibility_org,
+        },
+        spec: { instructions: "a conformant instruction body" },
+      }),
+    );
+    visibilityEvents.length = 0;
+    await command.updateVisibility({
+      resourceId: agent.metadata?.id ?? "",
+      visibility: ApiResourceVisibility.visibility_public,
+    });
+    expect(visibilityEvents).toHaveLength(1);
+    const event = visibilityEvents[0]!;
+    expect(event.shapesToCreate).toEqual(["public-viewer"]);
+    expect(event.shapesToDelete).toEqual([]);
+  });
+
+  it("delete fires the cleanup event; a cleanup failure never fails the delete", async () => {
+    const command = createClient(AgentCommandController, portTransport);
+    const query = createClient(AgentQueryController, portTransport);
+
+    const first = await command.create(
+      create(AgentSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Agent",
+        metadata: { name: "c2-deleted-agent", org: "c2seededorg" },
+        spec: { instructions: "a conformant instruction body" },
+      }),
+    );
+    deletedEvents.length = 0;
+    await command.delete({ value: first.metadata?.id ?? "" });
+    expect(deletedEvents).toHaveLength(1);
+    expect(deletedEvents[0]!.resourceId).toBe(first.metadata?.id);
+
+    const second = await command.create(
+      create(AgentSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Agent",
+        metadata: { name: "c2-orphaned-agent", org: "c2seededorg" },
+        spec: { instructions: "a conformant instruction body" },
+      }),
+    );
+    deletedEvents.length = 0;
+    failDeletes = true;
+    try {
+      // Best-effort contract: the delete succeeds although the driver threw.
+      await command.delete({ value: second.metadata?.id ?? "" });
+    } finally {
+      failDeletes = false;
+    }
+    expect(deletedEvents).toHaveLength(0);
+    let getError: ConnectError | undefined;
+    try {
+      await query.get({ value: second.metadata?.id ?? "" });
+    } catch (error) {
+      getError = ConnectError.from(error);
+    }
+    expect(getError?.code).toBe(Code.NotFound);
+  });
+
+  it("a driver failure on create fails the request but the row survives (inherited semantics)", async () => {
+    const command = createClient(AgentCommandController, portTransport);
+    const query = createClient(AgentQueryController, portTransport);
+    failCreates = true;
+    let refused: ConnectError | undefined;
+    try {
+      await command.create(
+        create(AgentSchema, {
+          apiVersion: "agentic.stigmer.ai/v1",
+          kind: "Agent",
+          metadata: { name: "c2-halfcreated-agent", org: "c2seededorg" },
+          spec: { instructions: "a conformant instruction body" },
+        }),
+      );
+    } catch (error) {
+      refused = ConnectError.from(error);
+    } finally {
+      failCreates = false;
+    }
+    expect(refused?.code).toBe(Code.Internal);
+    expect(refused?.rawMessage).toBe("failed to create authorization tuples");
+    // The step runs post-persist: the row survived the failed request
+    // (ids are generated, so the surviving row is found by reference).
+    const half = await query.getByReference({
+      org: "c2seededorg",
+      slug: "c2-halfcreated-agent",
+    });
+    expect(half.metadata?.name).toBe("c2-halfcreated-agent");
+  });
+
+  it("the directory's enumeration refusal answers UNIMPLEMENTED on a valid find", async () => {
+    const query = createClient(OrganizationQueryController, portTransport);
+    let refused: ConnectError | undefined;
+    try {
+      await query.find({ org: "c2seededorg", pageSize: 10, pageNumber: 1 });
+    } catch (error) {
+      refused = ConnectError.from(error);
+    }
+    expect(refused?.code).toBe(Code.Unimplemented);
+  });
+
+  it("findMyOrganizations answers exactly the directory's authorized set", async () => {
+    const query = createClient(OrganizationQueryController, portTransport);
+    const mine = await query.findMyOrganizations({});
+    expect(mine.entries.map((org) => org.metadata?.id)).toEqual(myOrgIds);
+  });
+
+  it("getByExternalOrgId registers with the directory lookup and resolves the mapping", async () => {
+    const query = createClient(OrganizationQueryController, portTransport);
+    // identity_provider_ref is proto-required on the lookup message; the
+    // directory's resolution key is the (globally unique) external id.
+    const idpRef = { org: "c2seededorg", slug: "test-idp" };
+    const org = await query.getByExternalOrgId({
+      identityProviderRef: idpRef,
+      externalOrgId: "ext-org-42",
+    });
+    expect(org.metadata?.id).toBe(myOrgIds[0]);
+
+    let missing: ConnectError | undefined;
+    try {
+      await query.getByExternalOrgId({
+        identityProviderRef: idpRef,
+        externalOrgId: "ext-org-unknown",
+      });
+    } catch (error) {
+      missing = ConnectError.from(error);
+    }
+    expect(missing?.code).toBe(Code.NotFound);
   });
 });

--- a/backend/services/stigmer-server/src/extensions/authorizer.ts
+++ b/backend/services/stigmer-server/src/extensions/authorizer.ts
@@ -30,11 +30,25 @@ export interface AuthzCheck {
   readonly resourceId: string;
 }
 
-/** The three-arm decision (blueprint §5a — deny and unavailable are distinct). */
+/**
+ * The decision arms (blueprint §5a — deny and unavailable are distinct).
+ *
+ * `not-found` is the C2 ruling-Q1 refinement (DD-007 addendum,
+ * 20260827.10): for RESOURCE-SCOPED checks, an authorizer that has
+ * verified the target does not exist answers not-found instead of deny —
+ * the Authorize step maps it to NOT_FOUND with the domain copy, matching
+ * the Java edition's deliberate load-before-authorize order
+ * (stigmer#224: a nonexistent id answers NOT_FOUND, never
+ * PERMISSION_DENIED). Only meaningful with a known kind and a non-empty
+ * resource id — anything else is an authorizer contract bug and surfaces
+ * as INTERNAL. The OSS permissive default never emits it.
+ */
 export type AuthzDecision =
   | { readonly kind: "allow" }
   /** A genuine denial — maps to PERMISSION_DENIED on the wire. */
   | { readonly kind: "deny"; readonly reason: string }
+  /** The resource-scoped target does not exist — maps to NOT_FOUND. */
+  | { readonly kind: "not-found" }
   /** An evaluation failure — maps to INTERNAL on the wire, never a denial. */
   | { readonly kind: "unavailable"; readonly cause: Error };
 

--- a/backend/services/stigmer-server/src/extensions/drivers.ts
+++ b/backend/services/stigmer-server/src/extensions/drivers.ts
@@ -24,6 +24,8 @@ import type { ArtifactStorageDriverFactory } from "../artifactstorage/artifact-s
 import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
 import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
 import type { SandboxProvisionerFactory } from "../sandbox/provisioner.js";
+import type { OrganizationDirectory } from "./organization-directory.js";
+import type { ResourceAuthorizationLifecycle } from "./resource-authorization.js";
 
 /** The driver contributions of one extension unit. */
 export interface ExtensionDrivers {
@@ -60,4 +62,19 @@ export interface ExtensionDrivers {
     string,
     SandboxProvisionerFactory
   >;
+  /**
+   * The resource-authorization lifecycle seam (C2, ruling Q2;
+   * single-instance point). When composed, the three shared tuple steps
+   * (CreateAuthorizationTuples / CleanupIamPolicies /
+   * UpdateVisibilityTuples) deliver resolved events to it; when absent,
+   * those steps no-op — OSS behavior byte-identical.
+   */
+  readonly resourceAuthorizationLifecycle?: ResourceAuthorizationLifecycle;
+  /**
+   * The organization query directory (C2, ruling Q7; single-instance
+   * point). When composed, the organization controller consults it for
+   * the three edition forks (enumeration posture, my-orgs filtering,
+   * external-org lookup); when absent, OSS behavior byte-identical.
+   */
+  readonly organizationDirectory?: OrganizationDirectory;
 }

--- a/backend/services/stigmer-server/src/extensions/organization-directory.ts
+++ b/backend/services/stigmer-server/src/extensions/organization-directory.ts
@@ -1,0 +1,54 @@
+/**
+ * The organization-directory extension point (convergence program C2,
+ * 20260827.10; plan-gate ruling Q7). Three organization query behaviors
+ * fork between editions — the forks are ratified vocabulary as the
+ * conformance capability flags, and this port is their ONE seam:
+ *
+ *   - `find` (org enumeration; capability `organizationEnumeration`):
+ *     single-tenant OSS enumerates freely; the cloud refuses with
+ *     UNIMPLEMENTED (tenant isolation — no caller may list orgs it does
+ *     not belong to).
+ *   - `findMyOrganizations` (capability `multiTenant`): OSS answers ALL
+ *     organizations (single-user semantics); the cloud filters to the
+ *     caller's authorized set.
+ *   - `getByExternalOrgId` (capability `externalOrgLookup`): deliberately
+ *     absent from the OSS partial registration (UNIMPLEMENTED by
+ *     construction); the cloud resolves external IdP org ids.
+ *
+ * No directory composed = the controller's OSS behavior, byte-identical.
+ * The controller stays the ONE owner of its chains — the directory
+ * answers policy questions and id lookups; it never handles RPCs.
+ */
+import type { CallerIdentity } from "./identity.js";
+
+/**
+ * The "no filtering" answer for listMyOrganizationIds — the OSS
+ * single-user semantics, also expressible by a composed directory.
+ */
+export const ALL_ORGANIZATIONS = "all";
+
+/** The directory contract (single-instance point, ExtensionDrivers.organizationDirectory). */
+export interface OrganizationDirectory {
+  /**
+   * When true, `find` refuses org enumeration with UNIMPLEMENTED before
+   * any store read (the cloud posture).
+   */
+  readonly refusesEnumeration: boolean;
+  /**
+   * The org ids the caller may see in findMyOrganizations, or
+   * ALL_ORGANIZATIONS for unfiltered results. Ids the store no longer
+   * holds are skipped by the controller (grants can outlive rows).
+   */
+  listMyOrganizationIds(
+    caller: CallerIdentity,
+  ): Promise<ReadonlyArray<string> | typeof ALL_ORGANIZATIONS>;
+  /**
+   * Resolves an external IdP organization id to the org's resource id;
+   * undefined = no mapping. When this method is present, the controller
+   * registers `getByExternalOrgId` (its chain stays controller-owned);
+   * when absent, the RPC stays unregistered and answers UNIMPLEMENTED.
+   */
+  getOrganizationIdByExternalOrgId?(
+    externalOrgId: string,
+  ): Promise<string | undefined>;
+}

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -48,6 +48,8 @@ import type { ExtensionDrivers } from "./drivers.js";
 import { DECLARED_GATE_SLOTS } from "./gate-slots.js";
 import type { GateSlotName, ResolvedGateSteps } from "./gate-slots.js";
 import type { IdentityVerifier } from "./identity.js";
+import type { OrganizationDirectory } from "./organization-directory.js";
+import type { ResourceAuthorizationLifecycle } from "./resource-authorization.js";
 import type {
   AgentExecutionResponseDecorator,
   AgentExecutionStatusHooks,
@@ -140,6 +142,12 @@ export interface ResolvedExtensions {
 export interface ResolvedExtensionDrivers {
   readonly modelCatalogProvider: ModelCatalogProvider | undefined;
   readonly runnerCredentialProvider: RunnerCredentialProvider | undefined;
+  /** The C2 tuple-lifecycle driver — undefined = the shared steps no-op. */
+  readonly resourceAuthorizationLifecycle:
+    | ResourceAuthorizationLifecycle
+    | undefined;
+  /** The C2 organization query directory — undefined = OSS behavior. */
+  readonly organizationDirectory: OrganizationDirectory | undefined;
   /** Registered name → factory, validated against the built-in names. */
   readonly artifactStorageDrivers: ReadonlyMap<
     string,
@@ -177,6 +185,12 @@ export function resolveExtensions(
   let catalogDeclaredBy: string | undefined;
   let runnerCredentialProvider: RunnerCredentialProvider | undefined;
   let credentialDeclaredBy: string | undefined;
+  let resourceAuthorizationLifecycle:
+    | ResourceAuthorizationLifecycle
+    | undefined;
+  let authorizationLifecycleDeclaredBy: string | undefined;
+  let organizationDirectory: OrganizationDirectory | undefined;
+  let organizationDirectoryDeclaredBy: string | undefined;
   const artifactStorageDrivers = new Map<
     string,
     ArtifactStorageDriverFactory
@@ -246,6 +260,27 @@ export function resolveExtensions(
       credentialDeclaredBy = unit.name;
     }
 
+    if (unit.drivers?.resourceAuthorizationLifecycle !== undefined) {
+      if (authorizationLifecycleDeclaredBy !== undefined) {
+        throw new Error(
+          `extension '${unit.name}' registers a ResourceAuthorizationLifecycle, but '${authorizationLifecycleDeclaredBy}' already did — exactly one may be composed`,
+        );
+      }
+      resourceAuthorizationLifecycle =
+        unit.drivers.resourceAuthorizationLifecycle;
+      authorizationLifecycleDeclaredBy = unit.name;
+    }
+
+    if (unit.drivers?.organizationDirectory !== undefined) {
+      if (organizationDirectoryDeclaredBy !== undefined) {
+        throw new Error(
+          `extension '${unit.name}' registers an OrganizationDirectory, but '${organizationDirectoryDeclaredBy}' already did — exactly one may be composed`,
+        );
+      }
+      organizationDirectory = unit.drivers.organizationDirectory;
+      organizationDirectoryDeclaredBy = unit.name;
+    }
+
     if (unit.drivers?.artifactStorageDrivers !== undefined) {
       for (const [name, factory] of unit.drivers.artifactStorageDrivers) {
         if ((BUILT_IN_STORAGE_TYPES as ReadonlyArray<string>).includes(name)) {
@@ -267,9 +302,9 @@ export function resolveExtensions(
     if (unit.drivers?.sandboxProvisionerDrivers !== undefined) {
       for (const [name, factory] of unit.drivers.sandboxProvisionerDrivers) {
         if (
-          (BUILT_IN_SANDBOX_PROVISIONER_TYPES as ReadonlyArray<string>).includes(
-            name,
-          )
+          (
+            BUILT_IN_SANDBOX_PROVISIONER_TYPES as ReadonlyArray<string>
+          ).includes(name)
         ) {
           throw new Error(
             `extension '${unit.name}' registers sandbox provisioner '${name}', which shadows a built-in driver — built-in names are reserved`,
@@ -324,6 +359,8 @@ export function resolveExtensions(
     drivers: {
       modelCatalogProvider,
       runnerCredentialProvider,
+      resourceAuthorizationLifecycle,
+      organizationDirectory,
       artifactStorageDrivers,
       sandboxProvisionerDrivers,
     },

--- a/backend/services/stigmer-server/src/extensions/resource-authorization.ts
+++ b/backend/services/stigmer-server/src/extensions/resource-authorization.ts
@@ -1,0 +1,119 @@
+/**
+ * The resource-authorization lifecycle extension point (convergence
+ * program C2, 20260827.10; plan-gate ruling Q2). The cloud edition writes
+ * relationship tuples (OpenFGA) at three verified points of every
+ * resource's life — creation, deletion, and visibility change — through
+ * ONE driver seam, mirroring the Java service's config-driven
+ * architecture (CreateAuthorizationTuplesStepV2 + cleanupIamPolicies +
+ * VisibilityTupleReconciler, the shapes production trusts today).
+ *
+ * Division of labor (the ratified design): the OSS steps
+ * (src/pipeline/steps/authorization-tuples.ts) resolve EVERYTHING
+ * edition-neutral — the kind's AuthorizationConfig from proto metadata,
+ * parent ids from spec fields, the visibility shape set-diff — and hand
+ * the driver fully-resolved events. The driver owns only the tuple
+ * writes. No driver composed = the steps no-op = OSS behavior is
+ * byte-identical (the empty-default doctrine, DD-006 §2a).
+ *
+ * Failure semantics are part of the contract (Java parity, verified
+ * against the cloud handlers 2026-08-27):
+ *   - onResourceCreated: SYNCHRONOUS, post-persist; a throw FAILS the
+ *     request (the resource row survives — half-created resources are an
+ *     inherited real state, healed by retry).
+ *   - onResourceDeleted: best-effort — the call site logs and continues;
+ *     a throw never fails the delete (orphaned grants are inert once the
+ *     resource row is gone; the cloud side owns convergence sweeps).
+ *   - onVisibilityChanged: SYNCHRONOUS, post-persist; a throw fails the
+ *     request (metadata may be persisted with tuples lagging — retrying
+ *     the same transition converges, the set-diff is idempotent).
+ */
+import type { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { OwnerAttributionType } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/authorization_config_pb";
+
+import type { CallerIdentity } from "./identity.js";
+
+/**
+ * The visibility tuple shapes of the shared FGA model, named
+ * edition-neutrally. The driver maps each to its tuple:
+ *   - org-viewer:      <kind>:<id>#viewer@organization:<org>#viewer
+ *   - public-viewer:   <kind>:<id>#viewer@identity_account:* (conditional)
+ *   - platform-viewer: <kind>:<id>#platform_viewer@identity_provider:<idp>#platform_user
+ *     (fans out per IdP the org owns — the driver's lookup, not OSS's)
+ */
+export type VisibilityTupleShape =
+  | "org-viewer"
+  | "public-viewer"
+  | "platform-viewer";
+
+/**
+ * One resolved structural link from the created resource to a parent
+ * object — the scope link (relation `organization` for ORGANIZATION
+ * scope, the configured relation for PARENT scope) and every configured
+ * additional parent, in that order. Parent ids are extracted from the
+ * resource's spec fields by the OSS resolution (the proto
+ * ParentRelationConfig.spec_field contract).
+ */
+export interface ResolvedParentLink {
+  /** The FGA relation on the created resource (e.g. "organization", "session", "subject"). */
+  readonly relation: string;
+  /** The parent object's kind. */
+  readonly parentKind: ApiResourceKind;
+  /** The parent object's resource id. */
+  readonly parentId: string;
+}
+
+/** Fired synchronously after a resource row is first persisted. */
+export interface ResourceCreatedEvent {
+  readonly kind: ApiResourceKind;
+  readonly resourceId: string;
+  /** metadata.org — empty for kinds outside org scope (e.g. organization itself). */
+  readonly orgId: string;
+  /** The authenticated creator — owner/creator tuples derive from it. */
+  readonly caller: CallerIdentity;
+  /**
+   * The kind's owner attribution (proto AuthorizationConfig.owner_type):
+   * DIRECT → owner tuple for the caller; SELF → owner tuple for the
+   * resource's own id; INHERITED/NONE/UNSPECIFIED → no owner tuple.
+   */
+  readonly ownerAttribution: OwnerAttributionType;
+  /** True only for kinds flagged requires_creator_tuple (immutable attribution). */
+  readonly requiresCreatorTuple: boolean;
+  /** Scope link + additional parents, fully resolved. */
+  readonly parentLinks: ReadonlyArray<ResolvedParentLink>;
+  /**
+   * The creation-time visibility expansion (the Java reconciler's
+   * `unspecified → level` transition), org floor included.
+   */
+  readonly visibilityShapes: ReadonlyArray<VisibilityTupleShape>;
+}
+
+/** Fired after a resource row is deleted (best-effort consumption). */
+export interface ResourceDeletedEvent {
+  readonly kind: ApiResourceKind;
+  readonly resourceId: string;
+  readonly orgId: string;
+  readonly caller: CallerIdentity;
+}
+
+/** Fired synchronously after a visibility change is persisted. */
+export interface VisibilityChangedEvent {
+  readonly kind: ApiResourceKind;
+  readonly resourceId: string;
+  readonly orgId: string;
+  /** Shapes present in the new level but not the old — to be written. */
+  readonly shapesToCreate: ReadonlyArray<VisibilityTupleShape>;
+  /** Shapes present in the old level but not the new — to be deleted. */
+  readonly shapesToDelete: ReadonlyArray<VisibilityTupleShape>;
+}
+
+/**
+ * The driver interface (single-instance point, registered via
+ * ExtensionDrivers.resourceAuthorizationLifecycle). Implementations must
+ * be idempotent per event — the surrounding chains retry whole requests,
+ * and duplicate grants must converge, not error.
+ */
+export interface ResourceAuthorizationLifecycle {
+  onResourceCreated(event: ResourceCreatedEvent): Promise<void>;
+  onResourceDeleted(event: ResourceDeletedEvent): Promise<void>;
+  onVisibilityChanged(event: VisibilityChangedEvent): Promise<void>;
+}

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -66,6 +66,23 @@ export type {
 } from "./extensions/status-hooks.js";
 export type { ExtensionDrivers } from "./extensions/drivers.js";
 export type { ResolvedExtensionDrivers } from "./extensions/registry.js";
+// The C2 seams (20260827.10): the tuple-lifecycle driver point and the
+// organization query directory, plus the shape-policy helpers a driver's
+// tests pin against.
+export type {
+  ResourceAuthorizationLifecycle,
+  ResourceCreatedEvent,
+  ResourceDeletedEvent,
+  VisibilityChangedEvent,
+  VisibilityTupleShape,
+  ResolvedParentLink,
+} from "./extensions/resource-authorization.js";
+export type { OrganizationDirectory } from "./extensions/organization-directory.js";
+export { ALL_ORGANIZATIONS } from "./extensions/organization-directory.js";
+export {
+  diffVisibilityShapes,
+  visibilityShapesFor,
+} from "./pipeline/steps/authorization-tuples.js";
 
 // The pipeline primitives extensions build gate steps from.
 export type { PipelineStep } from "./pipeline/pipeline.js";

--- a/backend/services/stigmer-server/src/pipeline/steps/__tests__/authorization-tuples.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/__tests__/authorization-tuples.test.ts
@@ -1,0 +1,318 @@
+/**
+ * Pins the edition-neutral half of the C2 tuple-lifecycle seam
+ * (20260827.10, ruling Q2): the visibility shape policy and its set-diff
+ * (re-pinning the Java VisibilityTupleReconcilerTest transition matrix),
+ * and the config-driven creation-event resolution
+ * (CreateAuthorizationTuplesStepV2's scope/owner/parent semantics,
+ * including every failure arm). The driver-facing behavior of the steps
+ * themselves is pinned end to end in
+ * extensions/__tests__/extension-composition.test.ts.
+ */
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentInstanceSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { MemorySchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { OwnerAttributionType } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/authorization_config_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { OrganizationSchema } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import type { CallerIdentity } from "../../../extensions/identity.js";
+import {
+  diffVisibilityShapes,
+  resolveResourceCreatedEvent,
+  visibilityShapesFor,
+} from "../authorization-tuples.js";
+
+const logger = createLogger({ level: "error", pretty: false, write: () => {} });
+
+const caller: CallerIdentity = {
+  identityId: "ida_test_creator",
+  callerClass: "user",
+  issuer: "",
+  rawToken: "",
+};
+
+const V = ApiResourceVisibility;
+
+describe("visibilityShapesFor (the reconciler's level→shape policy)", () => {
+  it("agent (blueprint with org floor): org / public / platform expansions", () => {
+    expect([
+      ...visibilityShapesFor(ApiResourceKind.agent, V.visibility_org),
+    ]).toEqual(["org-viewer"]);
+    expect(
+      [
+        ...visibilityShapesFor(ApiResourceKind.agent, V.visibility_public),
+      ].sort(),
+    ).toEqual(["org-viewer", "public-viewer"]);
+    expect(
+      [
+        ...visibilityShapesFor(ApiResourceKind.agent, V.visibility_platform),
+      ].sort(),
+    ).toEqual(["org-viewer", "platform-viewer"]);
+    expect([
+      ...visibilityShapesFor(ApiResourceKind.agent, V.visibility_private),
+    ]).toEqual([]);
+  });
+
+  it("workflow_instance (no org floor): public expands to the wildcard shape alone", () => {
+    expect([
+      ...visibilityShapesFor(
+        ApiResourceKind.workflow_instance,
+        V.visibility_public,
+      ),
+    ]).toEqual(["public-viewer"]);
+  });
+
+  it("session (no visibility config): every level yields nothing, silently", () => {
+    expect([
+      ...visibilityShapesFor(ApiResourceKind.session, V.visibility_public),
+    ]).toEqual([]);
+    expect([
+      ...visibilityShapesFor(ApiResourceKind.session, V.visibility_org),
+    ]).toEqual([]);
+  });
+
+  it("agent_instance supports org+public but never platform (tenant isolation)", () => {
+    expect([
+      ...visibilityShapesFor(
+        ApiResourceKind.agent_instance,
+        V.visibility_platform,
+      ),
+    ]).toEqual([]);
+  });
+});
+
+describe("diffVisibilityShapes (the reconciler's transition matrix, re-pinned)", () => {
+  const agent = ApiResourceKind.agent;
+
+  it("same level is a no-op", () => {
+    const diff = diffVisibilityShapes(
+      agent,
+      V.visibility_org,
+      V.visibility_org,
+    );
+    expect(diff.shapesToCreate).toEqual([]);
+    expect(diff.shapesToDelete).toEqual([]);
+  });
+
+  it("unspecified→public creates public + the org floor", () => {
+    const diff = diffVisibilityShapes(
+      agent,
+      V.api_resource_visibility_unspecified,
+      V.visibility_public,
+    );
+    expect([...diff.shapesToCreate].sort()).toEqual([
+      "org-viewer",
+      "public-viewer",
+    ]);
+    expect(diff.shapesToDelete).toEqual([]);
+  });
+
+  it("org→private deletes the org shape (the shipped stale-tuple bug's pin)", () => {
+    const diff = diffVisibilityShapes(
+      agent,
+      V.visibility_org,
+      V.visibility_private,
+    );
+    expect(diff.shapesToCreate).toEqual([]);
+    expect(diff.shapesToDelete).toEqual(["org-viewer"]);
+  });
+
+  it("public→org deletes ONLY the wildcard — the shared org shape stays untouched", () => {
+    const diff = diffVisibilityShapes(
+      agent,
+      V.visibility_public,
+      V.visibility_org,
+    );
+    expect(diff.shapesToCreate).toEqual([]);
+    expect(diff.shapesToDelete).toEqual(["public-viewer"]);
+  });
+
+  it("platform→public swaps the family shape and never touches the org floor", () => {
+    const diff = diffVisibilityShapes(
+      agent,
+      V.visibility_platform,
+      V.visibility_public,
+    );
+    expect(diff.shapesToCreate).toEqual(["public-viewer"]);
+    expect(diff.shapesToDelete).toEqual(["platform-viewer"]);
+  });
+
+  it("platform→private deletes both the family shape and the floor", () => {
+    const diff = diffVisibilityShapes(
+      agent,
+      V.visibility_platform,
+      V.visibility_private,
+    );
+    expect(diff.shapesToCreate).toEqual([]);
+    expect([...diff.shapesToDelete].sort()).toEqual([
+      "org-viewer",
+      "platform-viewer",
+    ]);
+  });
+});
+
+describe("resolveResourceCreatedEvent (the config-driven creation resolution)", () => {
+  it("agent: ORGANIZATION scope link + DIRECT owner + creation visibility shapes", () => {
+    const agent = create(AgentSchema, {
+      metadata: {
+        id: "agt_1",
+        org: "acme",
+        visibility: V.visibility_org,
+      },
+    });
+    const event = resolveResourceCreatedEvent(
+      ApiResourceKind.agent,
+      agent,
+      caller,
+      logger,
+    );
+    expect(event).toBeDefined();
+    expect(event?.parentLinks).toEqual([
+      {
+        relation: "organization",
+        parentKind: ApiResourceKind.organization,
+        parentId: "acme",
+      },
+    ]);
+    expect(event?.ownerAttribution).toBe(OwnerAttributionType.DIRECT);
+    expect(event?.requiresCreatorTuple).toBe(false);
+    expect(event?.visibilityShapes).toEqual(["org-viewer"]);
+    expect(event?.caller.identityId).toBe("ida_test_creator");
+  });
+
+  it("organization: OWNER_ONLY — owner attribution without any scope link", () => {
+    const org = create(OrganizationSchema, {
+      metadata: { id: "acme", org: "" },
+    });
+    const event = resolveResourceCreatedEvent(
+      ApiResourceKind.organization,
+      org,
+      caller,
+      logger,
+    );
+    expect(event?.parentLinks).toEqual([]);
+    expect(event?.ownerAttribution).toBe(OwnerAttributionType.DIRECT);
+  });
+
+  it("environment: the one requires_creator_tuple kind", () => {
+    const env = create(EnvironmentSchema, {
+      metadata: { id: "env_1", org: "acme" },
+    });
+    const event = resolveResourceCreatedEvent(
+      ApiResourceKind.environment,
+      env,
+      caller,
+      logger,
+    );
+    expect(event?.requiresCreatorTuple).toBe(true);
+  });
+
+  it("agent_execution: PARENT scope resolves the session link from spec.session_id, owner INHERITED", () => {
+    const execution = create(AgentExecutionSchema, {
+      metadata: { id: "aexec_1", org: "acme" },
+      spec: { sessionId: "ses_parent" },
+    });
+    const event = resolveResourceCreatedEvent(
+      ApiResourceKind.agent_execution,
+      execution,
+      caller,
+      logger,
+    );
+    expect(event?.parentLinks).toEqual([
+      {
+        relation: "session",
+        parentKind: ApiResourceKind.session,
+        parentId: "ses_parent",
+      },
+    ]);
+    expect(event?.ownerAttribution).toBe(OwnerAttributionType.INHERITED);
+  });
+
+  it("agent_execution with no session id fails the request (Java's missing-parent arm)", () => {
+    const execution = create(AgentExecutionSchema, {
+      metadata: { id: "aexec_2", org: "acme" },
+    });
+    expect(() =>
+      resolveResourceCreatedEvent(
+        ApiResourceKind.agent_execution,
+        execution,
+        caller,
+        logger,
+      ),
+    ).toThrowError(/failed to create authorization tuples/);
+  });
+
+  it("agent_instance: org scope link PLUS the additional agent parent from spec.agent_id", () => {
+    const instance = create(AgentInstanceSchema, {
+      metadata: { id: "agi_1", org: "acme" },
+      spec: { agentId: "agt_parent" },
+    });
+    const event = resolveResourceCreatedEvent(
+      ApiResourceKind.agent_instance,
+      instance,
+      caller,
+      logger,
+    );
+    expect(event?.parentLinks).toEqual([
+      {
+        relation: "organization",
+        parentKind: ApiResourceKind.organization,
+        parentId: "acme",
+      },
+      {
+        relation: "agent",
+        parentKind: ApiResourceKind.agent,
+        parentId: "agt_parent",
+      },
+    ]);
+  });
+
+  it("memory: owner NONE — the subject additional parent is the only principal-bearing link", () => {
+    const memory = create(MemorySchema, {
+      metadata: { id: "mem_1", org: "acme" },
+      spec: { subjectIdentityAccountId: "ida_subject" },
+    });
+    const event = resolveResourceCreatedEvent(
+      ApiResourceKind.memory,
+      memory,
+      caller,
+      logger,
+    );
+    expect(event?.ownerAttribution).toBe(OwnerAttributionType.NONE);
+    expect(event?.parentLinks).toContainEqual({
+      relation: "subject",
+      parentKind: ApiResourceKind.identity_account,
+      parentId: "ida_subject",
+    });
+  });
+
+  it("NONE-scoped kinds resolve to no event at all (Java's early return)", () => {
+    const platform = create(OrganizationSchema, {
+      metadata: { id: "stigmer" },
+    });
+    expect(
+      resolveResourceCreatedEvent(
+        ApiResourceKind.platform,
+        platform,
+        caller,
+        logger,
+      ),
+    ).toBeUndefined();
+  });
+
+  it("ORGANIZATION scope with a blank org fails the request", () => {
+    const agent = create(AgentSchema, {
+      metadata: { id: "agt_orgless", org: "" },
+    });
+    expect(() =>
+      resolveResourceCreatedEvent(ApiResourceKind.agent, agent, caller, logger),
+    ).toThrowError(/failed to create authorization tuples/);
+  });
+});

--- a/backend/services/stigmer-server/src/pipeline/steps/__tests__/authorize.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/__tests__/authorize.test.ts
@@ -121,6 +121,42 @@ describe("decision arms (wire contract, both pinned)", () => {
     );
     await expect(step.execute(agentCreateCtx())).resolves.toBeUndefined();
   });
+
+  it("not-found → NOT_FOUND with the load-first chain's copy (the C2 ruling-Q1 arm)", async () => {
+    const { authorizer } = fakeAuthorizer({ kind: "not-found" });
+    const step = newAuthorizeStep<typeof AgentSchema>(
+      AgentCommandController.method.create,
+      authorizer,
+    );
+    const error = await step
+      .execute(agentCreateCtx())
+      ?.catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.NotFound);
+    // Exactly what LoadTarget would answer for the missing target — the
+    // wire cannot tell which step spoke (stigmer#224 semantics).
+    expect((error as ConnectError).rawMessage).toBe(
+      "Organization not found: acme",
+    );
+  });
+
+  it("not-found on a non-resource-scoped check is an authorizer contract bug → INTERNAL", async () => {
+    const { authorizer } = fakeAuthorizer({ kind: "not-found" });
+    const step = newAuthorizeStep<typeof AgentSchema>(
+      AgentCommandController.method.create,
+      authorizer,
+    );
+    // Empty org → the resolved resource id is empty: not-found is
+    // meaningless here and must never soften into a NotFound answer.
+    const ctx = new RequestContext(
+      AgentSchema,
+      create(AgentSchema, { metadata: { name: "a", org: "" } }),
+      testCallerIdentity(),
+      ApiResourceKind.agent,
+    );
+    const error = await step.execute(ctx)?.catch((e: unknown) => e);
+    expect((error as ConnectError).code).toBe(Code.Internal);
+  });
 });
 
 describe("skip arms (the authorizer is never consulted)", () => {

--- a/backend/services/stigmer-server/src/pipeline/steps/authorization-tuples.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/authorization-tuples.ts
@@ -1,0 +1,447 @@
+/**
+ * Authorization-tuple lifecycle steps — the OSS half of the C2 seam
+ * (convergence 20260827.10, ruling Q2). Ports the Java service's
+ * config-driven tuple machinery: CreateAuthorizationTuplesStepV2 (create
+ * chains, post-persist), DeleteOperationCleanupIamPoliciesStep (delete
+ * chains, best-effort), and the VisibilityTupleReconciler's level→shape
+ * policy with set-diff transitions (updateVisibility chains,
+ * post-persist). Verified against the Java sources 2026-08-27; the
+ * behavioral inventory lives in the sub-project's T01 records.
+ *
+ * Everything edition-neutral resolves HERE — the kind's proto
+ * AuthorizationConfig (via kind_meta, the apiresource-meta idiom),
+ * parent ids from spec fields (the ParentRelationConfig.spec_field
+ * contract, proto reflection — zero hardcoded kind knowledge), and the
+ * visibility shape diff (org floor included). The composed
+ * ResourceAuthorizationLifecycle driver receives resolved events and
+ * owns only the tuple writes. No driver = every step no-ops before any
+ * resolution work — OSS behavior AND cost are byte-identical.
+ *
+ * Failure semantics (Java parity):
+ *   - create: a resolution gap (missing parent id, missing org) or a
+ *     driver throw FAILS the request as Internal — after persist, so a
+ *     half-created resource is a real, retry-healed state (inherited).
+ *   - delete cleanup: best-effort — log and continue, never fail the
+ *     delete (Java's step swallows everything; orphaned grants are inert
+ *     once the row is gone).
+ *   - visibility: a driver throw fails the request as Internal — after
+ *     persist; retrying the same transition converges (set-diff
+ *     idempotency).
+ *   - the PLATFORM scope arm is dead config in BOTH editions (no kind
+ *     uses it; Java's switch falls through to a warn) — ported as the
+ *     same conscious warn, never an implementation.
+ */
+import type { DescMessage, Message } from "@bufbuild/protobuf";
+
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import type { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import {
+  AuthorizationScopeType,
+  OwnerAttributionType,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/authorization_config_pb";
+import type {
+  AuthorizationConfig,
+  ParentRelationConfig,
+} from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/authorization_config_pb";
+
+import type { Logger } from "../../boot/logger.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import type {
+  ResolvedParentLink,
+  ResourceAuthorizationLifecycle,
+  ResourceCreatedEvent,
+  VisibilityTupleShape,
+} from "../../extensions/resource-authorization.js";
+import { getKindEnum, getKindMeta, getKindName } from "../apiresource-meta.js";
+import { internalError } from "../errors.js";
+import type { PipelineStep } from "../pipeline.js";
+import type { RequestContext } from "../request-context.js";
+import { EXISTING_RESOURCE_KEY } from "./load-existing.js";
+import type { HasMetadataShape } from "./shapes.js";
+import { metadataOf } from "./shapes.js";
+
+// ---------------------------------------------------------------------------
+// Visibility shape policy — the reconciler's level→shape mapping, ported
+// from the Java VisibilityTupleReconciler (its unit-test matrix is
+// re-pinned in this module's tests).
+// ---------------------------------------------------------------------------
+
+/**
+ * The tuple shapes a visibility level expands to for a kind. Levels the
+ * kind does not support yield the empty set SILENTLY (Java parity — the
+ * ValidateVisibility steps reject unsupported levels with
+ * InvalidArgument before persist; this policy never doubles as
+ * validation).
+ *
+ * The org floor: kinds flagged defaults_to_org_visibility (blueprints —
+ * shared org assets) keep the org-viewer shape at public and platform
+ * levels, so sharing a blueprint beyond the org never hides it from its
+ * own org's catalog (ListObjects suppresses the public wildcard).
+ */
+export function visibilityShapesFor(
+  kind: ApiResourceKind,
+  level: ApiResourceVisibility,
+): ReadonlySet<VisibilityTupleShape> {
+  const config = getKindMeta(kind).authorization?.visibility;
+  const shapes = new Set<VisibilityTupleShape>();
+  const orgFloor =
+    config?.defaultsToOrgVisibility === true && config.supportsOrg === true;
+  switch (level) {
+    case ApiResourceVisibility.visibility_org:
+      if (config?.supportsOrg === true) {
+        shapes.add("org-viewer");
+      }
+      break;
+    case ApiResourceVisibility.visibility_public:
+      if (config?.supportsPublic === true) {
+        shapes.add("public-viewer");
+        if (orgFloor) {
+          shapes.add("org-viewer");
+        }
+      }
+      break;
+    case ApiResourceVisibility.visibility_platform:
+      if (config?.supportsPlatform === true) {
+        shapes.add("platform-viewer");
+        if (orgFloor) {
+          shapes.add("org-viewer");
+        }
+      }
+      break;
+    default:
+      // private / unspecified / unknown → no visibility tuples.
+      break;
+  }
+  return shapes;
+}
+
+/** The set-diff of a visibility transition; shared shapes stay untouched. */
+export function diffVisibilityShapes(
+  kind: ApiResourceKind,
+  oldLevel: ApiResourceVisibility,
+  newLevel: ApiResourceVisibility,
+): {
+  readonly shapesToCreate: ReadonlyArray<VisibilityTupleShape>;
+  readonly shapesToDelete: ReadonlyArray<VisibilityTupleShape>;
+} {
+  if (oldLevel === newLevel) {
+    return { shapesToCreate: [], shapesToDelete: [] };
+  }
+  const oldShapes = visibilityShapesFor(kind, oldLevel);
+  const newShapes = visibilityShapesFor(kind, newLevel);
+  return {
+    shapesToCreate: [...newShapes].filter((shape) => !oldShapes.has(shape)),
+    shapesToDelete: [...oldShapes].filter((shape) => !newShapes.has(shape)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Parent-id resolution — the ParentIdExtractorRegistry port. Zero
+// hardcoded kind knowledge: the proto config names the spec field, this
+// module reads it structurally (protobuf-es spec messages are plain
+// objects whose properties are the camelCase proto field names).
+// ---------------------------------------------------------------------------
+
+/** proto snake_case field name → the generated property name. */
+function camelCaseFieldName(specField: string): string {
+  return specField.replace(/_([a-z0-9])/g, (_, ch: string) => ch.toUpperCase());
+}
+
+/**
+ * Extracts the parent id named by the config from the resource's spec.
+ * Returns "" for every miss (no spec, no field, non-string value) — the
+ * caller decides whether that is fatal, exactly as Java's registry
+ * returns null and the service throws.
+ */
+function extractParentId(resource: Message, specField: string): string {
+  // Structural access is the shapes.ts idiom: spec messages are plain
+  // objects; the property name is the camelCase form of the proto field.
+  const spec = (resource as unknown as { spec?: Record<string, unknown> }).spec;
+  if (spec === undefined) {
+    return "";
+  }
+  const value = spec[camelCaseFieldName(specField)];
+  return typeof value === "string" ? value : "";
+}
+
+function resolveParentLink(
+  kind: ApiResourceKind,
+  resource: Message,
+  parentConfig: ParentRelationConfig,
+): ResolvedParentLink {
+  const parentId = extractParentId(resource, parentConfig.specField);
+  if (parentId === "") {
+    // Java: "Parent ID required for X but not found" → the request fails.
+    throw internalError(
+      new Error(
+        `parent id for relation '${parentConfig.relation}' (spec field '${parentConfig.specField}') is missing on ${getKindName(kind)}`,
+      ),
+      "failed to create authorization tuples",
+    );
+  }
+  return {
+    relation: parentConfig.relation,
+    parentKind: getKindEnum(parentConfig.kind),
+    parentId,
+  };
+}
+
+/**
+ * The scope link + additional parents for a created resource — resolved
+ * in Java's order (scope first, additional parents after).
+ */
+function resolveParentLinks(
+  kind: ApiResourceKind,
+  config: AuthorizationConfig,
+  resource: Message,
+  orgId: string,
+  logger: Logger,
+): ReadonlyArray<ResolvedParentLink> {
+  const links: ResolvedParentLink[] = [];
+  switch (config.scopeType) {
+    case AuthorizationScopeType.ORGANIZATION: {
+      if (orgId === "") {
+        throw internalError(
+          new Error(
+            `organization id is required to create authorization tuples for ${getKindName(kind)}`,
+          ),
+          "failed to create authorization tuples",
+        );
+      }
+      links.push({
+        relation: "organization",
+        parentKind: getKindEnum("organization"),
+        parentId: orgId,
+      });
+      break;
+    }
+    case AuthorizationScopeType.PARENT: {
+      if (config.parent === undefined) {
+        throw internalError(
+          new Error(
+            `${getKindName(kind)} declares PARENT scope without a parent config`,
+          ),
+          "failed to create authorization tuples",
+        );
+      }
+      links.push(resolveParentLink(kind, resource, config.parent));
+      break;
+    }
+    case AuthorizationScopeType.OWNER_ONLY:
+      break;
+    case AuthorizationScopeType.PLATFORM:
+      // Dead config in both editions — Java's switch warns and writes no
+      // scope link (organization/identity_account are OWNER_ONLY in the
+      // shipped config). Ported as the same conscious warn.
+      logger.warn("unhandled PLATFORM authorization scope — no scope link", {
+        kind: getKindName(kind),
+      });
+      break;
+    default:
+      break;
+  }
+  for (const parent of config.additionalParents) {
+    links.push(resolveParentLink(kind, resource, parent));
+  }
+  return links;
+}
+
+// ---------------------------------------------------------------------------
+// The steps.
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the creation event for a just-persisted resource, or
+ * undefined for kinds whose scope is NONE/UNSPECIFIED (Java's early
+ * return — no owner tuple, no visibility either). Shared by the generic
+ * create step and the domain-local lanes whose pipeline message is not
+ * the resource (skill push rides SKILL_KEY).
+ */
+export function resolveResourceCreatedEvent(
+  kind: ApiResourceKind,
+  resource: Message,
+  caller: CallerIdentity,
+  logger: Logger,
+): ResourceCreatedEvent | undefined {
+  const config = getKindMeta(kind).authorization;
+  if (
+    config === undefined ||
+    config.scopeType === AuthorizationScopeType.NONE ||
+    config.scopeType === AuthorizationScopeType.UNSPECIFIED
+  ) {
+    return undefined;
+  }
+  const metadata = metadataOf(resource);
+  if (metadata === undefined || metadata.id === "") {
+    throw internalError(
+      new Error("resource metadata missing after persist"),
+      "failed to create authorization tuples",
+    );
+  }
+  return {
+    kind,
+    resourceId: metadata.id,
+    orgId: metadata.org,
+    caller,
+    ownerAttribution: config.ownerType,
+    requiresCreatorTuple: config.requiresCreatorTuple,
+    parentLinks: resolveParentLinks(
+      kind,
+      config,
+      resource,
+      metadata.org,
+      logger,
+    ),
+    // Creation is the unspecified→level transition (Java models it the
+    // same way through the reconciler).
+    visibilityShapes: [...visibilityShapesFor(kind, metadata.visibility)],
+  };
+}
+
+/**
+ * CreateAuthorizationTuples — post-persist in every create chain (apply
+ * delegates to create, so the apply lane is covered by construction).
+ */
+export function newCreateAuthorizationTuplesStep<Desc extends DescMessage>(
+  lifecycle: ResourceAuthorizationLifecycle | undefined,
+  logger: Logger,
+): PipelineStep<Desc> {
+  return {
+    name: "CreateAuthorizationTuples",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      if (lifecycle === undefined) {
+        return;
+      }
+      const event = resolveResourceCreatedEvent(
+        ctx.apiResourceKind,
+        ctx.newState,
+        ctx.callerIdentity,
+        logger,
+      );
+      if (event === undefined) {
+        return;
+      }
+      try {
+        await lifecycle.onResourceCreated(event);
+      } catch (error) {
+        throw internalError(error, "failed to create authorization tuples");
+      }
+    },
+  };
+}
+
+/**
+ * CleanupIamPolicies — after the store delete in every delete chain.
+ * Best-effort by contract: a driver failure is logged and the delete
+ * succeeds (Java's DeleteOperationCleanupIamPoliciesStep swallows all —
+ * the cloud side owns convergence for orphaned grants).
+ */
+export function newCleanupIamPoliciesStep<Desc extends DescMessage>(
+  lifecycle: ResourceAuthorizationLifecycle | undefined,
+  logger: Logger,
+): PipelineStep<Desc> {
+  return {
+    name: "CleanupIamPolicies",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      if (lifecycle === undefined) {
+        return;
+      }
+      const deleted = ctx.get(EXISTING_RESOURCE_KEY) as
+        | HasMetadataShape
+        | undefined;
+      const metadata = deleted?.metadata;
+      if (metadata === undefined || metadata.id === "") {
+        return;
+      }
+      try {
+        await lifecycle.onResourceDeleted({
+          kind: ctx.apiResourceKind,
+          resourceId: metadata.id,
+          orgId: metadata.org,
+          caller: ctx.callerIdentity,
+        });
+      } catch (error) {
+        logger.warn(
+          "authorization cleanup failed — orphaned IAM policies may remain",
+          {
+            kind: getKindName(ctx.apiResourceKind),
+            resourceId: metadata.id,
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+      }
+    },
+  };
+}
+
+/** Context key for the pre-update visibility level. */
+export const OLD_VISIBILITY_KEY = "authorizationOldVisibility";
+
+/**
+ * RecordVisibilityBeforeUpdate — captures the loaded resource's current
+ * level BEFORE the Set*Visibility step mutates it in place. Splices
+ * after the domain's load step; `resourceKey` names the domain-local
+ * context key holding the loaded resource.
+ */
+export function newRecordVisibilityBeforeUpdateStep<Desc extends DescMessage>(
+  resourceKey: string,
+): PipelineStep<Desc> {
+  return {
+    name: "RecordVisibilityBeforeUpdate",
+    execute(ctx: RequestContext<Desc>): void {
+      const resource = ctx.get(resourceKey) as HasMetadataShape | undefined;
+      ctx.set(
+        OLD_VISIBILITY_KEY,
+        resource?.metadata?.visibility ??
+          ApiResourceVisibility.api_resource_visibility_unspecified,
+      );
+    },
+  };
+}
+
+/**
+ * UpdateVisibilityTuples — post-persist in every updateVisibility chain
+ * (and the skill push lanes, which set visibility at creation time
+ * through the create step instead). A driver failure fails the request
+ * (Java parity: metadata persisted, tuples lagging, retry converges).
+ */
+export function newUpdateVisibilityTuplesStep<Desc extends DescMessage>(
+  lifecycle: ResourceAuthorizationLifecycle | undefined,
+  resourceKey: string,
+): PipelineStep<Desc> {
+  return {
+    name: "UpdateVisibilityTuples",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      if (lifecycle === undefined) {
+        return;
+      }
+      const resource = ctx.get(resourceKey) as HasMetadataShape | undefined;
+      const metadata = resource?.metadata;
+      if (metadata === undefined || metadata.id === "") {
+        return;
+      }
+      const oldLevel =
+        (ctx.get(OLD_VISIBILITY_KEY) as ApiResourceVisibility | undefined) ??
+        ApiResourceVisibility.api_resource_visibility_unspecified;
+      const { shapesToCreate, shapesToDelete } = diffVisibilityShapes(
+        ctx.apiResourceKind,
+        oldLevel,
+        metadata.visibility,
+      );
+      if (shapesToCreate.length === 0 && shapesToDelete.length === 0) {
+        return;
+      }
+      try {
+        await lifecycle.onVisibilityChanged({
+          kind: ctx.apiResourceKind,
+          resourceId: metadata.id,
+          orgId: metadata.org,
+          shapesToCreate,
+          shapesToDelete,
+        });
+      } catch (error) {
+        throw internalError(error, "failed to update visibility tuples");
+      }
+    },
+  };
+}

--- a/backend/services/stigmer-server/src/pipeline/steps/authorize.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/authorize.ts
@@ -13,6 +13,10 @@
  *   allow       → the chain proceeds;
  *   deny        → PERMISSION_DENIED, carrying the annotation's byte-pinned
  *                 `error_msg` (the reason arm is the fallback copy);
+ *   not-found   → NOT_FOUND with the load-first chain's copy (the C2
+ *                 ruling-Q1 refinement: a resource-scoped check on a
+ *                 nonexistent id answers what Java's load-before-authorize
+ *                 order answers, stigmer#224);
  *   unavailable → INTERNAL — an authorization-backend outage is NEVER
  *                 softened into a denial (the verified Java StepResult
  *                 lesson, DD-007's wire-visible contract).
@@ -43,8 +47,13 @@ import {
   is_skip_authorization,
 } from "@stigmer/protos/ai/stigmer/commons/rpc/method_options_pb";
 
-import type { Authorizer, AuthzDecision } from "../../extensions/authorizer.js";
-import { internalError } from "../errors.js";
+import type {
+  Authorizer,
+  AuthzCheck,
+  AuthzDecision,
+} from "../../extensions/authorizer.js";
+import { getKindName } from "../apiresource-meta.js";
+import { internalError, notFoundError } from "../errors.js";
 import type { PipelineStep } from "../pipeline.js";
 import type { RequestContext } from "../request-context.js";
 
@@ -89,7 +98,10 @@ export function newAuthorizeStep<Desc extends DescMessage>(
       if (ctx.callerIdentity.callerClass === "internal") {
         return;
       }
-      if (getOption(method, is_public) || getOption(method, is_skip_authorization)) {
+      if (
+        getOption(method, is_public) ||
+        getOption(method, is_skip_authorization)
+      ) {
         return;
       }
       if (!hasOption(method, rpcAuthorizationConfig)) {
@@ -97,7 +109,12 @@ export function newAuthorizeStep<Desc extends DescMessage>(
       }
       const config = getOption(method, rpcAuthorizationConfig);
 
-      const decision = await runAuthorizer(authorizer, ctx, config);
+      const check: AuthzCheck = {
+        permission: config.permission,
+        resourceKind: resolveResourceKind(ctx.input, config),
+        resourceId: resolveResourceId(ctx.input, config),
+      };
+      const decision = await runAuthorizer(authorizer, ctx, check);
       switch (decision.kind) {
         case "allow":
           return;
@@ -110,8 +127,31 @@ export function newAuthorizeStep<Desc extends DescMessage>(
                 : AUTHORIZATION_DENIED_FALLBACK_MESSAGE,
             Code.PermissionDenied,
           );
+        case "not-found": {
+          // The ruling-Q1 arm: the exact copy the load-first chain would
+          // answer for the missing id (LoadTarget's notFoundError), so
+          // the wire cannot distinguish which step spoke.
+          if (
+            check.resourceId === "" ||
+            check.resourceKind === ApiResourceKind.api_resource_kind_unknown
+          ) {
+            throw internalError(
+              new Error(
+                "authorizer answered not-found for a non-resource-scoped check",
+              ),
+              AUTHORIZATION_UNAVAILABLE_MESSAGE,
+            );
+          }
+          throw notFoundError(
+            getKindName(check.resourceKind),
+            check.resourceId,
+          );
+        }
         case "unavailable":
-          throw internalError(decision.cause, AUTHORIZATION_UNAVAILABLE_MESSAGE);
+          throw internalError(
+            decision.cause,
+            AUTHORIZATION_UNAVAILABLE_MESSAGE,
+          );
         default: {
           const exhaustive: never = decision;
           throw internalError(
@@ -132,14 +172,10 @@ export function newAuthorizeStep<Desc extends DescMessage>(
 async function runAuthorizer<Desc extends DescMessage>(
   authorizer: Authorizer,
   ctx: RequestContext<Desc>,
-  config: RpcAuthorizationConfig,
+  check: AuthzCheck,
 ): Promise<AuthzDecision> {
   try {
-    return await authorizer.authorize(ctx.callerIdentity, {
-      permission: config.permission,
-      resourceKind: resolveResourceKind(ctx.input, config),
-      resourceId: resolveResourceId(ctx.input, config),
-    });
+    return await authorizer.authorize(ctx.callerIdentity, check);
   } catch (error) {
     return {
       kind: "unavailable",

--- a/backend/services/stigmer-server/src/pipeline/steps/load-for-apply.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/load-for-apply.ts
@@ -4,7 +4,8 @@
  * flags the controller branches on (create vs update), and populates the
  * id when the resource exists.
  */
-import type { DescMessage } from "@bufbuild/protobuf";
+import { clone } from "@bufbuild/protobuf";
+import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
 
 import type { Store } from "../../store/interface.js";
 import type { PipelineStep } from "../pipeline.js";
@@ -53,4 +54,29 @@ export function newLoadForApplyStep<Desc extends DescMessage>(
       }
     },
   };
+}
+
+/**
+ * The apply update-arm delegation message: the ORIGINAL request (the Go
+ * pin — never the pipeline's mutated clone) with ONLY the resolved id
+ * copied on. Apply requests identify by name+org, not id, so without
+ * this the delegated update chain's Authorize step checks an EMPTY
+ * resource id — the permissive OSS default never noticed, but a real
+ * Authorizer (the cloud edition) must check the true target, exactly as
+ * the Java edition's post-load authorize order does (C2, 20260827.10).
+ * OSS wire behavior is unchanged: the update chain re-resolves and
+ * loads by slug regardless, and the rosters pin the byte-identity.
+ */
+export function withResolvedApplyId<Desc extends DescMessage>(
+  schema: Desc,
+  original: MessageShape<Desc>,
+  resolved: RequestContext<Desc>,
+): MessageShape<Desc> {
+  const enriched = clone(schema, original);
+  const metadata = metadataOf(enriched);
+  const resolvedId = metadataOf(resolved.newState)?.id ?? "";
+  if (metadata !== undefined && metadata.id === "" && resolvedId !== "") {
+    metadata.id = resolvedId;
+  }
+  return enriched;
 }

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -52,13 +52,18 @@ import type {
   IdentityVerifier,
   MintedToken,
   ModelCatalogProvider,
+  OrganizationDirectory,
   PipelineStep,
   PresignedUpload,
+  ResourceAuthorizationLifecycle,
+  ResourceCreatedEvent,
+  ResourceDeletedEvent,
   RunnerCredentialProvider,
   SandboxProvisioner,
   SandboxProvisionerFactory,
   ServerExtension,
   Store,
+  VisibilityChangedEvent,
   WorkerFactory,
 } from "@stigmer/server";
 
@@ -232,6 +237,41 @@ const registerBillingService = (router: ConnectRouter): void => {
   });
 };
 
+/**
+ * A consumer tuple-lifecycle driver (the C2 seam, ruling Q2) — receives
+ * fully-resolved events; the tuple writes are the consumer's own.
+ */
+const authorizationLifecycle: ResourceAuthorizationLifecycle = {
+  onResourceCreated: (event: ResourceCreatedEvent) => {
+    void event.parentLinks;
+    void event.ownerAttribution;
+    void event.visibilityShapes;
+    return Promise.resolve();
+  },
+  onResourceDeleted: (event: ResourceDeletedEvent) => {
+    void event.resourceId;
+    return Promise.resolve();
+  },
+  onVisibilityChanged: (event: VisibilityChangedEvent) => {
+    void event.shapesToCreate;
+    void event.shapesToDelete;
+    return Promise.resolve();
+  },
+};
+
+/** A consumer organization directory (the C2 seam, ruling Q7). */
+const organizationDirectory: OrganizationDirectory = {
+  refusesEnumeration: true,
+  listMyOrganizationIds: (caller: CallerIdentity) => {
+    void caller.identityId;
+    return Promise.resolve<ReadonlyArray<string>>([]);
+  },
+  getOrganizationIdByExternalOrgId: (externalOrgId: string) => {
+    void externalOrgId;
+    return Promise.resolve<string | undefined>(undefined);
+  },
+};
+
 /** The whole unit — every point a consumer can populate today. */
 export const fakeExtension: ServerExtension = {
   name: "consumer-fake",
@@ -258,6 +298,8 @@ export const fakeExtension: ServerExtension = {
     sandboxProvisionerDrivers: new Map([
       ["consumer-sandbox", consumerSandboxDriver],
     ]),
+    resourceAuthorizationLifecycle: authorizationLifecycle,
+    organizationDirectory,
   },
   services: [registerBillingService],
   workers: [workerFactory],


### PR DESCRIPTION
## Summary

The OSS half of the C2 IAM lifecycle extension (convergence program 20260827.10; plan-gate rulings Q2 and Q7, recorded in the sub-project's T01_1_review.md):

- **`ResourceAuthorizationLifecycle` driver point** — the config-driven port of the cloud's tuple machinery (`CreateAuthorizationTuplesStepV2` + delete cleanup + `VisibilityTupleReconciler`). Three shared steps splice at the Java-verified positions: `CreateAuthorizationTuples` post-persist in every create chain (in the org chain BEFORE the `org-create:post-persist` slot — the verified Java order), `CleanupIamPolicies` best-effort after every delete, and `UpdateVisibilityTuples`/`RecordVisibilityBeforeUpdate` around every updateVisibility persist, plus a domain-local adapter for the skill push upsert lane. All resolution is OSS-owned and edition-neutral (kind `AuthorizationConfig` from `kind_meta`, parent ids via `spec_field` proto reflection, the visibility shape set-diff with its org floor); the composed driver receives resolved events and owns only the tuple writes.
- **`OrganizationDirectory` driver point** — the three ratified organization query forks behind one domain port: `find`'s enumeration refusal (UNIMPLEMENTED), `findMyOrganizations` filtering to the caller's authorized set, and conditional `getByExternalOrgId` registration (absent = Unimplemented, exactly as today).
- Failure semantics port the verified Java arms: create/visibility driver failures fail the request post-persist (row survives, retry heals); delete cleanup never fails the delete. The dead PLATFORM scope arm stays a conscious warn. The ts-server guidelines document the new protected step vocabulary.

No driver composed = every step no-ops = OSS behavior byte-identical.

## Verification

- `tsc --noEmit` green; server unit suite **1959 passed** (38 new tests: the visibility transition matrix re-pinned from the Java reconciler tests, the per-scope-type event resolution incl. failure arms, and composed end-to-end proofs — driver events on create/delete/visibility including the in-process default-instance lane, best-effort delete, post-persist row survival, and all three directory forks).
- Extension-consumer compile proof green (the new points registered through the exports map alone).
- **All four conformance rosters green: local 498, local-postgres 498, local-execution 160, local-postgres-execution 160** (Node 22.22.1; the Class A count includes O3's new apikey suites) — the empty-set byte-identity instrument.

Part of C2 `sp.iam-lifecycle-extension` (cross-repo per ruling Q3); the stigmer-cloud PR carries the FGA-writing driver.

Made with [Cursor](https://cursor.com)