### PR TITLE
fix(sdk/react): redesign cursor-accounts coverage table to fit its 768px canvas

### DIFF
--- a/sdk/react/src/cursor-accounts/CursorAccountsConsole.tsx
+++ b/sdk/react/src/cursor-accounts/CursorAccountsConsole.tsx
@@ -44,8 +44,9 @@ type Flow =
  *   categories (on team with key / on team without key / key held but
  *   not on team), each row carrying Cursor's pool-usage percentages
  *   (first-party / API) and cycle spend dollars (included / on-demand).
- *   Off-team rows offer one-click copy of the account's Cursor team
- *   invite link when the operator has configured one.
+ *   The off-team group header offers one-click copy of the account's
+ *   Cursor team invite link when the operator has configured one (one
+ *   button for the group — the link is account-level).
  *
  * Requires `can_manage_cursor_accounts` on `platform:stigmer` —
  * non-operators see the designed access notice. Key material never

--- a/sdk/react/src/cursor-accounts/MemberCoverageTable.tsx
+++ b/sdk/react/src/cursor-accounts/MemberCoverageTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { MoreHorizontal, Pause, Play, Trash2 } from "lucide-react";
 import { useCopyFeedback } from "../internal/useCopyFeedback.js";
 import { cn } from "@stigmer/theme";
 import {
@@ -8,6 +9,7 @@ import {
   type CursorTeamMemberView,
 } from "@stigmer/protos/ai/stigmer/platform/cursoraccount/v1/io_pb";
 import type { CursorMemberSpend } from "@stigmer/protos/ai/stigmer/platform/cursoraccount/v1/cursor_account_pb";
+import { ActionMenu } from "../action-menu/index.js";
 import { Button } from "../button/index.js";
 import { TruncatedText } from "../internal/truncated-text.js";
 import { StateBadge } from "./badges.js";
@@ -17,19 +19,25 @@ import type { useCursorMemberKeyActions } from "./useCursorMemberKeyActions.js";
 
 /**
  * One grid template shared by the header and every row so the columns
- * can never drift apart: Member · Key · First-party % · API % ·
- * Included $ · On-demand $ · Status · Actions.
+ * can never drift apart: Member · First-party % · API % · Included $ ·
+ * On-demand $ · Status · actions kebab.
  *
  * The four numeric columns mirror Cursor's own Members page (First-Party
  * Models %, API %, On-Demand $) plus the included-quota dollars, so an
  * operator can read this table and the Cursor dashboard side by side.
  *
- * Member gets the largest flexible share: the email is the row's
- * identity, so it wraps rather than truncates when space runs out (see
- * MemberCell) while the key name stays truncate-with-tooltip.
+ * The column budget is sized for the table's real canvas: both client
+ * apps render settings inside `max-w-3xl` (768px), leaving ~720px of
+ * content. Fixed tracks total ~25rem, so the flexible member column
+ * keeps ~240px — enough to render typical emails whole (stigmer#929: an
+ * earlier 8-column layout with a three-button actions column consumed
+ * the full width and collapsed the member column to zero, shattering
+ * emails one character per line). Key name/label live inside the member
+ * cell and row actions inside a kebab menu precisely to defend that
+ * budget.
  */
 const ROW_GRID =
-  "stg:grid stg:grid-cols-[minmax(0,2.2fr)_minmax(0,1fr)_4.5rem_4.5rem_4.5rem_4.5rem_minmax(6rem,auto)_minmax(10rem,auto)] stg:items-center stg:gap-2 stg:px-3 stg:py-2";
+  "stg:grid stg:grid-cols-[minmax(0,1fr)_4rem_4rem_4.5rem_4.5rem_6rem_2.25rem] stg:items-center stg:gap-2 stg:px-3 stg:py-2";
 
 /**
  * The roster-coverage table: every member and every stored execution key
@@ -41,9 +49,17 @@ const ROW_GRID =
  *    help the operator prioritize whose key to import.
  * 3. **Key held, not on the team** — imported keys whose owner left the
  *    team or never joined it. Resolved by a Cursor-dashboard invite:
- *    when the account carries a team invite link, each row offers
- *    one-click copy (never navigation — opening an invite link would
- *    join the OPERATOR's own Cursor account to the team).
+ *    when the account carries a team invite link, the group header
+ *    offers one-click copy (one button, not one per row — the link is
+ *    account-level and identical for every owner; and always a copy,
+ *    never navigation, since opening an invite link would join the
+ *    OPERATOR's own Cursor account to the team).
+ *
+ * The categories render as grouped sections of ONE table — deliberately
+ * not tabs. Together they answer a single question ("is this roster
+ * healthy?"), so all three counts must be visible at once; groups are
+ * team-sized (5–30 rows), never large enough to need pagination-style
+ * chrome.
  *
  * Before the first sync there is no roster to classify against, so keys
  * render unclassified with a "sync now" notice instead of being falsely
@@ -64,119 +80,119 @@ export function MemberCoverageTable({
   readonly onChanged: () => void;
 }) {
   return (
-    <div
-      role="table"
-      aria-label="Team coverage"
-      className="stg:rounded-lg stg:border stg:border-border stg:bg-card"
-    >
-      <div
-        role="row"
-        className={cn(
-          ROW_GRID,
-          "stg:border-b stg:border-border stg:text-[11px] stg:font-medium stg:text-muted-foreground",
+    // Narrow-host guard (the ResourceTable idiom): below the grid's
+    // legible minimum the table scrolls horizontally instead of letting
+    // the flexible member column collapse. The scroll container carries
+    // the card chrome; the ARIA table starts inside it so `role="row"`
+    // children stay directly owned by the table.
+    <div className="stg:overflow-x-auto stg:rounded-lg stg:border stg:border-border stg:bg-card">
+      <div role="table" aria-label="Team coverage" className="stg:min-w-[40rem]">
+        <div
+          role="row"
+          className={cn(
+            ROW_GRID,
+            "stg:border-b stg:border-border stg:text-[11px] stg:font-medium stg:text-muted-foreground",
+          )}
+        >
+          <span role="columnheader">Member</span>
+          <span role="columnheader" className="stg:text-right">
+            First-party
+          </span>
+          <span role="columnheader" className="stg:text-right">
+            API
+          </span>
+          <span role="columnheader" className="stg:text-right">
+            Included
+          </span>
+          <span role="columnheader" className="stg:text-right">
+            On-demand
+          </span>
+          <span role="columnheader">Status</span>
+          <span role="columnheader">
+            <span className="stg:sr-only">Actions</span>
+          </span>
+        </div>
+
+        {!coverage.hasRoster && (
+          <CoverageGroup
+            title="Execution keys — not yet classified"
+            description='No roster sync has run for this account. Run "Sync now" to load the team roster and classify these keys.'
+            count={coverage.unclassified.length}
+          >
+            {coverage.unclassified.map((keyView) => (
+              <KeyRow
+                key={keyView.key?.keyId}
+                accountId={accountId}
+                keyView={keyView}
+                hasRoster={false}
+                actions={actions}
+                onChanged={onChanged}
+              />
+            ))}
+          </CoverageGroup>
         )}
-      >
-        <span role="columnheader">Member</span>
-        <span role="columnheader">Key</span>
-        <span role="columnheader" className="stg:text-right">
-          First-party
-        </span>
-        <span role="columnheader" className="stg:text-right">
-          API
-        </span>
-        <span role="columnheader" className="stg:text-right">
-          Included
-        </span>
-        <span role="columnheader" className="stg:text-right">
-          On-demand
-        </span>
-        <span role="columnheader">Status</span>
-        <span role="columnheader" className="stg:text-right">
-          Actions
-        </span>
+
+        {coverage.onTeamWithKey.length > 0 && (
+          <CoverageGroup
+            title="On the team — key held"
+            count={coverage.onTeamWithKey.length}
+          >
+            {coverage.onTeamWithKey.map((keyView) => (
+              <KeyRow
+                key={keyView.key?.keyId}
+                accountId={accountId}
+                keyView={keyView}
+                hasRoster
+                actions={actions}
+                onChanged={onChanged}
+              />
+            ))}
+          </CoverageGroup>
+        )}
+
+        {/* Rendered whenever a roster exists — an empty gap is an answer
+            ("fully covered"), not an absence. Hiding the group made a
+            healthy roster indistinguishable from a broken sync. */}
+        {coverage.hasRoster && (
+          <CoverageGroup
+            title="On the team — no execution key"
+            description={
+              coverage.onTeamWithoutKey.length > 0
+                ? "Sessions can never run under these members' identity or included quota. Add their user-scoped keys below to close the gap."
+                : "Every active roster member holds an execution key — the roster is fully covered."
+            }
+            count={coverage.onTeamWithoutKey.length}
+          >
+            {coverage.onTeamWithoutKey.map((memberView) => (
+              <GapRow key={memberView.member?.email} memberView={memberView} />
+            ))}
+          </CoverageGroup>
+        )}
+
+        {coverage.offTeamWithKey.length > 0 && (
+          <CoverageGroup
+            title="Key held — not on the team"
+            description={
+              inviteLink !== ""
+                ? "These key owners must join the Cursor team before their usage counts against its quota — copy the invite link, send it out-of-band, then \u201CSync now\u201D reclassifies once they join."
+                : "These key owners must join the Cursor team before their usage counts against its quota. Invites are sent from the Cursor dashboard (cursor.com \u2192 Invite Members); paste the team's invite link into the account editor to enable one-click copying here."
+            }
+            count={coverage.offTeamWithKey.length}
+            action={inviteLink !== "" ? <CopyInviteButton inviteLink={inviteLink} /> : undefined}
+          >
+            {coverage.offTeamWithKey.map((keyView) => (
+              <KeyRow
+                key={keyView.key?.keyId}
+                accountId={accountId}
+                keyView={keyView}
+                hasRoster
+                actions={actions}
+                onChanged={onChanged}
+              />
+            ))}
+          </CoverageGroup>
+        )}
       </div>
-
-      {!coverage.hasRoster && (
-        <CoverageGroup
-          title="Execution keys — not yet classified"
-          description='No roster sync has run for this account. Run "Sync now" to load the team roster and classify these keys.'
-          count={coverage.unclassified.length}
-        >
-          {coverage.unclassified.map((keyView) => (
-            <KeyRow
-              key={keyView.key?.keyId}
-              accountId={accountId}
-              keyView={keyView}
-              hasRoster={false}
-              inviteLink=""
-              actions={actions}
-              onChanged={onChanged}
-            />
-          ))}
-        </CoverageGroup>
-      )}
-
-      {coverage.onTeamWithKey.length > 0 && (
-        <CoverageGroup
-          title="On the team — key held"
-          count={coverage.onTeamWithKey.length}
-        >
-          {coverage.onTeamWithKey.map((keyView) => (
-            <KeyRow
-              key={keyView.key?.keyId}
-              accountId={accountId}
-              keyView={keyView}
-              hasRoster
-              inviteLink=""
-              actions={actions}
-              onChanged={onChanged}
-            />
-          ))}
-        </CoverageGroup>
-      )}
-
-      {/* Rendered whenever a roster exists — an empty gap is an answer
-          ("fully covered"), not an absence. Hiding the group made a
-          healthy roster indistinguishable from a broken sync. */}
-      {coverage.hasRoster && (
-        <CoverageGroup
-          title="On the team — no execution key"
-          description={
-            coverage.onTeamWithoutKey.length > 0
-              ? "Sessions can never run under these members' identity or included quota. Add their user-scoped keys below to close the gap."
-              : "Every active roster member holds an execution key — the roster is fully covered."
-          }
-          count={coverage.onTeamWithoutKey.length}
-        >
-          {coverage.onTeamWithoutKey.map((memberView) => (
-            <GapRow key={memberView.member?.email} memberView={memberView} />
-          ))}
-        </CoverageGroup>
-      )}
-
-      {coverage.offTeamWithKey.length > 0 && (
-        <CoverageGroup
-          title="Key held — not on the team"
-          description={
-            inviteLink !== ""
-              ? "These key owners must join the Cursor team before their usage counts against its quota. Copy the invite link, send it to them out-of-band, then \u201CSync now\u201D reclassifies once they join."
-              : "These key owners must join the Cursor team before their usage counts against its quota. Invites are sent from the Cursor dashboard (cursor.com \u2192 Invite Members); paste the team's invite link into the account editor to enable one-click copying here."
-          }
-          count={coverage.offTeamWithKey.length}
-        >
-          {coverage.offTeamWithKey.map((keyView) => (
-            <KeyRow
-              key={keyView.key?.keyId}
-              accountId={accountId}
-              keyView={keyView}
-              hasRoster
-              inviteLink={inviteLink}
-              actions={actions}
-              onChanged={onChanged}
-            />
-          ))}
-        </CoverageGroup>
-      )}
     </div>
   );
 }
@@ -189,28 +205,38 @@ function CoverageGroup({
   title,
   description,
   count,
+  action,
   children,
 }: {
   readonly title: string;
   readonly description?: string;
   readonly count: number;
+  /** Optional group-level action (e.g. the off-team invite copy). */
+  readonly action?: React.ReactNode;
   readonly children: React.ReactNode;
 }) {
   return (
     <div role="rowgroup" className="stg:border-b stg:border-border stg:last:border-b-0">
       <div role="row" className="stg:bg-muted-subtle stg:px-3 stg:py-1.5">
-        <div role="cell" aria-colspan={8}>
-          <span className="stg:text-[11px] stg:font-semibold stg:text-foreground">
-            {title}
-            <span className="stg:ml-1.5 stg:font-normal stg:text-muted-foreground">
-              {count}
+        <div
+          role="cell"
+          aria-colspan={7}
+          className="stg:flex stg:items-start stg:justify-between stg:gap-2"
+        >
+          <span className="stg:min-w-0">
+            <span className="stg:text-[11px] stg:font-semibold stg:text-foreground">
+              {title}
+              <span className="stg:ml-1.5 stg:font-normal stg:text-muted-foreground">
+                {count}
+              </span>
             </span>
+            {description && (
+              <span className="stg:block stg:text-[11px] stg:text-muted-foreground">
+                {description}
+              </span>
+            )}
           </span>
-          {description && (
-            <span className="stg:block stg:text-[11px] stg:text-muted-foreground">
-              {description}
-            </span>
-          )}
+          {action && <span className="stg:shrink-0">{action}</span>}
         </div>
       </div>
       {children}
@@ -224,30 +250,29 @@ function CoverageGroup({
 
 /**
  * The member-identity cell shared by key rows and gap rows. The email is
- * the row's identity, so it must be fully readable: it wraps onto more
- * lines when the column is narrow (emails are unbroken strings, so they
- * need explicit word-breaking), unlike the other text cells which
- * truncate. The secondary name line stays truncated — it is display
- * sugar, not identity.
+ * the row's identity and truncates with the overflow-gated house tooltip
+ * (never `break-words`: with grid columns under pressure, word-breaking
+ * degenerated to one character per line — stigmer#929; the full value
+ * stays available to selection, screen readers, and the tooltip). The
+ * secondary line carries what each row type actually has: the key
+ * name/label on key rows, the roster display name on gap rows
+ * (`CursorMemberKeyView` carries no member name to show).
  */
 function MemberCell({
   email,
-  name,
+  secondary,
 }: {
   readonly email: string;
-  readonly name?: string;
+  readonly secondary?: string;
 }) {
   return (
     <span role="cell" className="stg:min-w-0">
-      {/* No tooltip: break-words shows the full email, so a hover hint
-          would only repeat what is already visible. */}
-      <span className="stg:block stg:break-words stg:font-medium stg:text-foreground">
-        {email}
-      </span>
-      {name && (
-        <span className="stg:block stg:truncate stg:text-[11px] stg:text-muted-foreground">
-          {name}
-        </span>
+      <TruncatedText text={email} className="stg:font-medium stg:text-foreground" />
+      {secondary && (
+        <TruncatedText
+          text={secondary}
+          className="stg:text-[11px] stg:text-muted-foreground"
+        />
       )}
     </span>
   );
@@ -258,71 +283,70 @@ function KeyRow({
   accountId,
   keyView,
   hasRoster,
-  inviteLink,
   actions,
   onChanged,
 }: {
   readonly accountId: string;
   readonly keyView: CursorMemberKeyView;
   readonly hasRoster: boolean;
-  readonly inviteLink: string;
   readonly actions: ReturnType<typeof useCursorMemberKeyActions>;
   readonly onChanged: () => void;
 }) {
   const key = keyView.key;
   if (!key) return null;
 
+  const keyMeta = [key.cursorKeyName || "unnamed key", key.label]
+    .filter((part) => part !== "")
+    .join(" · ");
+
   return (
     <div role="row" className={cn(ROW_GRID, "stg:border-t stg:border-border-muted stg:text-xs")}>
-      <MemberCell email={key.boundEmail} />
-      <span role="cell" className="stg:min-w-0">
-        <TruncatedText
-          text={key.cursorKeyName || "unnamed key"}
-          className="stg:block stg:text-muted-foreground"
-        />
-        {key.label && (
-          <TruncatedText
-            text={key.label}
-            className="stg:block stg:text-[11px] stg:text-muted-foreground"
-          />
-        )}
-      </span>
+      <MemberCell email={key.boundEmail} secondary={keyMeta} />
       <SpendCells spend={keyView.spend} />
       <span role="cell" className="stg:flex stg:flex-wrap stg:items-center stg:gap-1">
         {keyView.usageGuardTripped && <StateBadge tone="warn" label="Usage guard" />}
         <KeyStatusBadge keyView={keyView} hasRoster={hasRoster} />
       </span>
-      <span role="cell" className="stg:flex stg:items-center stg:justify-end stg:gap-2">
-        {inviteLink !== "" && <CopyInviteButton inviteLink={inviteLink} />}
-        <Button
-          size="sm"
-          variant="outline"
-          disabled={actions.isSubmitting}
-          onClick={() => {
-            void actions
-              .setKeyEnabled(accountId, key.keyId, !key.enabled)
-              .then(onChanged, () => {
-                // Surfaced via actions.error.
-              });
-          }}
-        >
-          {key.enabled ? "Disable" : "Enable"}
-        </Button>
-        <Button
-          size="sm"
-          variant="destructive"
-          disabled={actions.isSubmitting}
-          onClick={() => {
-            void actions
-              .removeKey({ accountId, keyId: key.keyId })
-              .then(onChanged, () => {
-                // Surfaced via actions.error (incl. the live-pin guard's
-                // "disable instead, or force" message).
-              });
-          }}
-        >
-          Remove
-        </Button>
+      <span role="cell" className="stg:text-right">
+        <ActionMenu>
+          <ActionMenu.Trigger aria-label={`Actions for ${key.boundEmail}`}>
+            <MoreHorizontal className="stg:size-4" />
+          </ActionMenu.Trigger>
+          <ActionMenu.Content>
+            {/* `disabled` guards against a re-fire while a prior key
+                mutation is still in flight; outcomes surface via
+                actions.error under the table. */}
+            <ActionMenu.Item
+              icon={key.enabled ? <Pause /> : <Play />}
+              disabled={actions.isSubmitting}
+              onSelect={() => {
+                void actions
+                  .setKeyEnabled(accountId, key.keyId, !key.enabled)
+                  .then(onChanged, () => {
+                    // Surfaced via actions.error.
+                  });
+              }}
+            >
+              {key.enabled ? "Disable" : "Enable"}
+            </ActionMenu.Item>
+            <ActionMenu.Separator />
+            <ActionMenu.Item
+              icon={<Trash2 />}
+              variant="destructive"
+              disabled={actions.isSubmitting}
+              onSelect={() => {
+                void actions
+                  .removeKey({ accountId, keyId: key.keyId })
+                  .then(onChanged, () => {
+                    // Surfaced via actions.error (incl. the live-pin guard's
+                    // "disable instead, or force" message).
+                  });
+              }}
+            >
+              Remove
+            </ActionMenu.Item>
+          </ActionMenu.Content>
+        </ActionMenu>
       </span>
     </div>
   );
@@ -335,17 +359,14 @@ function GapRow({ memberView }: { readonly memberView: CursorTeamMemberView }) {
 
   return (
     <div role="row" className={cn(ROW_GRID, "stg:border-t stg:border-border-muted stg:text-xs")}>
-      <MemberCell email={member.email} name={member.name} />
-      <span role="cell" className="stg:text-muted-foreground">
-        —
-      </span>
+      <MemberCell email={member.email} secondary={member.name || undefined} />
       <SpendCells spend={memberView.spend} />
       <span role="cell">
         <StateBadge tone="muted" label="No key" />
       </span>
-      <span role="cell" className="stg:text-right stg:text-muted-foreground">
-        —
-      </span>
+      {/* No key, no actions — an empty cell keeps every row at the
+          header's seven columns. */}
+      <span role="cell" />
     </div>
   );
 }
@@ -415,9 +436,10 @@ function KeyStatusBadge({
 // ---------------------------------------------------------------------------
 
 /**
- * Copies the account-level team invite link. Deliberately a copy, never
- * a navigation: a Cursor invite link is a join link, and opening it
- * would join the operator's own Cursor account to the team.
+ * Copies the account-level team invite link, once per group (the link is
+ * identical for every off-team owner). Deliberately a copy, never a
+ * navigation: a Cursor invite link is a join link, and opening it would
+ * join the operator's own Cursor account to the team.
  */
 function CopyInviteButton({ inviteLink }: { readonly inviteLink: string }) {
   const { copy, copied } = useCopyFeedback();

--- a/sdk/react/src/cursor-accounts/MemberKeysPanel.tsx
+++ b/sdk/react/src/cursor-accounts/MemberKeysPanel.tsx
@@ -143,7 +143,31 @@ export function MemberKeysPanel({
 
   return (
     <section className="stg:space-y-2">
-      <h4 className="stg:text-xs stg:font-semibold stg:text-foreground">Team coverage</h4>
+      <div>
+        <h4 className="stg:text-xs stg:font-semibold stg:text-foreground">Team coverage</h4>
+        {/* One-line health subtitle so the coverage answer is readable
+            even when the gap group sits below the fold. The counts are
+            the table's own groups (no re-derivation); the gap count is
+            the attention point, tinted only when it is non-zero. Before
+            the first sync there is nothing to classify, so no subtitle. */}
+        {coverage.hasRoster && (
+          <p className="stg:text-[11px] stg:text-muted-foreground">
+            {coverage.onTeamWithKey.length} covered
+            {" · "}
+            <span
+              className={cn(
+                coverage.onTeamWithoutKey.length > 0 &&
+                  "stg:font-medium stg:text-destructive",
+              )}
+            >
+              {coverage.onTeamWithoutKey.length} without keys
+            </span>
+            {coverage.offTeamWithKey.length > 0
+              ? ` · ${coverage.offTeamWithKey.length} off-team`
+              : ""}
+          </p>
+        )}
+      </div>
 
       {keyViews.length === 0 && (
         <p className="stg:text-xs stg:text-muted-foreground" role="status">

--- a/sdk/react/src/cursor-accounts/__tests__/CursorAccountsConsole.test.tsx
+++ b/sdk/react/src/cursor-accounts/__tests__/CursorAccountsConsole.test.tsx
@@ -21,6 +21,7 @@ import {
 } from "@stigmer/protos/ai/stigmer/platform/cursoraccount/v1/io_pb";
 import { StigmerContext } from "../../context";
 import { FetchCacheContext } from "../../internal/FetchCacheProvider";
+import { openMenu } from "../../__tests__/helpers/open-menu";
 import { CursorAccountsConsole } from "../CursorAccountsConsole";
 
 interface MockCursorAccounts {
@@ -257,13 +258,17 @@ describe("CursorAccountsConsole", () => {
     await waitFor(() =>
       expect(screen.getByRole("table", { name: "Team coverage" })).toBeTruthy(),
     );
-    // Category 1: on the team, key held — email, key name, spend, status.
+    // Category 1: on the team, key held — the key name/label folds into
+    // the identity cell (no separate key column: stigmer#929 traded it
+    // for member-column width).
     expect(screen.getByText(/On the team — key held/)).toBeTruthy();
     expect(screen.getByText("zane@scenar.ai")).toBeTruthy();
     expect(screen.getByText("stigmer-prod")).toBeTruthy();
-    // The email is the row's identity: the cell wraps rather than
-    // truncates, so the full value is always visible text on both row
-    // kinds — and never a native title (banned, stigmer-cloud#268).
+    // The email is the row's identity: it truncates with the
+    // overflow-gated house tooltip (never break-words, which #929 showed
+    // degenerating to one character per line under column pressure) and
+    // never a native title (banned, stigmer-cloud#268) — the full value
+    // stays in the DOM as selectable text on both row kinds.
     expect(document.querySelector("[title]")).toBeNull();
     expect(screen.getByText("$0.17")).toBeTruthy(); // included, 169342 micro-USD
     expect(screen.getByText("Active")).toBeTruthy();
@@ -282,6 +287,12 @@ describe("CursorAccountsConsole", () => {
     // Header sync line: active members from server facts, removed seats
     // by list arithmetic (roster entries minus active members).
     expect(screen.getByText(/2 members · 1 removed seat/)).toBeTruthy();
+    // Only key-backed rows carry an actions kebab; gap rows have none.
+    expect(screen.getAllByRole("button", { name: /^Actions for/ })).toHaveLength(1);
+    // The heading subtitle answers roster health without scrolling to
+    // the gap group.
+    expect(screen.getByText(/1 covered/)).toBeTruthy();
+    expect(screen.getByText("1 without keys")).toBeTruthy();
   });
 
   it("affirms full coverage instead of hiding the gap group when every active member holds a key", async () => {
@@ -377,14 +388,16 @@ describe("CursorAccountsConsole", () => {
     expect(screen.getByText("Not on team")).toBeTruthy();
     expect(screen.getByText("Left team")).toBeTruthy();
 
-    // One "Copy invite" per off-team row — a copy, never a navigation.
-    const copyButtons = screen.getAllByRole("button", { name: "Copy invite" });
-    expect(copyButtons).toHaveLength(2);
-    await userEvent.click(copyButtons[0]);
+    // ONE "Copy invite" in the group header — the link is account-level
+    // and identical for every off-team owner, so per-row buttons were
+    // redundant (stigmer#929). Always a copy, never a navigation.
+    await userEvent.click(screen.getByRole("button", { name: "Copy invite" }));
     await waitFor(() =>
       expect(writeText).toHaveBeenCalledWith("https://cursor.com/team-invite/abc"),
     );
     expect(screen.getByRole("button", { name: "Copied" })).toBeTruthy();
+    // The heading subtitle counts the off-team keys.
+    expect(screen.getByText(/2 off-team/)).toBeTruthy();
   });
 
   it("points at the Cursor dashboard when no invite link is configured", async () => {
@@ -446,6 +459,49 @@ describe("CursorAccountsConsole", () => {
     );
     expect(screen.getByText("Awaiting sync")).toBeTruthy();
     expect(screen.queryByText(/Key held — not on the team/)).toBeNull();
+  });
+
+  it("drives Enable/Disable and Remove through the row's kebab menu", async () => {
+    const setMemberKeyEnabled = vi.fn().mockResolvedValue(scenarAccount());
+    const removeMemberKey = vi.fn().mockResolvedValue(scenarAccount());
+    const client = createMockStigmer({
+      listAccounts: vi.fn().mockResolvedValue({ accounts: [scenarSummary()] }),
+      getAccountView: vi.fn().mockResolvedValue(scenarView()),
+      setMemberKeyEnabled,
+      removeMemberKey,
+    });
+    render(<CursorAccountsConsole />, { wrapper: wrapper(client) });
+
+    await waitFor(() => expect(screen.getByText("scenar team")).toBeTruthy());
+    await userEvent.click(screen.getByRole("button", { name: /scenar team/ }));
+    await waitFor(() =>
+      expect(screen.getByRole("table", { name: "Team coverage" })).toBeTruthy(),
+    );
+
+    // The enabled key offers Disable; the menu closes on select.
+    await openMenu(
+      screen.getByRole("button", { name: "Actions for zane@scenar.ai" }),
+    );
+    await userEvent.click(screen.getByRole("menuitem", { name: "Disable" }));
+    await waitFor(() =>
+      expect(setMemberKeyEnabled).toHaveBeenCalledWith({
+        accountId: "acc-1",
+        keyId: "k-1",
+        enabled: false,
+      }),
+    );
+
+    // Remove is the kebab's destructive item (live-pin-guarded server-side).
+    await openMenu(
+      screen.getByRole("button", { name: "Actions for zane@scenar.ai" }),
+    );
+    await userEvent.click(screen.getByRole("menuitem", { name: "Remove" }));
+    await waitFor(() =>
+      expect(removeMemberKey).toHaveBeenCalledWith({
+        accountId: "acc-1",
+        keyId: "k-1",
+      }),
+    );
   });
 
   it("adds a member key and refreshes both views", async () => {

--- a/sdk/react/src/cursor-accounts/__tests__/MemberCoverageTable.layout.test.tsx
+++ b/sdk/react/src/cursor-accounts/__tests__/MemberCoverageTable.layout.test.tsx
@@ -1,0 +1,212 @@
+// Layout-contract regression suite for the coverage table's column
+// budget (stigmer#929). Runs in a real Chromium via
+// `vitest.a11y.config.ts` — the defect this pins was a grid-track
+// collapse (fixed tracks starving the flexible member column until
+// emails rendered one character per line), which only a real layout
+// engine can resolve.
+//
+// The contract has two halves:
+//
+// 1. At the settings-page canvas (both client apps render settings in
+//    `max-w-3xl`, ~720px of content), the table fits WITHOUT horizontal
+//    scroll and the member column keeps enough width to render typical
+//    emails whole.
+// 2. In a narrower host (the SDK component is embeddable at any width,
+//    DD-004), the grid's min-width guard turns crushing into horizontal
+//    scrolling — the member column never collapses.
+//
+// Like the provider layout suite (DD-019), this renders against the
+// SHIPPED stylesheet (`dist/styles.css`, built by `npm run build:libs`),
+// so the contract is verified on the artifact consumers actually load.
+
+import "../../../dist/styles.css";
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup, screen } from "@testing-library/react";
+import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+import type { Stigmer } from "@stigmer/sdk";
+import {
+  CursorAccountSchema,
+  CursorAccountSyncSnapshotSchema,
+  CursorMemberKeySchema,
+  CursorMemberSpendSchema,
+  CursorTeamMemberSchema,
+} from "@stigmer/protos/ai/stigmer/platform/cursoraccount/v1/cursor_account_pb";
+import {
+  CursorAccountViewSchema,
+  CursorMemberKeyViewSchema,
+  CursorMemberKeyState,
+  CursorTeamMemberViewSchema,
+} from "@stigmer/protos/ai/stigmer/platform/cursoraccount/v1/io_pb";
+import { StigmerProvider } from "../../provider";
+import { deriveCoverage } from "../cursor-account-coverage";
+import type { useCursorMemberKeyActions } from "../useCursorMemberKeyActions";
+import { MemberCoverageTable } from "../MemberCoverageTable";
+
+afterEach(cleanup);
+
+// A minimal client: the provider eagerly fetches registries on mount;
+// a null credential keeps that non-blocking and off the network.
+function makeClient(): Stigmer {
+  return {
+    baseUrl: "https://example.test",
+    getAuthCredential: async () => null,
+    fetch: (async () => {
+      throw new Error("network disabled in test");
+    }) as unknown as typeof globalThis.fetch,
+  } as unknown as Stigmer;
+}
+
+// The table renders actions through this hook's return; layout never
+// invokes them, so rejecting stubs are honest.
+const stubActions: ReturnType<typeof useCursorMemberKeyActions> = {
+  addKey: () => Promise.reject(new Error("unused in layout test")),
+  removeKey: () => Promise.reject(new Error("unused in layout test")),
+  setKeyEnabled: () => Promise.reject(new Error("unused in layout test")),
+  isSubmitting: false,
+  error: null,
+  clearError: () => {},
+};
+
+/**
+ * A view shaped like the account that exposed #929: all three coverage
+ * categories populated, real-length emails, a key with both a Cursor
+ * key name and an operator label (the widest identity cell).
+ */
+function fixtureView() {
+  const spend = (email: string) =>
+    create(CursorMemberSpendSchema, {
+      email,
+      autoPercentUsed: 12.4,
+      apiPercentUsed: 100,
+      includedSpendUsdMicros: 201550000n,
+      overageSpendUsdMicros: 0n,
+    });
+
+  return create(CursorAccountViewSchema, {
+    account: create(CursorAccountSchema, {
+      accountId: "acc-layout",
+      displayName: "layout team",
+      adminApiKey: "***REDACTED***",
+      enabled: true,
+      teamInviteLink: "https://cursor.com/team-invite/layout",
+    }),
+    snapshot: create(CursorAccountSyncSnapshotSchema, {
+      accountId: "acc-layout",
+      syncedAt: timestampFromDate(new Date("2026-08-28T10:00:00Z")),
+      members: [
+        create(CursorTeamMemberSchema, {
+          userId: "u1",
+          email: "timothy@leftbin.com",
+          name: "Timothy M",
+          role: "owner",
+        }),
+        create(CursorTeamMemberSchema, {
+          userId: "u2",
+          email: "amelia@leftbin.com",
+          name: "Amelia F",
+          role: "member",
+        }),
+      ],
+    }),
+    keyViews: [
+      create(CursorMemberKeyViewSchema, {
+        key: create(CursorMemberKeySchema, {
+          keyId: "k-1",
+          apiKey: "***REDACTED***",
+          boundEmail: "timothy@leftbin.com",
+          cursorKeyName: "stigmer-production-key",
+          label: "timothy — prod",
+          enabled: true,
+        }),
+        state: CursorMemberKeyState.member_key_active,
+        spend: spend("timothy@leftbin.com"),
+      }),
+      create(CursorMemberKeyViewSchema, {
+        key: create(CursorMemberKeySchema, {
+          keyId: "k-2",
+          apiKey: "***REDACTED***",
+          boundEmail: "lucasb@oneighty.com",
+          cursorKeyName: "personal-key",
+          enabled: true,
+        }),
+        state: CursorMemberKeyState.member_key_owner_unknown,
+        spend: spend("lucasb@oneighty.com"),
+      }),
+    ],
+    membersWithoutKeysViews: [
+      create(CursorTeamMemberViewSchema, {
+        member: create(CursorTeamMemberSchema, {
+          userId: "u2",
+          email: "amelia@leftbin.com",
+          name: "Amelia F",
+          role: "member",
+        }),
+      }),
+    ],
+  });
+}
+
+function renderTableAt(hostWidth: number) {
+  const view = fixtureView();
+  render(
+    <div style={{ width: hostWidth }}>
+      <StigmerProvider client={makeClient()}>
+        <MemberCoverageTable
+          accountId="acc-layout"
+          coverage={deriveCoverage(view)}
+          inviteLink={view.account?.teamInviteLink ?? ""}
+          actions={stubActions}
+          onChanged={() => {}}
+        />
+      </StigmerProvider>
+    </div>,
+  );
+
+  const table = screen.getByRole("table", { name: "Team coverage" });
+  // The overflow guard is the table's direct wrapper (the card-chrome div).
+  const scroller = table.parentElement as HTMLElement;
+  return { table, scroller };
+}
+
+function emailCell(email: string): HTMLElement {
+  const cell = screen.getByText(email).closest('[role="cell"]');
+  expect(cell, `member cell for ${email}`).not.toBeNull();
+  return cell as HTMLElement;
+}
+
+describe("MemberCoverageTable column budget (#929)", () => {
+  it("fits the 768px settings canvas without horizontal scroll, with a legible member column", () => {
+    // max-w-3xl (768px) minus the settings page's px-6 → ~720px content.
+    const { scroller } = renderTableAt(720);
+
+    expect(scroller.scrollWidth).toBe(scroller.clientWidth);
+
+    // The member column must hold real emails whole. The #929 failure
+    // rendered this cell ~1ch wide; anything under ~180px would push
+    // typical emails back into truncation as the norm rather than the
+    // exception.
+    const cell = emailCell("lucasb@oneighty.com");
+    expect(cell.getBoundingClientRect().width).toBeGreaterThan(180);
+
+    // One line: the email never wraps (truncation instead of the
+    // character-per-line wrapping that motivated this suite).
+    const emailEl = screen.getByText("lucasb@oneighty.com");
+    const lineHeight = parseFloat(getComputedStyle(emailEl).lineHeight);
+    expect(emailEl.getBoundingClientRect().height).toBeLessThan(lineHeight * 1.5);
+  });
+
+  it("scrolls horizontally in a narrow host instead of collapsing the member column", () => {
+    const { table, scroller } = renderTableAt(400);
+
+    // The min-width guard keeps the grid at its legible minimum and
+    // hands the difference to the scroll container.
+    expect(scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth);
+    expect(table.getBoundingClientRect().width).toBeGreaterThanOrEqual(640);
+
+    // Even mid-scroll the member cell keeps usable width.
+    const cell = emailCell("lucasb@oneighty.com");
+    expect(cell.getBoundingClientRect().width).toBeGreaterThan(100);
+  });
+});


### PR DESCRIPTION
## Summary

Redesigns the Cursor Accounts team-coverage table so it fits the settings page's real canvas (768px `max-w-3xl` in both client apps) and degrades honestly in narrower embeds. Emails now render whole on one line instead of shattering one character per line.

## Context

The table declared an 8-column grid — member, key, four spend columns, status, and an actions column holding up to three side-by-side buttons. The fixed tracks alone consumed nearly the full settings width, so the flexible member column collapsed toward zero and the email cell's `break-words` wrapped at every character (see #929 for screenshots and full diagnosis). The per-row "Copy invite" button compounded the squeeze while copying the identical account-level link on every row.

## Changes

- `MemberCoverageTable`: 7-column grid sized for the 768px canvas — identity, First-party %, API %, Included $, On-demand $, status, kebab. Key name/label fold into the identity cell's secondary line; emails truncate with the overflow-gated house tooltip (`TruncatedText`) instead of `break-words`.
- Row actions (Enable/Disable, destructive Remove) move into the house `ActionMenu` kebab, matching `AgentInstanceList`/`AgentShareList`/`AgentChannelsPanel`.
- "Copy invite" renders once in the off-team group header (the link is account-level); group descriptions tightened.
- `MemberKeysPanel`: coverage counts as a subtitle under the "Team coverage" heading ("N covered · N without keys · N off-team"), with the gap count tinted when non-zero.
- Narrow-host guard: `overflow-x-auto` + 40rem grid min-width (the `ResourceTable` idiom) so the member column never collapses — the table scrolls instead.
- New real-Chromium layout regression suite (`MemberCoverageTable.layout.test.tsx`) pinning both halves of the contract: no horizontal scroll at 720px with a ≥180px member column, and scroll-not-collapse at 400px.

## Implementation notes

- The three coverage categories stay grouped sections of one table — deliberately not tabs. Together they answer "is this roster healthy?", so all three counts must be visible at once; the rationale is documented on the component.
- No public API changes: `MemberCoverageTable`/`MemberKeysPanel` are internal to `CursorAccountsConsole` (not barrel-exported). Both client apps render the console bare, so DD-016 parity needs no client-app edits.

## Breaking changes

- None.

## Test plan

- `vitest run src/cursor-accounts` — 23 unit tests pass, including a new kebab-menu mutation test and updated invite-copy/subtitle assertions.
- `vitest run -c vitest.a11y.config.ts src/cursor-accounts` — 2 new Chromium layout tests pass.
- Full `@stigmer/react` suite: 4789 tests / 442 files pass. Lint 0 errors (remaining warnings pre-existing in untouched files); typecheck clean.
- Visually verified renders at 720px and 400px against #929-shaped fixture data.

## Risks

- Enable/Disable/Remove now sit one click deeper (kebab). This mirrors every other row-action surface in the SDK; revert is a single-file rollback of `MemberCoverageTable.tsx` if operators object.

## Checklist

- [x] Tests added/updated
- [x] Backward compatible
- [ ] Docs updated (not needed — internal console surface)

Closes #929

Made with [Cursor](https://cursor.com)