### PR TITLE
feat(backend/stigmer-server): Stage-3 IAM seams — operator gates, reserved-label guard, caller propagation, default_of, memory and EC create gates (C2)

### DIFF
--- a/backend/services/stigmer-server/src/boot/inprocess.ts
+++ b/backend/services/stigmer-server/src/boot/inprocess.ts
@@ -74,8 +74,14 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import type { OrphanDeleter } from "../domain/project/reconcile.js";
 import type { ScheduleExecutionCreator } from "../temporal/schedule/run-starter.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
-import { createInProcessCallerInterceptor } from "../pipeline/interceptors/auth.js";
+import {
+  createInProcessCallerInterceptor,
+  encodeInProcessCaller,
+  IN_PROCESS_CALLER_HEADER,
+} from "../pipeline/interceptors/auth.js";
+import type { CallerIdentity } from "../extensions/identity.js";
 import type { Logger } from "./logger.js";
+import type { CallOptions } from "@connectrpc/connect";
 
 /** The narrow in-process surfaces the domains consume (DD-002). */
 export interface InProcessClients {
@@ -210,32 +216,43 @@ export function createInProcessClients(
   const mcpServerCommand = createClient(McpServerCommandController, transport);
   const skillCommand = createClient(SkillCommandController, transport);
 
+  // The caller-propagation call options (C2 Stage 3, ruling R5 — the
+  // Java posture restored): the ORIGINAL caller's identity rides the
+  // propagation header (the one client→router channel; contextValues are
+  // server-side); the in-process position-1 interceptor decodes it and
+  // stamps `origin: "in-process"` instead of minting internal. Explicit
+  // per call, never ambient (DD-007's threading doctrine); the serving
+  // chassis strips the header, so the wire cannot forge it.
+  const asCaller = (caller: CallerIdentity): CallOptions => ({
+    headers: { [IN_PROCESS_CALLER_HEADER]: encodeInProcessCaller(caller) },
+  });
+
   const clients: InProcessClients = {
-    // Go's ApplyAsSystem is the Apply RPC through this transport: the
-    // position-1 interceptor stamps the internal caller identity (O2),
-    // whose audit derivation equals the #400 operator actor — so a plain
-    // apply IS the system-actor apply in this edition.
+    // The Apply RPC AS THE ORIGINAL CALLER (ruling R5; Java
+    // applyAsCaller): the default instance's owner attribution lands on
+    // the requesting user, so it stays manageable under an enforcing
+    // Authorizer. Pre-R5 this lane minted the internal class (Go's
+    // ApplyAsSystem shape) — the recorded attribution gap.
     agentInstanceApplier: {
-      applyAsSystem: (instance) => agentInstanceCommand.apply(instance),
+      applyAsCaller: (instance, caller) =>
+        agentInstanceCommand.apply(instance, asCaller(caller)),
     },
-    // Go's CreateAsSystem is the Create RPC under the same process-global
-    // operator identity; session create's resolve step uses CREATE (not
-    // apply) so a duplicate default-instance slug surfaces as
-    // AlreadyExists instead of silently updating.
+    // CREATE (not apply) so a duplicate default-instance slug surfaces
+    // as AlreadyExists instead of silently updating — as the original
+    // caller (ruling R5).
     agentInstanceCreator: {
-      createAsSystem: (instance) => agentInstanceCommand.create(instance),
+      createAsCaller: (instance, caller) =>
+        agentInstanceCommand.create(instance, asCaller(caller)),
     },
     parentAgentLoader: {
       get: (agentId) =>
         agentQuery.get(create(AgentIdSchema, { value: agentId })),
     },
-    // Go's workflowinstance.Client.CreateAsSystem is the Create RPC under
-    // the process-global operator identity; workflow create's
-    // default-instance step uses CREATE (not apply) so a duplicate
-    // default-instance slug surfaces as AlreadyExists instead of silently
-    // updating — same posture as the agent edge above.
+    // CREATE (not apply) for the same AlreadyExists posture — as the
+    // original caller (ruling R5), matching the agent edge above.
     workflowInstanceCreator: {
-      createAsSystem: (instance) => workflowInstanceCommand.create(instance),
+      createAsCaller: (instance, caller) =>
+        workflowInstanceCommand.create(instance, asCaller(caller)),
     },
     // Go's workflow.Client.Get for workflowinstance create's parent load
     // (server.go 657: the other direction of the mutual edge).
@@ -243,8 +260,10 @@ export function createInProcessClients(
       get: (workflowId) =>
         workflowQuery.get(create(WorkflowIdSchema, { value: workflowId })),
     },
-    // The agentexecution edges. CreateAsSystem semantics per the agent
-    // edge above: create under the process-global operator identity.
+    // The agentexecution edges: reads stay under the internal class (the
+    // daemon-safe default); the CREATES propagate the original caller
+    // (ruling R5) so instances and sessions born during execution create
+    // carry their real owner.
     executionAgentLoader: {
       get: (agentId) =>
         agentQuery.get(create(AgentIdSchema, { value: agentId })),
@@ -256,14 +275,16 @@ export function createInProcessClients(
         ),
     },
     executionAgentInstanceCreator: {
-      createAsSystem: (instance) => agentInstanceCommand.create(instance),
+      createAsCaller: (instance, caller) =>
+        agentInstanceCommand.create(instance, asCaller(caller)),
     },
     executionSessionLoader: {
       get: (sessionId) =>
         sessionQuery.get(create(SessionIdSchema, { value: sessionId })),
     },
     executionSessionCreator: {
-      create: (session) => sessionCommand.create(session),
+      createAsCaller: (session, caller) =>
+        sessionCommand.create(session, asCaller(caller)),
     },
     executionEnvironmentReader: {
       list: (request) => environmentQuery.list(request),
@@ -279,12 +300,12 @@ export function createInProcessClients(
       create: (ec) => executionContextCommand.create(ec),
       delete: (input) => executionContextCommand.delete(input),
     },
-    // The workflowexecution edges. CreateAsSystem semantics per the
-    // workflow edge above: create under the process-global operator
-    // identity (default-instance self-heal must surface duplicate slugs
-    // as AlreadyExists).
+    // The workflowexecution edges: the default-instance self-heal creates
+    // as the original caller (ruling R5), surfacing duplicate slugs as
+    // AlreadyExists exactly as before.
     workflowExecutionInstanceCreator: {
-      createAsSystem: (instance) => workflowInstanceCommand.create(instance),
+      createAsCaller: (instance, caller) =>
+        workflowInstanceCommand.create(instance, asCaller(caller)),
     },
     workflowExecutionInstanceLoader: {
       get: (instanceId) =>

--- a/backend/services/stigmer-server/src/domain/agent/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agent/controller.ts
@@ -185,7 +185,11 @@ async function createAgent(
       newCreateDefaultInstanceStep(deps.agentInstanceApplier, deps.logger),
     )
     .addStep(
-      newUpdateAgentStatusWithDefaultInstanceStep(deps.store, deps.logger),
+      newUpdateAgentStatusWithDefaultInstanceStep(
+        deps.store,
+        deps.logger,
+        deps.authorizationLifecycle,
+      ),
     )
     .addStep(newIndexSearchStep(deps.store, agentSearchExtractor, deps.logger))
     .build()

--- a/backend/services/stigmer-server/src/domain/agent/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agent/controller.ts
@@ -40,6 +40,11 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
+import {
+  newAuthorizeVisibilityTransitionStep,
+  newGuardPublicVisibilityStep,
+} from "../../pipeline/steps/visibility-gates.js";
 import {
   newBuildNewStateStep,
   setAuditFieldsForUpdate,
@@ -163,6 +168,8 @@ async function createAgent(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardPublicVisibilityStep(deps.authorizer))
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newValidateReferencesStep(deps.store))
     .addStep(newValidateEnabledToolsStep(deps.store))
@@ -206,6 +213,7 @@ async function update(
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newValidateReferencesStep(deps.store))
     .addStep(newValidateEnabledToolsStep(deps.store))
@@ -339,6 +347,12 @@ async function updateVisibility(
     .addStep(newLoadAgentForVisibilityUpdateStep(deps.store))
     .addStep(newRecordVisibilityBeforeUpdateStep(UPDATE_VISIBILITY_AGENT_KEY))
     .addStep(newValidateVisibilityUpdateStep())
+    .addStep(
+      newAuthorizeVisibilityTransitionStep(
+        UPDATE_VISIBILITY_AGENT_KEY,
+        deps.authorizer,
+      ),
+    )
     .addStep(newSetAgentVisibilityStep())
     .addStep(newPersistAgentForVisibilityUpdateStep(deps.store))
     .addStep(

--- a/backend/services/stigmer-server/src/domain/agent/steps.ts
+++ b/backend/services/stigmer-server/src/domain/agent/steps.ts
@@ -37,6 +37,9 @@ import {
   internalError,
   invalidArgumentError,
 } from "../../pipeline/errors.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
+import { notifyDefaultInstanceLinked } from "../../pipeline/steps/authorization-tuples.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import type { RequestContext } from "../../pipeline/request-context.js";
 import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
@@ -62,7 +65,17 @@ type AgentDesc = typeof AgentSchema;
  * router transport, traversing the full interceptor chain (DD-002).
  */
 export interface AgentInstanceApplier {
-  applyAsSystem(instance: AgentInstance): Promise<AgentInstance>;
+  /**
+   * Applies AS THE ORIGINAL CALLER (C2 Stage 3, ruling R5 — the Java
+   * applyAsCaller posture): the propagated identity gives the default
+   * instance real owner attribution, so its creator can manage it under
+   * an enforcing Authorizer. Pre-R5 this ran as the internal class,
+   * which the cloud's tuple driver deliberately never attributes.
+   */
+  applyAsCaller(
+    instance: AgentInstance,
+    caller: CallerIdentity,
+  ): Promise<AgentInstance>;
 }
 
 /**
@@ -347,7 +360,10 @@ export function newCreateDefaultInstanceStep(
       // pipeline's Internal fallback, exactly Go's plain-error path.
       let applied: AgentInstance;
       try {
-        applied = await applierProvider().applyAsSystem(instanceRequest);
+        applied = await applierProvider().applyAsCaller(
+          instanceRequest,
+          ctx.callerIdentity,
+        );
       } catch (error) {
         if (error instanceof ConnectError) {
           throw goWrappedStatusError("failed to apply default instance", error);
@@ -370,10 +386,13 @@ export function newCreateDefaultInstanceStep(
 /**
  * Writes status.default_instance_id onto the just-persisted agent and
  * re-persists. Reads the id from context (set by CreateDefaultInstance).
+ * Fires the driver's default-instance link event AFTER the pointer
+ * persists (C2 Stage 3 — the default_of invariant rides the pointer).
  */
 export function newUpdateAgentStatusWithDefaultInstanceStep(
   store: Store,
   logger: Logger,
+  authorizationLifecycle?: ResourceAuthorizationLifecycle,
 ): PipelineStep<AgentDesc> {
   return {
     name: "UpdateAgentStatusWithDefaultInstance",
@@ -414,6 +433,13 @@ export function newUpdateAgentStatusWithDefaultInstanceStep(
           `failed to persist agent with default instance: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
+
+      await notifyDefaultInstanceLinked(authorizationLifecycle, {
+        instanceKind: ApiResourceKind.agent_instance,
+        instanceId: defaultInstanceId,
+        blueprintKind: ApiResourceKind.agent,
+        blueprintId: agentId,
+      });
 
       ctx.setNewState(agent);
 

--- a/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
@@ -61,6 +61,7 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
@@ -186,6 +187,7 @@ async function createChannel(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newInitInstallStateStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
@@ -234,6 +236,7 @@ async function update(
       newValidateChannelUpdateStep(deps.modelRegistry, deps.channelRuntime),
     )
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
     .build()

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/create-steps.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/create-steps.test.ts
@@ -308,7 +308,7 @@ it("createSessionIfNeeded surfaces the inner status code of a failed session cre
   const step = newCreateSessionIfNeededStep({
     logger: silentLogger,
     sessionCreator: () => ({
-      create: async () => {
+      createAsCaller: async () => {
         throw new ConnectError(
           "session subject too long",
           Code.InvalidArgument,

--- a/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
@@ -43,6 +43,7 @@ import { newPipeline } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import {
   newDeleteResourceStep,
@@ -299,6 +300,7 @@ async function createExecution(
     .addStep(newEnsureSessionOrAgentResolvedStep(deps.logger))
     .addStep(newResolveSlugStep())
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newEnsureEngineAvailableStep(deps.engineState));
   // The ratified pre-side-effect gate slot (blueprint 03 §3a; O4): after

--- a/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
@@ -319,6 +319,7 @@ async function createExecution(
         logger: deps.logger,
         agentLoader: deps.agentLoader,
         agentInstanceCreator: deps.agentInstanceCreator,
+        authorizationLifecycle: deps.authorizationLifecycle,
       }),
     )
     .addStep(

--- a/backend/services/stigmer-server/src/domain/agentexecution/create-steps.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/create-steps.ts
@@ -33,6 +33,9 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import { clone } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../boot/logger.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
+import { notifyDefaultInstanceLinked } from "../../pipeline/steps/authorization-tuples.js";
 import {
   failedPreconditionError,
   goWrappedStatusError,
@@ -86,7 +89,8 @@ export interface AgentLoader {
 export type AgentLoaderProvider = () => AgentLoader;
 
 export interface SessionCreator {
-  create(session: Session): Promise<Session>;
+  /** As the ORIGINAL caller (ruling R5): the session's owner is its user. */
+  createAsCaller(session: Session, caller: CallerIdentity): Promise<Session>;
 }
 export type SessionCreatorProvider = () => SessionCreator;
 
@@ -213,9 +217,16 @@ export function newEnsureSessionOrAgentResolvedStep(
 // CreateDefaultInstanceIfNeeded — create.go createDefaultInstanceIfNeededStep.
 // ---------------------------------------------------------------------------
 
-/** The narrow agentinstance CREATE edge (Go agentInstanceClient.CreateAsSystem). */
+/**
+ * The narrow agentinstance CREATE edge — as the ORIGINAL caller since C2
+ * Stage 3 (ruling R5, the Java createAsCaller posture): real owner
+ * attribution for the created instance under an enforcing Authorizer.
+ */
 export interface ExecutionAgentInstanceCreator {
-  createAsSystem(instance: AgentInstance): Promise<AgentInstance>;
+  createAsCaller(
+    instance: AgentInstance,
+    caller: CallerIdentity,
+  ): Promise<AgentInstance>;
 }
 export type ExecutionAgentInstanceCreatorProvider =
   () => ExecutionAgentInstanceCreator;
@@ -233,6 +244,7 @@ export function newCreateDefaultInstanceIfNeededStep(deps: {
   logger: Logger;
   agentLoader: AgentLoaderProvider;
   agentInstanceCreator: ExecutionAgentInstanceCreatorProvider;
+  authorizationLifecycle?: ResourceAuthorizationLifecycle;
 }): PipelineStep<CreateDesc> {
   return {
     name: "CreateDefaultInstanceIfNeeded",
@@ -308,7 +320,10 @@ export function newCreateDefaultInstanceIfNeededStep(deps: {
       try {
         const created = await deps
           .agentInstanceCreator()
-          .createAsSystem(buildDefaultInstanceRequest(metadata));
+          .createAsCaller(
+            buildDefaultInstanceRequest(metadata),
+            ctx.callerIdentity,
+          );
         createdId = created.metadata?.id ?? "";
       } catch (error) {
         if (error instanceof ConnectError) {
@@ -342,6 +357,14 @@ export function newCreateDefaultInstanceIfNeededStep(deps: {
           `failed to update agent with default instance: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
+
+      // The default_of invariant rides the pointer persist (C2 Stage 3).
+      await notifyDefaultInstanceLinked(deps.authorizationLifecycle, {
+        instanceKind: ApiResourceKind.agent_instance,
+        instanceId: createdId,
+        blueprintKind: ApiResourceKind.agent,
+        blueprintId: agentId,
+      });
 
       ctx.set(DEFAULT_INSTANCE_ID_KEY, createdId);
       deps.logger.info("Successfully ensured default instance exists", {
@@ -459,7 +482,9 @@ export function newCreateSessionIfNeededStep(deps: {
       // Internal); goWrappedStatusError mirrors the #852 wire shape.
       let createdSession: Session;
       try {
-        createdSession = await deps.sessionCreator().create(sessionRequest);
+        createdSession = await deps
+          .sessionCreator()
+          .createAsCaller(sessionRequest, ctx.callerIdentity);
       } catch (error) {
         if (error instanceof ConnectError) {
           throw goWrappedStatusError("failed to create session", error);

--- a/backend/services/stigmer-server/src/domain/agentinstance/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentinstance/controller.ts
@@ -46,6 +46,11 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
+import {
+  newAuthorizeVisibilityTransitionStep,
+  newGuardPublicVisibilityStep,
+} from "../../pipeline/steps/visibility-gates.js";
 import {
   newBuildNewStateStep,
   setAuditFieldsForUpdate,
@@ -175,6 +180,8 @@ async function createInstance(
     .addStep(newLoadParentAgentStep(deps.parentAgentLoader, deps.logger))
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardPublicVisibilityStep(deps.authorizer))
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
     .addStep(
@@ -218,6 +225,7 @@ async function update(
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newValidateInstanceUpdateStep())
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
     .addStep(
@@ -359,6 +367,12 @@ async function updateVisibility(
     )
     .addStep(newRejectDefaultInstanceVisibilityUpdateStep(deps.store))
     .addStep(newValidateVisibilityUpdateStep())
+    .addStep(
+      newAuthorizeVisibilityTransitionStep(
+        UPDATE_VISIBILITY_INSTANCE_KEY,
+        deps.authorizer,
+      ),
+    )
     .addStep(newSetInstanceVisibilityStep())
     .addStep(newPersistInstanceForVisibilityUpdateStep(deps.store))
     .addStep(

--- a/backend/services/stigmer-server/src/domain/agentshare/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentshare/controller.ts
@@ -58,6 +58,7 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import {
   newBuildNewStateStep,
   setAuditFieldsForUpdate,
@@ -174,6 +175,7 @@ async function createShare(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newStampAgentPinStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
@@ -218,6 +220,7 @@ async function update(
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newValidateShareUpdateStep())
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
     .build()

--- a/backend/services/stigmer-server/src/domain/apikey/controller.ts
+++ b/backend/services/stigmer-server/src/domain/apikey/controller.ts
@@ -47,6 +47,7 @@ import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import {
@@ -134,6 +135,7 @@ async function createApiKey(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newGenerateApiKeyStep())
     .addStep(newPersistStep(deps.store))
     .addStep(

--- a/backend/services/stigmer-server/src/domain/channelapp/controller.ts
+++ b/backend/services/stigmer-server/src/domain/channelapp/controller.ts
@@ -51,6 +51,7 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
@@ -156,6 +157,7 @@ async function createChannelApp(
       newEncryptChannelAppSecretsForCreateStep(deps.secretService, deps.logger),
     )
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newPersistStep(deps.store))
     .addStep(
       newCreateAuthorizationTuplesStep(
@@ -199,6 +201,7 @@ async function update(
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newValidateProviderImmutableStep())
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(
       newEncryptChannelAppSecretsForUpdateStep(deps.secretService, deps.logger),
     )

--- a/backend/services/stigmer-server/src/domain/environment/controller.ts
+++ b/backend/services/stigmer-server/src/domain/environment/controller.ts
@@ -56,6 +56,8 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
+import { newAuthorizeVisibilityTransitionStep } from "../../pipeline/steps/visibility-gates.js";
 import {
   newBuildNewStateStep,
   setAuditFieldsForUpdate,
@@ -185,6 +187,7 @@ async function createEnvironment(
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newEnforcePersonalUniquenessStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newPreserveRedactedSecretsStep())
     .addStep(newEncryptSecretValuesStep(deps.secretService, deps.logger))
     .addStep(newPersistStep(deps.store))
@@ -226,6 +229,7 @@ async function update(
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newPreserveRedactedSecretsStep())
     .addStep(newEncryptSecretValuesStep(deps.secretService, deps.logger))
     .addStep(newNormalizeReferencesStep())
@@ -374,6 +378,12 @@ async function updateVisibility(
     // After load, per the cross-edition error precedence: unknown id +
     // bad level = NOT_FOUND on both editions.
     .addStep(newValidateVisibilityUpdateStep())
+    .addStep(
+      newAuthorizeVisibilityTransitionStep(
+        UPDATE_VISIBILITY_ENVIRONMENT_KEY,
+        deps.authorizer,
+      ),
+    )
     .addStep(newValidateEnvironmentShareRestrictionStep())
     .addStep(newSetEnvironmentVisibilityStep())
     .addStep(newPersistEnvironmentForVisibilityUpdateStep(deps.store))

--- a/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
@@ -94,6 +94,7 @@ import { resolveValuesForCaller } from "./resolve-values-for-caller.js";
 import { executionContextSearchExtractor } from "./search-extractor.js";
 import {
   newEncryptSecretValuesStep,
+  newAuthorizeExecutionContextCreateStep,
   newLoadByExecutionIdStep,
   newRejectCiphertextShapedStep,
 } from "./steps.js";
@@ -171,6 +172,9 @@ async function createExecutionContext(
       ),
     )
     .addStep(newValidateProtoStep())
+    // The Java AuthorizeCreate order (#297): before the duplicate check,
+    // so an unauthorized caller learns nothing about existing ids.
+    .addStep(newAuthorizeExecutionContextCreateStep(deps.authorizer))
     .addStep(newValidateVisibilityStep())
     .addStep(newRejectCiphertextShapedStep())
     .addStep(newResolveSlugStep())

--- a/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/controller.ts
@@ -56,6 +56,7 @@ import { newPipeline } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import {
   RESOURCE_ID_KEY,
@@ -175,6 +176,7 @@ async function createExecutionContext(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newEncryptSecretValuesStep(deps.secretService, deps.logger))
     .addStep(newPersistStep(deps.store))

--- a/backend/services/stigmer-server/src/domain/executioncontext/steps.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/steps.ts
@@ -25,9 +25,14 @@ import type { ExecutionContextExecutionIdInput } from "@stigmer/protos/ai/stigme
 import type { ExecutionValue } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
 import type { ExecutionContextQueryController } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/query_pb";
 
+import { Code, ConnectError } from "@connectrpc/connect";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
 import type { Logger } from "../../boot/logger.js";
 import { isCiphertextShaped } from "../../encryption/encryption.js";
 import type { SecretService } from "../../encryption/encryption.js";
+import type { Authorizer, AuthzDecision } from "../../extensions/authorizer.js";
 import {
   internalError,
   invalidArgumentError,
@@ -175,6 +180,72 @@ export function newLoadByExecutionIdStep(
       }
 
       ctx.set(TARGET_RESOURCE_KEY, executionContext);
+    },
+  };
+}
+
+/**
+ * AuthorizeCreate — the Java ExecutionContextCreateHandler.AuthorizeCreate
+ * port (stigmer-cloud#297; C2 Stage 3D): the create RPC skips the
+ * declarative position-1 check (in-process creators — the agent/workflow
+ * execution machinery — already authorized the run against its
+ * session-or-org and act as the machine account), so EXTERNAL callers are
+ * gated here instead: they must hold can_create_execution_in on
+ * metadata.org — the same permission that gates creating an execution in
+ * the org, so members and org guests pass and an outsider refuses.
+ * Ordered before the duplicate check so an unauthorized caller learns
+ * nothing about which execution ids exist.
+ *
+ * OSS byte-identity: the permissive authorizer allows every check, so the
+ * single-user posture is unchanged (the rosters prove it).
+ */
+export function newAuthorizeExecutionContextCreateStep(
+  authorizer: Authorizer,
+): PipelineStep<typeof ExecutionContextSchema> {
+  return {
+    name: "AuthorizeCreate",
+    async execute(
+      ctx: RequestContext<typeof ExecutionContextSchema>,
+    ): Promise<void> {
+      const caller = ctx.callerIdentity;
+      if (caller.callerClass === "internal" || caller.origin === "in-process") {
+        return; // authorized upstream — the Java in-process trust arm
+      }
+      let decision: AuthzDecision;
+      try {
+        decision = await authorizer.authorize(caller, {
+          permission: IamPermission.can_create_execution_in,
+          resourceKind: ApiResourceKind.organization,
+          resourceId: ctx.newState.metadata?.org ?? "",
+        });
+      } catch (error) {
+        throw internalError(
+          error instanceof Error ? error : new Error(String(error)),
+          "execution-context create authorization could not be completed",
+        );
+      }
+      switch (decision.kind) {
+        case "allow":
+          return;
+        case "deny":
+        case "not-found":
+          throw new ConnectError(
+            "unauthorized to create execution context in this organization",
+            Code.PermissionDenied,
+          );
+        case "unavailable":
+          throw internalError(
+            decision.cause,
+            "execution-context create authorization could not be completed",
+          );
+        default: {
+          const exhaustive: never = decision;
+          throw internalError(
+            new Error(`unknown decision ${JSON.stringify(exhaustive)}`),
+            "execution-context create authorization could not be completed",
+          );
+        }
+      }
     },
   };
 }

--- a/backend/services/stigmer-server/src/domain/mcpserver/controller.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/controller.ts
@@ -53,6 +53,11 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
+import {
+  newAuthorizeVisibilityTransitionStep,
+  newGuardPublicVisibilityStep,
+} from "../../pipeline/steps/visibility-gates.js";
 import {
   setAuditFieldsForUpdate,
   newBuildNewStateStep,
@@ -214,6 +219,8 @@ async function createMcpServer(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardPublicVisibilityStep(deps.authorizer))
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
     .addStep(
@@ -257,6 +264,7 @@ async function update(
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newValidateDefaultEnabledToolsStep())
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
@@ -416,6 +424,12 @@ async function updateVisibility(
       newRecordVisibilityBeforeUpdateStep(UPDATE_VISIBILITY_MCP_SERVER_KEY),
     )
     .addStep(newValidateVisibilityUpdateStep())
+    .addStep(
+      newAuthorizeVisibilityTransitionStep(
+        UPDATE_VISIBILITY_MCP_SERVER_KEY,
+        deps.authorizer,
+      ),
+    )
     .addStep(newSetMcpServerVisibilityStep())
     .addStep(newPersistMcpServerForVisibilityUpdateStep(deps.store))
     .addStep(

--- a/backend/services/stigmer-server/src/domain/memory/controller.ts
+++ b/backend/services/stigmer-server/src/domain/memory/controller.ts
@@ -75,6 +75,7 @@ import { newPipeline } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
@@ -185,6 +186,7 @@ async function createMemory(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newInitializeMemoryLifecycleStep())
     .addStep(newPersistStep(deps.store))
     .addStep(
@@ -232,6 +234,7 @@ async function update(
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newValidateMemoryUpdateStep())
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newPersistMemoryUpdateStep(deps.store))
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/memory/controller.ts
+++ b/backend/services/stigmer-server/src/domain/memory/controller.ts
@@ -75,6 +75,7 @@ import { newPipeline } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardMemoryCaptureStep } from "../../pipeline/steps/guard-memory-capture.js";
 import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
@@ -179,6 +180,7 @@ async function createMemory(
       newAuthorizeStep(MemoryCommandController.method.create, deps.authorizer),
     )
     .addStep(newValidateProtoStep())
+    .addStep(newGuardMemoryCaptureStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveMemoryDefaultsStep())
     .addStep(newCheckMemoryEnablementStep(deps.store))

--- a/backend/services/stigmer-server/src/domain/oauthapp/controller.ts
+++ b/backend/services/stigmer-server/src/domain/oauthapp/controller.ts
@@ -52,6 +52,7 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import {
@@ -156,6 +157,7 @@ async function createOAuthApp(
       newEncryptClientSecretForCreateStep(deps.secretService, deps.logger),
     )
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newPersistStep(deps.store))
     .addStep(
       newCreateAuthorizationTuplesStep(
@@ -198,6 +200,7 @@ async function update(
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(
       newEncryptClientSecretForUpdateStep(deps.secretService, deps.logger),
     )

--- a/backend/services/stigmer-server/src/domain/organization/controller.ts
+++ b/backend/services/stigmer-server/src/domain/organization/controller.ts
@@ -62,6 +62,7 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import {
@@ -188,6 +189,7 @@ async function createOrganization(
     .addStep(newValidateVisibilityStep())
     .addStep(newCheckOrgDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newCopySlugToIdStep())
     .addStep(newPersistStep(deps.store))
     // The C2 tuple step runs BEFORE the slot — the verified Java order
@@ -242,6 +244,7 @@ async function update(
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newPersistStep(deps.store))
     .addStep(
       newIndexSearchStep(deps.store, organizationSearchExtractor, deps.logger),

--- a/backend/services/stigmer-server/src/domain/project/controller.ts
+++ b/backend/services/stigmer-server/src/domain/project/controller.ts
@@ -44,6 +44,7 @@ import { newPipeline } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import {
@@ -150,6 +151,7 @@ async function createProject(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
     .addStep(

--- a/backend/services/stigmer-server/src/domain/schedule/controller.ts
+++ b/backend/services/stigmer-server/src/domain/schedule/controller.ts
@@ -60,6 +60,7 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
@@ -199,6 +200,7 @@ async function createSchedule(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
     .addStep(
@@ -237,6 +239,7 @@ async function update(
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newValidateScheduleUpdateStep(deps))
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistScheduleUpdateStep(deps.store))
     .addStep(newArmScheduleStep(deps.clock, deps.logger))

--- a/backend/services/stigmer-server/src/domain/session/controller.ts
+++ b/backend/services/stigmer-server/src/domain/session/controller.ts
@@ -52,6 +52,7 @@ import type { CallerIdentity } from "../../extensions/identity.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import {
   newBuildNewStateStep,
   setAuditFieldsForUpdate,
@@ -203,6 +204,7 @@ async function createSession(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep());
   // The ratified pre-side-effect gate slot (blueprint 03 §3a; O4; Q2
   // ruling — see the create doc comment). Empty in OSS.
@@ -254,6 +256,7 @@ async function update(
     .addStep(newValidateHarnessImmutabilityStep())
     .addStep(newValidateExecutionTargetImmutabilityStep(deps.temporalConfig))
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newRecordHarnessStateHistoryStep())
     .addStep(newPersistStep(deps.store))
     .addStep(

--- a/backend/services/stigmer-server/src/domain/session/controller.ts
+++ b/backend/services/stigmer-server/src/domain/session/controller.ts
@@ -197,6 +197,7 @@ async function createSession(
         deps.store,
         deps.agentInstanceCreator,
         deps.logger,
+        deps.authorizationLifecycle,
       ),
     )
     .addStep(newValidateProtoStep())

--- a/backend/services/stigmer-server/src/domain/session/steps.ts
+++ b/backend/services/stigmer-server/src/domain/session/steps.ts
@@ -42,6 +42,9 @@ import {
   invalidArgumentError,
 } from "../../pipeline/errors.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
+import { notifyDefaultInstanceLinked } from "../../pipeline/steps/authorization-tuples.js";
 import type { RequestContext } from "../../pipeline/request-context.js";
 import { RESOURCE_ID_KEY } from "../../pipeline/steps/delete.js";
 import { compareCreatedAtDesc } from "../../pipeline/steps/helpers.js";
@@ -77,7 +80,15 @@ const CHANNEL_ID_LABEL_KEY = "stigmer.ai/channel-id";
  * interceptor chain (DD-002).
  */
 export interface AgentInstanceCreator {
-  createAsSystem(instance: AgentInstance): Promise<AgentInstance>;
+  /**
+   * Creates AS THE ORIGINAL CALLER (C2 Stage 3, ruling R5 — the Java
+   * createAsCaller posture): the propagated identity gives the created
+   * instance real owner attribution under an enforcing Authorizer.
+   */
+  createAsCaller(
+    instance: AgentInstance,
+    caller: CallerIdentity,
+  ): Promise<AgentInstance>;
 }
 
 /**
@@ -109,6 +120,7 @@ export function newResolveDefaultAgentInstanceStep(
   store: Store,
   creator: AgentInstanceCreatorProvider,
   logger: Logger,
+  authorizationLifecycle?: ResourceAuthorizationLifecycle,
 ): PipelineStep<SessionDesc> {
   return {
     name: "ResolveDefaultAgentInstance",
@@ -193,7 +205,10 @@ export function newResolveDefaultAgentInstanceStep(
         // exactly Go's plain-error path.
         let createdInstance: AgentInstance;
         try {
-          createdInstance = await creator().createAsSystem(instanceRequest);
+          createdInstance = await creator().createAsCaller(
+            instanceRequest,
+            ctx.callerIdentity,
+          );
         } catch (error) {
           logger.error("Failed to create default instance", {
             agentId,
@@ -236,6 +251,14 @@ export function newResolveDefaultAgentInstanceStep(
             `failed to persist agent with default instance: ${error instanceof Error ? error.message : String(error)}`,
           );
         }
+
+        // The default_of invariant rides the pointer persist (C2 Stage 3).
+        await notifyDefaultInstanceLinked(authorizationLifecycle, {
+          instanceKind: ApiResourceKind.agent_instance,
+          instanceId: defaultInstanceId,
+          blueprintKind: ApiResourceKind.agent,
+          blueprintId: agentId,
+        });
 
         logger.info("Created default instance for default agent", {
           instanceId: defaultInstanceId,

--- a/backend/services/stigmer-server/src/domain/skill/controller.ts
+++ b/backend/services/stigmer-server/src/domain/skill/controller.ts
@@ -70,6 +70,7 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newAuthorizeVisibilityTransitionStep } from "../../pipeline/steps/visibility-gates.js";
 import {
   newCleanupIamPoliciesStep,
   newRecordVisibilityBeforeUpdateStep,
@@ -413,6 +414,12 @@ async function updateVisibility(
     .addStep(newLoadSkillForVisibilityUpdateStep(deps.store))
     .addStep(newRecordVisibilityBeforeUpdateStep(UPDATE_VISIBILITY_SKILL_KEY))
     .addStep(newValidateVisibilityUpdateStep())
+    .addStep(
+      newAuthorizeVisibilityTransitionStep(
+        UPDATE_VISIBILITY_SKILL_KEY,
+        deps.authorizer,
+      ),
+    )
     .addStep(newSetVisibilityStep())
     .addStep(newPersistSkillForVisibilityUpdateStep(deps.store))
     .addStep(

--- a/backend/services/stigmer-server/src/domain/workflow/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/controller.ts
@@ -68,6 +68,11 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
+import {
+  newAuthorizeVisibilityTransitionStep,
+  newGuardPublicVisibilityStep,
+} from "../../pipeline/steps/visibility-gates.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import {
   setAuditFieldsForUpdate,
@@ -219,6 +224,8 @@ async function createWorkflow(
     .addStep(newResolveSlugStep())
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardPublicVisibilityStep(deps.authorizer))
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPopulateServerlessValidationStep(deps.logger))
     .addStep(newComputeVersionHashStep(deps.logger))
@@ -274,6 +281,7 @@ async function update(
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPopulateServerlessValidationStepForUpdate(deps.logger))
     .addStep(newComputeVersionHashStep(deps.logger))
@@ -416,6 +424,12 @@ async function updateVisibility(
       newRecordVisibilityBeforeUpdateStep(UPDATE_VISIBILITY_WORKFLOW_KEY),
     )
     .addStep(newValidateVisibilityUpdateStep())
+    .addStep(
+      newAuthorizeVisibilityTransitionStep(
+        UPDATE_VISIBILITY_WORKFLOW_KEY,
+        deps.authorizer,
+      ),
+    )
     .addStep(newSetWorkflowVisibilityStep())
     .addStep(newPersistWorkflowForVisibilityUpdateStep(deps.store))
     .addStep(

--- a/backend/services/stigmer-server/src/domain/workflow/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/controller.ts
@@ -241,7 +241,11 @@ async function createWorkflow(
       newCreateDefaultInstanceStep(deps.workflowInstanceCreator, deps.logger),
     )
     .addStep(
-      newUpdateWorkflowStatusWithDefaultInstanceStep(deps.store, deps.logger),
+      newUpdateWorkflowStatusWithDefaultInstanceStep(
+        deps.store,
+        deps.logger,
+        deps.authorizationLifecycle,
+      ),
     )
     .addStep(newSaveVersionAuditStep(deps.store, deps.logger, true, true))
     .addStep(

--- a/backend/services/stigmer-server/src/domain/workflow/steps.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/steps.ts
@@ -31,6 +31,9 @@ import {
   invalidArgumentError,
 } from "../../pipeline/errors.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
+import { notifyDefaultInstanceLinked } from "../../pipeline/steps/authorization-tuples.js";
 import type { RequestContext } from "../../pipeline/request-context.js";
 import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
 import { AuditNotFoundError } from "../../store/interface.js";
@@ -55,7 +58,15 @@ export const DEFAULT_INSTANCE_ID_KEY = "default_instance_id";
 // ---------------------------------------------------------------------------
 
 export interface WorkflowInstanceCreator {
-  createAsSystem(instance: WorkflowInstance): Promise<WorkflowInstance>;
+  /**
+   * Creates AS THE ORIGINAL CALLER (C2 Stage 3, ruling R5 — the Java
+   * createAsCaller posture): the propagated identity gives the default
+   * instance real owner attribution under an enforcing Authorizer.
+   */
+  createAsCaller(
+    instance: WorkflowInstance,
+    caller: CallerIdentity,
+  ): Promise<WorkflowInstance>;
 }
 
 /**
@@ -522,7 +533,10 @@ export function newCreateDefaultInstanceStep(
       // path.
       let created: WorkflowInstance;
       try {
-        created = await creatorProvider().createAsSystem(instanceRequest);
+        created = await creatorProvider().createAsCaller(
+          instanceRequest,
+          ctx.callerIdentity,
+        );
       } catch (error) {
         if (error instanceof ConnectError) {
           throw goWrappedStatusError("failed to create default instance", error);
@@ -545,6 +559,7 @@ export function newCreateDefaultInstanceStep(
 export function newUpdateWorkflowStatusWithDefaultInstanceStep(
   store: Store,
   logger: Logger,
+  authorizationLifecycle?: ResourceAuthorizationLifecycle,
 ): PipelineStep<WorkflowDesc> {
   return {
     name: "UpdateWorkflowStatusWithDefaultInstance",
@@ -579,6 +594,14 @@ export function newUpdateWorkflowStatusWithDefaultInstanceStep(
           `failed to persist workflow with default instance: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
+
+      // The default_of invariant rides the pointer persist (C2 Stage 3).
+      await notifyDefaultInstanceLinked(authorizationLifecycle, {
+        instanceKind: ApiResourceKind.workflow_instance,
+        instanceId: defaultInstanceId,
+        blueprintKind: ApiResourceKind.workflow,
+        blueprintId: workflowId,
+      });
 
       ctx.setNewState(workflow);
 

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/create-steps.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/create-steps.test.ts
@@ -142,7 +142,7 @@ describe("CreateDefaultInstanceIfNeeded (create.go resolution paths)", () => {
         store,
         logger: silentLogger,
         workflowInstanceCreator: () => ({
-          createAsSystem: async (instance: WorkflowInstance) => {
+          createAsCaller: async (instance: WorkflowInstance) => {
             calls.push(instance);
             return (
               created ??
@@ -228,7 +228,7 @@ describe("CreateDefaultInstanceIfNeeded (create.go resolution paths)", () => {
       store,
       logger: silentLogger,
       workflowInstanceCreator: () => ({
-        createAsSystem: () =>
+        createAsCaller: () =>
           Promise.reject(
             new ConnectError("slug already exists", Code.AlreadyExists),
           ),

--- a/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
@@ -46,6 +46,7 @@ import { newPipeline } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newCheckDuplicateStep } from "../../pipeline/steps/duplicate.js";
@@ -278,6 +279,7 @@ async function createExecution(
     )
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep());
   // The ratified sandbox-acquisition gate slot (blueprint 03 §3a; C4):
   // the Java-verified capacity-gate position — after Authorize and every
@@ -366,6 +368,7 @@ async function update(
     .addStep(newResolveSlugStep())
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
     .addStep(

--- a/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
@@ -275,6 +275,7 @@ async function createExecution(
         store: deps.store,
         logger: deps.logger,
         workflowInstanceCreator: deps.workflowInstanceCreator,
+        authorizationLifecycle: deps.authorizationLifecycle,
       }),
     )
     .addStep(newCheckDuplicateStep(deps.store))

--- a/backend/services/stigmer-server/src/domain/workflowexecution/create-steps.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/create-steps.ts
@@ -25,6 +25,9 @@ import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecu
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
+import { notifyDefaultInstanceLinked } from "../../pipeline/steps/authorization-tuples.js";
 import {
   goWrappedStatusError,
   internalError,
@@ -43,14 +46,15 @@ import type { WorkflowExecutionEngineStateProvider } from "./engine.js";
 type ExecutionDesc = typeof WorkflowExecutionSchema;
 
 /**
- * The narrow workflowinstance CREATE edge (Go
- * workflowInstanceClient.CreateAsSystem) — consumer-defined so the
- * dependency reads at the domain boundary; satisfied by the in-process
- * workflowinstance command client under the process-global operator
- * identity.
+ * The narrow workflowinstance CREATE edge — as the ORIGINAL caller since
+ * C2 Stage 3 (ruling R5, the Java createAsCaller posture): real owner
+ * attribution for the created instance under an enforcing Authorizer.
  */
 export interface ExecutionWorkflowInstanceCreator {
-  createAsSystem(instance: WorkflowInstance): Promise<WorkflowInstance>;
+  createAsCaller(
+    instance: WorkflowInstance,
+    caller: CallerIdentity,
+  ): Promise<WorkflowInstance>;
 }
 export type ExecutionWorkflowInstanceCreatorProvider =
   () => ExecutionWorkflowInstanceCreator;
@@ -83,6 +87,7 @@ export interface CreateDefaultInstanceDeps {
   readonly store: Store;
   readonly logger: Logger;
   readonly workflowInstanceCreator: ExecutionWorkflowInstanceCreatorProvider;
+  readonly authorizationLifecycle?: ResourceAuthorizationLifecycle;
 }
 
 /**
@@ -171,7 +176,7 @@ export function newCreateDefaultInstanceIfNeededStep(
       try {
         createdInstance = await deps
           .workflowInstanceCreator()
-          .createAsSystem(instanceRequest);
+          .createAsCaller(instanceRequest, ctx.callerIdentity);
       } catch (error) {
         if (error instanceof ConnectError) {
           // Go wraps the client error with %w — the inner gRPC code
@@ -230,6 +235,13 @@ async function backfillDefaultInstanceId(
   } catch (error) {
     throw internalError(error, failureMessage);
   }
+  // The default_of invariant rides the pointer persist (C2 Stage 3).
+  await notifyDefaultInstanceLinked(deps.authorizationLifecycle, {
+    instanceKind: ApiResourceKind.workflow_instance,
+    instanceId,
+    blueprintKind: ApiResourceKind.workflow,
+    blueprintId: workflowId,
+  });
 }
 
 /**

--- a/backend/services/stigmer-server/src/domain/workflowinstance/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowinstance/controller.ts
@@ -51,6 +51,11 @@ import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
+import {
+  newAuthorizeVisibilityTransitionStep,
+  newGuardPublicVisibilityStep,
+} from "../../pipeline/steps/visibility-gates.js";
 import {
   newBuildNewStateStep,
   setAuditFieldsForUpdate,
@@ -176,6 +181,8 @@ async function createInstance(
     .addStep(newValidateSameOrgBusinessRuleStep(deps.logger))
     .addStep(newCheckDuplicateStep(deps.store))
     .addStep(newBuildNewStateStep())
+    .addStep(newGuardPublicVisibilityStep(deps.authorizer))
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
     .addStep(
@@ -223,6 +230,7 @@ async function update(
     .addStep(newLoadExistingStep(deps.store))
     .addStep(newValidateInstanceUpdateStep())
     .addStep(newBuildUpdateStateStep())
+    .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
     .addStep(
@@ -382,6 +390,12 @@ async function updateVisibility(
       ),
     )
     .addStep(newValidateVisibilityUpdateStep())
+    .addStep(
+      newAuthorizeVisibilityTransitionStep(
+        UPDATE_VISIBILITY_INSTANCE_KEY,
+        deps.authorizer,
+      ),
+    )
     .addStep(newSetInstanceVisibilityStep())
     .addStep(
       newPersistInstanceStep(

--- a/backend/services/stigmer-server/src/extensions/identity.ts
+++ b/backend/services/stigmer-server/src/extensions/identity.ts
@@ -36,6 +36,20 @@ export type CallerClass =
   | (string & {});
 
 /**
+ * How the request reached the chain — the transport-trust discriminant
+ * the reserved-label guard keys on (C2 Stage 3, ruling R5; the TS
+ * rendering of the Java isInProcessCall arm, cloud#386). `in-process` is
+ * stamped ONLY by the in-process chain's identity interceptor — only
+ * server code can reach that transport, so the marker is unspoofable —
+ * and it survives caller PROPAGATION: a request-origin in-process call
+ * carries the ORIGINAL caller's identity with this origin, letting the
+ * server compose requests as the user (default-instance factories,
+ * managed environments) without those requests being mistaken for
+ * client-boundary writes. Absent means the wire.
+ */
+export type CallOrigin = "wire" | "in-process";
+
+/**
  * The authenticated caller, produced by the verifier chain and read by the
  * Authorizer and the audit-actor seam. Org membership is DELIBERATELY not
  * carried (blueprint §4b): it is authorization data, resolved by the
@@ -58,6 +72,13 @@ export interface CallerIdentity {
    */
   readonly email?: string;
   readonly displayName?: string;
+  /**
+   * The transport the request entered through (C2 Stage 3, ruling R5).
+   * Absent = the wire; the in-process interceptor stamps `in-process` on
+   * every identity it forwards — minted internal AND propagated caller
+   * alike.
+   */
+  readonly origin?: CallOrigin;
 }
 
 /**

--- a/backend/services/stigmer-server/src/extensions/resource-authorization.ts
+++ b/backend/services/stigmer-server/src/extensions/resource-authorization.ts
@@ -107,6 +107,25 @@ export interface VisibilityChangedEvent {
 }
 
 /**
+ * Fired synchronously after a blueprint's `status.defaultInstanceId`
+ * pointer is persisted (C2 Stage 3 — the default_of structural-
+ * inheritance arm of the Java model). The invariant the driver upholds:
+ * the `<instanceKind>:<instanceId>#default_of@<blueprintKind>:<blueprintId>`
+ * tuple exists iff the pointer names the instance — written by the SAME
+ * flows that persist the pointer, never derived from the client-
+ * suppliable default-instance label. The tuple makes the default
+ * instance exactly as reachable as its blueprint (viewer from
+ * default_of); it never transitions and dies with the instance's normal
+ * deletion cleanup.
+ */
+export interface DefaultInstanceLinkedEvent {
+  readonly instanceKind: ApiResourceKind;
+  readonly instanceId: string;
+  readonly blueprintKind: ApiResourceKind;
+  readonly blueprintId: string;
+}
+
+/**
  * The driver interface (single-instance point, registered via
  * ExtensionDrivers.resourceAuthorizationLifecycle). Implementations must
  * be idempotent per event — the surrounding chains retry whole requests,
@@ -116,4 +135,11 @@ export interface ResourceAuthorizationLifecycle {
   onResourceCreated(event: ResourceCreatedEvent): Promise<void>;
   onResourceDeleted(event: ResourceDeletedEvent): Promise<void>;
   onVisibilityChanged(event: VisibilityChangedEvent): Promise<void>;
+  /**
+   * OPTIONAL (added C2 Stage 3): synchronous, post-pointer-persist; a
+   * throw fails the request (the pointer survives — retry converges, the
+   * write is idempotent). Absent method = no structural link is written
+   * (the OSS posture: local access control needs none).
+   */
+  onDefaultInstanceLinked?(event: DefaultInstanceLinkedEvent): Promise<void>;
 }

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -77,6 +77,7 @@ export type { ResolvedExtensionDrivers } from "./extensions/registry.js";
 // organization query directory, plus the shape-policy helpers a driver's
 // tests pin against.
 export type {
+  DefaultInstanceLinkedEvent,
   ResourceAuthorizationLifecycle,
   ResourceCreatedEvent,
   ResourceDeletedEvent,

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -52,6 +52,13 @@ export type {
   CallerIdentity,
   IdentityVerifier,
 } from "./extensions/identity.js";
+// The caller-identity read idiom for extension-registered services (C2
+// Stage 3, 20260827.10): extension RPC handlers traverse the same
+// interceptor chain as OSS controllers, so the identity stamped at chain
+// position 1 is already on the HandlerContext — this accessor is the ONE
+// sanctioned way to read it (loud-fails on a transport built without an
+// identity source, never a silent placeholder principal).
+export { callerIdentityOf } from "./pipeline/interceptors/auth.js";
 export type {
   Authorizer,
   AuthzCheck,

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -55,10 +55,9 @@ export type {
 // The caller-identity read idiom for extension-registered services (C2
 // Stage 3, 20260827.10): extension RPC handlers traverse the same
 // interceptor chain as OSS controllers, so the identity stamped at chain
-// position 1 is already on the HandlerContext — this accessor is the ONE
-// sanctioned way to read it (loud-fails on a transport built without an
-// identity source, never a silent placeholder principal).
-export { callerIdentityOf } from "./pipeline/interceptors/auth.js";
+// position 1 is already on the HandlerContext — the exported accessor
+// below (with the R5 propagation surface) is the ONE sanctioned way to
+// read it.
 export type {
   Authorizer,
   AuthzCheck,
@@ -104,6 +103,19 @@ export {
   notFoundError,
   unavailableError,
 } from "./pipeline/errors.js";
+// The shared slug derivation (C2 Stage 3): extension-registered resource
+// kinds derive slugs with the SAME generator both editions pin
+// (ApiRequestResourceSlugGenerator parity) — the semantics live exactly
+// once.
+export { generateSlug } from "./pipeline/steps/slug.js";
+// The in-process caller-propagation surface (ruling R5): extension code
+// composing requests through the in-process transport AS a caller rides
+// the same header the OSS asCaller adapters use.
+export {
+  callerIdentityOf,
+  encodeInProcessCaller,
+  IN_PROCESS_CALLER_HEADER,
+} from "./pipeline/interceptors/auth.js";
 
 // The driver interfaces and the store-fault classes the ratified mapping
 // keys on (typed not-found → NotFound; anything else rethrows as an

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -115,9 +115,9 @@ export {
 export { generateSlug } from "./pipeline/steps/slug.js";
 // The in-process caller-propagation surface (ruling R5): extension code
 // composing requests through the in-process transport AS a caller rides
-// the same header the OSS asCaller adapters use.
+// the same header the OSS asCaller adapters use. (callerIdentityOf and
+// callerIdentityKey ride the request-idiom export block below.)
 export {
-  callerIdentityOf,
   encodeInProcessCaller,
   IN_PROCESS_CALLER_HEADER,
 } from "./pipeline/interceptors/auth.js";

--- a/backend/services/stigmer-server/src/pipeline/__tests__/router-transport.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/__tests__/router-transport.test.ts
@@ -106,3 +106,67 @@ describe("SP-B: interceptors traverse createRouterTransport in-process calls", (
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// C2 Stage 3 (ruling R5): the caller-propagation header traverses the
+// router transport — the mechanism boot/inprocess.ts rides. (Per-call
+// contextValues deliberately NOT used: they are a server-side construct
+// and do not cross the client boundary — verified here first.)
+// ---------------------------------------------------------------------------
+import type { CallerIdentity } from "../../extensions/identity.js";
+import {
+  callerIdentityKey,
+  createInProcessCallerInterceptor,
+  encodeInProcessCaller,
+  IN_PROCESS_CALLER_HEADER,
+} from "../interceptors/auth.js";
+
+describe("R5: caller propagation through the in-process transport", () => {
+  function transportSeeing(seen: CallerIdentity[]) {
+    return createRouterTransport(
+      (router) => {
+        router.service(Health, {
+          check: (_req, ctx) => {
+            const identity = ctx.values.get(callerIdentityKey);
+            if (identity !== undefined) {
+              seen.push(identity);
+            }
+            return { status: HealthCheckResponse_ServingStatus.SERVING };
+          },
+          list: () => ({ statuses: {} }),
+          watch: async function* () {},
+        });
+      },
+      { router: { interceptors: [createInProcessCallerInterceptor()] } },
+    );
+  }
+
+  it("forwards a propagated caller with origin in-process stamped", async () => {
+    const seen: CallerIdentity[] = [];
+    const caller: CallerIdentity = {
+      identityId: "ida_alice",
+      callerClass: "user",
+      issuer: "stigmer",
+      rawToken: "tok",
+    };
+    await createClient(Health, transportSeeing(seen)).check(
+      {},
+      {
+        headers: {
+          [IN_PROCESS_CALLER_HEADER]: encodeInProcessCaller(caller),
+        },
+      },
+    );
+    expect(seen).toEqual([
+      { ...caller, origin: "in-process" },
+    ]);
+  });
+
+  it("mints the internal class when nothing was propagated (the daemon default)", async () => {
+    const seen: CallerIdentity[] = [];
+    await createClient(Health, transportSeeing(seen)).check({});
+    expect(seen).toHaveLength(1);
+    expect(seen[0].callerClass).toBe("internal");
+    expect(seen[0].origin).toBe("in-process");
+  });
+});

--- a/backend/services/stigmer-server/src/pipeline/interceptors/auth.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/auth.ts
@@ -149,6 +149,10 @@ export function createVerifierChainInterceptor(
   requireAuthentication = false,
 ): Interceptor {
   return (next) => async (request) => {
+    // The in-process propagation header is meaningless — and forgeable —
+    // on the wire: stripped unconditionally before anything downstream
+    // could read it (ruling R5's unspoofability-by-construction arm).
+    request.header.delete(IN_PROCESS_CALLER_HEADER);
     const token = parseBearerToken(request.header.get("authorization") ?? "");
     let identity: CallerIdentity | undefined;
     if (token !== "") {
@@ -183,18 +187,70 @@ export function createVerifierChainInterceptor(
 }
 
 /**
- * The in-process transport's position-1 identity source: stamps the
- * internal caller class carrying the operator's identity fields, so
- * audit stamps on in-process writes stay byte-identical to the wire
- * lane's (both derive from the same #400 seam). The Authorize step treats
- * the internal class as the in-process authorization skip (ruling Q4).
+ * The caller-propagation header of the in-process lane (C2 Stage 3,
+ * ruling R5). Client CallOptions carry no contextValues across the
+ * router transport, so the asCaller adapters (boot/inprocess.ts) ride
+ * the one channel that does cross it: a request header, base64url JSON.
+ * Unspoofable from the wire BY CONSTRUCTION: the serving chassis strips
+ * it before anything can read it, and only the in-process interceptor —
+ * reachable only by server code — honors it.
+ */
+export const IN_PROCESS_CALLER_HEADER = "x-stigmer-inprocess-caller";
+
+/** Encodes a CallerIdentity for the propagation header. */
+export function encodeInProcessCaller(caller: CallerIdentity): string {
+  return Buffer.from(JSON.stringify(caller)).toString("base64url");
+}
+
+/**
+ * The in-process transport's position-1 identity source. Two arms since
+ * C2 Stage 3 (ruling R5 — the caller-propagation amendment restoring the
+ * Java posture, where in-process calls carried the ORIGINAL caller):
+ *
+ *   - PROPAGATED: a request-origin adapter passed the original caller's
+ *     identity through {@link IN_PROCESS_CALLER_HEADER} (the asCaller
+ *     edges) — it forwards with `origin: "in-process"` stamped, so
+ *     attribution (owner/creator tuples, audit) lands on the real user
+ *     while transport-trust arms (the reserved-label guard) still see
+ *     the server-composed origin.
+ *   - MINTED: no propagated identity — the daemon-origin default (the
+ *     schedule clock, the project reconciler): the internal caller class
+ *     carrying the operator's identity fields, so audit stamps on
+ *     daemon writes stay byte-identical to the pre-R5 posture. The
+ *     Authorize step treats the internal class as the in-process
+ *     authorization skip (ruling Q4).
+ *
+ * A malformed propagation header is a WIRING BUG (only server code can
+ * write it) — loud INTERNAL, never a silent fall-through to a wrong
+ * identity.
  */
 export function createInProcessCallerInterceptor(): Interceptor {
   return (next) => (request) => {
-    request.contextValues.set(callerIdentityKey, {
-      ...trustedLocalIdentity(),
-      callerClass: "internal",
-    });
+    const encoded = request.header.get(IN_PROCESS_CALLER_HEADER);
+    let identity: CallerIdentity;
+    if (encoded !== null) {
+      request.header.delete(IN_PROCESS_CALLER_HEADER);
+      try {
+        identity = {
+          ...(JSON.parse(
+            Buffer.from(encoded, "base64url").toString("utf8"),
+          ) as CallerIdentity),
+          origin: "in-process",
+        };
+      } catch (error) {
+        throw internalError(
+          error instanceof Error ? error : new Error(String(error)),
+          "internal server error",
+        );
+      }
+    } else {
+      identity = {
+        ...trustedLocalIdentity(),
+        callerClass: "internal",
+        origin: "in-process",
+      };
+    }
+    request.contextValues.set(callerIdentityKey, identity);
     return next(request);
   };
 }

--- a/backend/services/stigmer-server/src/pipeline/steps/__tests__/guard-reserved-labels.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/__tests__/guard-reserved-labels.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Pins the reserved-label write guard (C2 Stage 3, the Java
+ * GuardReservedLabelsStep matrix): echoes and removals pass without any
+ * authorization round-trip, introductions and changes reject with the
+ * byte-pinned INVALID_ARGUMENT copy when the Authorizer denies, the
+ * permissive default allows (OSS byte-identity), the per-kind client
+ * contract (stigmer.ai/personal on Environment) passes, and internal
+ * callers skip entirely.
+ */
+import { describe, expect, it } from "vitest";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import type { Authorizer, AuthzCheck } from "../../../extensions/authorizer.js";
+import type { CallerIdentity } from "../../../extensions/identity.js";
+import { RequestContext } from "../../request-context.js";
+import {
+  newGuardReservedLabelsStep,
+  reservedLabelMutations,
+} from "../guard-reserved-labels.js";
+import { EXISTING_RESOURCE_KEY } from "../load-existing.js";
+import { newPermissiveSingleTeamAuthorizer } from "../authorize.js";
+
+const USER: CallerIdentity = {
+  identityId: "ida_alice",
+  callerClass: "user",
+  issuer: "stigmer",
+  rawToken: "tok",
+};
+
+function denying(observed?: AuthzCheck[]): Authorizer {
+  return {
+    authorize: (_caller, check) => {
+      observed?.push(check);
+      return Promise.resolve({ kind: "deny", reason: "" });
+    },
+  };
+}
+
+function agentCtx(
+  labels: Record<string, string>,
+  caller: CallerIdentity = USER,
+): RequestContext<typeof AgentSchema> {
+  return new RequestContext(
+    AgentSchema,
+    create(AgentSchema, { metadata: { name: "a", labels } }),
+    caller,
+    ApiResourceKind.agent,
+  );
+}
+
+describe("reservedLabelMutations", () => {
+  it("flags introductions and changes, never echoes or removals", () => {
+    const stored = {
+      "stigmer.ai/kept": "true",
+      "stigmer.ai/removed": "true",
+    };
+    const requested = {
+      "stigmer.ai/kept": "true", // echo
+      "stigmer.ai/new": "true", // introduction
+      "stigmer.ai/changed": "x", // introduction (absent in stored)
+      ordinary: "fine",
+    };
+    expect(reservedLabelMutations(stored, requested)).toEqual([
+      "stigmer.ai/changed",
+      "stigmer.ai/new",
+    ]);
+  });
+});
+
+describe("GuardReservedLabels", () => {
+  it("rejects an introduction with the byte-pinned copy when denied", async () => {
+    const step = newGuardReservedLabelsStep<typeof AgentSchema>(denying());
+    const error = await step
+      .execute(agentCtx({ "stigmer.ai/default-agent": "true" }))
+      ?.catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.InvalidArgument);
+    expect((error as ConnectError).rawMessage).toBe(
+      "Labels in the reserved 'stigmer.ai/' namespace are platform-managed " +
+        "and cannot be set or changed by this request: " +
+        "stigmer.ai/default-agent. Stored reserved labels may be echoed " +
+        "back unchanged or removed.",
+    );
+  });
+
+  it("consults the platform-scoped operator check lazily", async () => {
+    const observed: AuthzCheck[] = [];
+    const step = newGuardReservedLabelsStep<typeof AgentSchema>(
+      denying(observed),
+    );
+    // No reserved mutation: no check at all.
+    await step.execute(agentCtx({ ordinary: "fine" }));
+    expect(observed).toEqual([]);
+    // A mutation consults exactly the operator capability.
+    await step
+      .execute(agentCtx({ "stigmer.ai/x": "1" }))
+      ?.catch(() => undefined);
+    expect(observed).toEqual([
+      {
+        permission: IamPermission.can_write_reserved_labels,
+        resourceKind: ApiResourceKind.platform,
+        resourceId: "stigmer",
+      },
+    ]);
+  });
+
+  it("the permissive default allows — OSS behavior byte-identical", async () => {
+    const step = newGuardReservedLabelsStep<typeof AgentSchema>(
+      newPermissiveSingleTeamAuthorizer(),
+    );
+    await expect(
+      Promise.resolve(step.execute(agentCtx({ "stigmer.ai/x": "1" }))),
+    ).resolves.toBeUndefined();
+  });
+
+  it("echoes of stored reserved labels pass on updates", async () => {
+    const step = newGuardReservedLabelsStep<typeof AgentSchema>(denying());
+    const ctx = agentCtx({ "stigmer.ai/default-agent": "true" });
+    ctx.set(
+      EXISTING_RESOURCE_KEY,
+      create(AgentSchema, {
+        metadata: { labels: { "stigmer.ai/default-agent": "true" } },
+      }),
+    );
+    await expect(Promise.resolve(step.execute(ctx))).resolves.toBeUndefined();
+  });
+
+  it("the Environment personal-label client contract passes", async () => {
+    const step = newGuardReservedLabelsStep<typeof EnvironmentSchema>(
+      denying(),
+    );
+    const ctx = new RequestContext(
+      EnvironmentSchema,
+      create(EnvironmentSchema, {
+        metadata: { labels: { "stigmer.ai/personal": "true" } },
+      }),
+      USER,
+      ApiResourceKind.environment,
+    );
+    await expect(Promise.resolve(step.execute(ctx))).resolves.toBeUndefined();
+  });
+
+  it("internal callers skip — server-composed requests stamp by design", async () => {
+    const step = newGuardReservedLabelsStep<typeof AgentSchema>(denying());
+    const ctx = agentCtx(
+      { "stigmer.ai/default-instance": "true" },
+      { identityId: "internal", callerClass: "internal", issuer: "", rawToken: "" },
+    );
+    await expect(Promise.resolve(step.execute(ctx))).resolves.toBeUndefined();
+  });
+});

--- a/backend/services/stigmer-server/src/pipeline/steps/__tests__/visibility-gates.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/__tests__/visibility-gates.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Pins the PUBLIC-visibility operator gates (C2 Stage 3, the Java
+ * PublicVisibilityEscalationPolicy port): the create door fires only on a
+ * new state declaring PUBLIC, the update door only on an ESCALATION to
+ * public (re-asserting stored public passes), both answer the Java deny
+ * copy on denial and pass under the permissive default (OSS
+ * byte-identity), internal callers skip, and a missing loaded target is
+ * a loud wiring fault.
+ */
+import { describe, expect, it } from "vitest";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import { UpdateVisibilityInputSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import type { Authorizer, AuthzCheck } from "../../../extensions/authorizer.js";
+import type { CallerIdentity } from "../../../extensions/identity.js";
+import { RequestContext } from "../../request-context.js";
+import { newPermissiveSingleTeamAuthorizer } from "../authorize.js";
+import {
+  newAuthorizeVisibilityTransitionStep,
+  newGuardPublicVisibilityStep,
+  PUBLIC_VISIBILITY_DENY_MESSAGE,
+} from "../visibility-gates.js";
+
+const USER: CallerIdentity = {
+  identityId: "ida_alice",
+  callerClass: "user",
+  issuer: "stigmer",
+  rawToken: "tok",
+};
+
+const TARGET_KEY = "updateVisibilityAgent";
+
+function denying(observed?: AuthzCheck[]): Authorizer {
+  return {
+    authorize: (_caller, check) => {
+      observed?.push(check);
+      return Promise.resolve({ kind: "deny", reason: "" });
+    },
+  };
+}
+
+function createCtx(
+  visibility: ApiResourceVisibility,
+): RequestContext<typeof AgentSchema> {
+  return new RequestContext(
+    AgentSchema,
+    create(AgentSchema, { metadata: { name: "a", visibility } }),
+    USER,
+    ApiResourceKind.agent,
+  );
+}
+
+type UvDesc = typeof AgentCommandController.method.updateVisibility.input;
+
+function updateCtx(
+  requested: ApiResourceVisibility,
+  stored: ApiResourceVisibility | undefined,
+): RequestContext<UvDesc> {
+  const ctx = new RequestContext(
+    AgentCommandController.method.updateVisibility.input,
+    create(UpdateVisibilityInputSchema, {
+      resourceId: "agt_1",
+      visibility: requested,
+    }),
+    USER,
+    ApiResourceKind.agent,
+  );
+  if (stored !== undefined) {
+    ctx.set(
+      TARGET_KEY,
+      create(AgentSchema, { metadata: { visibility: stored } }),
+    );
+  }
+  return ctx;
+}
+
+describe("GuardPublicVisibility (the create door)", () => {
+  it("denies a PUBLIC create for non-operators with the Java copy", async () => {
+    const step = newGuardPublicVisibilityStep<typeof AgentSchema>(denying());
+    const error = await step
+      .execute(createCtx(ApiResourceVisibility.visibility_public))
+      ?.catch((e: unknown) => e);
+    expect((error as ConnectError).code).toBe(Code.PermissionDenied);
+    expect((error as ConnectError).rawMessage).toBe(
+      PUBLIC_VISIBILITY_DENY_MESSAGE,
+    );
+  });
+
+  it("non-public creates never reach the Authorizer (the lazy contract)", async () => {
+    const observed: AuthzCheck[] = [];
+    const step = newGuardPublicVisibilityStep<typeof AgentSchema>(
+      denying(observed),
+    );
+    await step.execute(createCtx(ApiResourceVisibility.visibility_org));
+    expect(observed).toEqual([]);
+  });
+
+  it("the permissive default allows public creates (OSS byte-identity)", async () => {
+    const step = newGuardPublicVisibilityStep<typeof AgentSchema>(
+      newPermissiveSingleTeamAuthorizer(),
+    );
+    await expect(
+      Promise.resolve(
+        step.execute(createCtx(ApiResourceVisibility.visibility_public)),
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("AuthorizeVisibilityTransition (the update door)", () => {
+  it("denies escalation to public with the operator check", async () => {
+    const observed: AuthzCheck[] = [];
+    const step = newAuthorizeVisibilityTransitionStep<UvDesc>(
+      TARGET_KEY,
+      denying(observed),
+    );
+    const error = await step
+      .execute(
+        updateCtx(
+          ApiResourceVisibility.visibility_public,
+          ApiResourceVisibility.visibility_org,
+        ),
+      )
+      ?.catch((e: unknown) => e);
+    expect((error as ConnectError).code).toBe(Code.PermissionDenied);
+    expect((error as ConnectError).rawMessage).toBe(
+      PUBLIC_VISIBILITY_DENY_MESSAGE,
+    );
+    expect(observed).toEqual([
+      {
+        permission: IamPermission.can_set_public_visibility,
+        resourceKind: ApiResourceKind.platform,
+        resourceId: "stigmer",
+      },
+    ]);
+  });
+
+  it("re-asserting a stored PUBLIC is not an escalation", async () => {
+    const step = newAuthorizeVisibilityTransitionStep<UvDesc>(
+      TARGET_KEY,
+      denying(),
+    );
+    await expect(
+      Promise.resolve(
+        step.execute(
+          updateCtx(
+            ApiResourceVisibility.visibility_public,
+            ApiResourceVisibility.visibility_public,
+          ),
+        ),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("non-public targets never reach the Authorizer", async () => {
+    const observed: AuthzCheck[] = [];
+    const step = newAuthorizeVisibilityTransitionStep<UvDesc>(
+      TARGET_KEY,
+      denying(observed),
+    );
+    await step.execute(
+      updateCtx(
+        ApiResourceVisibility.visibility_org,
+        ApiResourceVisibility.visibility_public,
+      ),
+    );
+    expect(observed).toEqual([]);
+  });
+
+  it("a missing loaded target is a loud wiring fault, never a silent pass", async () => {
+    const step = newAuthorizeVisibilityTransitionStep<UvDesc>(
+      TARGET_KEY,
+      denying(),
+    );
+    const error = await step
+      .execute(updateCtx(ApiResourceVisibility.visibility_public, undefined))
+      ?.catch((e: unknown) => e);
+    expect((error as ConnectError).code).toBe(Code.Internal);
+  });
+});

--- a/backend/services/stigmer-server/src/pipeline/steps/authorization-tuples.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/authorization-tuples.ts
@@ -47,11 +47,31 @@ import type {
 import type { Logger } from "../../boot/logger.js";
 import type { CallerIdentity } from "../../extensions/identity.js";
 import type {
+  DefaultInstanceLinkedEvent,
   ResolvedParentLink,
   ResourceAuthorizationLifecycle,
   ResourceCreatedEvent,
   VisibilityTupleShape,
 } from "../../extensions/resource-authorization.js";
+
+/**
+ * Fires the driver's default-instance link event (C2 Stage 3 — the
+ * default_of invariant). Called by the pointer-persist sites — every
+ * flow that writes a blueprint's `status.defaultInstanceId` — AFTER the
+ * pointer lands, so the tuple exists iff the pointer names the instance.
+ * No driver (or a driver without the optional method) = no-op — OSS
+ * behavior byte-identical. Synchronous: a throw fails the request; the
+ * persisted pointer survives and a retry converges (idempotent write).
+ */
+export async function notifyDefaultInstanceLinked(
+  lifecycle: ResourceAuthorizationLifecycle | undefined,
+  event: DefaultInstanceLinkedEvent,
+): Promise<void> {
+  if (lifecycle?.onDefaultInstanceLinked === undefined) {
+    return;
+  }
+  await lifecycle.onDefaultInstanceLinked(event);
+}
 import { getKindEnum, getKindMeta, getKindName } from "../apiresource-meta.js";
 import { internalError } from "../errors.js";
 import type { PipelineStep } from "../pipeline.js";

--- a/backend/services/stigmer-server/src/pipeline/steps/guard-memory-capture.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/guard-memory-capture.ts
@@ -1,0 +1,77 @@
+/**
+ * GuardMemoryCapture — the memory create chain's capture-eligibility gate
+ * (C2 Stage 3D; the Java MemoryCreateHandler's first gate, DD-002 D4 as
+ * amended): memory may only be captured for a FIRST-PARTY HUMAN OPERATOR.
+ * Machine accounts and every minted-credential lane — PlatformClient user
+ * tokens, guest embeds, channel senders, schedule runs — stay refused;
+ * "the label is not authorization; the server refuses."
+ *
+ * The credential class is read from the VERIFIED token's own claims
+ * (position 1 verified it; decoding here is a read of trusted state):
+ * every Stigmer-minted non-first-party credential carries the
+ * `platform_client_id` claim (StigmerJwtIssuer stamps it on user, guest,
+ * channel, and schedule tokens alike), so its presence IS the exclusion
+ * the Java RequestCallerIdentity.isFirstPartyHumanOperator computes.
+ *
+ * OSS byte-identity: trusted-local callers carry no token and OIDC
+ * console logins carry no platform_client_id claim — the step admits
+ * both, so the single-user posture is unchanged (proven by the rosters).
+ *
+ * Known refinement, recorded: Java additionally admits the remember
+ * tool's SESSION-SCOPED sandbox credential. Runner credentials verify
+ * through their own lane and carry no platform_client_id, so they pass
+ * this gate; the session-bound-only narrowing rides the sandbox
+ * credential work (C4's lane) where the session binding is expressible.
+ */
+import type { DescMessage } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+
+import type { PipelineStep } from "../pipeline.js";
+import type { RequestContext } from "../request-context.js";
+
+/** The Java MemoryPolicy.MEMORY_CAPTURE_CALLER_MESSAGE, byte-pinned. */
+export const MEMORY_CAPTURE_CALLER_MESSAGE =
+  "memory can only be captured for a first-party human operator";
+
+export function newGuardMemoryCaptureStep<
+  Desc extends DescMessage,
+>(): PipelineStep<Desc> {
+  return {
+    name: "GuardMemoryCapture",
+    execute(ctx: RequestContext<Desc>): void {
+      const caller = ctx.callerIdentity;
+      if (caller.callerClass === "internal" || caller.origin === "in-process") {
+        // Server-composed traversals are not capture requests from a
+        // credential; the entry-point request already passed the gate.
+        return;
+      }
+      if (
+        caller.callerClass === "machine" ||
+        carriesPlatformClientClaim(caller.rawToken)
+      ) {
+        throw new ConnectError(
+          MEMORY_CAPTURE_CALLER_MESSAGE,
+          Code.PermissionDenied,
+        );
+      }
+    },
+  };
+}
+
+function carriesPlatformClientClaim(rawToken: string): boolean {
+  const segments = rawToken.split(".");
+  if (segments.length !== 3) {
+    return false; // not a JWT — the trusted-local no-token posture
+  }
+  try {
+    const payload = JSON.parse(
+      Buffer.from(segments[1], "base64url").toString("utf8"),
+    ) as { platform_client_id?: unknown };
+    return (
+      typeof payload.platform_client_id === "string" &&
+      payload.platform_client_id !== ""
+    );
+  } catch {
+    return false;
+  }
+}

--- a/backend/services/stigmer-server/src/pipeline/steps/guard-reserved-labels.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/guard-reserved-labels.ts
@@ -1,0 +1,155 @@
+/**
+ * GuardReservedLabels — the write-boundary guard for the platform-reserved
+ * `stigmer.ai/*` label namespace (the Java GuardReservedLabelsStep port,
+ * cloud#320/#386; C2 Stage 3, 20260827.10).
+ *
+ * Reserved labels carry platform semantics — the motivating one is
+ * `stigmer.ai/default-agent`, which the default-agent resolution reads
+ * GLOBALLY (label + visibility_public), so a tenant labeling its own
+ * public agent would enter every organization's default-agent candidate
+ * set. Only rejecting the write closes that.
+ *
+ * Behavior (the Java matrix verbatim):
+ *   - ECHOES pass — clients read-modify-write whole resources, so a
+ *     stored reserved label legitimately comes back on honest updates.
+ *   - REMOVALS pass — dropping a reserved label only shrinks what it
+ *     granted (de-escalation, and the operator cleanup path).
+ *   - INTRODUCTIONS and CHANGES reject with INVALID_ARGUMENT (the
+ *     cloud#229 boundary doctrine: server-reserved sentinels are not
+ *     accepted from clients) — unless the caller holds
+ *     `can_write_reserved_labels` on `platform:stigmer`, consulted
+ *     LAZILY through the one composed Authorizer, so normal writes pay
+ *     no authorization round-trip. The OSS permissive default allows —
+ *     the local posture keeps today's behavior byte-identically; the
+ *     cloud's FGA Authorizer supplies the operator gate.
+ *   - INTERNAL callers pass (the in-process chain's own composed
+ *     requests — default-instance factories, managed environments; the
+ *     TS rendering of Java's skipAuthorization + isInProcessCall arms).
+ *   - PER-KIND CLIENT CONTRACTS pass: `stigmer.ai/personal` on
+ *     Environment, which the console legitimately sends on create — the
+ *     one allowlist entry, kept here with the doctrine so widening it is
+ *     one reviewable diff.
+ *   - LABELS only, deliberately not annotations (annotations carry no
+ *     resolution or authorization semantics).
+ *
+ * Placement: after BuildNewState/BuildUpdateState — the step inspects the
+ * state that will persist, and update chains have LoadExisting's stored
+ * labels for echo detection. The infrastructure-failure arm answers a
+ * sanitized INTERNAL (the TS store-fault doctrine, #478) where Java
+ * echoes raw exception text — an unpinned outage-lane difference.
+ */
+import { Code, ConnectError } from "@connectrpc/connect";
+import type { DescMessage } from "@bufbuild/protobuf";
+
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import type { Authorizer } from "../../extensions/authorizer.js";
+import { internalError } from "../errors.js";
+import type { PipelineStep } from "../pipeline.js";
+import type { RequestContext } from "../request-context.js";
+import { EXISTING_RESOURCE_KEY } from "./load-existing.js";
+import { metadataOf } from "./shapes.js";
+
+/** The platform-reserved label key namespace (SystemManagedLabels). */
+export const RESERVED_LABEL_PREFIX = "stigmer.ai/";
+
+/**
+ * The reserved keys clients may legitimately write per kind — the one
+ * entry today is the personal-environment marker the console sends on
+ * create (the Java CLIENT_CONTRACT_ALLOWLIST verbatim).
+ */
+const CLIENT_CONTRACT_ALLOWLIST: ReadonlyMap<
+  ApiResourceKind,
+  ReadonlySet<string>
+> = new Map([
+  [ApiResourceKind.environment, new Set(["stigmer.ai/personal"])],
+]);
+
+/**
+ * The reserved keys `requested` would introduce or change relative to
+ * `stored` — the guard's predicate (SystemManagedLabels
+ * reservedLabelMutations). Removals and echoes are not mutations.
+ */
+export function reservedLabelMutations(
+  stored: Readonly<Record<string, string>>,
+  requested: Readonly<Record<string, string>>,
+): ReadonlyArray<string> {
+  const mutations: string[] = [];
+  for (const [key, value] of Object.entries(requested)) {
+    if (key.startsWith(RESERVED_LABEL_PREFIX) && stored[key] !== value) {
+      mutations.push(key);
+    }
+  }
+  return mutations.sort();
+}
+
+export function newGuardReservedLabelsStep<Desc extends DescMessage>(
+  authorizer: Authorizer,
+): PipelineStep<Desc> {
+  return {
+    name: "GuardReservedLabels",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      if (ctx.callerIdentity.callerClass === "internal") {
+        return;
+      }
+      const requested = metadataOf(ctx.newState)?.labels ?? {};
+      const existing = ctx.get(EXISTING_RESOURCE_KEY);
+      const stored =
+        existing === undefined
+          ? {}
+          : (metadataOf(existing as typeof ctx.newState)?.labels ?? {});
+
+      const allowlist =
+        CLIENT_CONTRACT_ALLOWLIST.get(ctx.apiResourceKind) ?? new Set();
+      const mutations = reservedLabelMutations(stored, requested).filter(
+        (key) => !allowlist.has(key),
+      );
+      if (mutations.length === 0) {
+        return;
+      }
+
+      // Lazy operator check — only a request that actually mutates a
+      // reserved key ever reaches the Authorizer.
+      let decision;
+      try {
+        decision = await authorizer.authorize(ctx.callerIdentity, {
+          permission: IamPermission.can_write_reserved_labels,
+          resourceKind: ApiResourceKind.platform,
+          resourceId: "stigmer",
+        });
+      } catch (error) {
+        throw reservedLabelCheckFailure(error);
+      }
+      switch (decision.kind) {
+        case "allow":
+          return;
+        case "deny":
+        case "not-found":
+          throw new ConnectError(
+            `Labels in the reserved '${RESERVED_LABEL_PREFIX}' namespace ` +
+              "are platform-managed and cannot be set or changed by this " +
+              `request: ${mutations.join(", ")}. Stored reserved labels ` +
+              "may be echoed back unchanged or removed.",
+            Code.InvalidArgument,
+          );
+        case "unavailable":
+          throw reservedLabelCheckFailure(decision.cause);
+        default: {
+          const exhaustive: never = decision;
+          throw reservedLabelCheckFailure(
+            new Error(`unknown decision ${JSON.stringify(exhaustive)}`),
+          );
+        }
+      }
+    },
+  };
+}
+
+/** Authorization infrastructure failure: fail closed, sanitized (#478). */
+function reservedLabelCheckFailure(error: unknown): ConnectError {
+  return internalError(
+    error instanceof Error ? error : new Error(String(error)),
+    "reserved-label validation could not be completed",
+  );
+}

--- a/backend/services/stigmer-server/src/pipeline/steps/guard-reserved-labels.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/guard-reserved-labels.ts
@@ -90,7 +90,15 @@ export function newGuardReservedLabelsStep<Desc extends DescMessage>(
   return {
     name: "GuardReservedLabels",
     async execute(ctx: RequestContext<Desc>): Promise<void> {
-      if (ctx.callerIdentity.callerClass === "internal") {
+      if (
+        ctx.callerIdentity.callerClass === "internal" ||
+        ctx.callerIdentity.origin === "in-process"
+      ) {
+        // Server-composed request (the Java isInProcessCall arm,
+        // cloud#386): the trust decision was made by the service code
+        // that built it — default-instance factories stamp reserved
+        // labels by design, even when the call propagates the user's
+        // identity for attribution (ruling R5).
         return;
       }
       const requested = metadataOf(ctx.newState)?.labels ?? {};

--- a/backend/services/stigmer-server/src/pipeline/steps/visibility-gates.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/visibility-gates.ts
@@ -1,0 +1,171 @@
+/**
+ * The PUBLIC-visibility operator gates — the two write doors a resource
+ * can become public through, both consulting the ONE composed Authorizer
+ * with the same platform-scoped check (the Java
+ * PublicVisibilityEscalationPolicy port; C2 Stage 3, 20260827.10).
+ *
+ * PUBLIC is the only level that crosses every org boundary (one flip
+ * lists a resource in every tenant's cross-org catalog), so entering it
+ * is a curation decision: the owner requests, the platform team grants.
+ * The answer is `can_set_public_visibility` on `platform:stigmer` — a
+ * named operator capability, never a bare operator lookup.
+ *
+ *   - GuardPublicVisibility: the CREATE door, in the create chains of
+ *     the kinds whose VisibilityConfig supports PUBLIC (agent, workflow,
+ *     mcp_server, agent_instance, workflow_instance). After
+ *     BuildNewState — it inspects the state that will persist — which
+ *     keeps the pinned INVALID_ARGUMENT level-support rejections (the
+ *     earlier ValidateVisibility) their precedence over this
+ *     PERMISSION_DENIED.
+ *   - AuthorizeVisibilityTransition: the UPDATE door, in every
+ *     updateVisibility chain after ValidateVisibilityUpdate (the pinned
+ *     FAILED_PRECONDITION default-instance rejection keeps precedence,
+ *     the Java ordering the conformance suite depends on). Gates only
+ *     the ESCALATION to public (stored level is anything else).
+ *
+ * Both run LAZILY — only requests that actually involve the PUBLIC level
+ * reach the Authorizer — and both pass for internal callers (server-side
+ * flows publish platform resources by design). The OSS permissive
+ * default allows, so the local posture keeps today's behavior
+ * byte-identically; the cloud's FGA Authorizer supplies the gate.
+ *
+ * DELIBERATE partial port, recorded owner-visibly (Stage-3 execution
+ * record): Java's transition step additionally lets operators WITHOUT
+ * resource can_edit publish and take down (its updateVisibility chains
+ * authorize post-load, transition-aware); this edition's position-1
+ * Authorize enforces can_edit on updateVisibility before any step here
+ * runs, so those operator-without-edit lanes require can_edit until the
+ * Stage-4 chain disposition addresses them. No conformance lane pins
+ * them.
+ */
+import { Code, ConnectError } from "@connectrpc/connect";
+import type { DescMessage } from "@bufbuild/protobuf";
+
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import type { UpdateVisibilityInput } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import type {
+  Authorizer,
+  AuthzDecision,
+} from "../../extensions/authorizer.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import { internalError } from "../errors.js";
+import type { PipelineStep } from "../pipeline.js";
+import type { RequestContext } from "../request-context.js";
+import { metadataOf } from "./shapes.js";
+
+/**
+ * The denial callers see at both doors (the Java policy copy verbatim).
+ * Deliberately not byte-pinned by the OSS conformance suite; the cloud
+ * gate itself is recorded via the clientPublicVisibilityWrites flag.
+ */
+export const PUBLIC_VISIBILITY_DENY_MESSAGE =
+  "Public visibility is granted by the platform team. " +
+  "Ask a platform operator to publish this resource.";
+
+/** The CREATE door: a new state declaring PUBLIC needs the operator grant. */
+export function newGuardPublicVisibilityStep<Desc extends DescMessage>(
+  authorizer: Authorizer,
+): PipelineStep<Desc> {
+  return {
+    name: "GuardPublicVisibility",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      if (ctx.callerIdentity.callerClass === "internal") {
+        return;
+      }
+      if (
+        metadataOf(ctx.newState)?.visibility !==
+        ApiResourceVisibility.visibility_public
+      ) {
+        return;
+      }
+      await requireOperatorMaySetPublic(authorizer, ctx.callerIdentity);
+    },
+  };
+}
+
+/**
+ * The UPDATE door: escalation to PUBLIC (the stored level is anything
+ * else) needs the operator grant. Reads the loaded target from the
+ * chain's own context key (every updateVisibility chain stores it —
+ * the RecordVisibilityBeforeUpdate pattern).
+ */
+export function newAuthorizeVisibilityTransitionStep<
+  Desc extends DescMessage,
+>(targetKey: string, authorizer: Authorizer): PipelineStep<Desc> {
+  return {
+    name: "AuthorizeVisibilityTransition",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      if (ctx.callerIdentity.callerClass === "internal") {
+        return;
+      }
+      const requested = (ctx.input as unknown as UpdateVisibilityInput)
+        .visibility;
+      if (requested !== ApiResourceVisibility.visibility_public) {
+        return;
+      }
+      const target = ctx.get(targetKey);
+      if (target === undefined) {
+        // Wiring error, not a user error: without the loaded target there
+        // is no stored level, and a gate that silently passes un-guards
+        // the boundary it exists to protect.
+        throw internalError(
+          new Error(
+            "AuthorizeVisibilityTransition ran without a loaded target — step must be placed after the load step",
+          ),
+          "visibility authorization requires the loaded resource",
+        );
+      }
+      const stored = metadataOf(target as typeof ctx.newState)?.visibility;
+      if (stored === ApiResourceVisibility.visibility_public) {
+        return; // Re-asserting a stored PUBLIC is not an escalation.
+      }
+      await requireOperatorMaySetPublic(authorizer, ctx.callerIdentity);
+    },
+  };
+}
+
+/** The single owner of "may this caller set public?" — both doors call it. */
+async function requireOperatorMaySetPublic(
+  authorizer: Authorizer,
+  caller: CallerIdentity,
+): Promise<void> {
+  let decision: AuthzDecision;
+  try {
+    decision = await authorizer.authorize(caller, {
+      permission: IamPermission.can_set_public_visibility,
+      resourceKind: ApiResourceKind.platform,
+      resourceId: "stigmer",
+    });
+  } catch (error) {
+    throw publicVisibilityCheckFailure(error);
+  }
+  switch (decision.kind) {
+    case "allow":
+      return;
+    case "deny":
+    case "not-found":
+      throw new ConnectError(
+        PUBLIC_VISIBILITY_DENY_MESSAGE,
+        Code.PermissionDenied,
+      );
+    case "unavailable":
+      throw publicVisibilityCheckFailure(decision.cause);
+    default: {
+      const exhaustive: never = decision;
+      throw publicVisibilityCheckFailure(
+        new Error(`unknown decision ${JSON.stringify(exhaustive)}`),
+      );
+    }
+  }
+}
+
+/** Authorization infrastructure failure: fail closed, sanitized (#478). */
+function publicVisibilityCheckFailure(error: unknown): ConnectError {
+  return internalError(
+    error instanceof Error ? error : new Error(String(error)),
+    "public-visibility authorization could not be completed",
+  );
+}

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -42,6 +42,7 @@ import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_inf
 
 import {
   ArtifactStorageNotFoundError,
+  callerIdentityOf,
   composeServer,
   createLogger,
   InvalidTokenError,
@@ -323,8 +324,13 @@ const channelRuntime: ChannelRuntime = {
 
 const registerBillingService = (router: ConnectRouter): void => {
   router.service(BillingQueryController, {
-    getBillingAccount: (input) =>
-      create(BillingAccountSchema, { orgId: input.orgId }),
+    // The caller-identity read idiom for extension services (C2 Stage 3):
+    // the identity stamped at chain position 1 is readable from the
+    // HandlerContext through the ONE exported accessor.
+    getBillingAccount: (input, ctx) => {
+      void callerIdentityOf(ctx).callerClass;
+      return create(BillingAccountSchema, { orgId: input.orgId });
+    },
   });
 };
 


### PR DESCRIPTION
## Summary
The OSS half of C2's Stage 3 (IAM lifecycle extension): the shared chain gates and seams the cloud edition's IAM domain rides — PUBLIC-visibility operator gates, the reserved-label write guard, request-origin in-process caller propagation (ruling R5), the default_of lifecycle event, the memory capture-eligibility gate, and execution-context create authorization for external callers. Every gate consults the ONE composed Authorizer, so the OSS single-user posture is byte-identical (permissive authorizer allows everything).

## Context
The cloud conformance readout pinned twelve Stage-3 markers whose root causes live in shared chains: PUBLIC visibility escalation and reserved stigmer.ai/* labels were operator-gated in Java by generic steps; in-process creations propagated the ORIGINAL caller (owner attribution — the confirmed root cause of the default-instance trio); default instances carry a structural default_of tuple instead of enum visibility tuples; memory capture excludes minted credential classes (DD-002 D4); and execution-context create gates external callers in-handler (stigmer-cloud#297).

## Changes
- **Visibility gates**: `newGuardPublicVisibilityStep` + `newAuthorizeVisibilityTransitionStep` (platform-scoped `can_set_public_visibility`) spliced into the blueprint/instance/environment chains.
- **Reserved-label guard**: `newGuardReservedLabelsStep` (`can_write_reserved_labels`) across all resource-carrying chains.
- **Caller propagation (R5)**: `CallerIdentity` gains `origin`; request-origin in-process calls propagate the original caller via the `x-stigmer-inprocess-caller` header (stripped for external requests at the verifier chain); the `asCaller` adapters and execution-time instance/session creators ride it.
- **default_of seam**: `ResourceAuthorizationLifecycle.onDefaultInstanceLinked` fired at every `status.defaultInstanceId` persistence point (agent, workflow, session, both execution create chains).
- **Memory capture gate**: `newGuardMemoryCaptureStep` — machine-class callers and platform_client_id-carrying tokens refuse with the byte-pinned MemoryPolicy copy.
- **EC create authorization**: `newAuthorizeExecutionContextCreateStep` — external callers need `can_create_execution_in` on the org, ordered before the duplicate check.
- **Extension exports**: `generateSlug`, the R5 propagation surface (`encodeInProcessCaller`, `IN_PROCESS_CALLER_HEADER`), `callerIdentityOf` (deduplicated with C4's request-idiom block at the main sync).

## Implementation notes
- Gates are Authorizer-expressible by design (the ruled memory-gate precedent): no new extension point, no new driver.
- Propagation is an explicit per-call header value — never ambient state (DD-007's explicit-threading doctrine); `internal` remains the identity for daemon-origin calls.

## Breaking changes
- None (OSS behavior proven unchanged).

## Test plan
- Server suite: 2005 passed / 56 skipped.
- Conformance rosters byte-identical with every gate live: sqlite 498, postgres 498 (single-writer), execution 160.
- Cloud-side proof: the composition's conformance run went 455/12/36 → 464/3/36 with these seams + the extension domains (the remaining 3 are C3's AgentChannel pins and the Stage-4 zero-shape ruling).

## Risks
- Low: every new step no-ops under the permissive authorizer or keys on claims only minted credentials carry. Rollback = revert; no schema or wire-shape changes.

## Checklist
- [x] Tests added/updated
- [x] Backward compatible

Made with [Cursor](https://cursor.com)