### PR TITLE
feat(backend/stigmer-server): add the retention sweep index to the Postgres chain (v2) (C4 Stage 4)

### DIFF
--- a/backend/services/stigmer-server/src/store/postgres/__tests__/migrations.test.ts
+++ b/backend/services/stigmer-server/src/store/postgres/__tests__/migrations.test.ts
@@ -1,7 +1,8 @@
 /**
  * Pins the Postgres migration chain (DD-010 §3, independent v1): fresh
  * replay creates the full schema and records the version, reopen is
- * idempotent, and concurrent first boots serialize on the advisory lock
+ * idempotent, a mid-chain database resumes (v1 → v2 picks up the sweep
+ * index), and concurrent first boots serialize on the advisory lock
  * instead of racing the chain — the multi-instance failure class sqlite's
  * single-file lock never had.
  *
@@ -67,6 +68,47 @@ describe.skipIf(testDatabaseAdminUrl() === undefined)(
           "signal_dedupe",
           "workflow_execution_events",
         ]);
+
+        // v2's index: the retention sweep's scan (see migrateToV2).
+        const sweepIndex = await client.query(
+          `SELECT indexname FROM pg_indexes
+           WHERE tablename = 'workflow_execution_events'
+             AND indexname = 'idx_wfee_created_at'`,
+        );
+        expect(sweepIndex.rowCount, "the v2 sweep index exists").toBe(1);
+      } finally {
+        await client.end();
+      }
+    });
+
+    it("a v1 database resumes the chain on reopen: v2's sweep index arrives", async () => {
+      const store = await PostgresStore.open(db.databaseUrl);
+      await store.close();
+
+      // Rewind to a v1 database: drop exactly what v2 created and its
+      // version row — the state any pre-v2 deployment is actually in.
+      const client = new pg.Client({ connectionString: db.databaseUrl });
+      await client.connect();
+      try {
+        await client.query(`DROP INDEX idx_wfee_created_at`);
+        await client.query(`DELETE FROM schema_version WHERE version = 2`);
+
+        const reopened = await PostgresStore.open(db.databaseUrl);
+        await reopened.close();
+
+        const sweepIndex = await client.query(
+          `SELECT indexname FROM pg_indexes
+           WHERE tablename = 'workflow_execution_events'
+             AND indexname = 'idx_wfee_created_at'`,
+        );
+        expect(sweepIndex.rowCount, "reopen applied v2 mid-chain").toBe(1);
+
+        const version = await client.query(
+          `SELECT COALESCE(MAX(version), 0) AS version FROM schema_version`,
+        );
+        expect(Number((version.rows[0] as { version: string }).version)).toBe(
+          CURRENT_SCHEMA_VERSION,
+        );
       } finally {
         await client.end();
       }

--- a/backend/services/stigmer-server/src/store/postgres/migrations.ts
+++ b/backend/services/stigmer-server/src/store/postgres/migrations.ts
@@ -39,9 +39,10 @@
 import type { PoolClient } from "pg";
 
 export const SCHEMA_VERSION_1 = 1;
+export const SCHEMA_VERSION_2 = 2;
 
 /** Target version for new databases. */
-export const CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_1;
+export const CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_2;
 
 /**
  * Advisory lock key for the migration chain. Arbitrary but stable 64-bit
@@ -70,7 +71,10 @@ export async function runMigrations(client: PoolClient): Promise<void> {
 
     const chain: ReadonlyArray<
       readonly [number, (client: PoolClient) => Promise<void>]
-    > = [[SCHEMA_VERSION_1, migrateToV1]];
+    > = [
+      [SCHEMA_VERSION_1, migrateToV1],
+      [SCHEMA_VERSION_2, migrateToV2],
+    ];
 
     for (const [version, migrate] of chain) {
       if (currentVersion < version) {
@@ -249,5 +253,26 @@ async function migrateToV1(client: PoolClient): Promise<void> {
     );
 
     CREATE INDEX idx_pending_oauth_state_created ON pending_oauth_state (created_at);
+  `);
+}
+
+/**
+ * v2: the retention sweep's scan on workflow_execution_events.
+ *
+ * The cloud composition's retention sweep (the C4 port of the Java
+ * platform.retention engine) deletes events older than the policy window
+ * with `created_at < cutoff` range scans; without this index every hourly
+ * pass would seq-scan the largest table in the schema. The Java edition
+ * built the identical index for the identical reason (V7's
+ * idx_wfee_occurred_at — "The retention sweep's scan"), and schedule_runs
+ * shipped v1 with idx_schedule_runs_prune under the same doctrine: a table
+ * whose rows expire carries the index its reaper needs (DD-003 "every
+ * query pattern has an index" — the pattern's owner being a cloud
+ * extension does not exempt it). The OSS server itself runs no sweep;
+ * the index is inert weight locally and load-bearing for the composition.
+ */
+async function migrateToV2(client: PoolClient): Promise<void> {
+  await client.query(`
+    CREATE INDEX idx_wfee_created_at ON workflow_execution_events (created_at);
   `);
 }


### PR DESCRIPTION
## Summary

- Postgres chain v2: `idx_wfee_created_at ON workflow_execution_events (created_at)` — the scan the cloud composition's retention sweep (the C4 port of the Java `platform.retention` engine) range-scans hourly. The Java edition built the identical index for the identical reason (V7's `idx_wfee_occurred_at`, commented "The retention sweep's scan"), and `schedule_runs` shipped v1 with `idx_schedule_runs_prune` under the same born-with doctrine: a table whose rows expire carries the index its reaper needs. The OSS server itself runs no sweep; the index is inert weight locally and load-bearing for the composition.
- Migration tests gain the index-presence pin and a mid-chain (v1 → v2) resume proof; the version assertions key off `CURRENT_SCHEMA_VERSION` and follow the bump.
- The SQLite chain deliberately does not mirror this (the Postgres chain header's own doctrine: the chains are independent).

## Verification

- `tsc --noEmit` clean; 2045 server units green (`TEST_DATABASE_URL` set, all Postgres suites exercised).
- Empty-extension byte-identity: all four local conformance rosters at main's counts — local 498, local-execution 160, local-postgres 498, local-postgres-execution 160 (Node 22.22.1).
- Paired cloud PR (retention port + M1 c4 wave) pins its submodule to this branch; this PR merges FIRST (the C1 precedent).

Made with [Cursor](https://cursor.com)