### PR TITLE
docs(guides/self-hosting): add the Cloud vs self-hosted comparison page

### DIFF
--- a/docs/_inventory/classification.yaml
+++ b/docs/_inventory/classification.yaml
@@ -675,6 +675,17 @@ pages:
       pricing and spend-reduction mechanics that belong nearer the billing
       guides; the concept survives, the operational halves move out.
 
+  guides/self-hosting/cloud-vs-self-hosted:
+    fate: keep
+    diataxis: explanation
+    teaches:
+      Which way to run Stigmer fits the reader's team — what self-hosting
+      includes (the full contract, Postgres, OIDC + API keys, isolation
+      drivers), what Stigmer Cloud adds (tenancy, SSO, fine-grained
+      permissions, channels, metered billing, managed ops), and the honest
+      limitations of self-hosting today.
+    medium: none
+
   guides/self-hosting/docker-compose:
     fate: keep
     diataxis: how-to

--- a/docs/guides/self-hosting/cloud-vs-self-hosted.mdx
+++ b/docs/guides/self-hosting/cloud-vs-self-hosted.mdx
@@ -101,11 +101,11 @@ Two honest caveats before you commit to self-hosting today:
 
 - **The web console cannot sign in to an authenticated server yet.** With
   authentication on, use the CLI and SDKs; keep the console for unauthenticated
-  local use. Console login is planned separately — see the
+  local use. Console login is on the roadmap — see the
   [authentication guide's limitation note](/docs/guides/self-hosting/authentication#known-limitation-the-web-console).
 - **Docker Compose is the supported packaging.** There is no Helm chart or
   Kubernetes operator for the stack itself; you adapt the compose file to your
-  environment.
+  own infrastructure.
 
 ## Next step
 

--- a/docs/guides/self-hosting/cloud-vs-self-hosted.mdx
+++ b/docs/guides/self-hosting/cloud-vs-self-hosted.mdx
@@ -1,0 +1,125 @@
+---
+title: Cloud vs self-hosted
+description:
+  Stigmer is one platform you can run two ways. Compare what self-hosting
+  includes with what Stigmer Cloud adds, and decide which fits your team.
+---
+
+Stigmer is fully open source under Apache 2.0, and the same platform runs two
+ways. **Self-hosting** gives your team everything it needs to run Stigmer for
+itself, on infrastructure you control. **Stigmer Cloud** is the managed service:
+it runs the same platform for many teams at once and adds the capabilities that
+only make sense when someone operates Stigmer as a service — tenancy, SSO,
+billing, and the operations behind them.
+
+The contracts are identical either way. Your Agents, Workflows, Skills, and the
+CLI and SDKs that drive them work against both — moving between them is a
+configuration change, not a rewrite.
+
+## The short answer
+
+**Choose self-hosted if:**
+
+- Your data or compliance posture requires everything on your infrastructure.
+- You already operate Postgres and Docker (or Kubernetes) and want full control.
+- One team uses the server, and your own OIDC provider handles sign-in.
+- You want to pay LLM providers directly with your own API keys.
+
+**Choose Stigmer Cloud if:**
+
+- You want to build with Agents today, not operate a platform.
+- You need multiple Organizations, SSO/SAML, or per-resource permissions.
+- You want Agents reachable in Slack and WhatsApp.
+- You prefer one metered bill over managing provider keys and infrastructure.
+
+## Side by side
+
+| Capability                                       | Self-hosted                                                           | Stigmer Cloud                                               |
+| ------------------------------------------------ | --------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Agents, Workflows, Skills, Sessions, MCP servers | Full — the same contracts                                             | Full — the same contracts                                   |
+| Storage                                          | Your Postgres                                                         | Managed                                                     |
+| Authentication                                   | Your OIDC provider + API keys                                         | Hosted login, SSO/SAML, identity federation, PlatformClient |
+| Organizations                                    | One                                                                   | As many as you need                                         |
+| Permissions                                      | One team — every authenticated member has full access                 | Fine-grained, per-resource roles and sharing                |
+| Sandbox isolation                                | Pluggable drivers: local process, Docker, Kubernetes (off by default) | Managed Kubernetes isolation                                |
+| Channels (Slack, WhatsApp)                       | Not available                                                         | Included                                                    |
+| LLM costs                                        | Your provider keys, billed by providers directly                      | Metered prepaid credits, one bill                           |
+| Model catalog                                    | Bundled, refreshes automatically                                      | Always current                                              |
+| Operations, backups, upgrades                    | Yours                                                                 | Managed                                                     |
+
+## What self-hosting includes
+
+Self-hosting is not a trial edition. The
+[Docker Compose stack](/docs/guides/self-hosting/docker-compose) runs the
+complete platform — the server, a real Temporal server, Postgres, and the runner
+that executes your Agents and Workflows — with durable state in volumes you own
+and back up.
+
+- **The full platform contract.** Every Agent, Workflow, Skill, Session, and MCP
+  server capability works exactly as it does on Stigmer Cloud, through the same
+  API, CLI, and SDKs.
+- **Authentication on your terms.** Point the server at any OIDC provider you
+  control — Keycloak, Okta, Auth0, Dex — and mint API keys for machines. See
+  [Enable authentication](/docs/guides/self-hosting/authentication).
+- **Your LLM relationships.** You bring your own provider API keys and pay
+  providers directly. There is no Stigmer billing when you self-host — see
+  [Billing](/docs/concepts/billing#self-hosting).
+- **Sandbox isolation as configuration.** The server can start execution
+  sandboxes through pluggable isolation drivers — local process, Docker, or
+  Kubernetes. Isolation is off by default: the stock Docker Compose stack runs
+  the runner as a single trust domain, as its setup guide states up front.
+- **One Organization, one team.** Everyone who can authenticate can use
+  everything on the server. There are no per-resource permissions.
+
+## What Stigmer Cloud adds
+
+Stigmer Cloud runs the same platform and layers on what a managed, multi-tenant
+service requires:
+
+- **Tenancy and governance.** Multiple Organizations, invitations, SSO/SAML, and
+  fine-grained per-resource permissions and sharing.
+- **Identity for your product.** Bring your users with
+  [identity federation or PlatformClient](/docs/guides/authentication/overview)
+  — trust relationships and token minting that let your platform's users reach
+  Stigmer without managing credentials themselves.
+- **Channels.** Agents that talk to your users
+  [in Slack and WhatsApp](/docs/guides/channels) — webhook delivery, provider
+  apps, and outbound messaging are cloud infrastructure.
+- **Metered LLM billing.** LLM calls route through the managed proxy with
+  per-call metering, budget reservations, and cost caps — prepaid credits
+  instead of juggling provider keys. See [Billing](/docs/concepts/billing).
+- **Someone else on call.** Upgrades, backups, scaling, and sandbox isolation
+  are operated for you.
+
+The boundary is deliberate: capabilities land in open source when a team
+self-hosting Stigmer for itself needs them, and in Stigmer Cloud when they only
+exist because Stigmer runs the platform as a service for many teams.
+
+## Know the limitations
+
+Two honest caveats before you commit to self-hosting today:
+
+- **The web console cannot sign in to an authenticated server yet.** With
+  authentication on, use the CLI and SDKs; keep the console for unauthenticated
+  local use. Console login is planned separately — see the
+  [authentication guide's limitation note](/docs/guides/self-hosting/authentication#known-limitation-the-web-console).
+- **Docker Compose is the supported packaging.** There is no Helm chart or
+  Kubernetes operator for the stack itself; you adapt the compose file to your
+  environment.
+
+## Next step
+
+Self-hosting starts with one compose file and a `.env`.
+
+<Cards>
+  <Card
+    title="Self-host with Docker Compose"
+    href="/docs/guides/self-hosting/docker-compose"
+  >
+    Run the complete stack — server, Postgres, Temporal, and runner — on a
+    machine you control, and run your first Agent on it.
+  </Card>
+  <Card title="Start on Stigmer Cloud" href="https://app.stigmer.ai">
+    Skip the infrastructure. Sign in and run your first Agent in minutes.
+  </Card>
+</Cards>

--- a/docs/guides/self-hosting/meta.json
+++ b/docs/guides/self-hosting/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Self-hosting",
-  "pages": ["docker-compose", "authentication", "operations"]
+  "pages": ["cloud-vs-self-hosted", "docker-compose", "authentication", "operations"]
 }

--- a/site/src/components/pages/PricingPage.tsx
+++ b/site/src/components/pages/PricingPage.tsx
@@ -60,7 +60,14 @@ const HOW_IT_WORKS_STEPS = [
   },
 ] as const;
 
-const FAQ_ITEMS = [
+type FaqItem = {
+  q: string;
+  a: string;
+  /** Optional deep link rendered after the answer. */
+  link?: { href: string; label: string };
+};
+
+const FAQ_ITEMS: readonly FaqItem[] = [
   {
     q: "What are credits?",
     a: "Credits are dollar-denominated units used for Stigmer Cloud billing. 1 credit = $0.01 USD. When your AI agents make LLM calls, tokens are metered and the cost is debited from your credit balance.",
@@ -80,6 +87,10 @@ const FAQ_ITEMS = [
   {
     q: "Can I self-host for free?",
     a: "Yes. Stigmer is fully open source under Apache 2.0. Self-host it anywhere — there is no vendor lock-in. Cloud billing only applies when you use Stigmer Cloud (app.stigmer.ai).",
+    link: {
+      href: "/docs/guides/self-hosting/cloud-vs-self-hosted",
+      label: "Compare cloud and self-hosted",
+    },
   },
   {
     q: "How is pricing calculated?",
@@ -258,6 +269,18 @@ function PricingPage() {
                     </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
                       {item.a}
+                      {item.link && (
+                        <>
+                          {" "}
+                          <Link
+                            href={item.link.href}
+                            className="text-foreground underline underline-offset-4 hover:text-foreground/80"
+                          >
+                            {item.link.label}
+                          </Link>
+                          .
+                        </>
+                      )}
                     </p>
                   </div>
                 </FadeInUp>

--- a/site/src/components/sections/OpenSource.tsx
+++ b/site/src/components/sections/OpenSource.tsx
@@ -61,6 +61,13 @@ function OpenSource({ className, ...props }: OpenSourceProps) {
               Run locally
               <Icon name="arrow-right" size="xs" />
             </Link>
+            <Link
+              href="/docs/guides/self-hosting/cloud-vs-self-hosted"
+              className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Cloud vs self-hosted
+              <Icon name="arrow-right" size="xs" />
+            </Link>
           </div>
         </FadeInUp>
       </div>


### PR DESCRIPTION
## Summary

Adds the Cloud vs self-hosted comparison page to the self-hosting docs section — an Explanation page that states what self-hosting includes, what Stigmer Cloud adds, and how to choose. The pricing FAQ and the OpenSource marketing section now link to it.

## Context

Self-hosting recently became a complete story (Postgres storage, OIDC + API keys, named CLI backends), but the docs had no page answering the first question an evaluating team asks: "should we self-host or use Stigmer Cloud?" The closest surfaces were one pricing FAQ answer and scattered notes across concept pages. This page is the canonical comparison; the existing pages keep the details and this page links to them.

## Changes

- `docs/guides/self-hosting/cloud-vs-self-hosted.mdx` — the page: the decision rule in plain words, choose-lists, a ten-row side-by-side table, what self-hosting includes (present-tense shipped facts only), what Stigmer Cloud adds, honest limitations, and next-step cards into the Docker Compose guide and app.stigmer.ai.
- `docs/guides/self-hosting/meta.json` — the page leads the section: the "should I self-host?" decision precedes the how-to arc.
- `docs/_inventory/classification.yaml` — the page's inventory entry (explanation, medium none), same commit.
- `site/src/components/pages/PricingPage.tsx` — FAQ items gain an optional typed `link` rendered after the answer; the "Can I self-host for free?" answer now points at the comparison.
- `site/src/components/sections/OpenSource.tsx` — a "Cloud vs self-hosted" link beside "Run locally", same pattern.

## Implementation notes

- The page owns the comparison, never the details: every cross-edition fact links to its canonical page (billing, identity, the auth guides) so there is exactly one place to update each fact.
- Honesty posture: the page carries the two known self-hosting caveats plainly — the web console cannot sign in to an authenticated server yet (#924), and Docker Compose is the supported packaging.
- Sandbox isolation is stated at exactly the level that ships: pluggable drivers (local process, Docker, Kubernetes) that are off by default. A follow-up issue proposes a how-to guide for configuring them.
- The three existing self-hosting guides are untouched; the new page bridges one-way into their arc.

## Breaking changes

- None.

## Test plan

- `make check-site` green end to end in the branch worktree: Vale (0 errors, 0 warnings), prettier, docs YAML contracts, docs inventory (204 pages OK), site lint, typecheck, unit tests, full static build (llms exports regenerated), demo validation, lychee link check (1,666 links, 0 errors).

## Risks

- Docs-and-marketing-only change; no runtime code touched. Rollback is a revert.

## Checklist

- [x] Docs updated
- [x] Classification inventory updated in the same commit
- [x] Backward compatible

Made with [Cursor](https://cursor.com)