### PR TITLE
feat(backend/stigmer-server): export dispatch-policy configs + loaded-execution key for gate steps

### DIFF
--- a/backend/services/stigmer-server/src/domain/agentexecution/lifecycle.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/lifecycle.ts
@@ -58,7 +58,10 @@ import {
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { CallerIdentity } from "../../extensions/identity.js";
-import { RequestContext } from "../../pipeline/request-context.js";
+import {
+  LOADED_EXECUTION_KEY,
+  RequestContext,
+} from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
@@ -74,8 +77,9 @@ import { notifyStatusObservers } from "./status-observers.js";
 import { settleInterruptedToolCalls } from "./tool-call-settle.js";
 import type { StreamBroker } from "./stream-broker.js";
 
-// Context keys — Go's key strings, verbatim.
-const LOADED_EXECUTION_KEY = "loadedExecution";
+// Context keys — Go's key strings, verbatim. The loaded-execution key is
+// the shared pipeline constant (request-context.ts): extension gate steps
+// in the recover slot read the loaded execution through it.
 const REASON_KEY = "reason";
 const ALREADY_IN_TARGET_STATE_KEY = "alreadyInTargetState";
 

--- a/backend/services/stigmer-server/src/domain/workflowexecution/lifecycle.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/lifecycle.ts
@@ -62,7 +62,10 @@ import {
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { CallerIdentity } from "../../extensions/identity.js";
-import { RequestContext } from "../../pipeline/request-context.js";
+import {
+  LOADED_EXECUTION_KEY,
+  RequestContext,
+} from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 
@@ -83,8 +86,10 @@ import { EngineWorkflowNotFoundError } from "./engine.js";
 import type { WorkflowExecutionEngineStateProvider } from "./engine.js";
 import type { StreamBroker } from "./stream-broker.js";
 
-// Context keys (Go lifecycle_steps.go constants).
-const LOADED_EXECUTION_KEY = "loadedExecution";
+// Context keys (Go lifecycle_steps.go constants). The loaded-execution
+// key is the shared pipeline constant (request-context.ts): extension
+// gate steps in the sandbox-acquisition slot read the loaded execution
+// through it.
 const REASON_KEY = "reason";
 const ALREADY_IN_TARGET_STATE_KEY = "alreadyInTargetState";
 

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -17,7 +17,9 @@
  *   - the extension-point types (§2 — the whole src/extensions contract)
  *   - the pipeline primitives extensions build gates from (PipelineStep,
  *     RequestContext, the semantic error helpers, and the typed store
- *     not-found errors the ratified store-fault mapping keys on)
+ *     not-found errors the ratified store-fault mapping keys on; C4
+ *     Stage 3 added the dispatch-policy configs and the loaded-execution
+ *     context key its capacity gates consume)
  *   - the driver interfaces (Store, ArtifactStorage; O5 added §6a/§6b/§6c —
  *     ModelCatalogProvider, the widened storage surface, and
  *     RunnerCredentialProvider; O6 added §6d — SandboxProvisioner and its
@@ -172,6 +174,25 @@ export type {
   SandboxScope,
 } from "./sandbox/provisioner.js";
 export { BUILT_IN_SANDBOX_PROVISIONER_TYPES } from "./sandbox/provisioner.js";
+
+// The C4 Stage 3 gate seams: the dispatch-policy configs a capacity gate
+// reads — the UNSPECIFIED-resolution rules and routing modes are single
+// definitions by doctrine (oss#397), and their own headers name "a future
+// policy consumer" as the reason they must be consumed, never re-derived.
+// Plus the lifecycle chains' loaded-execution context key: recover-chain
+// gate steps read the loaded resource through it (ctx.newState on those
+// chains is the input message, not the resource).
+export {
+  AgentExecutionTemporalConfig,
+  ROUTING_SESSION,
+  newConfigFromEnv as newAgentExecutionTemporalConfigFromEnv,
+} from "./domain/agentexecution/temporal/config.js";
+export {
+  WORKFLOW_ROUTING_EXECUTION,
+  WorkflowExecutionTemporalConfig,
+  newWorkflowExecutionConfigFromEnv,
+} from "./domain/workflowexecution/temporal/config.js";
+export { LOADED_EXECUTION_KEY } from "./pipeline/request-context.js";
 
 // The C3 driver seam (DD-004's serving half, ruling Q1): the channel
 // delivery runtime a composition registers to SERVE the install,

--- a/backend/services/stigmer-server/src/pipeline/__tests__/pipeline.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/__tests__/pipeline.test.ts
@@ -15,7 +15,7 @@ import { create } from "@bufbuild/protobuf";
 import type { Logger } from "../../boot/logger.js";
 import { INTERNAL_FALLBACK_MESSAGE, newPipeline } from "../pipeline.js";
 import type { PipelineStep } from "../pipeline.js";
-import { RequestContext } from "../request-context.js";
+import { LOADED_EXECUTION_KEY, RequestContext } from "../request-context.js";
 
 const silentLogger: Logger = {
   debug() {},
@@ -133,5 +133,9 @@ describe("RequestContext", () => {
     expect(ctx.get("missing")).toBeUndefined();
     ctx.set("shouldCreate", true);
     expect(ctx.get("shouldCreate")).toBe(true);
+  });
+
+  it("pins the loaded-execution context key (C4 Stage 3): both lifecycle chains stamp it and extension gate steps read it", () => {
+    expect(LOADED_EXECUTION_KEY).toBe("loadedExecution");
   });
 });

--- a/backend/services/stigmer-server/src/pipeline/request-context.ts
+++ b/backend/services/stigmer-server/src/pipeline/request-context.ts
@@ -29,6 +29,17 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { CallerIdentity } from "../extensions/identity.js";
 
+/**
+ * The lifecycle chains' loaded-resource context key (Go's key string,
+ * verbatim). On lifecycle pipelines the request `Desc` is the INPUT
+ * message, so `ctx.newState` is the input — the loaded resource rides the
+ * metadata map under this key, stamped by each chain's LoadExecutionById
+ * step. Hoisted here (C4 Stage 3) so the two lifecycle modules and
+ * extension gate steps registered into recover-chain slots share ONE
+ * definition of the string instead of three copies of a silent contract.
+ */
+export const LOADED_EXECUTION_KEY = "loadedExecution";
+
 export class RequestContext<Desc extends DescMessage> {
   /** The original, immutable request message. */
   readonly input: MessageShape<Desc>;

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -46,15 +46,21 @@ import {
   createLogger,
   InvalidTokenError,
   loadConfig,
+  LOADED_EXECUTION_KEY,
   MintingDisabledError,
+  newAgentExecutionTemporalConfigFromEnv,
   newModelCatalogProviderFromDocument,
   newR2ArtifactStorage,
+  newWorkflowExecutionConfigFromEnv,
   notFoundError,
   ResourceNotFoundError,
+  ROUTING_SESSION,
   TOKEN_TYPE_EXECUTION_SCOPED,
+  WORKFLOW_ROUTING_EXECUTION,
 } from "@stigmer/server";
 import type {
   AgentExecutionResponseDecorator,
+  AgentExecutionTemporalConfig,
   AgentExecutionStatusObserver,
   ArtifactStorage,
   ArtifactStorageDriverFactory,
@@ -83,6 +89,7 @@ import type {
   Store,
   VisibilityChangedEvent,
   WorkerFactory,
+  WorkflowExecutionTemporalConfig,
 } from "@stigmer/server";
 
 /** A permissive Authorizer in the consumer's own code (the O2 shape). */
@@ -132,6 +139,33 @@ export function consumerGateStep(): PipelineStep<DescMessage> {
 /** The typed store not-found classes are importable for the instanceof idiom. */
 export function isStoreNotFound(error: unknown): boolean {
   return error instanceof ResourceNotFoundError;
+}
+
+/**
+ * A capacity-gate-shaped consumer of the C4 Stage 3 seams: the
+ * dispatch-policy configs read through their exported constructors (the
+ * oss#397 one-definition rule consumed, never re-derived from env), and
+ * the loaded execution read through the exported lifecycle context key —
+ * on recover chains ctx.newState is the input message, so the resource
+ * rides the metadata map under that key.
+ */
+const agentExecutionDispatchPolicy: AgentExecutionTemporalConfig =
+  newAgentExecutionTemporalConfigFromEnv();
+const workflowExecutionDispatchPolicy: WorkflowExecutionTemporalConfig =
+  newWorkflowExecutionConfigFromEnv();
+
+export function consumerCapacityGateStep(): PipelineStep<DescMessage> {
+  return {
+    name: "ConsumerCapacityGate",
+    execute: (ctx) => {
+      void (agentExecutionDispatchPolicy.activityRouting === ROUTING_SESSION);
+      void (
+        workflowExecutionDispatchPolicy.workflowActivityRouting ===
+        WORKFLOW_ROUTING_EXECUTION
+      );
+      void ctx.get(LOADED_EXECUTION_KEY);
+    },
+  };
 }
 
 const statusObserver: AgentExecutionStatusObserver = (transition) => {
@@ -377,10 +411,17 @@ export const fakeExtension: ServerExtension = {
   // GateSlotName fails this compile (the §2b contract's compile-time layer).
   gateSteps: new Map<GateSlotName, ReadonlyArray<PipelineStep<DescMessage>>>([
     ["agent-execution-create:pre-side-effect-gate", [consumerGateStep()]],
+    // The recover slot consumes the exported loaded-execution key (C4
+    // Stage 3) — the capacity-gate shape reads the resource off the
+    // metadata map there.
+    [
+      "agent-execution-recover:pre-side-effect-gate",
+      [consumerCapacityGateStep()],
+    ],
     ["org-create:post-persist", [consumerGateStep()]],
     // The sixth ratified slot (C4): the workflow-execution chains'
     // capacity-gate position.
-    ["sandbox-acquisition:gate", [consumerGateStep()]],
+    ["sandbox-acquisition:gate", [consumerCapacityGateStep()]],
   ]),
   statusTransitionHooks: {
     observers: [statusObserver],


### PR DESCRIPTION
## Summary
The C4 Stage 3 seam exports (gate ruling Q1, 2026-08-28): the two domain temporal config classes with their env constructors and routing constants, plus the lifecycle chains' `loadedExecution` context key hoisted into one shared, exported constant. Exports-map additions and a same-string hoist only — behavior is byte-identical.

## Context
The cloud composition's sandbox-capacity gates (C4 Stage 3, the E9 port) need the UNSPECIFIED-resolution rules and routing modes to decide whether a launch would provision a sandbox. Those rules are single definitions by doctrine (oss#397 — "a future policy consumer must use it rather than re-derive the default"), and the exports map's own contract names the alternative a reach-around (DD-005). The recover-chain gates also read the loaded execution off the pipeline metadata map, whose key string previously existed as two module-local copies — a silent cross-module contract an extension would have had to hard-code.

## Changes
- `src/index.ts`: export `AgentExecutionTemporalConfig` + `newConfigFromEnv` (aliased `newAgentExecutionTemporalConfigFromEnv`) + `ROUTING_SESSION`; `WorkflowExecutionTemporalConfig` + `newWorkflowExecutionConfigFromEnv` + `WORKFLOW_ROUTING_EXECUTION`; `LOADED_EXECUTION_KEY`
- `src/pipeline/request-context.ts`: the hoisted, documented `LOADED_EXECUTION_KEY` constant ("loadedExecution", Go's key string verbatim)
- Both lifecycle modules consume the shared constant instead of their module-local copies
- `test/extension-consumer/src/fake-extension.ts`: a capacity-gate-shaped consumer exercising every new export through the bare package import
- `src/pipeline/__tests__/pipeline.test.ts`: the key string pinned by a unit test

## Breaking changes
- None (additive exports; the hoist preserves the exact string)

## Test plan
- `npm run typecheck` clean; 1989 server units green (Node 22.22.1)
- All four local conformance rosters byte-identical: local 498, local-execution 160, local-postgres 498, local-postgres-execution 160
- Extension-consumer compile proof green against the built dist
- Prettier clean

## Risks
- Minimal: no behavior change; the new surface is owner-ruled (Stage 3 gate Q1). Rollback = revert the export additions.

## Checklist
- [x] Tests added/updated
- [x] Backward compatible

Made with [Cursor](https://cursor.com)