### PR TITLE
feat(sdk/react): densify console sidebars and narrow the column to 240px

### DIFF
--- a/client-apps/desktop/src/shell/AppShell.tsx
+++ b/client-apps/desktop/src/shell/AppShell.tsx
@@ -52,10 +52,10 @@ export function AppShell() {
             "shrink-0 overflow-hidden",
             "border-r border-sidebar-border",
             "transition-[width] duration-200 ease-in-out motion-reduce:transition-none",
-            sidebar.isOpen ? "w-[280px]" : "w-0",
+            sidebar.isOpen ? "w-60" : "w-0",
           )}
         >
-          <div className="h-full w-[280px]">
+          <div className="h-full w-60">
             <div
               key={isManagementZone ? "management" : "session"}
               className="h-full animate-in fade-in duration-150"

--- a/client-apps/web/src/domain/_shared/layout/AppShell.tsx
+++ b/client-apps/web/src/domain/_shared/layout/AppShell.tsx
@@ -94,11 +94,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             "shrink-0 overflow-hidden",
             "border-sidebar-border border-r",
             "transition-[width] duration-200 ease-in-out motion-reduce:transition-none",
-            sidebar.isOpen ? "w-70" : "w-0",
+            sidebar.isOpen ? "w-60" : "w-0",
             "max-lg:fixed max-lg:inset-y-0 max-lg:left-0 max-lg:z-50 max-lg:shadow-lg",
           )}
         >
-          <div className="h-full w-70">
+          <div className="h-full w-60">
             <div
               key={isManagementZone ? "management" : "session"}
               className="h-full animate-in fade-in duration-150"

--- a/demos/README.md
+++ b/demos/README.md
@@ -42,7 +42,7 @@ and "own" is literal, not aspirational: the two shells render the SDK's
 `WorkspaceSidebar` and `SettingsSidebar` — the same components the web
 console and desktop app ship (sdk-console DD-020; stigmer/stigmer#317) —
 so the depicted sidebar cannot drift from the product. What a shell adds
-is only the Scenar seams: the 280px column the console's app shell owns,
+is only the Scenar seams: the 240px column the console's app shell owns,
 `data-cursor-target` markers and `PulseHighlight` attached through the
 sidebar's `renderLink`, fixture recents/user/org on the frozen clock, and
 the content transition; the sidebar subtree is `inert`. `SessionView` and
@@ -169,12 +169,12 @@ the viewport boundary owns it.
 - **Canonical viewport is 1440×900** (16:10), set explicitly by
   `scripts/pack-all.mjs` — never the CLI default. It is derived, not chosen:
   the `--stage` framing insets 48px per side, so the depicted browser
-  window is 1344px — comfortably above the console's layout minimum (280px
-  sidebar + 48px main padding + 896px `max-w-4xl` content cap = 1224px)
+  window is 1344px — comfortably above the console's layout minimum (240px
+  sidebar + 48px main padding + 896px `max-w-4xl` content cap = 1184px)
   and in the range of a typical laptop window, so the depicted density
   matches what a real user sees. (The original 1280×800 left the app only
-  1184px after stage insets — below that minimum — which made every
-  component read oversized.) The docs embed re-states this viewport as its
+  1184px after stage insets — below the 1224px minimum of the then-280px
+  sidebar — which made every component read oversized.) The docs embed re-states this viewport as its
   pre-handshake aspect pin (`site/src/components/docs/scenar-embed.tsx`);
   gate invariant 9 holds the two in lockstep.
 - **The iframe is the canonical viewport** (M2, iframe-as-screen — landed
@@ -191,8 +191,8 @@ the viewport boundary owns it.
 - **Author at the console's real metrics.** The sidebar needs no
   transcription — the shells render the SDK's own sidebar components
   (DD-020), so its metrics are the console's by construction. What the
-  demos still re-state is pinned by gate invariant 7: the 280px sidebar
-  column (`w-70`, owned by the console's app shell, not its sidebar) and
+  demos still re-state is pinned by gate invariant 7: the 240px sidebar
+  column (`w-60`, owned by the console's app shell, not its sidebar) and
   `SessionView`'s frame. Page content uses the real zone geometry (library
   `mx-auto max-w-4xl px-6 py-8`, settings `max-w-3xl`).
 - **Never author `zoom` or `transform: scale()` in a tour** — not as a

--- a/demos/scripts/pack-all.mjs
+++ b/demos/scripts/pack-all.mjs
@@ -105,13 +105,13 @@ rmSync(bundlesDir, { recursive: true, force: true });
  * 1440x900: a real 16:10 desktop browser-window size, chosen so the depicted
  * console lays out at the density a real user sees. The `--stage` framing
  * insets 48px per side, leaving the depicted window 1344px wide —
- * comfortably above the console's layout minimum (280px sidebar + 48px main
- * padding + 896px `max-w-4xl` content cap = 1224px, the narrowest window at
+ * comfortably above the console's layout minimum (240px sidebar + 48px main
+ * padding + 896px `max-w-4xl` content cap = 1184px, the narrowest window at
  * which the content column renders at full design width) and in the range
  * of a typical laptop browser window. The previous 1280x800 left the app
- * only 1184px after stage insets — below that minimum — so every component
- * occupied an oversized share of the frame and tours read less compact than
- * the product. Tours author at the console's real metrics and this single
+ * only 1184px after stage insets — below the 1224px minimum of the
+ * then-280px sidebar — so every component occupied an oversized share of
+ * the frame and tours read less compact than the product. Tours author at the console's real metrics and this single
  * scale factor at the viewport boundary does all the fitting (DD-008).
  *
  * The docs embed pins this ratio pre-handshake (site scenar-embed.tsx); the

--- a/demos/tours/_shared/AppShell.css
+++ b/demos/tours/_shared/AppShell.css
@@ -1,6 +1,6 @@
 /*
  * AppShell frame — only what the console's app shell (not its sidebar)
- * owns: the 280px sidebar column (`w-70` + right border), the content
+ * owns: the 240px sidebar column (`w-60` + right border), the content
  * pane, and the Scenar seams (pulse anchoring, engine-driven hover).
  * The sidebar's own chrome is the real `WorkspaceSidebar` from
  * `@stigmer/react`, styled by the compiled SDK stylesheet — there is no
@@ -22,10 +22,10 @@
   font-family: var(--stgm-font-sans);
 }
 
-/* The sidebar column the console's AppShell owns: 280px (`w-70`), right
+/* The sidebar column the console's AppShell owns: 240px (`w-60`), right
    border, no shrink. The real sidebar fills it. */
 .demo-shell__nav {
-  width: 280px;
+  width: 240px;
   flex-shrink: 0;
   overflow: hidden;
   border-right: 1px solid var(--stgm-sidebar-border);

--- a/demos/tours/_shared/AppShell.tsx
+++ b/demos/tours/_shared/AppShell.tsx
@@ -49,8 +49,8 @@ interface AppShellProps {
  * `WorkspaceSidebar`, so the depicted chrome cannot drift from the product
  * (stigmer/stigmer#317; the `SessionView` precedent applied to the shell).
  *
- * What stays demo-owned is exactly the Scenar seams: the 280px column the
- * console's app shell owns (`w-70`), the `data-cursor-target` markers and
+ * What stays demo-owned is exactly the Scenar seams: the 240px column the
+ * console's app shell owns (`w-60`), the `data-cursor-target` markers and
  * `PulseHighlight` attached through the sidebar's `renderLink`, the frozen
  * `DEMO_NOW` clock, fixture recents/user, and the content transition. The
  * sidebar subtree is `inert` so a paused embed's real menus never open

--- a/demos/tours/_shared/ManagementShell.css
+++ b/demos/tours/_shared/ManagementShell.css
@@ -1,6 +1,6 @@
 /*
  * ManagementShell frame — only what the console's app shell (not its
- * sidebar) owns: the 280px sidebar column (`w-70` + right border), the
+ * sidebar) owns: the 240px sidebar column (`w-60` + right border), the
  * content pane, and the Scenar seams (engine-driven hover). The sidebar's
  * own chrome is the real `SettingsSidebar` from `@stigmer/react`, styled
  * by the compiled SDK stylesheet — there is no replica CSS left to drift
@@ -18,10 +18,10 @@
   font-family: var(--stgm-font-sans);
 }
 
-/* The sidebar column the console's AppShell owns: 280px (`w-70`), right
+/* The sidebar column the console's AppShell owns: 240px (`w-60`), right
    border, no shrink. The real sidebar fills it. */
 .sx-mgmt__nav {
-  width: 280px;
+  width: 240px;
   flex-shrink: 0;
   overflow: hidden;
   border-right: 1px solid var(--stgm-sidebar-border);

--- a/demos/tours/_shared/ManagementShell.tsx
+++ b/demos/tours/_shared/ManagementShell.tsx
@@ -51,7 +51,7 @@ interface ManagementShellProps {
  * sidebar consumes, so the depicted chrome cannot drift from the shipped
  * one (stigmer/stigmer#317).
  *
- * Demo-owned seams only: the 280px column, `data-cursor-target` markers on
+ * Demo-owned seams only: the 240px column, `data-cursor-target` markers on
  * every row (ids are the route basenames plus `back-to-sessions`), fixture
  * identity, and the content transition. The sidebar subtree is `inert` so
  * a paused embed's real menus never open under a reader's stray click.

--- a/docs/sdk/react/sidebar.mdx
+++ b/docs/sdk/react/sidebar.mdx
@@ -63,7 +63,7 @@ render it too, which is the point: the depicted chrome cannot drift
 from the product because it *is* the product (stigmer/stigmer#317).
 
 Layout note: the sidebar fills its container's height and defines no
-width — the console's app shell owns the `w-70` (280px) column.
+width — the console's app shell owns the `w-60` (240px) column.
 
 **Props** — `WorkspaceSidebarProps`
 

--- a/docs/sdk/theme/tokens.mdx
+++ b/docs/sdk/theme/tokens.mdx
@@ -153,7 +153,7 @@ Tokens without a **Dark** value inherit their light value in dark mode.
 | `--stgm-sidebar-primary` | <TokenValue v="oklch(0.52 0.12 190)" /> | <TokenValue v="oklch(0.72 0.12 190)" /> | Brand action color inside the sidebar. |
 | `--stgm-sidebar-primary-foreground` | <TokenValue v="oklch(0.985 0 0)" /> | <TokenValue v="oklch(0.145 0 0)" /> | Text on sidebar-primary fills. |
 | `--stgm-sidebar-muted` | <TokenValue v="oklch(0.94 0 0)" /> | <TokenValue v="oklch(0.20 0 0)" /> | Muted panel fill inside the sidebar. |
-| `--stgm-sidebar-muted-foreground` | <TokenValue v="oklch(0.5 0 0)" /> | <TokenValue v="oklch(0.708 0 0)" /> | Supporting text in the sidebar (section headers). |
+| `--stgm-sidebar-muted-foreground` | <TokenValue v="oklch(0.5 0 0)" /> | <TokenValue v="oklch(0.708 0 0)" /> | Supporting text in the sidebar (section headers, resting nav labels). |
 | `--stgm-sidebar-accent` | <TokenValue v="oklch(0.94 0 0)" /> | <TokenValue v="oklch(0.20 0 0)" /> | Hover/active item fill in the sidebar. |
 | `--stgm-sidebar-accent-foreground` | <TokenValue v="oklch(0.205 0 0)" /> | <TokenValue v="oklch(0.985 0 0)" /> | Text on sidebar accent fills. |
 | `--stgm-sidebar-border` | <TokenValue v="oklch(0.885 0 0)" /> | <TokenValue v="oklch(1 0 0 / 14%)" /> | Borders and dividers inside the sidebar. |

--- a/scripts/verify-scenar-tours.mjs
+++ b/scripts/verify-scenar-tours.mjs
@@ -63,7 +63,7 @@
  *    recordings — a single live frame composited four of them.
  *
  * 7. REPLICA METRICS. Each REPLICA_METRIC_PAIRS entry pins one geometry
- *    fact the demos re-state (the shells' 280px column, SessionView's
+ *    fact the demos re-state (the shells' 240px column, SessionView's
  *    frame) on both sides so drift in either direction fails here instead
  *    of shipping (the drift class that produced the 112px/10px sidebar
  *    whose "New Session" wrapped onto two lines). The sidebar chrome
@@ -449,23 +449,23 @@ export function findCssScaleFactors(cssText) {
  * (stigmer/stigmer#317), the console, desktop app, and tours share one
  * markup source and that whole drift class is structural, not policed.
  * What remains pinned is the one sidebar fact the demo re-states (the
- * 280px `w-70` column the console's AppShell owns) and the SessionView
+ * 240px `w-60` column the console's AppShell owns) and the SessionView
  * geometry the demo owns around the real `SessionViewerLayout`.
  */
 export const REPLICA_METRIC_PAIRS = [
   {
-    fact: "sidebar column width (console `w-70` = 280px)",
+    fact: "sidebar column width (console `w-60` = 240px)",
     replica: "demos/tours/_shared/AppShell.css",
-    replicaNeedle: "width: 280px",
+    replicaNeedle: "width: 240px",
     real: "client-apps/web/src/domain/_shared/layout/AppShell.tsx",
-    realNeedle: '"w-70"',
+    realNeedle: '"w-60"',
   },
   {
-    fact: "management sidebar column width (console `w-70` = 280px)",
+    fact: "management sidebar column width (console `w-60` = 240px)",
     replica: "demos/tours/_shared/ManagementShell.css",
-    replicaNeedle: "width: 280px",
+    replicaNeedle: "width: 240px",
     real: "client-apps/web/src/domain/_shared/layout/AppShell.tsx",
-    realNeedle: '"w-70"',
+    realNeedle: '"w-60"',
   },
   // SessionView renders the SDK's own SessionViewerLayout (scenar-cloud
   // DD-010), so the split and chip geometry need no pairs — there is no

--- a/sdk/react/src/internal/ResizableSplit.tsx
+++ b/sdk/react/src/internal/ResizableSplit.tsx
@@ -66,7 +66,7 @@ export interface ResizableSplitProps {
    * query. 48rem clears the session layout's content minimums (320px min
    * chat + drag handle + a usable workspace panel) and approximately
    * preserves the console's previous viewport-`lg` trigger point, where the
-   * viewer's box is the ~1024px window minus the ~280px sidebar. It is
+   * viewer's box is the ~1024px window minus the ~240px sidebar. It is
    * deliberately not a prop: container-query conditions cannot read CSS
    * custom properties, so a runtime threshold would need an inline-`<style>`
    * or ResizeObserver mechanism — heavier than the static utility this is,

--- a/sdk/react/src/sidebar/SettingsSidebar.tsx
+++ b/sdk/react/src/sidebar/SettingsSidebar.tsx
@@ -4,7 +4,12 @@ import type { ReactNode } from "react";
 import { ArrowLeft } from "lucide-react";
 import type { Organization } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
 import type { SettingsNavGroup } from "../settings/settings-nav.js";
-import { SidebarChrome, SidebarSeparator, navRowClassName } from "./chrome.js";
+import {
+  SidebarChrome,
+  SidebarSeparator,
+  navRowClassName,
+  sectionLabelClassName,
+} from "./chrome.js";
 import type { RenderSidebarLink } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -86,13 +91,14 @@ export function SettingsSidebar({
       onOrgChanged={onOrgChanged}
       footer={footer}
     >
-      {/* Back to Sessions */}
+      {/* Back to Sessions — an exit, not a destination; the resting-row
+          treatment (muted, brightening on hover) already reads as such. */}
       <div className="stg:flex-none stg:px-3 stg:py-1">
         {renderLink({
           id: "back-to-sessions",
           href: backHref,
           active: false,
-          className: navRowClassName(false, { muted: true }),
+          className: navRowClassName(false),
           "aria-current": undefined,
           children: (
             <>
@@ -106,10 +112,10 @@ export function SettingsSidebar({
       <SidebarSeparator />
 
       {/* Settings nav links — grouped, permission-aware via `groups` */}
-      <div className="stg:flex stg:flex-col stg:gap-4 stg:px-3 stg:py-1">
+      <div className="stg:flex stg:flex-col stg:gap-5 stg:px-3 stg:py-1">
         {groups.map((group) => (
           <div key={group.label} className="stg:flex stg:flex-col stg:gap-0.5">
-            <span className="stg:text-sidebar-muted-foreground stg:px-2 stg:pb-1 stg:text-[11px] stg:font-medium stg:tracking-wider stg:uppercase">
+            <span className={`${sectionLabelClassName()} stg:pb-1`}>
               {group.label}
             </span>
             {group.items.map((item) => {

--- a/sdk/react/src/sidebar/WorkspaceSidebar.tsx
+++ b/sdk/react/src/sidebar/WorkspaceSidebar.tsx
@@ -23,7 +23,12 @@ import {
   TooltipTrigger,
   TooltipContent,
 } from "../internal/tooltip.js";
-import { SidebarChrome, SidebarSeparator, navRowClassName } from "./chrome.js";
+import {
+  SidebarChrome,
+  SidebarSeparator,
+  navRowClassName,
+  sectionLabelClassName,
+} from "./chrome.js";
 import type { RenderSidebarLink } from "./types.js";
 
 // ---------------------------------------------------------------------------
@@ -110,7 +115,7 @@ export interface WorkspaceSidebarProps {
  * from the product because it *is* the product (stigmer/stigmer#317).
  *
  * Layout note: the sidebar fills its container's height and defines no
- * width — the console's app shell owns the `w-70` (280px) column.
+ * width — the console's app shell owns the `w-60` (240px) column.
  *
  * @example
  * ```tsx
@@ -153,55 +158,57 @@ export function WorkspaceSidebar({
       onOrgChanged={onOrgChanged}
       footer={footer}
     >
-      <PrimaryNavRow
-        id="new-session"
-        href="/"
-        label="New Session"
-        icon={Plus}
-        active={activeNav === "new-session"}
-        renderLink={renderLink}
-      />
-      <PrimaryNavRow
-        id="dashboard"
-        href="/dashboard"
-        label="Dashboard"
-        icon={LayoutDashboard}
-        active={activeNav === "dashboard"}
-        renderLink={renderLink}
-      />
-      {/* MessagesSquare, deliberately not MessageSquare — the singular
-          mark is the session glyph in Recents, and the two areas must
-          not read as one. */}
-      <PrimaryNavRow
-        id="conversations"
-        href="/conversations"
-        label="Conversations"
-        icon={MessagesSquare}
-        active={activeNav === "conversations"}
-        renderLink={renderLink}
-        accessory={
-          conversationsBadgeCount !== undefined && conversationsBadgeCount > 0 ? (
-            <WantsHumanBadge count={conversationsBadgeCount} />
-          ) : null
-        }
-      />
-      <PrimaryNavRow
-        id="library"
-        href="/library"
-        label="Library"
-        icon={Library}
-        active={activeNav === "library"}
-        renderLink={renderLink}
-      />
+      {/* Primary nav — one group container with the same row rhythm as
+          the settings groups (gap-0.5), so the two zones share one beat. */}
+      <div className="stg:flex stg:flex-none stg:flex-col stg:gap-0.5 stg:px-3 stg:py-1">
+        <PrimaryNavRow
+          id="new-session"
+          href="/"
+          label="New Session"
+          icon={Plus}
+          active={activeNav === "new-session"}
+          renderLink={renderLink}
+        />
+        <PrimaryNavRow
+          id="dashboard"
+          href="/dashboard"
+          label="Dashboard"
+          icon={LayoutDashboard}
+          active={activeNav === "dashboard"}
+          renderLink={renderLink}
+        />
+        {/* MessagesSquare, deliberately not MessageSquare — the singular
+            mark is the session glyph in Recents, and the two areas must
+            not read as one. */}
+        <PrimaryNavRow
+          id="conversations"
+          href="/conversations"
+          label="Conversations"
+          icon={MessagesSquare}
+          active={activeNav === "conversations"}
+          renderLink={renderLink}
+          accessory={
+            conversationsBadgeCount !== undefined && conversationsBadgeCount > 0 ? (
+              <WantsHumanBadge count={conversationsBadgeCount} />
+            ) : null
+          }
+        />
+        <PrimaryNavRow
+          id="library"
+          href="/library"
+          label="Library"
+          icon={Library}
+          active={activeNav === "library"}
+          renderLink={renderLink}
+        />
+      </div>
 
       <SidebarSeparator />
 
       {/* Scrollable recents */}
       <ScrollArea className="stg:flex-1">
         <div className="stg:p-3">
-          <p className="stg:text-sidebar-muted-foreground stg:mb-2 stg:px-1 stg:text-[11px] stg:font-semibold stg:tracking-wider stg:uppercase">
-            Recents
-          </p>
+          <p className={`${sectionLabelClassName()} stg:mb-2`}>Recents</p>
           {isLoading ? (
             <RecentsSkeletons />
           ) : error ? (
@@ -246,24 +253,20 @@ function PrimaryNavRow({
   /** Trailing row content (e.g. the Conversations count pill). */
   readonly accessory?: ReactNode;
 }) {
-  return (
-    <div className="stg:flex-none stg:px-3 stg:py-1">
-      {renderLink({
-        id,
-        href,
-        active,
-        className: navRowClassName(active),
-        "aria-current": active ? "page" : undefined,
-        children: (
-          <>
-            <Icon className="stg:size-4 stg:shrink-0" />
-            {label}
-            {accessory}
-          </>
-        ),
-      })}
-    </div>
-  );
+  return renderLink({
+    id,
+    href,
+    active,
+    className: navRowClassName(active),
+    "aria-current": active ? "page" : undefined,
+    children: (
+      <>
+        <Icon className="stg:size-4 stg:shrink-0" />
+        {label}
+        {accessory}
+      </>
+    ),
+  });
 }
 
 /**
@@ -311,7 +314,8 @@ function ActivityGroupList({
       <div className="stg:space-y-4">
         {groups.map((group) => (
           <div key={group.label}>
-            <p className="stg:text-sidebar-muted-foreground stg:mb-1 stg:px-2 stg:text-[10px] stg:font-medium stg:tracking-wider stg:uppercase">
+            {/* One step below the section label: same voice, 10px. */}
+            <p className="stg:text-sidebar-muted-foreground stg:mb-1 stg:px-2 stg:text-[10px] stg:font-medium stg:tracking-wide stg:uppercase">
               {group.label}
             </p>
             <ul className={`${UNSTYLED_LIST} stg:space-y-0.5`} role="list">
@@ -404,11 +408,15 @@ const ActivityEntry = memo(function ActivityEntry({
   );
 });
 
-/** Recents rows are denser than primary nav: 12px text, top-aligned icon. */
+/**
+ * Recents rows are denser than primary nav: 12px text, top-aligned icon.
+ * Same state grammar as `navRowClassName` — muted at rest, accent fill
+ * when active, constant weight so activation never shifts text width.
+ */
 function cnActivityRow(active: boolean): string {
   return active
-    ? "stg:flex stg:items-start stg:gap-2 stg:rounded-lg stg:px-2 stg:py-1.5 stg:text-xs stg:transition-colors stg:bg-sidebar-accent stg:text-sidebar-accent-foreground stg:font-medium"
-    : "stg:flex stg:items-start stg:gap-2 stg:rounded-lg stg:px-2 stg:py-1.5 stg:text-xs stg:transition-colors stg:text-sidebar-foreground stg:hover:bg-sidebar-accent stg:hover:text-sidebar-accent-foreground";
+    ? "stg:flex stg:items-start stg:gap-2 stg:rounded-md stg:px-2 stg:py-1 stg:text-xs stg:transition-colors stg:bg-sidebar-accent stg:text-sidebar-accent-foreground"
+    : "stg:flex stg:items-start stg:gap-2 stg:rounded-md stg:px-2 stg:py-1 stg:text-xs stg:transition-colors stg:text-sidebar-muted-foreground stg:hover:bg-sidebar-accent stg:hover:text-sidebar-accent-foreground";
 }
 
 function RecentsSkeletons() {

--- a/sdk/react/src/sidebar/__tests__/SettingsSidebar.test.tsx
+++ b/sdk/react/src/sidebar/__tests__/SettingsSidebar.test.tsx
@@ -85,15 +85,19 @@ describe("SettingsSidebar", () => {
     expect(inactive.getAttribute("aria-current")).toBeNull();
   });
 
-  it("renders Back to Sessions as a muted exit row targeting backHref", () => {
+  it("renders Back to Sessions as a resting (never-active) row targeting backHref", () => {
     const { container } = renderSidebar(
       <SettingsSidebar {...baseProps()} backHref="/sessions/ses_123" />,
     );
 
     const back = container.querySelector('[data-row-id="back-to-sessions"]')!;
     expect(back.getAttribute("href")).toBe("/sessions/ses_123");
-    expect(back.className).toContain("stg:text-sidebar-muted-foreground");
     expect(back.textContent).toContain("Back to Sessions");
+    // An exit, not a destination: always the resting-row treatment, never
+    // the active accent — even though it is the row you "came from".
+    expect(back.getAttribute("aria-current")).toBeNull();
+    expect(back.className.split(" ")).toContain("stg:text-sidebar-muted-foreground");
+    expect(back.className.split(" ")).not.toContain("stg:bg-sidebar-accent");
   });
 
   it("renders the footer slot", () => {

--- a/sdk/react/src/sidebar/chrome.tsx
+++ b/sdk/react/src/sidebar/chrome.tsx
@@ -9,8 +9,9 @@ import { OrgSwitcher } from "../organization/OrgSwitcher.js";
 // ---------------------------------------------------------------------------
 // Shared sidebar chrome — the pieces WorkspaceSidebar and SettingsSidebar
 // have in common: the nav container, the top row (collapse toggle + org
-// switcher), the hairline separator, the footer band, and the one nav-row
-// class recipe. Internal to the sidebar domain; not exported from the SDK.
+// switcher), the hairline separator, the footer band, and the shared class
+// recipes (nav rows, section labels). Internal to the sidebar domain; not
+// exported from the SDK.
 //
 // Every class here is transcribed from the console's sidebars — this file
 // IS the console's chrome now, so a change here changes the console, the
@@ -107,23 +108,36 @@ export function SidebarSeparator() {
 }
 
 /**
- * The one nav-row class recipe both sidebars share: 14px medium labels,
- * 16px icons (sized by callers), 8px/6px padding, rounded row highlight.
+ * The one nav-row class recipe both sidebars share: 13px/16px regular
+ * labels, 16px icons (sized by callers), 8px/4px padding — 24px rows.
+ * The explicit `leading-4` is load-bearing: without it the inherited
+ * line-height (~1.5) pads every row to ~28px, and across a full column
+ * of rows that difference alone decides whether the sidebar breathes.
+ * 24px also stays exactly at the WCAG 2.5.8 minimum pointer-target size.
  *
- * `muted` renders the resting label in the muted sidebar tone — used by
- * "Back to Sessions", which is an exit, not a destination.
+ * Resting rows are muted so the navigation recedes and the content leads;
+ * the active row carries the accent fill, hover brightens to the accent
+ * foreground. Font weight is constant across states — state is expressed
+ * through color and fill only, so activating a row never shifts its text
+ * width. The muted-on-sidebar pairing is held to WCAG AA by the theme's
+ * contrast contract (sdk/theme/src/contract/pairs.ts) in every preset.
  */
-export function navRowClassName(
-  active: boolean,
-  { muted = false }: { muted?: boolean } = {},
-): string {
+export function navRowClassName(active: boolean): string {
   return cn(
-    "stg:flex stg:items-center stg:gap-2 stg:rounded-lg stg:px-2 stg:py-1.5 stg:text-sm stg:font-medium stg:transition-colors",
+    "stg:flex stg:items-center stg:gap-2 stg:rounded-md stg:px-2 stg:py-1 stg:text-[13px] stg:leading-4 stg:transition-colors",
     active
       ? "stg:bg-sidebar-accent stg:text-sidebar-accent-foreground"
-      : cn(
-          muted ? "stg:text-sidebar-muted-foreground" : "stg:text-sidebar-foreground",
-          "stg:hover:bg-sidebar-accent stg:hover:text-sidebar-accent-foreground",
-        ),
+      : "stg:text-sidebar-muted-foreground stg:hover:bg-sidebar-accent stg:hover:text-sidebar-accent-foreground",
   );
+}
+
+/**
+ * The section-label recipe both sidebars share (settings group labels,
+ * the Recents heading): 11px/16px medium uppercase in the muted sidebar
+ * tone. Spacing around a label stays with the caller — it is a layout
+ * concern; this recipe owns only the typography, so the two sidebars
+ * cannot drift.
+ */
+export function sectionLabelClassName(): string {
+  return "stg:text-sidebar-muted-foreground stg:px-2 stg:text-[11px] stg:leading-4 stg:font-medium stg:tracking-wide stg:uppercase";
 }

--- a/sdk/theme/src/contract/pairs.ts
+++ b/sdk/theme/src/contract/pairs.ts
@@ -110,7 +110,7 @@ export const CONTRAST_PAIRS: readonly ContrastPair[] = [
 
   // ── Sidebar context ─────────────────────────────────────────────────
   pair("--stgm-sidebar-foreground", "--stgm-sidebar", "text", "sidebar navigation labels"),
-  pair("--stgm-sidebar-muted-foreground", "--stgm-sidebar", "text", "sidebar section headers, secondary labels"),
+  pair("--stgm-sidebar-muted-foreground", "--stgm-sidebar", "text", "sidebar resting nav labels, section headers, secondary labels"),
   pair("--stgm-sidebar-primary-foreground", "--stgm-sidebar-primary", "text", "sidebar primary actions"),
   pair("--stgm-sidebar-accent-foreground", "--stgm-sidebar-accent", "text", "sidebar active/hovered items"),
 

--- a/sdk/theme/src/tokens.css
+++ b/sdk/theme/src/tokens.css
@@ -160,7 +160,7 @@
   --stgm-sidebar-primary-foreground: oklch(0.985 0 0);
   /* Muted panel fill inside the sidebar. */
   --stgm-sidebar-muted: oklch(0.94 0 0);
-  /* Supporting text in the sidebar (section headers). */
+  /* Supporting text in the sidebar (section headers, resting nav labels). */
   --stgm-sidebar-muted-foreground: oklch(0.5 0 0);
   /* Hover/active item fill in the sidebar. */
   --stgm-sidebar-accent: oklch(0.94 0 0);

--- a/test/e2e/tests/functional/responsive.spec.ts
+++ b/test/e2e/tests/functional/responsive.spec.ts
@@ -4,7 +4,7 @@ import { test, expect } from "@playwright/test";
  * Responsive layout tests.
  *
  * Verifies sidebar behavior at mobile (< 1024px) and desktop (>= 1024px)
- * viewports. The sidebar uses width-based collapse (w-70 / w-0 with
+ * viewports. The sidebar uses width-based collapse (w-60 / w-0 with
  * overflow-hidden), not translate-x or hidden. At mobile viewports it
  * becomes a fixed overlay with a backdrop.
  *


### PR DESCRIPTION
## Summary

Brings the console's navigation sidebars (workspace + settings zones) to Cursor-level polish: a quieter 13px/16px type scale on 24px rows, muted resting items so only the active row and hovers carry full contrast, softened section labels, and a 240px app-shell column. All typography/density changes live in the SDK-owned sidebar chrome (`sdk/react/src/sidebar/`), so the web console, desktop app, and documentation tours update together (DD-020).

## Context

With only ~17 settings items the sidebar filled its full height, while denser products (e.g. Cursor's dashboard) fit more items with room to spare. Three compounding causes: tall rows (14px medium text, ~32px rows, inherited ~1.5 line-height), every item at full contrast, and loud uppercase section headers — plus the workspace primary nav double-spacing itself with per-row wrappers.

## Changes

- `chrome.tsx`: nav-row recipe is now 13px regular with explicit `leading-4` (24px rows — exactly the WCAG 2.5.8 pointer-target minimum), muted at rest, accent fill when active, constant font weight across states (no text-width shift on activation); obsolete `muted` option removed; new shared `sectionLabelClassName()` recipe (11px medium, `tracking-wide`) both sidebars consume.
- `WorkspaceSidebar`: four per-row `px-3 py-1` wrappers consolidated into one `gap-0.5` group container (same rhythm as settings groups); Recents header adopts the shared label recipe (fixes the `font-semibold`/`px-1` outliers); recents rows tightened to `py-1`/`rounded-md` with the same muted-at-rest grammar.
- `SettingsSidebar`: group labels use the shared recipe; inter-group spacing `gap-4` → `gap-5`; "Back to Sessions" renders as a plain resting row (the special-cased muted flag is gone).
- App-shell column 280px → 240px: web `w-70` → `w-60`, desktop `w-[280px]` → `w-60` (removes an arbitrary-value divergence, DD-016), demo tour replica CSS, and the `verify-scenar-tours.mjs` `REPLICA_METRIC_PAIRS` needles.
- Docs truth: every comment/doc stating the old metrics updated (chrome docstring, `WorkspaceSidebar` layout note, `pack-all.mjs` viewport arithmetic, `ResizableSplit` comment, demo shell headers, `demos/README.md`, e2e spec header); `tokens.css` description and contrast-contract `usage` for `--stgm-sidebar-muted-foreground` extended to cover resting nav labels; generated docs (`docs/sdk/react/sidebar.mdx`, `docs/sdk/theme/tokens.mdx`) regenerated via `make gen-react-sdk-docs` / `make gen-theme-docs`.

## Implementation notes

- Muted resting labels are contrast-safe by construction: the `sidebar-muted-foreground`-on-`sidebar` pair is already a `"text"` (4.5:1) pair in the CI-gated contrast contract, enforced across every preset × color mode.
- Constant font weight across states is deliberate — bolder active text would shift row text width on every navigation.
- 24px rows are the intentional floor (WCAG 2.5.8 minimum pointer-target size), documented in the recipe comment.

## Breaking changes

- None for SDK consumers: `navRowClassName`/`sectionLabelClassName` are internal to the sidebar domain (not exported from `@stigmer/react`). Hosts that pinned the sidebar column at 280px in their own CSS should move to 240px to match the console.

## Test plan

- Full `sdk/react` suite: 442 files / 4789 tests green; `@stigmer/theme` contract tests green.
- `SettingsSidebar` Back-to-Sessions test rewritten for the new semantics (always resting, never the active accent).
- `make lint` token-compliance rules clean (`no-main-tokens-in-sidebar`, `no-token-opacity-modifiers`); `verify-scenar-tours.mjs` green with the new needles; `gen-react-sdk-docs-check`/`gen-theme-docs-check` staleness gates satisfied.
- Visual verification against a local full stack (Temporal + stigmer-server + runner) in the real web console: settings and workspace zones screenshotted in light and dark; owner signed off.

## Risks

- Purely visual change to depicted chrome; rollback is a straight revert. Tours re-render the SDK components, so no demo re-recording is needed.

Made with [Cursor](https://cursor.com)