### PR TITLE
feat(backend/stigmer-server): add the ChannelRuntime driver seam — DD-004's serving half (C3)

### DIFF
--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -747,9 +747,15 @@ export async function composeServer(
       // and the registry lanes read — the channel model-pin rule
       // (stigmer/stigmer#774) can never drift from the served pickers.
       modelRegistry: modelCatalog,
+      // DD-004's serving seam (C3): undefined = the byte-pinned refusal
+      // posture; a composed runtime serves install + write/delete hooks.
+      channelRuntime: extensions.drivers.channelRuntime,
     });
-    registerChannelMessageServices(router);
-    registerChannelConversationServices(router);
+    registerChannelMessageServices(router, extensions.drivers.channelRuntime);
+    registerChannelConversationServices(
+      router,
+      extensions.drivers.channelRuntime,
+    );
     registerChannelAppServices(router, {
       store,
       logger,

--- a/backend/services/stigmer-server/src/domain/agentchannel/__tests__/channel-runtime.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/__tests__/channel-runtime.test.ts
@@ -1,0 +1,548 @@
+/**
+ * Pins the ChannelRuntime driver seam's SERVING posture (channel-runtime.ts,
+ * C3 ruling Q1) — the complement of agentchannel.test.ts, which pins the
+ * storing posture this seam must leave byte-identical. Same real stack:
+ * a composed server on an ephemeral port with ONE extension unit carrying
+ * a recording fake runtime, native gRPC clients, the full interceptor
+ * chain.
+ *
+ * What this file proves, arm by arm:
+ *   - every delegated RPC reaches the driver with its input and the
+ *     caller identity, and the driver's reply rides back on the wire
+ *     (delegation, not tail-end refusal-then-driver);
+ *   - the OSS-owned prefixes survive composition: the install lane's
+ *     load-then-X NOT_FOUND and Layer-1 proto validation both fire
+ *     BEFORE the driver (the driver records zero calls on those paths);
+ *   - enforceWriteConstraints runs at create/apply/update AFTER the
+ *     edition-neutral rules, sees the RESOLVED channel, and its refusal
+ *     is the request's refusal;
+ *   - teardownOnDelete runs between the load and the row delete: a
+ *     throwing teardown fails the delete AND leaves the row (idempotent
+ *     retry heals — the cloud#425 ordering).
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import { AgentChannelCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/command_pb";
+import { AgentChannelQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/query_pb";
+import { ChannelMessageCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_command_pb";
+import { ChannelMessageQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_query_pb";
+import { ChannelConversationCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_command_pb";
+import { ChannelConversationQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_query_pb";
+import {
+  ChannelConversationListSchema,
+  ChannelConversationSchema,
+  ConversationMediaDownloadUrlSchema,
+  ConversationTimelineSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_io_pb";
+import { InitiateChannelInstallOutputSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/io_pb";
+import {
+  ChannelTemplatesSchema,
+  MessagingChannelsSchema,
+  SendChannelMessageOutputSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import { invalidArgumentError } from "../../../pipeline/errors.js";
+import type { CallerIdentity } from "../../../extensions/identity.js";
+import type { ChannelRuntime } from "../channel-runtime.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const ORG = "channel-runtime-test-org";
+
+/** The refusal the fake's write-constraint arm throws when armed. */
+const FAKE_PIN_REQUIRED_MESSAGE =
+  "spec.run_config.model_name must name a pinned model when the run would use the Cursor harness";
+const FAKE_TEARDOWN_FAILURE_MESSAGE =
+  "fake teardown failure — cascade unavailable";
+
+/** One recorded driver invocation: the arm name and what it saw. */
+interface RecordedCall {
+  readonly arm: string;
+  readonly caller: CallerIdentity;
+  readonly channelId?: string;
+  readonly inputMarker?: string;
+}
+
+const calls: RecordedCall[] = [];
+let refuseWrites = false;
+let failTeardown = false;
+
+/**
+ * The recording fake: every arm logs what it saw and answers a schema-
+ * empty (or sentinel) reply. The two hooks are switchable so the refusal
+ * arms are provable through the same composed server.
+ */
+const fakeRuntime: ChannelRuntime = {
+  installs: {
+    initiateInstall: (channel, input, caller) => {
+      calls.push({
+        arm: "initiateInstall",
+        caller,
+        channelId: channel.metadata?.id,
+        inputMarker: input.resourceId,
+      });
+      return Promise.resolve(
+        create(InitiateChannelInstallOutputSchema, {
+          authorizationUrl: "https://consent.invalid/fake",
+          state: "fake-state-token",
+        }),
+      );
+    },
+    completeInstall: (channel, input, caller) => {
+      calls.push({
+        arm: "completeInstall",
+        caller,
+        channelId: channel.metadata?.id,
+        inputMarker: input.state,
+      });
+      return Promise.resolve(channel);
+    },
+  },
+  messaging: {
+    sendMessage: (input, caller) => {
+      calls.push({ arm: "sendMessage", caller, inputMarker: input.recipient });
+      return Promise.resolve(create(SendChannelMessageOutputSchema));
+    },
+    listTemplates: (input, caller) => {
+      calls.push({ arm: "listTemplates", caller, inputMarker: input.channel });
+      return Promise.resolve(create(ChannelTemplatesSchema));
+    },
+    listMessagingChannels: (_input, caller) => {
+      calls.push({ arm: "listMessagingChannels", caller });
+      return Promise.resolve(create(MessagingChannelsSchema));
+    },
+  },
+  conversations: {
+    listConversations: (input, caller) => {
+      calls.push({ arm: "listConversations", caller, inputMarker: input.org });
+      return Promise.resolve(
+        create(ChannelConversationListSchema, { totalCount: 42 }),
+      );
+    },
+    getConversation: (input, caller) => {
+      calls.push({
+        arm: "getConversation",
+        caller,
+        inputMarker: input.conversationKey,
+      });
+      return Promise.resolve(create(ChannelConversationSchema));
+    },
+    getTimeline: (input, caller) => {
+      calls.push({
+        arm: "getTimeline",
+        caller,
+        inputMarker: input.conversationKey,
+      });
+      return Promise.resolve(create(ConversationTimelineSchema));
+    },
+    getMediaDownloadUrl: (input, caller) => {
+      calls.push({
+        arm: "getMediaDownloadUrl",
+        caller,
+        inputMarker: input.itemId,
+      });
+      return Promise.resolve(create(ConversationMediaDownloadUrlSchema));
+    },
+    reply: (input, caller) => {
+      calls.push({ arm: "reply", caller, inputMarker: input.conversationKey });
+      return Promise.resolve(create(SendChannelMessageOutputSchema));
+    },
+    takeOver: (input, caller) => {
+      calls.push({
+        arm: "takeOver",
+        caller,
+        inputMarker: input.conversationKey,
+      });
+      return Promise.resolve(create(ChannelConversationSchema));
+    },
+    handBack: (input, caller) => {
+      calls.push({
+        arm: "handBack",
+        caller,
+        inputMarker: input.conversationKey,
+      });
+      return Promise.resolve(create(ChannelConversationSchema));
+    },
+    clearAttention: (input, caller) => {
+      calls.push({
+        arm: "clearAttention",
+        caller,
+        inputMarker: input.conversationKey,
+      });
+      return Promise.resolve(create(ChannelConversationSchema));
+    },
+    escalate: (input, caller) => {
+      calls.push({ arm: "escalate", caller, inputMarker: input.reason });
+      return Promise.resolve(create(ChannelConversationSchema));
+    },
+  },
+  enforceWriteConstraints: (channel) => {
+    calls.push({
+      arm: "enforceWriteConstraints",
+      // The hook deliberately carries no caller (it is a spec rule, not an
+      // authorization decision) — a placeholder keeps the record uniform.
+      caller: {
+        identityId: "",
+        callerClass: "internal",
+        issuer: "",
+        rawToken: "",
+      },
+      channelId: channel.metadata?.id,
+      inputMarker: channel.spec?.agentRef?.org,
+    });
+    if (refuseWrites) {
+      return Promise.reject(invalidArgumentError(FAKE_PIN_REQUIRED_MESSAGE));
+    }
+    return Promise.resolve();
+  },
+  teardownOnDelete: (channel, caller) => {
+    calls.push({
+      arm: "teardownOnDelete",
+      caller,
+      channelId: channel.metadata?.id,
+    });
+    if (failTeardown) {
+      return Promise.reject(new Error(FAKE_TEARDOWN_FAILURE_MESSAGE));
+    }
+    return Promise.resolve();
+  },
+};
+
+let server: ComposedServer;
+let channels: Client<typeof AgentChannelCommandController>;
+let query: Client<typeof AgentChannelQueryController>;
+let agents: Client<typeof AgentCommandController>;
+let messageCommand: Client<typeof ChannelMessageCommandController>;
+let messageQuery: Client<typeof ChannelMessageQueryController>;
+let conversationCommand: Client<typeof ChannelConversationCommandController>;
+let conversationQuery: Client<typeof ChannelConversationQueryController>;
+let dir: string;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "channel-runtime-test-"));
+  vi.stubEnv("STIGMER_ENCRYPTION_KEY", Buffer.alloc(32, 7).toString("base64"));
+  vi.stubEnv(
+    "STIGMER_RUNNER_TOKEN_KEY",
+    Buffer.alloc(32, 8).toString("base64"),
+  );
+  server = await composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      // No engine behind composed tests — the agentchannel.test.ts posture.
+      TEMPORAL_HOST_PORT: "127.0.0.1:1",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+    extensions: [
+      { name: "fake-channels", drivers: { channelRuntime: fakeRuntime } },
+    ],
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  channels = createClient(AgentChannelCommandController, transport);
+  query = createClient(AgentChannelQueryController, transport);
+  agents = createClient(AgentCommandController, transport);
+  messageCommand = createClient(ChannelMessageCommandController, transport);
+  messageQuery = createClient(ChannelMessageQueryController, transport);
+  conversationCommand = createClient(
+    ChannelConversationCommandController,
+    transport,
+  );
+  conversationQuery = createClient(
+    ChannelConversationQueryController,
+    transport,
+  );
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+beforeEach(() => {
+  calls.length = 0;
+  refuseWrites = false;
+  failTeardown = false;
+});
+
+let counter = 0;
+function uniqueName(base: string): string {
+  counter += 1;
+  return `${base} ${counter}`;
+}
+
+async function createTestAgent(name: string): Promise<Agent> {
+  return agents.create({
+    apiVersion: API_VERSION,
+    kind: "Agent",
+    metadata: { name, org: ORG },
+    spec: {
+      description: "Agent for channel-runtime seam tests",
+      instructions: "You are a helpful agent for seam verification.",
+    },
+  });
+}
+
+async function createTestChannel(agentSlug: string): Promise<AgentChannel> {
+  return channels.create({
+    apiVersion: API_VERSION,
+    kind: "AgentChannel",
+    metadata: { name: uniqueName("runtime channel"), org: ORG },
+    spec: {
+      agentRef: { kind: ApiResourceKind.agent, slug: agentSlug },
+      providerConfig: { case: "slack", value: {} },
+    },
+  });
+}
+
+function lastCall(arm: string): RecordedCall {
+  const found = calls.filter((c) => c.arm === arm).at(-1);
+  expect(found, `driver arm '${arm}' was invoked`).toBeDefined();
+  return found!;
+}
+
+async function expectCode(
+  fn: () => Promise<unknown>,
+  code: Code,
+): Promise<ConnectError> {
+  try {
+    await fn();
+  } catch (error) {
+    const connectErr = ConnectError.from(error);
+    expect(connectErr.code).toBe(code);
+    return connectErr;
+  }
+  throw new Error("expected the call to fail, but it succeeded");
+}
+
+describe("install arms — per-arm delegation behind the OSS load contract", () => {
+  it("initiateInstall delegates with the LOADED channel and returns the driver's output", async () => {
+    const agent = await createTestAgent(uniqueName("install agent"));
+    const channel = await createTestChannel(agent.metadata!.slug);
+
+    const out = await channels.initiateInstall({
+      resourceId: channel.metadata!.id,
+    });
+    expect(out.authorizationUrl).toBe("https://consent.invalid/fake");
+    expect(out.state).toBe("fake-state-token");
+
+    const call = lastCall("initiateInstall");
+    expect(call.channelId).toBe(channel.metadata!.id);
+    expect(call.inputMarker).toBe(channel.metadata!.id);
+    expect(call.caller.identityId).not.toBe("");
+  });
+
+  it("completeInstall delegates the same way", async () => {
+    const agent = await createTestAgent(uniqueName("complete agent"));
+    const channel = await createTestChannel(agent.metadata!.slug);
+
+    await channels.completeInstall({
+      resourceId: channel.metadata!.id,
+      state: "state-token-1",
+      code: "oauth-code-1",
+    });
+    const call = lastCall("completeInstall");
+    expect(call.channelId).toBe(channel.metadata!.id);
+    expect(call.inputMarker).toBe("state-token-1");
+  });
+
+  it("keeps the OSS NOT_FOUND load contract — the driver never sees a missing id", async () => {
+    const err = await expectCode(
+      () => channels.initiateInstall({ resourceId: "ach_01runtimemissing" }),
+      Code.NotFound,
+    );
+    expect(err.rawMessage).toBe("AgentChannel not found: ach_01runtimemissing");
+    expect(calls.filter((c) => c.arm === "initiateInstall")).toHaveLength(0);
+  });
+});
+
+describe("messaging surface — whole-method delegation", () => {
+  it("delegates all three methods with input and caller threaded", async () => {
+    await messageCommand.sendMessage({
+      channel: "chan-1",
+      recipient: "15551234567",
+      payload: { kind: { case: "text", value: { body: "hello" } } },
+    });
+    expect(lastCall("sendMessage").inputMarker).toBe("15551234567");
+
+    await messageQuery.listTemplates({ channel: "chan-1" });
+    expect(lastCall("listTemplates").inputMarker).toBe("chan-1");
+
+    await messageQuery.listMessagingChannels({});
+    expect(lastCall("listMessagingChannels").caller.identityId).not.toBe("");
+  });
+
+  it("Layer-1 validation still precedes delegation (driver sees nothing)", async () => {
+    await expectCode(
+      () => messageCommand.sendMessage({ channel: "c", recipient: "" }),
+      Code.InvalidArgument,
+    );
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("conversation surface — whole-method delegation", () => {
+  it("delegates every query, sentinel replies riding back", async () => {
+    const list = await conversationQuery.listConversations({ org: ORG });
+    expect(list.totalCount).toBe(42);
+    expect(lastCall("listConversations").inputMarker).toBe(ORG);
+
+    await conversationQuery.getConversation({
+      agentChannelId: "ach_x",
+      conversationKey: "conv-1",
+    });
+    expect(lastCall("getConversation").inputMarker).toBe("conv-1");
+
+    await conversationQuery.getTimeline({
+      agentChannelId: "ach_x",
+      conversationKey: "conv-2",
+    });
+    expect(lastCall("getTimeline").inputMarker).toBe("conv-2");
+
+    await conversationQuery.getMediaDownloadUrl({
+      agentChannelId: "ach_x",
+      conversationKey: "conv-3",
+      itemId: "item-9",
+    });
+    expect(lastCall("getMediaDownloadUrl").inputMarker).toBe("item-9");
+  });
+
+  it("delegates every command", async () => {
+    const control = { agentChannelId: "ach_x", conversationKey: "conv-cmd" };
+    await conversationCommand.reply({
+      ...control,
+      payload: { kind: { case: "text", value: { body: "hi" } } },
+    });
+    expect(lastCall("reply").inputMarker).toBe("conv-cmd");
+
+    await conversationCommand.takeOver(control);
+    expect(lastCall("takeOver").inputMarker).toBe("conv-cmd");
+
+    await conversationCommand.handBack(control);
+    expect(lastCall("handBack").inputMarker).toBe("conv-cmd");
+
+    await conversationCommand.clearAttention(control);
+    expect(lastCall("clearAttention").inputMarker).toBe("conv-cmd");
+
+    await conversationCommand.escalate({ reason: "needs a human" });
+    expect(lastCall("escalate").inputMarker).toBe("needs a human");
+  });
+});
+
+describe("enforceWriteConstraints — the edition-split CRUD hook", () => {
+  it("runs on create with the RESOLVED channel (agent_ref.org normalized)", async () => {
+    const agent = await createTestAgent(uniqueName("constraint agent"));
+    await createTestChannel(agent.metadata!.slug);
+
+    const call = lastCall("enforceWriteConstraints");
+    // The request left agent_ref.org empty; the hook saw it resolved —
+    // proof it runs AFTER the edition-neutral resolution.
+    expect(call.inputMarker).toBe(ORG);
+  });
+
+  it("runs on update", async () => {
+    const agent = await createTestAgent(uniqueName("update agent"));
+    const channel = await createTestChannel(agent.metadata!.slug);
+    calls.length = 0;
+
+    await channels.update(channel);
+    expect(lastCall("enforceWriteConstraints").channelId).toBe(
+      channel.metadata!.id,
+    );
+  });
+
+  it("a refusing constraint refuses the create with the driver's code and copy", async () => {
+    const agent = await createTestAgent(uniqueName("refusal agent"));
+    refuseWrites = true;
+
+    const err = await expectCode(
+      () =>
+        channels.create({
+          apiVersion: API_VERSION,
+          kind: "AgentChannel",
+          metadata: { name: uniqueName("refused channel"), org: ORG },
+          spec: {
+            agentRef: {
+              kind: ApiResourceKind.agent,
+              slug: agent.metadata!.slug,
+            },
+            providerConfig: { case: "slack", value: {} },
+          },
+        }),
+      Code.InvalidArgument,
+    );
+    expect(err.rawMessage).toBe(FAKE_PIN_REQUIRED_MESSAGE);
+  });
+});
+
+describe("teardownOnDelete — the delete-chain cascade hook", () => {
+  it("a failing teardown fails the delete AND the row survives for retry", async () => {
+    const agent = await createTestAgent(uniqueName("teardown agent"));
+    const channel = await createTestChannel(agent.metadata!.slug);
+
+    failTeardown = true;
+    await expectCode(
+      () => channels.delete({ value: channel.metadata!.id }),
+      Code.Internal,
+    );
+    expect(lastCall("teardownOnDelete").channelId).toBe(channel.metadata!.id);
+
+    // The row outlived the failed cascade — the teardown-before-row order.
+    const still = await query.get({ value: channel.metadata!.id });
+    expect(still.metadata?.id).toBe(channel.metadata!.id);
+
+    // The idempotent retry heals once the cascade succeeds.
+    failTeardown = false;
+    await channels.delete({ value: channel.metadata!.id });
+    await expectCode(
+      () => query.get({ value: channel.metadata!.id }),
+      Code.NotFound,
+    );
+  });
+
+  it("delegates with the loaded channel and the caller identity", async () => {
+    const agent = await createTestAgent(uniqueName("delete agent"));
+    const channel = await createTestChannel(agent.metadata!.slug);
+    calls.length = 0;
+
+    await channels.delete({ value: channel.metadata!.id });
+    const call = lastCall("teardownOnDelete");
+    expect(call.channelId).toBe(channel.metadata!.id);
+    expect(call.caller.identityId).not.toBe("");
+  });
+});

--- a/backend/services/stigmer-server/src/domain/agentchannel/channel-runtime.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/channel-runtime.ts
@@ -1,0 +1,211 @@
+/**
+ * The channel-runtime driver seam — convergence program 20260826.02,
+ * DD-004's "contract OSS, delivery runtime cloud" expressed as code;
+ * ratified at C3's plan gate (20260827.11, ruling Q1, with the two hooks
+ * added by the pre-Stage-1 deep pass recorded in its T01_1_review.md).
+ * Lives in src/domain/agentchannel beside the surfaces it fronts (the
+ * ModelCatalogProvider / RunnerCredentialProvider placement precedent).
+ *
+ * OSS serves the AgentChannel CONTRACT: resource CRUD, discovery-shaped
+ * reads, and engineered refusals on every arm that would need a delivery
+ * runtime (constants.ts — the three byte-pinned "requires Stigmer Cloud"
+ * strings). A composition that HAS a delivery runtime registers ONE
+ * ChannelRuntime through the drivers registry point
+ * (extensions/drivers.ts, single-instance), and the OSS controllers
+ * delegate exactly those arms to it. With no driver composed, behavior is
+ * byte-identical to the refusal posture — proven by the four conformance
+ * rosters on every change to this seam.
+ *
+ * What stays OSS-owned on every delegated path (the driver never re-does
+ * it): Layer-1 proto validation (the transport interceptor chain — the
+ * INVALID_ARGUMENT contract holds before any delegation, exactly as it
+ * held before any refusal), and the install lane's load-then-X contract
+ * (loadChannelForInstall answers cloud's LoadChannel NOT_FOUND verbatim;
+ * the loaded channel is handed to the driver so nothing loads twice).
+ * What the driver owns: provider I/O, runtime state, and its own error
+ * semantics — including cloud's deliberate fail-closed arms (an unknown
+ * send target answers PERMISSION_DENIED, DD-002 D4: no existence leak),
+ * which is exactly why the messaging/conversation groups delegate WHOLE
+ * methods rather than tail-ends.
+ *
+ * The two hooks exist because the edition split is wider than the refused
+ * RPCs (the deep-pass findings):
+ *
+ *   - enforceWriteConstraints: the write-time rules that only make sense
+ *     where the runtime serves. The known one is the pin-REQUIRED rule —
+ *     the serving edition refuses an unpinned run_config.model_name at
+ *     create/apply/update (InvalidArgument, its copy conformance-pinned
+ *     on the cloud target) because its channel execution profile would
+ *     bill an unpinned run as Auto. The CONDITION is runtime-profile
+ *     knowledge (which harness would serve the run), so the driver owns
+ *     both condition and copy — hard-coding "driver present = pin
+ *     required" here would bake one composition's harness default into
+ *     OSS (the RunnerCredentialProvider lane-vocabulary discipline).
+ *     OSS keeps only the edition-neutral pin EXISTENCE rule (steps.ts,
+ *     stigmer/stigmer#774).
+ *   - teardownOnDelete: the delete-time cascade over runtime state OSS
+ *     never materializes (controller.ts delete header: the managed
+ *     credentials environment, the OAuth grant, pending-delivery
+ *     abandonment). Spliced teardown-BEFORE-row-delete so a failed
+ *     teardown leaves the row for an idempotent retry (the cloud#425
+ *     ordering family: dependent state dies before the row). A thrown
+ *     error fails the delete; fail-soft arms are the driver's own choice,
+ *     made per cause, never imposed here.
+ *
+ * All groups and both hooks are REQUIRED: a composition with a channel
+ * runtime implements the whole surface, and a gap is a compile error in
+ * the extension package, never a silent OSS refusal a live channel user
+ * meets in production.
+ */
+import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import type {
+  CompleteChannelInstallInput,
+  InitiateChannelInstallInput,
+  InitiateChannelInstallOutput,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/io_pb";
+import type {
+  ChannelTemplates,
+  ListChannelTemplatesInput,
+  ListMessagingChannelsInput,
+  MessagingChannels,
+  SendChannelMessageInput,
+  SendChannelMessageOutput,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
+import type {
+  ChannelConversation,
+  ChannelConversationList,
+  ConversationControlInput,
+  ConversationMediaDownloadUrl,
+  ConversationTimeline,
+  EscalateConversationInput,
+  GetChannelConversationInput,
+  GetConversationMediaDownloadUrlInput,
+  GetConversationTimelineInput,
+  ListChannelConversationsInput,
+  ReplyToConversationInput,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_io_pb";
+
+import type { CallerIdentity } from "../../extensions/identity.js";
+
+/**
+ * The provider install lane (Go install.go's cloud arm). OSS has already
+ * validated the input and loaded the channel — the NOT_FOUND contract is
+ * spent before the driver runs; `channel` is that loaded resource.
+ */
+export interface ChannelRuntimeInstalls {
+  /** The OAuth-initiate arm — the driver issues the state token and the redirect. */
+  initiateInstall(
+    channel: AgentChannel,
+    input: InitiateChannelInstallInput,
+    caller: CallerIdentity,
+  ): Promise<InitiateChannelInstallOutput>;
+  /** The OAuth-complete arm — the driver exchanges the code and stamps install status. */
+  completeInstall(
+    channel: AgentChannel,
+    input: CompleteChannelInstallInput,
+    caller: CallerIdentity,
+  ): Promise<AgentChannel>;
+}
+
+/**
+ * The messaging runtime surface (message.ts's serving arm). The caller
+ * identity is load-bearing: the serving edition resolves
+ * listMessagingChannels from the CALLER's agent session and refuses bare
+ * direct calls (a verified, two-arm-pinned edition divergence), and
+ * sendMessage's authorization is reach-based over the caller's session —
+ * both driver-owned decisions this seam only transports.
+ */
+export interface ChannelRuntimeMessaging {
+  sendMessage(
+    input: SendChannelMessageInput,
+    caller: CallerIdentity,
+  ): Promise<SendChannelMessageOutput>;
+  listTemplates(
+    input: ListChannelTemplatesInput,
+    caller: CallerIdentity,
+  ): Promise<ChannelTemplates>;
+  listMessagingChannels(
+    input: ListMessagingChannelsInput,
+    caller: CallerIdentity,
+  ): Promise<MessagingChannels>;
+}
+
+/**
+ * The conversation runtime surface (conversation.ts's serving arm) —
+ * queries AND commands: on the serving edition even the discovery reads
+ * are real store-backed lookups (the truthful-emptiness contract both
+ * editions share is an outcome there, not a stub), and getMediaDownloadUrl
+ * must keep the byte-pinned uniform miss across every cause (constants.ts
+ * NO_DOWNLOADABLE_MEDIA_MESSAGE — a prober cannot learn which items
+ * exist). escalate carries no channel id by design: the driver derives
+ * the conversation from the caller's session labels.
+ */
+export interface ChannelRuntimeConversations {
+  listConversations(
+    input: ListChannelConversationsInput,
+    caller: CallerIdentity,
+  ): Promise<ChannelConversationList>;
+  getConversation(
+    input: GetChannelConversationInput,
+    caller: CallerIdentity,
+  ): Promise<ChannelConversation>;
+  getTimeline(
+    input: GetConversationTimelineInput,
+    caller: CallerIdentity,
+  ): Promise<ConversationTimeline>;
+  getMediaDownloadUrl(
+    input: GetConversationMediaDownloadUrlInput,
+    caller: CallerIdentity,
+  ): Promise<ConversationMediaDownloadUrl>;
+  reply(
+    input: ReplyToConversationInput,
+    caller: CallerIdentity,
+  ): Promise<SendChannelMessageOutput>;
+  takeOver(
+    input: ConversationControlInput,
+    caller: CallerIdentity,
+  ): Promise<ChannelConversation>;
+  handBack(
+    input: ConversationControlInput,
+    caller: CallerIdentity,
+  ): Promise<ChannelConversation>;
+  clearAttention(
+    input: ConversationControlInput,
+    caller: CallerIdentity,
+  ): Promise<ChannelConversation>;
+  escalate(
+    input: EscalateConversationInput,
+    caller: CallerIdentity,
+  ): Promise<ChannelConversation>;
+}
+
+/**
+ * One composition's channel delivery runtime, grouped by the surfaces it
+ * takes over (the groups mirror the OSS file seams — controller.ts's
+ * install lane, message.ts, conversation.ts — which are themselves the
+ * retired Go server's file seams).
+ */
+export interface ChannelRuntime {
+  readonly installs: ChannelRuntimeInstalls;
+  readonly messaging: ChannelRuntimeMessaging;
+  readonly conversations: ChannelRuntimeConversations;
+  /**
+   * Write-time constraints only a serving runtime can state, invoked by
+   * ResolveChannelDefaults (create/apply) and ValidateChannelUpdate
+   * (update) AFTER the edition-neutral rules pass, with the fully
+   * resolved channel. Refuses by throwing a ConnectError with the
+   * correct code and the runtime's conformance-pinned copy; returning
+   * resolves the write.
+   */
+  enforceWriteConstraints(channel: AgentChannel): Promise<void>;
+  /**
+   * The delete-time cascade over runtime state (credentials environment,
+   * OAuth grant, pending deliveries), invoked after LoadExistingForDelete
+   * and BEFORE the row delete — a thrown error fails the delete and
+   * leaves the row for an idempotent retry.
+   */
+  teardownOnDelete(
+    channel: AgentChannel,
+    caller: CallerIdentity,
+  ): Promise<void>;
+}

--- a/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
@@ -13,8 +13,11 @@
  * channel (byte-identical NOT_FOUND with cloud's LoadChannel step), then
  * refuse FailedPrecondition — this edition has no webhook receiver and no
  * delivery runtime, so an installed channel could never serve traffic.
- * Nothing is persisted on that path. The messaging/conversation runtime
- * surfaces live in message.ts / conversation.ts (Go's file seams).
+ * Nothing is persisted on that path. A composition WITH a delivery
+ * runtime registers a ChannelRuntime driver (channel-runtime.ts, C3
+ * ruling Q1) and the final refuse line becomes a delegation instead —
+ * everything before it is posture-independent. The messaging/conversation
+ * runtime surfaces live in message.ts / conversation.ts (Go's file seams).
  *
  * NOT search-indexed by design; channels are NOT swept on agent delete
  * (only same-org shares are) — a dangling channel is tolerated because
@@ -89,10 +92,12 @@ import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
 import type { Store } from "../../store/interface.js";
 import type { ModelCatalogProvider } from "../workflow/registry/model-catalog-provider.js";
+import type { ChannelRuntime } from "./channel-runtime.js";
 import { INSTALL_UNAVAILABLE_MESSAGE } from "./constants.js";
 import {
   newInitInstallStateStep,
   newResolveChannelDefaultsStep,
+  newTeardownChannelRuntimeStep,
   newValidateChannelUpdateStep,
 } from "./steps.js";
 
@@ -102,6 +107,13 @@ export interface AgentChannelControllerDeps {
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
   readonly modelRegistry: ModelCatalogProvider;
+  /**
+   * The composed channel delivery runtime, or undefined on the storing
+   * edition (channel-runtime.ts — DD-004's serving seam, C3 ruling Q1).
+   * Explicitly `| undefined` rather than optional: every construction
+   * site states which posture it composes.
+   */
+  readonly channelRuntime: ChannelRuntime | undefined;
 }
 
 /** Registers both agentchannel resource services on the router. */
@@ -157,7 +169,13 @@ async function createChannel(
     )
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
-    .addStep(newResolveChannelDefaultsStep(deps.store, deps.modelRegistry))
+    .addStep(
+      newResolveChannelDefaultsStep(
+        deps.store,
+        deps.modelRegistry,
+        deps.channelRuntime,
+      ),
+    )
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
@@ -199,7 +217,9 @@ async function update(
     .addStep(newValidateProtoStep())
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
-    .addStep(newValidateChannelUpdateStep(deps.modelRegistry))
+    .addStep(
+      newValidateChannelUpdateStep(deps.modelRegistry, deps.channelRuntime),
+    )
     .addStep(newBuildUpdateStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
@@ -241,7 +261,13 @@ async function apply(
       ),
     )
     .addStep(newValidateProtoStep())
-    .addStep(newResolveChannelDefaultsStep(deps.store, deps.modelRegistry))
+    .addStep(
+      newResolveChannelDefaultsStep(
+        deps.store,
+        deps.modelRegistry,
+        deps.channelRuntime,
+      ),
+    )
     .addStep(newResolveSlugStep())
     .addStep(newLoadForApplyStep(deps.store))
     .build()
@@ -264,8 +290,10 @@ async function apply(
 // Install lane — Go install.go. Input validation is Layer-1 (the transport
 // interceptor chain validates every request, matching Go's explicit
 // SharedValidator call); the channel is loaded FIRST so the NOT_FOUND
-// contract is identical to cloud's LoadChannel step, and only the final
-// step diverges — the documented one. Nothing is persisted.
+// contract is identical to cloud's LoadChannel step in BOTH postures, and
+// only the final step splits: refuse-or-delegate (channel-runtime.ts, C3
+// ruling Q1). With no runtime composed nothing is persisted; a composed
+// runtime owns the install flow end to end.
 // ---------------------------------------------------------------------------
 
 async function initiateInstall(
@@ -273,32 +301,54 @@ async function initiateInstall(
   input: InitiateChannelInstallInput,
   ctx: HandlerContext,
 ): Promise<InitiateChannelInstallOutput> {
-  await loadChannelForInstall(deps, ctx, input.resourceId);
-  throw failedPreconditionError(INSTALL_UNAVAILABLE_MESSAGE);
+  const channel = await loadChannelForInstall(deps, ctx, input.resourceId);
+  if (deps.channelRuntime === undefined) {
+    throw failedPreconditionError(INSTALL_UNAVAILABLE_MESSAGE);
+  }
+  return deps.channelRuntime.installs.initiateInstall(
+    channel,
+    input,
+    callerIdentityOf(ctx),
+  );
 }
 
 /**
- * CompleteInstall — same load-then-refuse contract; a completion can only
- * be reached with a state token from a successful initiate, which this
- * edition never issues.
+ * CompleteInstall — same load-then-X contract; on the storing edition a
+ * completion can only be reached with a state token from a successful
+ * initiate, which it never issues.
  */
 async function completeInstall(
   deps: AgentChannelControllerDeps,
   input: CompleteChannelInstallInput,
   ctx: HandlerContext,
 ): Promise<AgentChannel> {
-  await loadChannelForInstall(deps, ctx, input.resourceId);
-  throw failedPreconditionError(INSTALL_UNAVAILABLE_MESSAGE);
+  const channel = await loadChannelForInstall(deps, ctx, input.resourceId);
+  if (deps.channelRuntime === undefined) {
+    throw failedPreconditionError(INSTALL_UNAVAILABLE_MESSAGE);
+  }
+  return deps.channelRuntime.installs.completeInstall(
+    channel,
+    input,
+    callerIdentityOf(ctx),
+  );
 }
 
-/** Verifies the target exists — cloud's LoadChannel NOT_FOUND, verbatim. */
+/**
+ * Loads the install target — cloud's LoadChannel NOT_FOUND, verbatim.
+ * Returns the loaded channel so a composed runtime receives it without a
+ * second load (the load-then-X contract stays OSS-owned).
+ */
 async function loadChannelForInstall(
   deps: AgentChannelControllerDeps,
   ctx: HandlerContext,
   resourceId: string,
-): Promise<void> {
+): Promise<AgentChannel> {
   try {
-    await deps.store.getResource(kindOf(ctx), resourceId, AgentChannelSchema);
+    return await deps.store.getResource(
+      kindOf(ctx),
+      resourceId,
+      AgentChannelSchema,
+    );
   } catch {
     throw notFoundError("AgentChannel", resourceId);
   }
@@ -306,10 +356,12 @@ async function loadChannelForInstall(
 
 /**
  * Delete — the connection's full teardown; disabling (update with
- * enabled=false) is the config-preserving pause. Versus cloud, OSS
- * excludes the teardown cascade (managed credentials environment, OAuth
- * grant, pending-delivery abandonment) — none of that state can exist
- * here because the install flow never runs (§0-b).
+ * enabled=false) is the config-preserving pause. On the storing edition
+ * there is no teardown cascade — none of that state can exist because the
+ * install flow never runs (§0-b). A composed runtime splices its cascade
+ * (TeardownChannelRuntime — credentials environment, OAuth grant, pending
+ * deliveries) between the load and the row delete, so dependent runtime
+ * state dies before the row (the cloud#425 ordering family).
  */
 async function deleteChannel(
   deps: AgentChannelControllerDeps,
@@ -322,10 +374,9 @@ async function deleteChannel(
     callerIdentityOf(ctx),
     kindOf(ctx),
   );
-  await newPipeline<typeof AgentChannelCommandController.method.delete.input>(
-    "agent-channel-delete",
-    deps.logger,
-  )
+  const pipeline = newPipeline<
+    typeof AgentChannelCommandController.method.delete.input
+  >("agent-channel-delete", deps.logger)
     .addStep(
       newAuthorizeStep(
         AgentChannelCommandController.method.delete,
@@ -334,7 +385,11 @@ async function deleteChannel(
     )
     .addStep(newValidateProtoStep())
     .addStep(newExtractResourceIdStep())
-    .addStep(newLoadExistingForDeleteStep(deps.store, AgentChannelSchema))
+    .addStep(newLoadExistingForDeleteStep(deps.store, AgentChannelSchema));
+  if (deps.channelRuntime !== undefined) {
+    pipeline.addStep(newTeardownChannelRuntimeStep(deps.channelRuntime));
+  }
+  await pipeline
     .addStep(newDeleteResourceStep(deps.store))
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/agentchannel/conversation.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/conversation.ts
@@ -2,24 +2,34 @@
  * ChannelConversation controllers — ports pkg/domain/agentchannel/
  * controller/conversation.go: the conversation surface beside the channel
  * messaging controllers, on the same runtime side of the resource/runtime
- * split. Stateless — no store.
+ * split. Stateless on the storing edition — no store.
  *
- * Queries answer EMPTY and commands refuse FailedPrecondition, the two
- * established postures side by side (channel-conversations DD-003 D-f): a
- * conversation list is a discovery-shaped read whose truthful OSS answer
- * is "none" (conversations are created by the cloud channel runtime,
- * which does not run here), while every command asks to DO a cloud-only
- * thing. The single-row reads cannot answer "empty" — getConversation
- * answers NotFound unconditionally, and getMediaDownloadUrl answers the
+ * The whole surface is posture-split at REGISTRATION (channel-runtime.ts,
+ * C3 ruling Q1): with no ChannelRuntime composed the storing bodies below
+ * serve byte-identically to before the seam existed; with one composed,
+ * EVERY method delegates — on the serving edition even the discovery
+ * reads are real store-backed lookups (truthful emptiness is an OUTCOME
+ * there, not a stub), and the uniform-miss reads must cover every cause
+ * identically, which only the runtime can do.
+ *
+ * Storing posture — queries answer EMPTY and commands refuse
+ * FailedPrecondition, the two established postures side by side
+ * (channel-conversations DD-003 D-f): a conversation list is a
+ * discovery-shaped read whose truthful storing answer is "none"
+ * (conversations are created by the serving channel runtime, which does
+ * not run here), while every command asks to DO a cloud-only thing. The
+ * single-row reads cannot answer "empty" — getConversation answers
+ * NotFound unconditionally, and getMediaDownloadUrl answers the
  * byte-pinned uniform miss (raw copy — the "%s not found: %s" helper
  * shape cannot say it). As in message.ts, there is deliberately NO
  * load-then-NOT_FOUND: probing local stores for conversations this
- * edition never materializes would create an edition divergence, not
+ * posture never materializes would create an edition divergence, not
  * prevent one.
  *
  * Input validation is Layer-1: the transport interceptor chain validates
  * every request (matching Go's explicit SharedValidator calls), so the
- * INVALID_ARGUMENT contract holds before every refusal.
+ * INVALID_ARGUMENT contract holds before every refusal AND before every
+ * delegation.
  *
  * Proven by agentchannel.conformance.test.ts (CONFORMANCE_TARGET=local)
  * and __tests__/agentchannel.test.ts.
@@ -40,49 +50,98 @@ import type {
   GetChannelConversationInput,
 } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_io_pb";
 
-import { failedPreconditionError, notFoundError } from "../../pipeline/errors.js";
+import {
+  failedPreconditionError,
+  notFoundError,
+} from "../../pipeline/errors.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
+import type { ChannelRuntime } from "./channel-runtime.js";
 import {
   CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE,
   NO_DOWNLOADABLE_MEDIA_MESSAGE,
 } from "./constants.js";
 
-/** Registers both channel-conversation services on the router. */
-export function registerChannelConversationServices(router: ConnectRouter): void {
+/**
+ * Registers both channel-conversation services on the router, in the
+ * posture the composition declares: storing bodies with no runtime,
+ * whole-method delegation with one.
+ */
+export function registerChannelConversationServices(
+  router: ConnectRouter,
+  channelRuntime: ChannelRuntime | undefined,
+): void {
+  if (channelRuntime === undefined) {
+    router.service(ChannelConversationQueryController, {
+      // Discovery-shaped reads answer truthful emptiness.
+      listConversations: (): ChannelConversationList =>
+        create(ChannelConversationListSchema),
+      getTimeline: (): ConversationTimeline =>
+        create(ConversationTimelineSchema),
+      // Single-row reads answer the uniform miss, with no local probing.
+      getConversation: (input: GetChannelConversationInput) => {
+        throw notFoundError("channel conversation", input.conversationKey);
+      },
+      getMediaDownloadUrl: () => {
+        // Byte-identical with the serving handler's uniform miss (which
+        // covers every cause the same way so a prober cannot learn which
+        // items exist) — a raw ConnectError because notFoundError's
+        // "%s not found: %s" shape cannot express this copy.
+        throw new ConnectError(NO_DOWNLOADABLE_MEDIA_MESSAGE, Code.NotFound);
+      },
+    });
+    router.service(ChannelConversationCommandController, {
+      // Every command asks to DO a cloud-only thing: staff replies ride the
+      // outbound delivery lane; take-over/hand-back/attention are the
+      // participation state machine; escalation is ingest — all cloud-only.
+      reply: () => {
+        throw failedPreconditionError(
+          CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE,
+        );
+      },
+      takeOver: () => {
+        throw failedPreconditionError(
+          CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE,
+        );
+      },
+      handBack: () => {
+        throw failedPreconditionError(
+          CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE,
+        );
+      },
+      clearAttention: () => {
+        throw failedPreconditionError(
+          CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE,
+        );
+      },
+      escalate: () => {
+        throw failedPreconditionError(
+          CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE,
+        );
+      },
+    });
+    return;
+  }
+
+  const { conversations } = channelRuntime;
   router.service(ChannelConversationQueryController, {
-    // Discovery-shaped reads answer truthful emptiness.
-    listConversations: (): ChannelConversationList =>
-      create(ChannelConversationListSchema),
-    getTimeline: (): ConversationTimeline => create(ConversationTimelineSchema),
-    // Single-row reads answer the uniform miss, with no local probing.
-    getConversation: (input: GetChannelConversationInput) => {
-      throw notFoundError("channel conversation", input.conversationKey);
-    },
-    getMediaDownloadUrl: () => {
-      // Byte-identical with the cloud handler's uniform miss (which
-      // covers every cause the same way so a prober cannot learn which
-      // items exist) — a raw ConnectError because notFoundError's
-      // "%s not found: %s" shape cannot express this copy.
-      throw new ConnectError(NO_DOWNLOADABLE_MEDIA_MESSAGE, Code.NotFound);
-    },
+    listConversations: (input, ctx) =>
+      conversations.listConversations(input, callerIdentityOf(ctx)),
+    getConversation: (input, ctx) =>
+      conversations.getConversation(input, callerIdentityOf(ctx)),
+    getTimeline: (input, ctx) =>
+      conversations.getTimeline(input, callerIdentityOf(ctx)),
+    getMediaDownloadUrl: (input, ctx) =>
+      conversations.getMediaDownloadUrl(input, callerIdentityOf(ctx)),
   });
   router.service(ChannelConversationCommandController, {
-    // Every command asks to DO a cloud-only thing: staff replies ride the
-    // outbound delivery lane; take-over/hand-back/attention are the
-    // participation state machine; escalation is ingest — all cloud-only.
-    reply: () => {
-      throw failedPreconditionError(CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE);
-    },
-    takeOver: () => {
-      throw failedPreconditionError(CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE);
-    },
-    handBack: () => {
-      throw failedPreconditionError(CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE);
-    },
-    clearAttention: () => {
-      throw failedPreconditionError(CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE);
-    },
-    escalate: () => {
-      throw failedPreconditionError(CONVERSATION_PARTICIPATION_UNAVAILABLE_MESSAGE);
-    },
+    reply: (input, ctx) => conversations.reply(input, callerIdentityOf(ctx)),
+    takeOver: (input, ctx) =>
+      conversations.takeOver(input, callerIdentityOf(ctx)),
+    handBack: (input, ctx) =>
+      conversations.handBack(input, callerIdentityOf(ctx)),
+    clearAttention: (input, ctx) =>
+      conversations.clearAttention(input, callerIdentityOf(ctx)),
+    escalate: (input, ctx) =>
+      conversations.escalate(input, callerIdentityOf(ctx)),
   });
 }

--- a/backend/services/stigmer-server/src/domain/agentchannel/message.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/message.ts
@@ -1,26 +1,38 @@
 /**
  * ChannelMessage controllers — ports pkg/domain/agentchannel/controller/
  * message.go: the runtime messaging surface beside the AgentChannel
- * resource controllers, kept off the resource CRUD surface. Stateless —
- * no store.
+ * resource controllers, kept off the resource CRUD surface. Stateless on
+ * the storing edition — no store.
  *
- * Both command-shaped RPCs are cloud-only runtime and refuse with
- * FailedPrecondition. Unlike the install refusal (controller.ts), there
- * is deliberately NO load-then-NOT_FOUND here: the cloud send handler
- * fails closed with PERMISSION_DENIED for an unknown channel (DD-002 D4's
- * error table, no existence leak), so probing the store first would
- * CREATE an edition divergence rather than prevent one.
+ * The whole surface is posture-split at REGISTRATION (channel-runtime.ts,
+ * C3 ruling Q1): with no ChannelRuntime composed the storing bodies below
+ * serve byte-identically to before the seam existed; with one composed,
+ * EVERY method delegates — the driver owns runtime state and its own
+ * error semantics, including the fail-closed arms this module's storing
+ * bodies deliberately do not probe for (see below). Tail-end delegation
+ * would force the storing refusals to run first and break exactly those
+ * semantics, which is why the split is per-service, not per-line.
+ *
+ * Storing posture — both command-shaped RPCs are cloud-only runtime and
+ * refuse with FailedPrecondition. Unlike the install refusal
+ * (controller.ts), there is deliberately NO load-then-NOT_FOUND here: the
+ * serving send handler fails closed with PERMISSION_DENIED for an unknown
+ * channel (DD-002 D4's error table, no existence leak), so probing the
+ * store first would CREATE an edition divergence rather than prevent one.
  *
  * listMessagingChannels answers an EMPTY list — a deliberate divergence
  * from its refusing siblings (proactive-messaging DD-006 D3): it is a
  * capability-DISCOVERY read the runner issues on every agent execution to
  * decide whether to attach the send_channel_message tool. The truthful
- * OSS answer is "none", and an expected-error path in that hot loop would
- * be noise; the empty list produces the identical, honest outcome.
+ * storing answer is "none", and an expected-error path in that hot loop
+ * would be noise; the empty list produces the identical, honest outcome.
+ * (The serving edition resolves this read from the caller's agent session
+ * and refuses bare direct calls — the two-armed conformance pin.)
  *
  * Input validation is Layer-1: the transport interceptor chain validates
  * every request (matching Go's explicit SharedValidator calls), so the
- * INVALID_ARGUMENT contract holds before every refusal.
+ * INVALID_ARGUMENT contract holds before every refusal AND before every
+ * delegation.
  *
  * Proven by agentchannel.conformance.test.ts (CONFORMANCE_TARGET=local)
  * and __tests__/agentchannel.test.ts.
@@ -34,23 +46,47 @@ import { MessagingChannelsSchema } from "@stigmer/protos/ai/stigmer/agentic/agen
 import type { MessagingChannels } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
 
 import { failedPreconditionError } from "../../pipeline/errors.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
+import type { ChannelRuntime } from "./channel-runtime.js";
 import { PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE } from "./constants.js";
 
-/** Registers both channel-message services on the router (routes stage). */
-export function registerChannelMessageServices(router: ConnectRouter): void {
+/**
+ * Registers both channel-message services on the router (routes stage),
+ * in the posture the composition declares: storing bodies with no
+ * runtime, whole-method delegation with one.
+ */
+export function registerChannelMessageServices(
+  router: ConnectRouter,
+  channelRuntime: ChannelRuntime | undefined,
+): void {
+  if (channelRuntime === undefined) {
+    router.service(ChannelMessageCommandController, {
+      // Business-initiated channel messaging is cloud-only runtime.
+      sendMessage: () => {
+        throw failedPreconditionError(PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE);
+      },
+    });
+    router.service(ChannelMessageQueryController, {
+      // Provider registry reads are cloud-only runtime; consumers degrade
+      // to honest absence (no template section, typed console error state).
+      listTemplates: () => {
+        throw failedPreconditionError(PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE);
+      },
+      listMessagingChannels: (): MessagingChannels =>
+        create(MessagingChannelsSchema),
+    });
+    return;
+  }
+
+  const { messaging } = channelRuntime;
   router.service(ChannelMessageCommandController, {
-    // Business-initiated channel messaging is cloud-only runtime.
-    sendMessage: () => {
-      throw failedPreconditionError(PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE);
-    },
+    sendMessage: (input, ctx) =>
+      messaging.sendMessage(input, callerIdentityOf(ctx)),
   });
   router.service(ChannelMessageQueryController, {
-    // Provider registry reads are cloud-only runtime; consumers degrade
-    // to honest absence (no template section, typed console error state).
-    listTemplates: () => {
-      throw failedPreconditionError(PROACTIVE_MESSAGING_UNAVAILABLE_MESSAGE);
-    },
-    listMessagingChannels: (): MessagingChannels =>
-      create(MessagingChannelsSchema),
+    listTemplates: (input, ctx) =>
+      messaging.listTemplates(input, callerIdentityOf(ctx)),
+    listMessagingChannels: (input, ctx) =>
+      messaging.listMessagingChannels(input, callerIdentityOf(ctx)),
   });
 }

--- a/backend/services/stigmer-server/src/domain/agentchannel/steps.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/steps.ts
@@ -10,6 +10,7 @@
  * and __tests__/agentchannel.test.ts.
  */
 import { create } from "@bufbuild/protobuf";
+import type { DescMessage } from "@bufbuild/protobuf";
 
 import { AgentChannelSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
 import type { AgentChannel } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
@@ -35,6 +36,7 @@ import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
 import type { Store } from "../../store/interface.js";
 import { unknownModelPinRefusal } from "../workflow/registry/pin-validation.js";
 import type { ModelCatalogProvider } from "../workflow/registry/model-catalog-provider.js";
+import type { ChannelRuntime } from "./channel-runtime.js";
 import {
   AGENT_REF_SLUG_REQUIRED_MESSAGE,
   APP_REF_FROZEN_WHILE_INSTALLED_MESSAGE,
@@ -97,6 +99,7 @@ function validateChannelModelPin(
 export function newResolveChannelDefaultsStep(
   store: Store,
   registry: ModelCatalogProvider,
+  channelRuntime: ChannelRuntime | undefined,
 ): PipelineStep<AgentChannelDesc> {
   return {
     name: "ResolveChannelDefaults",
@@ -158,6 +161,15 @@ export function newResolveChannelDefaultsStep(
       }
 
       agentRef!.org = refOrg;
+
+      // Write-time constraints only a serving runtime can state (the
+      // pin-REQUIRED rule and its successors — channel-runtime.ts).
+      // AFTER every edition-neutral rule so a composed runtime never
+      // changes their order or copy; absent runtime = the storing
+      // edition's posture, unchanged.
+      if (channelRuntime !== undefined) {
+        await channelRuntime.enforceWriteConstraints(ctx.newState);
+      }
     },
   };
 }
@@ -217,11 +229,14 @@ export function providerFieldName(spec: AgentChannelSpec | undefined): string {
  */
 export function newValidateChannelUpdateStep(
   registry: ModelCatalogProvider,
+  channelRuntime: ChannelRuntime | undefined,
 ): PipelineStep<AgentChannelDesc> {
   return {
     name: "ValidateChannelUpdate",
-    execute(ctx: RequestContext<AgentChannelDesc>): void {
-      const existing = ctx.get(EXISTING_RESOURCE_KEY) as AgentChannel | undefined;
+    async execute(ctx: RequestContext<AgentChannelDesc>): Promise<void> {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as
+        | AgentChannel
+        | undefined;
       if (existing === undefined) {
         throw internalError(
           new Error("existing agent channel not found in context"),
@@ -235,26 +250,75 @@ export function newValidateChannelUpdateStep(
       // Normalize the input ref's org the same way create does (empty
       // means the channel's own org) before comparing.
       const inputOrg =
-        (inputRef?.org ?? "") !== "" ? inputRef!.org : (existing.metadata?.org ?? "");
+        (inputRef?.org ?? "") !== ""
+          ? inputRef!.org
+          : (existing.metadata?.org ?? "");
 
       if (
         (inputRef?.slug ?? "") !== (existingRef?.slug ?? "") ||
         inputOrg !== (existingRef?.org ?? "")
       ) {
         throw failedPreconditionError(
-          agentRefImmutableMessage(existingRef?.org ?? "", existingRef?.slug ?? ""),
+          agentRefImmutableMessage(
+            existingRef?.org ?? "",
+            existingRef?.slug ?? "",
+          ),
         );
       }
 
       const inputProvider = providerFieldName(ctx.input.spec);
       const existingProvider = providerFieldName(existing.spec);
       if (inputProvider !== existingProvider) {
-        throw failedPreconditionError(providerImmutableMessage(existingProvider));
+        throw failedPreconditionError(
+          providerImmutableMessage(existingProvider),
+        );
       }
 
       validateChannelModelPin(registry, ctx.input.spec);
 
       validateAppRefUpdate(ctx, existing);
+
+      // The serving runtime's write constraints, on the spec that would
+      // be written (ctx.input carries it here — BuildUpdateState runs
+      // after this step). Same posture as ResolveChannelDefaults: last,
+      // and only when composed.
+      if (channelRuntime !== undefined) {
+        await channelRuntime.enforceWriteConstraints(ctx.input);
+      }
+    },
+  };
+}
+
+/**
+ * TeardownChannelRuntime — the serving runtime's delete-time cascade
+ * (channel-runtime.ts: credentials environment, OAuth grant, pending
+ * deliveries). Spliced into the delete chain ONLY when a runtime is
+ * composed, after LoadExistingForDelete and before DeleteResource —
+ * dependent runtime state dies before the row (the cloud#425 ordering
+ * family), and a thrown teardown error leaves the row for an idempotent
+ * retry. The storing edition's delete chain is byte-identical to before
+ * this seam existed.
+ *
+ * Generic over the chain desc: the delete chain is typed on the delete
+ * INPUT (AgentChannelId), and this step reads the loaded resource from
+ * EXISTING_RESOURCE_KEY exactly as the controller's post-chain read does.
+ */
+export function newTeardownChannelRuntimeStep<Desc extends DescMessage>(
+  channelRuntime: ChannelRuntime,
+): PipelineStep<Desc> {
+  return {
+    name: "TeardownChannelRuntime",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as
+        | AgentChannel
+        | undefined;
+      if (existing === undefined) {
+        throw internalError(
+          new Error("existing agent channel not found in context"),
+          "existing agent channel not found in context",
+        );
+      }
+      await channelRuntime.teardownOnDelete(existing, ctx.callerIdentity);
     },
   };
 }
@@ -285,7 +349,9 @@ function validateAppRefUpdate(
   let inputAppOrg = "";
   if ((inputAppRef?.slug ?? "") !== "") {
     inputAppOrg =
-      inputAppRef!.org !== "" ? inputAppRef!.org : (existing.metadata?.org ?? "");
+      inputAppRef!.org !== ""
+        ? inputAppRef!.org
+        : (existing.metadata?.org ?? "");
   }
 
   if (inputAppOrg !== "" && inputAppOrg !== (existing.metadata?.org ?? "")) {
@@ -296,7 +362,8 @@ function validateAppRefUpdate(
     existing.status?.installState === AgentChannelInstallState.installed;
   const changed =
     (inputAppRef?.slug ?? "") !== (existingAppRef?.slug ?? "") ||
-    ((inputAppRef?.slug ?? "") !== "" && inputAppOrg !== (existingAppRef?.org ?? ""));
+    ((inputAppRef?.slug ?? "") !== "" &&
+      inputAppOrg !== (existingAppRef?.org ?? ""));
 
   if (installed && changed) {
     throw failedPreconditionError(APP_REF_FROZEN_WHILE_INSTALLED_MESSAGE);

--- a/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
@@ -16,6 +16,7 @@ import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_inf
 import type { DescMessage } from "@bufbuild/protobuf";
 
 import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
+import type { ChannelRuntime } from "../../domain/agentchannel/channel-runtime.js";
 import type { ModelCatalogProvider } from "../../domain/workflow/registry/model-catalog-provider.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
@@ -83,6 +84,33 @@ const fakeSandboxDriver: SandboxProvisionerFactory = () => {
   throw new Error("unit-test sandbox driver factory — never constructed");
 };
 
+function fakeChannelRuntime(): ChannelRuntime {
+  const never = (): never => {
+    throw new Error("unit-test channel runtime — never invoked");
+  };
+  return {
+    installs: { initiateInstall: never, completeInstall: never },
+    messaging: {
+      sendMessage: never,
+      listTemplates: never,
+      listMessagingChannels: never,
+    },
+    conversations: {
+      listConversations: never,
+      getConversation: never,
+      getTimeline: never,
+      getMediaDownloadUrl: never,
+      reply: never,
+      takeOver: never,
+      handBack: never,
+      clearAttention: never,
+      escalate: never,
+    },
+    enforceWriteConstraints: never,
+    teardownOnDelete: never,
+  };
+}
+
 describe("resolveExtensions — defaults", () => {
   it("resolves the omitted set to explicit empty defaults, edition oss", () => {
     const resolved = resolveExtensions();
@@ -97,6 +125,7 @@ describe("resolveExtensions — defaults", () => {
     expect(resolved.drivers.runnerCredentialProvider).toBeUndefined();
     expect(resolved.drivers.artifactStorageDrivers.size).toBe(0);
     expect(resolved.drivers.sandboxProvisionerDrivers.size).toBe(0);
+    expect(resolved.drivers.channelRuntime).toBeUndefined();
     expect(resolved.services).toEqual([]);
     expect(resolved.workers).toEqual([]);
   });
@@ -200,6 +229,14 @@ describe("resolveExtensions — merge semantics", () => {
     expect(resolved.drivers.sandboxProvisionerDrivers.get("fly-machines")).toBe(
       fakeSandboxDriver,
     );
+  });
+
+  it("keeps the declared ChannelRuntime as the resolved singleton (C3 ruling Q1)", () => {
+    const runtime = fakeChannelRuntime();
+    const resolved = resolveExtensions([
+      { name: "channels", drivers: { channelRuntime: runtime } },
+    ]);
+    expect(resolved.drivers.channelRuntime).toBe(runtime);
   });
 });
 
@@ -338,6 +375,23 @@ describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
       ]),
     ).toThrowError(
       /extension 'second-catalog' registers a ModelCatalogProvider, but 'first-catalog' already did/,
+    );
+  });
+
+  it("throws on a second ChannelRuntime, naming both units", () => {
+    expect(() =>
+      resolveExtensions([
+        {
+          name: "channels-a",
+          drivers: { channelRuntime: fakeChannelRuntime() },
+        },
+        {
+          name: "channels-b",
+          drivers: { channelRuntime: fakeChannelRuntime() },
+        },
+      ]),
+    ).toThrow(
+      "extension 'channels-b' registers a ChannelRuntime, but 'channels-a' already did — exactly one may be composed",
     );
   });
 

--- a/backend/services/stigmer-server/src/extensions/drivers.ts
+++ b/backend/services/stigmer-server/src/extensions/drivers.ts
@@ -9,6 +9,8 @@
  *     registration + runner-credential provider (§6b/§6c) — landed, O5
  *     (20260827.02)
  *   - sandbox provisioners (§6d) — landed, O6 (20260827.05)
+ *   - channel runtime (DD-004's serving seam) — landed with C3
+ *     (20260827.11, plan-gate ruling Q1)
  *
  * Merge rules (enforced by resolveExtensions, DD-006 §2b): the two
  * provider kinds are single-instance points — a second declaring unit is
@@ -21,6 +23,7 @@
  * doctrine).
  */
 import type { ArtifactStorageDriverFactory } from "../artifactstorage/artifact-storage.js";
+import type { ChannelRuntime } from "../domain/agentchannel/channel-runtime.js";
 import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
 import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
 import type { SandboxProvisionerFactory } from "../sandbox/provisioner.js";
@@ -60,4 +63,12 @@ export interface ExtensionDrivers {
     string,
     SandboxProvisionerFactory
   >;
+  /**
+   * The channel delivery runtime (DD-004's serving seam; single-instance
+   * point). When composed, the agentchannel install arms, the whole
+   * messaging and conversation surfaces, and the two write/delete hooks
+   * delegate to it; with none, the byte-pinned refusal posture serves
+   * (src/domain/agentchannel/channel-runtime.ts carries the contract).
+   */
+  readonly channelRuntime?: ChannelRuntime;
 }

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -37,6 +37,7 @@ import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_inf
 
 import type { ArtifactStorageDriverFactory } from "../artifactstorage/artifact-storage.js";
 import { BUILT_IN_STORAGE_TYPES } from "../artifactstorage/artifact-storage.js";
+import type { ChannelRuntime } from "../domain/agentchannel/channel-runtime.js";
 import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
 import type { PipelineStep } from "../pipeline/pipeline.js";
 import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
@@ -150,6 +151,13 @@ export interface ResolvedExtensionDrivers {
     string,
     SandboxProvisionerFactory
   >;
+  /**
+   * The composed channel runtime, or undefined when none is registered —
+   * the agentchannel consumption sites serve the byte-pinned refusal
+   * posture for the undefined arm (the default lives with the consumer
+   * that defines its semantics, not with this data holder).
+   */
+  readonly channelRuntime: ChannelRuntime | undefined;
 }
 
 /**
@@ -177,6 +185,8 @@ export function resolveExtensions(
   let catalogDeclaredBy: string | undefined;
   let runnerCredentialProvider: RunnerCredentialProvider | undefined;
   let credentialDeclaredBy: string | undefined;
+  let channelRuntime: ChannelRuntime | undefined;
+  let channelRuntimeDeclaredBy: string | undefined;
   const artifactStorageDrivers = new Map<
     string,
     ArtifactStorageDriverFactory
@@ -246,6 +256,16 @@ export function resolveExtensions(
       credentialDeclaredBy = unit.name;
     }
 
+    if (unit.drivers?.channelRuntime !== undefined) {
+      if (channelRuntimeDeclaredBy !== undefined) {
+        throw new Error(
+          `extension '${unit.name}' registers a ChannelRuntime, but '${channelRuntimeDeclaredBy}' already did — exactly one may be composed`,
+        );
+      }
+      channelRuntime = unit.drivers.channelRuntime;
+      channelRuntimeDeclaredBy = unit.name;
+    }
+
     if (unit.drivers?.artifactStorageDrivers !== undefined) {
       for (const [name, factory] of unit.drivers.artifactStorageDrivers) {
         if ((BUILT_IN_STORAGE_TYPES as ReadonlyArray<string>).includes(name)) {
@@ -267,9 +287,9 @@ export function resolveExtensions(
     if (unit.drivers?.sandboxProvisionerDrivers !== undefined) {
       for (const [name, factory] of unit.drivers.sandboxProvisionerDrivers) {
         if (
-          (BUILT_IN_SANDBOX_PROVISIONER_TYPES as ReadonlyArray<string>).includes(
-            name,
-          )
+          (
+            BUILT_IN_SANDBOX_PROVISIONER_TYPES as ReadonlyArray<string>
+          ).includes(name)
         ) {
           throw new Error(
             `extension '${unit.name}' registers sandbox provisioner '${name}', which shadows a built-in driver — built-in names are reserved`,
@@ -326,6 +346,7 @@ export function resolveExtensions(
       runnerCredentialProvider,
       artifactStorageDrivers,
       sandboxProvisionerDrivers,
+      channelRuntime,
     },
     services,
     workers,

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -156,5 +156,18 @@ export type {
 } from "./sandbox/provisioner.js";
 export { BUILT_IN_SANDBOX_PROVISIONER_TYPES } from "./sandbox/provisioner.js";
 
+// The C3 driver seam (DD-004's serving half, ruling Q1): the channel
+// delivery runtime a composition registers to SERVE the install,
+// messaging, and conversation arms the storing posture refuses — plus
+// the write-constraints and delete-teardown hooks that carry the two
+// edition-split CRUD sites. One driver, grouped by the surfaces it takes
+// over; with none composed the byte-pinned refusals serve unchanged.
+export type {
+  ChannelRuntime,
+  ChannelRuntimeConversations,
+  ChannelRuntimeInstalls,
+  ChannelRuntimeMessaging,
+} from "./domain/agentchannel/channel-runtime.js";
+
 // The worker factory types extension workers implement (§8).
 export type { WorkerFactory, WorkerFactoryDeps } from "./temporal/manager.js";

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -23,6 +23,19 @@ import { create } from "@bufbuild/protobuf";
 import type { DescMessage } from "@bufbuild/protobuf";
 import type { ConnectRouter } from "@connectrpc/connect";
 
+import { AgentChannelSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import {
+  ChannelConversationListSchema,
+  ChannelConversationSchema,
+  ConversationMediaDownloadUrlSchema,
+  ConversationTimelineSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/conversation_io_pb";
+import { InitiateChannelInstallOutputSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/io_pb";
+import {
+  ChannelTemplatesSchema,
+  MessagingChannelsSchema,
+  SendChannelMessageOutputSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
 import { BillingAccountSchema } from "@stigmer/protos/ai/stigmer/billing/v1/billing_account_pb";
 import { BillingQueryController } from "@stigmer/protos/ai/stigmer/billing/v1/query_pb";
 import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
@@ -47,6 +60,7 @@ import type {
   ArtifactStorageDriverFactory,
   Authorizer,
   CallerIdentity,
+  ChannelRuntime,
   ComposedServer,
   GateSlotName,
   IdentityVerifier,
@@ -249,6 +263,59 @@ const consumerSandboxDriver: SandboxProvisionerFactory = ({
   };
 };
 
+/**
+ * A consumer-shaped channel runtime (the C3 seam, 20260827.11 ruling Q1) —
+ * the full grouped surface: install delegation, whole-method messaging
+ * and conversation serving, and the two edition-split CRUD hooks. All
+ * groups are required by the type, so a composition that forgets an arm
+ * fails THIS compile rather than serving a storing-posture refusal to a
+ * live channel user.
+ */
+const channelRuntime: ChannelRuntime = {
+  installs: {
+    initiateInstall: (channel, input, caller) => {
+      void channel.metadata?.id;
+      void caller.identityId;
+      return Promise.resolve(
+        create(InitiateChannelInstallOutputSchema, {
+          authorizationUrl: `https://consent.invalid/${input.resourceId}`,
+          state: "fake-state",
+        }),
+      );
+    },
+    completeInstall: (channel) =>
+      Promise.resolve(create(AgentChannelSchema, channel)),
+  },
+  messaging: {
+    sendMessage: () => Promise.resolve(create(SendChannelMessageOutputSchema)),
+    listTemplates: () => Promise.resolve(create(ChannelTemplatesSchema)),
+    listMessagingChannels: () =>
+      Promise.resolve(create(MessagingChannelsSchema)),
+  },
+  conversations: {
+    listConversations: () =>
+      Promise.resolve(create(ChannelConversationListSchema)),
+    getConversation: () => Promise.resolve(create(ChannelConversationSchema)),
+    getTimeline: () => Promise.resolve(create(ConversationTimelineSchema)),
+    getMediaDownloadUrl: () =>
+      Promise.resolve(create(ConversationMediaDownloadUrlSchema)),
+    reply: () => Promise.resolve(create(SendChannelMessageOutputSchema)),
+    takeOver: () => Promise.resolve(create(ChannelConversationSchema)),
+    handBack: () => Promise.resolve(create(ChannelConversationSchema)),
+    clearAttention: () => Promise.resolve(create(ChannelConversationSchema)),
+    escalate: () => Promise.resolve(create(ChannelConversationSchema)),
+  },
+  enforceWriteConstraints: (channel) => {
+    void channel.spec?.runConfig?.modelName;
+    return Promise.resolve();
+  },
+  teardownOnDelete: (channel, caller) => {
+    void channel.status?.installState;
+    void caller.callerClass;
+    return Promise.resolve();
+  },
+};
+
 const registerBillingService = (router: ConnectRouter): void => {
   router.service(BillingQueryController, {
     getBillingAccount: (input) =>
@@ -285,6 +352,9 @@ export const fakeExtension: ServerExtension = {
     sandboxProvisionerDrivers: new Map([
       ["consumer-sandbox", consumerSandboxDriver],
     ]),
+    // The C3 serving seam: a composed runtime flips the agentchannel
+    // install/messaging/conversation arms from refusal to serving.
+    channelRuntime,
   },
   services: [registerBillingService],
   workers: [workerFactory],


### PR DESCRIPTION
## Summary

C3 Stage 1 of the convergence program (`20260827.11.sp.channel-delivery-extension`, plan-gate ruling Q1): the `ChannelRuntime` extension driver point — DD-004's "contract OSS, delivery runtime cloud" expressed as code. A composition WITH a channel delivery runtime registers one driver and the OSS agentchannel controllers serve through it; with none composed, the byte-pinned refusal posture serves exactly as before, proven by all four conformance rosters. This is the accumulating C3 OSS PR — later stages land on this branch.

## Context

The OSS channel domain implements the AgentChannel CONTRACT (CRUD, discovery reads, engineered refusals on every arm needing a delivery runtime). The cloud composition must SERVE those arms, but extension services append after the OSS set — nothing could take over a registered RPC. The C3 plan gate ratified a single-instance driver point (the O5/O6 pattern), with two hooks added by the pre-implementation deep pass: the conformance suite pins an edition-split CRUD rule (the serving edition refuses unpinned channels at write time), and the delete chain has a cloud-only teardown cascade.

## Changes

- **New `src/domain/agentchannel/channel-runtime.ts`** — the `ChannelRuntime` interface, grouped by the surfaces it takes over (`installs`, `messaging`, `conversations`) plus the `enforceWriteConstraints` and `teardownOnDelete` hooks. All groups required: driver completeness is compile-enforced.
- **Registry** (`extensions/drivers.ts`, `extensions/registry.ts`) — `channelRuntime` as a single-instance driver point with the boot-throw merge rule (a second registration names both units).
- **Delegation** — install arms delegate per-arm behind the OSS-owned load contract (the NOT_FOUND copy stays OSS; the loaded channel is handed to the driver — single load); `message.ts`/`conversation.ts` delegate at the service-registration level (the driver owns the serving edition's error semantics, including the fail-closed arms the storing bodies deliberately do not probe for); the write hook runs LAST in `ResolveChannelDefaults`/`ValidateChannelUpdate`; the teardown step splices between load and row delete (dependent state dies before the row — a failed cascade leaves the row for an idempotent retry).
- **Exports** — `ChannelRuntime` + the three group types on the DD-005 exports map; the extension-consumer compile proof gains a full fake runtime.
- **Tests** — `__tests__/channel-runtime.test.ts` pins the serving posture through a real composed server (delegation per arm, OSS prefixes surviving composition, hook semantics both ways); `registry.test.ts` pins the merge rules. The storing-posture pins in `agentchannel.test.ts` are untouched.

## Implementation notes

- The write-constraints CONDITION ("would the run use the Cursor harness") is composition profile knowledge, so the driver owns both condition and copy — hard-coding "driver present = pin required" into OSS would bake one composition's harness default into the wrong layer (the RunnerCredentialProvider lane-vocabulary discipline).
- The teardown step is spliced conditionally: the storing edition's delete chain is byte-identical to before this seam existed.

## Breaking changes

- None on the wire. Internal signature additions only: `registerChannelMessageServices`/`registerChannelConversationServices` gain the driver parameter and `AgentChannelControllerDeps` gains a `channelRuntime: ChannelRuntime | undefined` field (explicitly modeled, not optional).

## Test plan

- `npm run typecheck` clean; full unit suite 147 files, 1956 passed.
- All four conformance rosters byte-identical: local 498, local-postgres 498, local-execution 160, local-postgres-execution 160 (each with the one recorded skip).
- Extension-consumer compile proof (`test/extension-consumer`) green with the new surface.

## Risks

- Low: purely additive; the undefined-driver path is the exact previous code shape and the rosters pin it. Rollback is a revert.

## Checklist

- [x] Tests added/updated
- [x] Backward compatible
- [x] Byte-pinned refusal copy untouched

Made with [Cursor](https://cursor.com)