### PR TITLE
feat(backend/stigmer-server): bless the extension-service request idiom on the exports map (C4 Stage 4)

### DIFF
--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -112,7 +112,14 @@ export {
 // the sanitized-Internal error contract). Blessing these keeps
 // authorization and validation semantics single-definition: an extension
 // hand-rolling either would re-derive ratified wire behavior.
-export { callerIdentityOf } from "./pipeline/interceptors/auth.js";
+// callerIdentityKey is the stamp side of the same contract — production
+// stamping stays the interceptors' job, but an extension's OWN service
+// tests must stamp what the serving chain stamps (the auth.test.ts
+// idiom) to exercise their chains over a router transport.
+export {
+  callerIdentityKey,
+  callerIdentityOf,
+} from "./pipeline/interceptors/auth.js";
 export { newPipeline } from "./pipeline/pipeline.js";
 export { newAuthorizeStep } from "./pipeline/steps/authorize.js";
 export { newValidateProtoStep } from "./pipeline/steps/validation.js";

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -15,11 +15,14 @@
  *   - the compose entry and config loading (composeServer + its options'
  *     required types: ServerConfig via loadConfig, Logger via createLogger)
  *   - the extension-point types (§2 — the whole src/extensions contract)
- *   - the pipeline primitives extensions build gates from (PipelineStep,
- *     RequestContext, the semantic error helpers, and the typed store
- *     not-found errors the ratified store-fault mapping keys on; C4
- *     Stage 3 added the dispatch-policy configs and the loaded-execution
- *     context key its capacity gates consume)
+ *   - the pipeline primitives extensions build gates AND extension-
+ *     registered services from (PipelineStep, RequestContext, the semantic
+ *     error helpers, and the typed store not-found errors the ratified
+ *     store-fault mapping keys on; C4 Stage 3 added the dispatch-policy
+ *     configs and the loaded-execution context key its capacity gates
+ *     consume; C4 Stage 4 added the executor, the identity read idiom,
+ *     and the two chain-front steps so extension services run the SAME
+ *     request idiom OSS controllers run)
  *   - the driver interfaces (Store, ArtifactStorage; O5 added §6a/§6b/§6c —
  *     ModelCatalogProvider, the widened storage surface, and
  *     RunnerCredentialProvider; O6 added §6d — SandboxProvisioner and its
@@ -98,6 +101,21 @@ export {
   notFoundError,
   unavailableError,
 } from "./pipeline/errors.js";
+
+// The request idiom for extension-REGISTERED services (C4 Stage 4): a
+// service contributed through ServerExtension.services runs the same
+// chain shape every OSS controller runs — identity read once
+// (callerIdentityOf), then Authorize (descriptor-driven from the
+// `(ai.stigmer.commons.rpc.config)` method options, owning the ratified
+// three-arm decision mapping and the `internal`-caller skip) and
+// ValidateProto at the chain front, executed by the pipeline (which owns
+// the sanitized-Internal error contract). Blessing these keeps
+// authorization and validation semantics single-definition: an extension
+// hand-rolling either would re-derive ratified wire behavior.
+export { callerIdentityOf } from "./pipeline/interceptors/auth.js";
+export { newPipeline } from "./pipeline/pipeline.js";
+export { newAuthorizeStep } from "./pipeline/steps/authorize.js";
+export { newValidateProtoStep } from "./pipeline/steps/validation.js";
 
 // The driver interfaces and the store-fault classes the ratified mapping
 // keys on (typed not-found → NotFound; anything else rethrows as an

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -42,6 +42,7 @@ import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_inf
 
 import {
   ArtifactStorageNotFoundError,
+  callerIdentityOf,
   composeServer,
   createLogger,
   InvalidTokenError,
@@ -49,10 +50,14 @@ import {
   LOADED_EXECUTION_KEY,
   MintingDisabledError,
   newAgentExecutionTemporalConfigFromEnv,
+  newAuthorizeStep,
   newModelCatalogProviderFromDocument,
+  newPipeline,
   newR2ArtifactStorage,
+  newValidateProtoStep,
   newWorkflowExecutionConfigFromEnv,
   notFoundError,
+  RequestContext,
   ResourceNotFoundError,
   ROUTING_SESSION,
   TOKEN_TYPE_EXECUTION_SCOPED,
@@ -359,10 +364,35 @@ const channelRuntime: ChannelRuntime = {
   },
 };
 
+/**
+ * An extension-registered service handler built the OSS controller idiom
+ * (C4 Stage 4): the verified caller read once via callerIdentityOf, then
+ * a chain fronted by the exported Authorize (descriptor-driven from the
+ * method's proto options — the ratified three-arm decision mapping and
+ * the internal-caller skip consumed, never re-derived) and ValidateProto
+ * steps, executed by the exported pipeline (which owns the
+ * sanitized-Internal error contract). This is the shape every cloud
+ * fleet-domain service takes.
+ */
 const registerBillingService = (router: ConnectRouter): void => {
+  const method = BillingQueryController.method.getBillingAccount;
   router.service(BillingQueryController, {
-    getBillingAccount: (input) =>
-      create(BillingAccountSchema, { orgId: input.orgId }),
+    getBillingAccount: async (input, ctx) => {
+      const reqCtx = new RequestContext(
+        method.input,
+        input,
+        callerIdentityOf(ctx),
+      );
+      await newPipeline<typeof method.input>(
+        "consumer-billing-get",
+        createLogger({ level: "error", pretty: false }),
+      )
+        .addStep(newAuthorizeStep(method, authorizer))
+        .addStep(newValidateProtoStep())
+        .build()
+        .execute(reqCtx);
+      return create(BillingAccountSchema, { orgId: reqCtx.newState.orgId });
+    },
   });
 };
 

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -42,6 +42,7 @@ import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_inf
 
 import {
   ArtifactStorageNotFoundError,
+  callerIdentityKey,
   callerIdentityOf,
   composeServer,
   createLogger,
@@ -378,6 +379,11 @@ const registerBillingService = (router: ConnectRouter): void => {
   const method = BillingQueryController.method.getBillingAccount;
   router.service(BillingQueryController, {
     getBillingAccount: async (input, ctx) => {
+      // The stamp side of the identity contract compiles for consumers
+      // too — extension service TESTS set this key on their router
+      // transport's contextValues (production stamping stays the
+      // interceptors' job).
+      void ctx.values.get(callerIdentityKey);
       const reqCtx = new RequestContext(
         method.input,
         input,


### PR DESCRIPTION
## Summary
Blesses the request idiom extension-REGISTERED ConnectRPC services run on the `@stigmer/server` exports map, so the first extension services (the C4 fleet domains in stigmer-cloud) consume the ratified authorization/validation semantics from their one OSS definition instead of re-deriving them.

## Context
`ServerExtension.services` has existed since O1, but no extension had registered a service yet. A service handler needs the OSS controller chain shape — identity read, descriptor-driven Authorize, protovalidate, the pipeline's sanitized-Internal error contract — and none of it was on the blessed surface. Per DD-005, a consumer need not on the surface is a seam request to OSS, never a reach-around; hand-rolling authorization in extension code would re-derive the ratified three-arm decision mapping (an authz outage must never soften into a denial) and the internal-caller skip.

## Changes
- Exports-map additions (pure surface blessing — every symbol already module-exported; no behavior change): `callerIdentityOf`, `newPipeline`, `newAuthorizeStep`, `newValidateProtoStep`, and `callerIdentityKey` (the stamp side, for extension-service tests — client contextValues do not cross a router transport, so tests stamp identity through a server-side interceptor exactly as production does).
- The extension-consumer compile proof gains a chain-fronted service handler exercising every new export.

## Implementation notes
- The index.ts header's "pipeline primitives" section now names extension services alongside gate steps as consumers.

## Breaking changes
- None.

## Test plan
- All four local conformance rosters byte-identical at main's counts (local 498, local-execution 160, local-postgres 498, local-postgres-execution 160; Node 22.22.1) — run on both commits.
- 1989 server units green; `test/extension-consumer` typecheck green; prettier clean.

## Risks
- None beyond surface growth: the additions are re-exports of existing, tested modules.

## Checklist
- [x] Tests added/updated (consumer proof extended)
- [x] Backward compatible

Made with [Cursor](https://cursor.com)