### PR TITLE
feat(backend): payload-key resolver seam — codec resolveKey option + provider resolvePayloadKey capability (C4 Stage 2)

### DIFF
--- a/backend/libs/ts/temporal-codecs/src/__tests__/encryption-codec.test.ts
+++ b/backend/libs/ts/temporal-codecs/src/__tests__/encryption-codec.test.ts
@@ -23,7 +23,9 @@ import { makeInMemoryClaimcheckStorage } from "../__test-utils__/fake-claimcheck
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-function makeKeyConfig(overrides: Partial<PayloadEncryptionConfig> = {}): PayloadEncryptionConfig {
+function makeKeyConfig(
+  overrides: Partial<PayloadEncryptionConfig> = {},
+): PayloadEncryptionConfig {
   return {
     primary: { keyId: "test-key-1", key: randomBytes(32) },
     ...overrides,
@@ -121,7 +123,92 @@ describe("EncryptionPayloadCodec", () => {
       secondary: oldKey,
     });
     const [decoded] = await rotatedReader.decode([encoded]);
-    expect(JSON.parse(Buffer.from(decoded.data!).toString())).toEqual({ rotated: true });
+    expect(JSON.parse(Buffer.from(decoded.data!).toString())).toEqual({
+      rotated: true,
+    });
+  });
+
+  // The resolveKey seam (C4 Stage 2): decrypt-only fallback for key ids
+  // outside the static pair — the cloud server's database-resident rpk_
+  // keys. Pinned properties: resolved keys decode, resolved material is
+  // cached (one lookup per id per process), misses are NOT cached, an
+  // unresolvable id keeps the fail-closed unknown-key-id throw, and
+  // encode never consults the resolver.
+  describe("resolveKey fallback", () => {
+    it("decodes a payload under a resolver-supplied key and caches the material", async () => {
+      const runnerKey = { keyId: "rpk_abc123", key: randomBytes(32) };
+      const writer = new EncryptionPayloadCodec({ primary: runnerKey });
+      const [encoded] = await writer.encode([
+        makeJsonPayload({ desktop: true }),
+      ]);
+
+      const lookups: string[] = [];
+      const reader = new EncryptionPayloadCodec({
+        ...makeKeyConfig(),
+        resolveKey: async (keyId) => {
+          lookups.push(keyId);
+          return keyId === runnerKey.keyId ? runnerKey.key : undefined;
+        },
+      });
+
+      const [first] = await reader.decode([encoded]);
+      expect(JSON.parse(Buffer.from(first.data!).toString())).toEqual({
+        desktop: true,
+      });
+
+      const [second] = await reader.decode([encoded]);
+      expect(JSON.parse(Buffer.from(second.data!).toString())).toEqual({
+        desktop: true,
+      });
+      expect(lookups).toEqual(["rpk_abc123"]);
+    });
+
+    it("fails closed when the resolver does not know the key id, and retries on the next decode", async () => {
+      const runnerKey = { keyId: "rpk_late", key: randomBytes(32) };
+      const writer = new EncryptionPayloadCodec({ primary: runnerKey });
+      const [encoded] = await writer.encode([makeJsonPayload({ a: 1 })]);
+
+      let known = false;
+      const lookups: string[] = [];
+      const reader = new EncryptionPayloadCodec({
+        ...makeKeyConfig(),
+        resolveKey: async (keyId) => {
+          lookups.push(keyId);
+          return known && keyId === runnerKey.keyId ? runnerKey.key : undefined;
+        },
+      });
+
+      await expect(reader.decode([encoded])).rejects.toThrow(
+        /unknown key id 'rpk_late'/,
+      );
+
+      // The miss was not cached: once the key exists (minted after this
+      // process booted), the next decode finds it.
+      known = true;
+      const [decoded] = await reader.decode([encoded]);
+      expect(JSON.parse(Buffer.from(decoded.data!).toString())).toEqual({
+        a: 1,
+      });
+      expect(lookups).toEqual(["rpk_late", "rpk_late"]);
+    });
+
+    it("never consults the resolver for the static keys or on encode", async () => {
+      const lookups: string[] = [];
+      const codec = new EncryptionPayloadCodec({
+        ...makeKeyConfig(),
+        resolveKey: async (keyId) => {
+          lookups.push(keyId);
+          return undefined;
+        },
+      });
+
+      const [encoded] = await codec.encode([makeJsonPayload({ b: 2 })]);
+      const [decoded] = await codec.decode([encoded]);
+      expect(JSON.parse(Buffer.from(decoded.data!).toString())).toEqual({
+        b: 2,
+      });
+      expect(lookups).toEqual([]);
+    });
   });
 });
 
@@ -177,9 +264,11 @@ describe("loadPayloadEncryptionConfig", () => {
   });
 
   it("loads primary and secondary keys", () => {
-    process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY = randomBytes(32).toString("base64");
+    process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY =
+      randomBytes(32).toString("base64");
     process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY_ID = "k2";
-    process.env.STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY = randomBytes(32).toString("base64");
+    process.env.STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY =
+      randomBytes(32).toString("base64");
     process.env.STIGMER_PAYLOAD_ENCRYPTION_SECONDARY_KEY_ID = "k1";
 
     const config = loadPayloadEncryptionConfig(readEnv);
@@ -189,16 +278,20 @@ describe("loadPayloadEncryptionConfig", () => {
   });
 
   it("fails the boot when a key is set without an id", () => {
-    process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY = randomBytes(32).toString("base64");
+    process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY =
+      randomBytes(32).toString("base64");
     expect(() => loadPayloadEncryptionConfig(readEnv)).toThrow(
       /STIGMER_PAYLOAD_ENCRYPTION_KEY_ID is required/,
     );
   });
 
   it("fails the boot on a key of the wrong length", () => {
-    process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY = randomBytes(16).toString("base64");
+    process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY =
+      randomBytes(16).toString("base64");
     process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY_ID = "k1";
-    expect(() => loadPayloadEncryptionConfig(readEnv)).toThrow(/must decode to 32 bytes/);
+    expect(() => loadPayloadEncryptionConfig(readEnv)).toThrow(
+      /must decode to 32 bytes/,
+    );
   });
 
   // Server-managed key material from getRunnerBootstrapConfig (stigmer#398):
@@ -220,7 +313,8 @@ describe("loadPayloadEncryptionConfig", () => {
     });
 
     it("env-configured key wins over bootstrap material", () => {
-      process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY = randomBytes(32).toString("base64");
+      process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY =
+        randomBytes(32).toString("base64");
       process.env.STIGMER_PAYLOAD_ENCRYPTION_KEY_ID = "env-key";
 
       const config = loadPayloadEncryptionConfig(readEnv, bootstrapKeys());
@@ -230,7 +324,9 @@ describe("loadPayloadEncryptionConfig", () => {
 
     it("fails the boot on a bootstrap key without its id (server contract violation)", () => {
       expect(() =>
-        loadPayloadEncryptionConfig(readEnv, { key: randomBytes(32).toString("base64") }),
+        loadPayloadEncryptionConfig(readEnv, {
+          key: randomBytes(32).toString("base64"),
+        }),
       ).toThrow(/payload_encryption_key_id/);
     });
 
@@ -264,7 +360,10 @@ describe("cross-language conformance fixture", () => {
   // lockstep.
   it("decrypts the committed fixture to the expected payload", async () => {
     const fixture = JSON.parse(
-      readFileSync(join(__dirname, "fixtures", "encrypted-payload-fixture.json"), "utf-8"),
+      readFileSync(
+        join(__dirname, "fixtures", "encrypted-payload-fixture.json"),
+        "utf-8",
+      ),
     );
 
     const codec = new EncryptionPayloadCodec({
@@ -276,9 +375,9 @@ describe("cross-language conformance fixture", () => {
 
     const encrypted: Payload = {
       metadata: Object.fromEntries(
-        Object.entries(fixture.encrypted.metadataBase64 as Record<string, string>).map(
-          ([k, v]) => [k, Buffer.from(v, "base64")],
-        ),
+        Object.entries(
+          fixture.encrypted.metadataBase64 as Record<string, string>,
+        ).map(([k, v]) => [k, Buffer.from(v, "base64")]),
       ),
       data: Buffer.from(fixture.encrypted.dataBase64, "base64"),
     };

--- a/backend/libs/ts/temporal-codecs/src/encryption/config.ts
+++ b/backend/libs/ts/temporal-codecs/src/encryption/config.ts
@@ -42,11 +42,30 @@ export interface EncryptionKey {
   readonly key: Buffer;
 }
 
+/**
+ * Resolves decrypt-key material for a key id absent from the static
+ * config (C4, stigmer-cloud 20260827.09: the cloud server decodes
+ * desktop-runner histories written under server-managed per-identity
+ * `rpk_` keys, whose material lives in a database, not the environment).
+ * Returns undefined when the id is unknown — the codec then fails closed
+ * with its pinned unknown-key-id error. Implementations own their lookup
+ * and unsealing; the codec caches every RESOLVED key for the process
+ * lifetime (key material per id is immutable — rotation mints a new id),
+ * and never caches misses (the key may be minted moments later).
+ */
+export type PayloadKeyResolver = (keyId: string) => Promise<Buffer | undefined>;
+
 export interface PayloadEncryptionConfig {
   /** Key used to encrypt outgoing payloads (and decrypt its own). */
   readonly primary: EncryptionKey;
   /** Decrypt-only key accepted during rotation windows. */
   readonly secondary?: EncryptionKey;
+  /**
+   * Decrypt-only fallback consulted when a payload names a key id the
+   * static pair does not cover ({@link PayloadKeyResolver}). Encode never
+   * consults it — outgoing payloads are always written under `primary`.
+   */
+  readonly resolveKey?: PayloadKeyResolver;
 }
 
 /**
@@ -114,7 +133,10 @@ export function loadPayloadEncryptionConfig(
 
   if (bootstrap?.key) {
     const primary: EncryptionKey = {
-      keyId: requireBootstrapKeyId(bootstrap.keyId, "payload_encryption_key_id"),
+      keyId: requireBootstrapKeyId(
+        bootstrap.keyId,
+        "payload_encryption_key_id",
+      ),
       key: parseKey(bootstrap.key, "bootstrap payload_encryption_key"),
     };
 
@@ -124,7 +146,10 @@ export function loadPayloadEncryptionConfig(
             bootstrap.secondaryKeyId,
             "payload_encryption_secondary_key_id",
           ),
-          key: parseKey(bootstrap.secondaryKey, "bootstrap payload_encryption_secondary_key"),
+          key: parseKey(
+            bootstrap.secondaryKey,
+            "bootstrap payload_encryption_secondary_key",
+          ),
         }
       : undefined;
 
@@ -147,7 +172,10 @@ function requireKeyId(envName: string): string {
   return keyId;
 }
 
-function requireBootstrapKeyId(keyId: string | undefined, fieldName: string): string {
+function requireBootstrapKeyId(
+  keyId: string | undefined,
+  fieldName: string,
+): string {
   if (!keyId) {
     throw new Error(
       `Runner bootstrap returned a payload encryption key without its ${fieldName} — ` +
@@ -162,7 +190,9 @@ function parseKey(rawBase64: string, envName: string): Buffer {
   try {
     key = Buffer.from(rawBase64, "base64");
   } catch {
-    throw new Error(`Payload encryption misconfigured: ${envName} is not valid base64`);
+    throw new Error(
+      `Payload encryption misconfigured: ${envName} is not valid base64`,
+    );
   }
   if (key.length !== AES_256_KEY_BYTES) {
     throw new Error(

--- a/backend/libs/ts/temporal-codecs/src/encryption/payload-codec.ts
+++ b/backend/libs/ts/temporal-codecs/src/encryption/payload-codec.ts
@@ -28,6 +28,14 @@
  * fails closed: unknown key id, missing key id, and ciphertext tampering
  * all throw rather than surfacing bogus payloads.
  *
+ * Key ids outside the static primary/secondary pair may be resolved
+ * through the config's optional resolveKey seam (C4: the cloud server
+ * decodes desktop-runner histories under database-resident `rpk_` keys).
+ * Resolution is decode-only, resolved keys are cached for the process
+ * lifetime (an id's material is immutable — rotation mints a new id),
+ * misses are never cached, and an unresolvable id keeps the pinned
+ * fail-closed throw.
+ *
  * Moved from backend/services/runner/src/encryption/payload-codec.ts when
  * the codecs became @stigmer/temporal-codecs (one home for the
  * cross-language envelope contract; the TS server is the second consumer).
@@ -58,7 +66,9 @@ export class EncryptionPayloadCodec implements PayloadCodec {
   private readonly decryptKeysById: Map<string, Buffer>;
 
   constructor(private readonly config: PayloadEncryptionConfig) {
-    this.decryptKeysById = new Map([[config.primary.keyId, config.primary.key]]);
+    this.decryptKeysById = new Map([
+      [config.primary.keyId, config.primary.key],
+    ]);
     if (config.secondary) {
       this.decryptKeysById.set(config.secondary.keyId, config.secondary.key);
     }
@@ -69,7 +79,7 @@ export class EncryptionPayloadCodec implements PayloadCodec {
   }
 
   async decode(payloads: Payload[]): Promise<Payload[]> {
-    return payloads.map((p) => this.decodePayload(p));
+    return Promise.all(payloads.map((p) => this.decodePayload(p)));
   }
 
   private encodePayload(payload: Payload): Payload {
@@ -90,7 +100,7 @@ export class EncryptionPayloadCodec implements PayloadCodec {
     };
   }
 
-  private decodePayload(payload: Payload): Payload {
+  private async decodePayload(payload: Payload): Promise<Payload> {
     if (!isEncryptedPayload(payload)) {
       return payload;
     }
@@ -102,7 +112,7 @@ export class EncryptionPayloadCodec implements PayloadCodec {
       );
     }
     const keyId = Buffer.from(keyIdBytes).toString("utf-8");
-    const key = this.decryptKeysById.get(keyId);
+    const key = await this.decryptKeyFor(keyId);
     if (!key) {
       throw new Error(
         `Encrypted payload uses unknown key id '${keyId}' — configure it as the ` +
@@ -112,6 +122,26 @@ export class EncryptionPayloadCodec implements PayloadCodec {
 
     const plaintext = decrypt(payload.data!, key, keyId);
     return temporal.api.common.v1.Payload.decode(plaintext);
+  }
+
+  /**
+   * The static map first; on a miss, the config's resolver (when present),
+   * caching the RESOLVED key only — a miss stays unresolved so a key
+   * minted after this process booted is found on the next decode.
+   */
+  private async decryptKeyFor(keyId: string): Promise<Buffer | undefined> {
+    const known = this.decryptKeysById.get(keyId);
+    if (known !== undefined) {
+      return known;
+    }
+    if (this.config.resolveKey === undefined) {
+      return undefined;
+    }
+    const resolved = await this.config.resolveKey(keyId);
+    if (resolved !== undefined) {
+      this.decryptKeysById.set(keyId, resolved);
+    }
+    return resolved;
   }
 }
 

--- a/backend/libs/ts/temporal-codecs/src/index.ts
+++ b/backend/libs/ts/temporal-codecs/src/index.ts
@@ -25,6 +25,7 @@ export type {
   BootstrapKeyMaterial,
   EncryptionKey,
   PayloadEncryptionConfig,
+  PayloadKeyResolver,
   SecretReader,
 } from "./encryption/config.js";
 

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -436,7 +436,12 @@ export async function composeServer(
     hostPort: config.temporalHostPort,
     namespace: config.temporalNamespace,
     logger,
-    payloadCodecs: loadServerPayloadCodecs(),
+    // The composed provider's optional resolvePayloadKey capability rides
+    // the decode codec (C4 Stage 2): database-resident rpk_ keys for
+    // desktop-runner histories. Absent → env keys only, today's behavior.
+    payloadCodecs: loadServerPayloadCodecs(
+      runnerCredentials.resolvePayloadKey?.bind(runnerCredentials),
+    ),
     workerFactories: [
       newAgentExecutionWorkerFactory({
         store,

--- a/backend/services/stigmer-server/src/runnerauth/runner-credential-provider.ts
+++ b/backend/services/stigmer-server/src/runnerauth/runner-credential-provider.ts
@@ -204,6 +204,19 @@ export interface RunnerCredentialProvider {
     rawToken: string,
     executionId: string,
   ): Promise<boolean>;
+
+  /**
+   * Decrypt-key material for a Temporal payload-encryption key id the
+   * server's env-configured codec does not hold (C4 Stage 2: the
+   * server-managed per-identity `rpk_` keys bootstrapCredentials hands
+   * out — resolution belongs on the same object that distributes them).
+   * Threaded into the server's decode-only payload codec at compose;
+   * consulted only when that codec is installed at all (env-keyed — the
+   * cloud composition always configures the platform key). Undefined
+   * means unknown: the codec keeps its pinned fail-closed throw. Absent
+   * method → today's exact behavior (static env keys only).
+   */
+  resolvePayloadKey?(keyId: string): Promise<Buffer | undefined>;
 }
 
 /**

--- a/backend/services/stigmer-server/src/temporal/__tests__/payload-codec.test.ts
+++ b/backend/services/stigmer-server/src/temporal/__tests__/payload-codec.test.ts
@@ -82,7 +82,9 @@ describe("ServerDecryptionPayloadCodec", () => {
     const [encrypted] = await runnerSide.encode([textPayload("secret")]);
     const tampered: Payload = {
       metadata: encrypted!.metadata,
-      data: Buffer.from(encrypted!.data!.map((b, i) => (i === 20 ? b ^ 0xff : b))),
+      data: Buffer.from(
+        encrypted!.data!.map((b, i) => (i === 20 ? b ^ 0xff : b)),
+      ),
     };
 
     await expect(serverSide.decode([tampered])).rejects.toThrow();
@@ -129,5 +131,48 @@ describe("loadServerPayloadCodecs", () => {
     process.env["STIGMER_PAYLOAD_ENCRYPTION_KEY_ID"] = KEY_ID;
 
     expect(() => loadServerPayloadCodecs()).toThrow(/32 bytes/);
+  });
+
+  // The resolvePayloadKey threading (C4 Stage 2): the composed provider's
+  // capability rides the decode codec as its resolveKey fallback —
+  // consulted for key ids outside the env pair, never installed without
+  // the env-keyed codec (the named coupling in the module header).
+  it("threads the resolver into the decode codec for rpk_ key ids", async () => {
+    process.env["STIGMER_PAYLOAD_ENCRYPTION_KEY"] = KEY.toString("base64");
+    process.env["STIGMER_PAYLOAD_ENCRYPTION_KEY_ID"] = KEY_ID;
+
+    const runnerKey = { keyId: "rpk_identity1", key: randomBytes(32) };
+    const desktopRunner = new EncryptionPayloadCodec({ primary: runnerKey });
+    const [encrypted] = await desktopRunner.encode([
+      textPayload("desktop runner activity result"),
+    ]);
+
+    const [codec] = loadServerPayloadCodecs(async (keyId) =>
+      keyId === runnerKey.keyId ? runnerKey.key : undefined,
+    );
+    const [decoded] = await codec!.decode([encrypted!]);
+
+    expect(Buffer.from(decoded!.data!).toString()).toBe(
+      JSON.stringify("desktop runner activity result"),
+    );
+  });
+
+  it("keeps the fail-closed throw when the resolver does not know the id", async () => {
+    process.env["STIGMER_PAYLOAD_ENCRYPTION_KEY"] = KEY.toString("base64");
+    process.env["STIGMER_PAYLOAD_ENCRYPTION_KEY_ID"] = KEY_ID;
+
+    const desktopRunner = new EncryptionPayloadCodec({
+      primary: { keyId: "rpk_unknown", key: randomBytes(32) },
+    });
+    const [encrypted] = await desktopRunner.encode([textPayload("secret")]);
+
+    const [codec] = loadServerPayloadCodecs(async () => undefined);
+    await expect(codec!.decode([encrypted!])).rejects.toThrow(
+      /unknown key id 'rpk_unknown'/,
+    );
+  });
+
+  it("returns no codecs even with a resolver when encryption is not configured", () => {
+    expect(loadServerPayloadCodecs(async () => undefined)).toEqual([]);
   });
 });

--- a/backend/services/stigmer-server/src/temporal/payload-codec.ts
+++ b/backend/services/stigmer-server/src/temporal/payload-codec.ts
@@ -29,6 +29,7 @@ import {
   EncryptionPayloadCodec,
   loadPayloadEncryptionConfig,
 } from "@stigmer/temporal-codecs";
+import type { PayloadKeyResolver } from "@stigmer/temporal-codecs";
 
 export class ServerDecryptionPayloadCodec implements PayloadCodec {
   constructor(private readonly inner: EncryptionPayloadCodec) {}
@@ -64,13 +65,28 @@ export class ServerDecryptionPayloadCodec implements PayloadCodec {
  * trap. The server runs no agent shells; plain env reads are its custody
  * policy, the same source Go's LoadConfigFromEnv reads.
  *
+ * The optional resolver is the composed credential provider's
+ * resolvePayloadKey capability (C4 Stage 2): decrypt-only fallback for
+ * key ids outside the env pair — the server-managed per-identity `rpk_`
+ * keys desktop runners encrypt under. Deliberate coupling, named: the
+ * resolver rides the env-keyed codec, so it is consulted only when
+ * payload encryption is configured at all (the cloud composition always
+ * configures the platform key; an env-less deployment has no encrypted
+ * histories of its own to decode).
+ *
  * @throws when a key is present but malformed or missing its id (boot
  *   error, never a silent plaintext downgrade).
  */
-export function loadServerPayloadCodecs(): PayloadCodec[] {
+export function loadServerPayloadCodecs(
+  resolveKey?: PayloadKeyResolver,
+): PayloadCodec[] {
   const config = loadPayloadEncryptionConfig((name) => process.env[name]);
   if (config === undefined) {
     return [];
   }
-  return [new ServerDecryptionPayloadCodec(new EncryptionPayloadCodec(config))];
+  return [
+    new ServerDecryptionPayloadCodec(
+      new EncryptionPayloadCodec({ ...config, resolveKey }),
+    ),
+  ];
 }

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -202,6 +202,10 @@ const credentialProvider: RunnerCredentialProvider = {
   mintSandboxCredential: (request: SandboxCredentialRequest): string =>
     `fake-${request.scope}-token`,
   authorizeExecutionContextRead: async (): Promise<boolean> => false,
+  // The fifth capability (C4 Stage 2): decrypt-key resolution for the
+  // server-managed rpk_ payload keys the bootstrap arm above hands out.
+  resolvePayloadKey: async (keyId: string): Promise<Buffer | undefined> =>
+    keyId === "rpk_fake" ? Buffer.from("a2V5", "base64") : undefined,
 };
 
 /**


### PR DESCRIPTION
## Summary

The C4 wave's Stage 2 OSS seam (convergence program 20260826.02, sub-project 20260827.09): the cloud composition decodes desktop-runner Temporal histories written under server-managed per-identity `rpk_` keys whose material is database-resident, not env-configured. Two additive seams carry it, both byte-identical with no extension composed:

- **`@stigmer/temporal-codecs`**: optional `resolveKey?: (keyId: string) => Promise<Buffer | undefined>` on `PayloadEncryptionConfig` — a decrypt-only fallback consulted on a static-map miss. Resolved keys are cached for the process lifetime (an id's material is immutable — rotation mints a new id), misses are never cached (a key minted after boot is found on the next decode), and an unresolvable id keeps the pinned fail-closed throw. Encode never consults it; the runner's construction sites pass none.
- **`@stigmer/server`**: `resolvePayloadKey?` as the FIFTH optional capability method on `RunnerCredentialProvider` (the C4 gate's Q1 cohesion ruling — the provider already distributes `rpk_` material via `bootstrapCredentials`, so resolution belongs on the same object; no new `ExtensionDrivers` field). `boot/compose.ts` threads the composed provider's capability into `loadServerPayloadCodecs()`; absent method → today's exact behavior. The named coupling (the resolver rides the env-keyed codec) is recorded in the module header.

## Verification

- temporal-codecs: 38 tests (resolver hit / miss-throws-and-retries / positive-only caching / encode-never-consults).
- server: `tsc --noEmit` clean; 1988 units; the extension-consumer compile proof extended to the fifth member.
- All four local conformance rosters byte-identical: local 498, local-execution 160, local-postgres 498, local-postgres-execution 160 (Node 22.22.1).
- Prettier clean on changed files.

## Cross-repo

The consuming cloud extension rides stigmer-cloud's C4 Stage 2 PR (the cloud provider implements the capability over its runnerkey service; the composition's codec HTTP lane passes the same resolver). This PR merges FIRST (the C1 precedent); the cloud PR's submodule re-pins to the squash commit.

Made with [Cursor](https://cursor.com)