### PR TITLE
fix(backend/stigmer-server): construct workers through the manager's createWorker capability

### DIFF
--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -252,5 +252,18 @@ export type {
   ChannelRuntimeMessaging,
 } from "./domain/agentchannel/channel-runtime.js";
 
-// The worker factory types extension workers implement (§8).
-export type { WorkerFactory, WorkerFactoryDeps } from "./temporal/manager.js";
+// The worker factory seam extension workers implement (§8). Factories
+// construct workers ONLY through deps.createWorker — this package's
+// @temporalio/worker instance — so a composition never loads a second
+// native bridge for its extension workers (the finding-16 fix; see
+// WorkerFactoryDeps.createWorker in temporal/manager.ts).
+export type {
+  CreateWorkerOptions,
+  WorkerFactory,
+  WorkerFactoryDeps,
+  WorkerWorkflowSource,
+} from "./temporal/manager.js";
+// The SDK's pure-JS workflow bundler, re-exported so factories that
+// prebuild a shared bundle (the channel sweeps' pattern) need no runtime
+// dependency on @temporalio/worker of their own.
+export { bundleWorkflowCode } from "@temporalio/worker";

--- a/backend/services/stigmer-server/src/temporal/__tests__/manager.test.ts
+++ b/backend/services/stigmer-server/src/temporal/__tests__/manager.test.ts
@@ -1,6 +1,6 @@
 /**
- * TemporalManager lifecycle tests — pins the two panel findings plus the
- * availability posture:
+ * TemporalManager lifecycle tests — pins the two panel findings, the
+ * availability posture, and the worker-construction capability:
  *
  *   - close() racing an in-flight reconnect must NOT resurrect the
  *     manager (fresh dial discarded; no workers recreated; no hooks
@@ -10,25 +10,56 @@
  *     workers TRACKED so close() can stop them (an untracked poller
  *     lives forever — latent until #21/#22 add factories);
  *   - the Go availability parity: getClient() is undefined only until
- *     the first successful connect.
+ *     the first successful connect;
+ *   - deps.createWorker builds through THIS package's Worker.create with
+ *     the manager's connection, namespace, and codec chain pre-wired
+ *     (the finding-16 seam — factories never see the NativeConnection);
+ *   - a worker's run() rejection logs at ERROR with its queue identity
+ *     (a permanent death re-dies on every recreate while the worker
+ *     reports RUNNING — the log line is the only signal).
  *
- * The manager's private dial and the SDK's NativeConnection are stubbed
- * (module mock + private-seam override): the real connect path is proven
- * end-to-end by local-execution; these tests pin the manager's OWN
- * state machine, which only misbehaves in windows no live harness can
- * schedule deterministically.
+ * The manager's private dial and the SDK's NativeConnection/Worker.create
+ * are stubbed (module mock + private-seam override): the real connect
+ * path is proven end-to-end by local-execution; these tests pin the
+ * manager's OWN state machine and wiring, which only misbehave in windows
+ * no live harness can schedule deterministically.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { createLogger } from "../../boot/logger.js";
 import { TemporalManager, type WorkerFactory } from "../manager.js";
 
+const sdkSpy = vi.hoisted(() => ({
+  /** Options of every Worker.create call, in order. */
+  createCalls: [] as Record<string, unknown>[],
+  /** The connection object the mocked NativeConnection.connect returned last. */
+  lastConnection: undefined as unknown,
+}));
+
 vi.mock("@temporalio/worker", async (importOriginal) => {
   const original = await importOriginal<typeof import("@temporalio/worker")>();
   return {
     ...original,
     NativeConnection: {
-      connect: async () => ({ close: async () => {} }),
+      connect: async () => {
+        const connection = { close: async () => {} };
+        sdkSpy.lastConnection = connection;
+        return connection;
+      },
+    },
+    Worker: {
+      create: async (options: Record<string, unknown>) => {
+        sdkSpy.createCalls.push(options);
+        let release: (() => void) | undefined;
+        const done = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return {
+          options: { taskQueue: options["taskQueue"] },
+          run: () => done,
+          shutdown: () => release?.(),
+        };
+      },
     },
   };
 });
@@ -41,6 +72,8 @@ const silentLogger = createLogger({
 
 const managers: TemporalManager[] = [];
 afterEach(async () => {
+  sdkSpy.createCalls.length = 0;
+  sdkSpy.lastConnection = undefined;
   for (const manager of managers.splice(0)) {
     await manager.close();
   }
@@ -58,6 +91,7 @@ function fakeWorkerFactory(record: FakeWorkerRecord): WorkerFactory {
       release = resolve;
     });
     return {
+      options: { taskQueue: "fake-queue" },
       run: () => done,
       shutdown: () => {
         record.shutdowns++;
@@ -67,12 +101,20 @@ function fakeWorkerFactory(record: FakeWorkerRecord): WorkerFactory {
   };
 }
 
-function newManager(factories: WorkerFactory[]): TemporalManager {
+function newManager(
+  factories: WorkerFactory[],
+  options?: {
+    logger?: typeof silentLogger;
+    payloadCodecs?: ConstructorParameters<
+      typeof TemporalManager
+    >[0]["payloadCodecs"];
+  },
+): TemporalManager {
   const manager = new TemporalManager({
     hostPort: "127.0.0.1:1",
     namespace: "default",
-    logger: silentLogger,
-    payloadCodecs: [],
+    logger: options?.logger ?? silentLogger,
+    payloadCodecs: options?.payloadCodecs ?? [],
     workerFactories: factories,
   });
   managers.push(manager);
@@ -118,10 +160,20 @@ describe("TemporalManager close/reconnect race", () => {
     releaseDial!();
     await reconnectPromise;
 
-    expect(manager.isConnected(), "a closed manager must stay down").toBe(false);
-    expect(manager.getClient(), "the fresh client must be discarded").toBeUndefined();
-    expect(hookFired, "reconnect hooks must never fire after shutdown").toBe(false);
-    expect(freshConnection.closed, "the discarded dial's connection is closed").toBe(1);
+    expect(manager.isConnected(), "a closed manager must stay down").toBe(
+      false,
+    );
+    expect(
+      manager.getClient(),
+      "the fresh client must be discarded",
+    ).toBeUndefined();
+    expect(hookFired, "reconnect hooks must never fire after shutdown").toBe(
+      false,
+    );
+    expect(
+      freshConnection.closed,
+      "the discarded dial's connection is closed",
+    ).toBe(1);
     expect(record.shutdowns, "no workers may be created after close").toBe(0);
   });
 });
@@ -135,7 +187,10 @@ describe("TemporalManager worker tracking", () => {
         throw new Error("factory two exploded");
       },
     ]);
-    stubDial(manager, async () => ({ connection: { close: async () => {} }, client: {} }));
+    stubDial(manager, async () => ({
+      connection: { close: async () => {} },
+      client: {},
+    }));
 
     await manager.initialConnect();
     // startWorkers logs the factory failure as a warning (Go posture)…
@@ -156,10 +211,115 @@ describe("TemporalManager availability posture", () => {
     expect(manager.getClient()).toBeUndefined();
 
     const client = { marker: "client-1" };
-    stubDial(manager, async () => ({ connection: { close: async () => {} }, client }));
+    stubDial(manager, async () => ({
+      connection: { close: async () => {} },
+      client,
+    }));
     await manager.initialConnect();
 
     expect(manager.getClient()).toBe(client);
     expect(manager.isConnected()).toBe(true);
+  });
+});
+
+describe("TemporalManager createWorker capability (the finding-16 seam)", () => {
+  it("builds through this package's Worker.create with connection, namespace, and codecs pre-wired", async () => {
+    const fakeCodec = { encode: async () => [], decode: async () => [] };
+    const manager = newManager(
+      [
+        (deps) =>
+          deps.createWorker({
+            taskQueue: "capability-queue",
+            activities: { doThing: async () => {} },
+            workflows: { workflowsPath: "/tmp/workflows.js" },
+          }),
+      ],
+      { payloadCodecs: [fakeCodec] },
+    );
+    stubDial(manager, async () => ({
+      connection: { close: async () => {} },
+      client: {},
+    }));
+
+    await manager.initialConnect();
+    await manager.startWorkers();
+
+    expect(sdkSpy.createCalls).toHaveLength(1);
+    const created = sdkSpy.createCalls[0]!;
+    expect(
+      created["connection"],
+      "the worker must be bound to the manager's own NativeConnection",
+    ).toBe(sdkSpy.lastConnection);
+    expect(created["namespace"]).toBe("default");
+    expect(created["taskQueue"]).toBe("capability-queue");
+    expect(created["workflowsPath"]).toBe("/tmp/workflows.js");
+    expect(
+      created["dataConverter"],
+      "the decode-only codec chain must reach every worker (the choke point)",
+    ).toEqual({ payloadCodecs: [fakeCodec] });
+  });
+
+  it("omits dataConverter when no codecs are configured (the SQLite-local shape)", async () => {
+    const manager = newManager([
+      (deps) =>
+        deps.createWorker({
+          taskQueue: "codecless-queue",
+          activities: {},
+          workflows: { workflowBundle: { code: "bundled" } },
+        }),
+    ]);
+    stubDial(manager, async () => ({
+      connection: { close: async () => {} },
+      client: {},
+    }));
+
+    await manager.initialConnect();
+    await manager.startWorkers();
+
+    expect(sdkSpy.createCalls).toHaveLength(1);
+    const created = sdkSpy.createCalls[0]!;
+    expect("dataConverter" in created).toBe(false);
+    expect(created["workflowBundle"]).toEqual({ code: "bundled" });
+  });
+});
+
+describe("TemporalManager worker-death observability", () => {
+  it("logs a run() rejection at ERROR with the dead worker's queue identity", async () => {
+    const lines: string[] = [];
+    const capturingLogger = createLogger({
+      level: "error",
+      pretty: false,
+      write: (line) => {
+        lines.push(line);
+      },
+    });
+    const manager = newManager(
+      [
+        async () =>
+          ({
+            options: { taskQueue: "doomed-queue" },
+            run: () => Promise.reject(new Error("poller exploded")),
+            shutdown: () => {},
+          }) as unknown as Awaited<ReturnType<WorkerFactory>>,
+      ],
+      { logger: capturingLogger },
+    );
+    stubDial(manager, async () => ({
+      connection: { close: async () => {} },
+      client: {},
+    }));
+
+    await manager.initialConnect();
+    await manager.startWorkers();
+    // The rejection is handled asynchronously; drain the microtask queue.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const death = lines.find((line) =>
+      line.includes("Temporal worker stopped with error"),
+    );
+    expect(death, "the death must be logged").toBeDefined();
+    expect(death).toContain('"level":"error"');
+    expect(death).toContain('"task_queue":"doomed-queue"');
+    expect(death).toContain("poller exploded");
   });
 });

--- a/backend/services/stigmer-server/src/temporal/agentexecution/worker.ts
+++ b/backend/services/stigmer-server/src/temporal/agentexecution/worker.ts
@@ -19,8 +19,6 @@
  * brief #7 — the operative mode until #24 ships prebuilt bundles; the
  * prebuilt sibling is the hook it fills).
  */
-import { Worker } from "@temporalio/worker";
-
 import type { Logger } from "../../boot/logger.js";
 import type { AgentExecutionTemporalConfig } from "../../domain/agentexecution/temporal/config.js";
 import type { StreamBroker } from "../../domain/agentexecution/stream-broker.js";
@@ -49,7 +47,7 @@ export interface AgentExecutionWorkerDeps {
 export function newAgentExecutionWorkerFactory(
   deps: AgentExecutionWorkerDeps,
 ): WorkerFactory {
-  return async ({ nativeConnection, namespace, payloadCodecs, client }) => {
+  return async ({ createWorker, client }) => {
     const activities = createAgentExecutionActivities({
       store: deps.store,
       logger: deps.logger,
@@ -79,18 +77,16 @@ export function newAgentExecutionWorkerFactory(
       workflow_source: workflowSource.kind,
     });
 
-    return Worker.create({
-      connection: nativeConnection,
-      namespace,
+    // Connection, namespace, and the decode-only codec chain are the
+    // capability's concern (manager.ts's choke-point note) — the factory
+    // decides only queue, activities, and workflow source.
+    return createWorker({
       taskQueue: deps.temporalConfig.stigmerQueue,
       activities,
-      ...(workflowSource.kind === "prebuilt"
-        ? { workflowBundle: { codePath: workflowSource.codePath } }
-        : { workflowsPath: workflowSource.workflowsPath }),
-      // The decode-only codec chain: workflow tasks replay history
-      // containing runner-encrypted activity results (manager.ts's
-      // choke-point note).
-      ...(payloadCodecs.length > 0 ? { dataConverter: { payloadCodecs } } : {}),
+      workflows:
+        workflowSource.kind === "prebuilt"
+          ? { workflowBundle: { codePath: workflowSource.codePath } }
+          : { workflowsPath: workflowSource.workflowsPath },
     });
   };
 }

--- a/backend/services/stigmer-server/src/temporal/manager.ts
+++ b/backend/services/stigmer-server/src/temporal/manager.ts
@@ -33,13 +33,18 @@
  * health monitor swaps in a fresh client when the server returns.
  *
  * One choke point for payload decryption: the codecs are installed on the
- * client at dial AND handed to every worker factory (the TS SDK's
- * Worker.create takes its own dataConverter; Go workers inherit the
- * client's — same coverage, two installation sites, one source array).
+ * client at dial AND wired into every worker by the deps' createWorker
+ * capability (the TS SDK's Worker.create takes its own dataConverter; Go
+ * workers inherit the client's — same coverage, two installation sites,
+ * one source array, one construction path).
  */
 import { Client, Connection } from "@temporalio/client";
 import type { PayloadCodec } from "@temporalio/common";
-import { NativeConnection, type Worker } from "@temporalio/worker";
+import {
+  NativeConnection,
+  Worker,
+  type WorkerOptions,
+} from "@temporalio/worker";
 
 import type { Logger } from "../boot/logger.js";
 
@@ -83,18 +88,51 @@ const RECONNECT_BACKOFF_CAP_MS = 30_000;
 const TEMPORAL_HEALTH_SERVICE =
   "temporal.api.workflowservice.v1.WorkflowService";
 
+/**
+ * The workflow code a worker serves — exactly one source, structurally.
+ * `workflowsPath` bundles on boot inside Worker.create (the SDK's webpack
+ * path); `workflowBundle` carries a prebuilt bundle, in-memory (`code`,
+ * a factory's own bundleWorkflowCode output) or on disk (`codePath`, the
+ * slim-artifact sibling from workflow-source.ts).
+ */
+export type WorkerWorkflowSource =
+  | { readonly workflowsPath: string }
+  | {
+      readonly workflowBundle:
+        { readonly code: string } | { readonly codePath: string };
+    };
+
+/**
+ * What a factory decides about its worker — the queue, the activity
+ * registrations, and the workflow source; nothing more (derived from what
+ * every real factory passes, OSS and extension alike). Connection,
+ * namespace, and the codec chain are deliberately NOT options: createWorker
+ * owns them (see WorkerFactoryDeps.createWorker).
+ */
+export interface CreateWorkerOptions {
+  readonly taskQueue: string;
+  /** Activity registrations keyed by activity name (the SDK's own shape). */
+  readonly activities: object;
+  readonly workflows: WorkerWorkflowSource;
+}
+
 export interface WorkerFactoryDeps {
-  readonly nativeConnection: NativeConnection;
-  readonly namespace: string;
   /**
-   * The decode-only codec chain — Worker.create must receive it as its
-   * dataConverter so workflow tasks can decode runner-encrypted activity
-   * results in history (see the module header's choke-point note).
+   * The ONLY way a factory constructs its Worker. The capability closes
+   * over the manager's NativeConnection, namespace, and decode-only codec
+   * chain, so every worker — OSS and extension alike — is built by THIS
+   * package's @temporalio/worker instance. Handing factories the raw
+   * NativeConnection instead was the finding-16 trap (stigmer-cloud C4
+   * session 6): a composition's own @temporalio/worker copy pairs the
+   * foreign connection with its own Tokio bridge, every extension poller
+   * dies at boot with "there is no reactor running", and the worker still
+   * reports RUNNING.
    */
-  readonly payloadCodecs: PayloadCodec[];
+  readonly createWorker: (options: CreateWorkerOptions) => Promise<Worker>;
   /**
    * Live client provider for activities that call the Temporal API
-   * (CompleteExternalActivity). Reads the manager's CURRENT client, so a
+   * (CompleteExternalActivity) and for factories' boot-time side work
+   * (extension schedule upserts). Reads the manager's CURRENT client, so a
    * reconnect needs no re-registration. Throws if no client ever
    * connected — unreachable from a running activity, because a polling
    * worker implies a connect succeeded.
@@ -104,7 +142,8 @@ export interface WorkerFactoryDeps {
 
 /**
  * Creates one domain worker (agent-execution here; workflow-execution and
- * the schedule clock append theirs in #21/#22 — Go createWorkers' list).
+ * the schedule clock append theirs in #21/#22 — Go createWorkers' list;
+ * extension workers append after the OSS set via the registry).
  */
 export type WorkerFactory = (deps: WorkerFactoryDeps) => Promise<Worker>;
 
@@ -242,9 +281,12 @@ export class TemporalManager {
         worker_count: this.workers.length,
       });
     } catch (error) {
-      this.logger.warn("Failed to start Temporal workers - health monitor will retry", {
-        error: errorMessage(error),
-      });
+      this.logger.warn(
+        "Failed to start Temporal workers - health monitor will retry",
+        {
+          error: errorMessage(error),
+        },
+      );
     }
   }
 
@@ -313,7 +355,9 @@ export class TemporalManager {
         }
         return;
       }
-      this.logger.warn("Temporal connection unhealthy, initiating reconnection");
+      this.logger.warn(
+        "Temporal connection unhealthy, initiating reconnection",
+      );
     }
     await this.attemptReconnection();
   }
@@ -322,7 +366,8 @@ export class TemporalManager {
     try {
       const response = await connection.withDeadline(
         Date.now() + HEALTH_CHECK_TIMEOUT_MS,
-        () => connection.healthService.check({ service: TEMPORAL_HEALTH_SERVICE }),
+        () =>
+          connection.healthService.check({ service: TEMPORAL_HEALTH_SERVICE }),
       );
       // 1 = SERVING in grpc.health.v1; anything else is unhealthy.
       return response.status === 1;
@@ -453,9 +498,29 @@ export class TemporalManager {
     this.nativeConnection = nativeConnection;
 
     const deps: WorkerFactoryDeps = {
-      nativeConnection,
-      namespace: this.namespace,
-      payloadCodecs: this.payloadCodecs,
+      createWorker: (options) => {
+        // Widening the exactly-one union to the SDK's optional pair keeps
+        // the spread below assignable without a per-variant Worker.create
+        // call.
+        const workflows: Pick<
+          WorkerOptions,
+          "workflowsPath" | "workflowBundle"
+        > = options.workflows;
+        return Worker.create({
+          connection: nativeConnection,
+          namespace: this.namespace,
+          taskQueue: options.taskQueue,
+          activities: options.activities,
+          ...workflows,
+          // The decode-only codec chain, wired here for EVERY worker (the
+          // module header's choke-point note): workflow tasks replay
+          // history containing runner-encrypted activity results, so each
+          // worker's converter must match the client's.
+          ...(this.payloadCodecs.length > 0
+            ? { dataConverter: { payloadCodecs: this.payloadCodecs } }
+            : {}),
+        });
+      },
       client: () => {
         if (this.client === undefined) {
           throw new Error(
@@ -473,11 +538,17 @@ export class TemporalManager {
     this.workers = [];
     for (const factory of this.workerFactories) {
       const worker = await factory(deps);
+      const taskQueue = worker.options.taskQueue;
+      this.logger.info("Temporal worker started", { task_queue: taskQueue });
       // run() resolves on graceful shutdown and rejects on fatal worker
       // errors; a rejection is logged and left to the health monitor —
-      // exactly Go's "worker died, reconnect recreates it" model.
+      // Go's "worker died, reconnect recreates it" model. ERROR level with
+      // the queue identity, deliberately: a PERMANENT death (finding 16's
+      // dual-module-instance class) re-dies on every recreate while the
+      // worker still reports RUNNING — this line is the only signal.
       const runPromise = worker.run().catch((error: unknown) => {
-        this.logger.warn("Temporal worker stopped with error", {
+        this.logger.error("Temporal worker stopped with error", {
+          task_queue: taskQueue,
           error: errorMessage(error),
         });
       });

--- a/backend/services/stigmer-server/src/temporal/schedule/worker.ts
+++ b/backend/services/stigmer-server/src/temporal/schedule/worker.ts
@@ -19,8 +19,6 @@
  * activities register under their slash names as the activities object's
  * keys.
  */
-import { Worker } from "@temporalio/worker";
-
 import type { Logger } from "../../boot/logger.js";
 import type { Store } from "../../store/interface.js";
 import type { WorkerFactory } from "../manager.js";
@@ -38,8 +36,10 @@ export interface ScheduleWorkerDeps {
   readonly logger: Logger;
 }
 
-export function newScheduleWorkerFactory(deps: ScheduleWorkerDeps): WorkerFactory {
-  return async ({ nativeConnection, namespace, payloadCodecs }) => {
+export function newScheduleWorkerFactory(
+  deps: ScheduleWorkerDeps,
+): WorkerFactory {
+  return async ({ createWorker }) => {
     const activities = createScheduleTickActivities({
       store: deps.store,
       config: deps.config,
@@ -55,7 +55,10 @@ export function newScheduleWorkerFactory(deps: ScheduleWorkerDeps): WorkerFactor
         // The tsx dev loop runs from src/ — the SDK bundler compiles TS.
         new URL("./workflows/index.ts", import.meta.url),
       ],
-      prebuiltSibling: new URL("./workflow-bundle-schedule.js", import.meta.url),
+      prebuiltSibling: new URL(
+        "./workflow-bundle-schedule.js",
+        import.meta.url,
+      ),
     });
 
     deps.logger.info("Creating schedule-clock Temporal worker", {
@@ -63,19 +66,16 @@ export function newScheduleWorkerFactory(deps: ScheduleWorkerDeps): WorkerFactor
       workflow_source: workflowSource.kind,
     });
 
-    return Worker.create({
-      connection: nativeConnection,
-      namespace,
+    // Connection, namespace, and the decode-only codec chain are the
+    // capability's concern (manager.ts's choke-point note) — the factory
+    // decides only queue, activities, and workflow source.
+    return createWorker({
       taskQueue: deps.config.stigmerQueue,
       activities,
-      ...(workflowSource.kind === "prebuilt"
-        ? { workflowBundle: { codePath: workflowSource.codePath } }
-        : { workflowsPath: workflowSource.workflowsPath }),
-      // The decode-only codec chain (manager.ts's choke-point note) — the
-      // tick's payloads are plain JSON today, but the worker's converter
-      // must match the client's so a future encrypted payload in history
-      // replays instead of wedging.
-      ...(payloadCodecs.length > 0 ? { dataConverter: { payloadCodecs } } : {}),
+      workflows:
+        workflowSource.kind === "prebuilt"
+          ? { workflowBundle: { codePath: workflowSource.codePath } }
+          : { workflowsPath: workflowSource.workflowsPath },
     });
   };
 }

--- a/backend/services/stigmer-server/src/temporal/workflowexecution/worker.ts
+++ b/backend/services/stigmer-server/src/temporal/workflowexecution/worker.ts
@@ -22,8 +22,6 @@
  * brief #7 of sub-project 20260824.03 — the operative mode until #24
  * ships prebuilt bundles; the prebuilt sibling is the hook it fills).
  */
-import { Worker } from "@temporalio/worker";
-
 import type { Logger } from "../../boot/logger.js";
 import type { WorkflowExecutionTemporalConfig } from "../../domain/workflowexecution/temporal/config.js";
 import type { StreamBroker } from "../../domain/workflowexecution/stream-broker.js";
@@ -45,7 +43,7 @@ export interface WorkflowExecutionWorkerDeps {
 export function newWorkflowExecutionWorkerFactory(
   deps: WorkflowExecutionWorkerDeps,
 ): WorkerFactory {
-  return async ({ nativeConnection, namespace, payloadCodecs }) => {
+  return async ({ createWorker }) => {
     const activities = createWorkflowExecutionActivities({
       store: deps.store,
       logger: deps.logger,
@@ -72,20 +70,16 @@ export function newWorkflowExecutionWorkerFactory(
       workflow_source: workflowSource.kind,
     });
 
-    return Worker.create({
-      connection: nativeConnection,
-      namespace,
+    // Connection, namespace, and the decode-only codec chain are the
+    // capability's concern (manager.ts's choke-point note) — the factory
+    // decides only queue, activities, and workflow source.
+    return createWorker({
       taskQueue: deps.temporalConfig.stigmerQueue,
       activities,
-      ...(workflowSource.kind === "prebuilt"
-        ? { workflowBundle: { codePath: workflowSource.codePath } }
-        : { workflowsPath: workflowSource.workflowsPath }),
-      // The decode-only codec chain: workflow tasks replay history
-      // containing runner-encrypted payloads (manager.ts's choke-point
-      // note).
-      ...(payloadCodecs.length > 0
-        ? { dataConverter: { payloadCodecs } }
-        : {}),
+      workflows:
+        workflowSource.kind === "prebuilt"
+          ? { workflowBundle: { codePath: workflowSource.codePath } }
+          : { workflowsPath: workflowSource.workflowsPath },
     });
   };
 }

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -189,8 +189,18 @@ const responseDecorator: AgentExecutionResponseDecorator = (
   void response.signal;
 };
 
-const workerFactory: WorkerFactory = () =>
-  Promise.reject(new Error("compile-proof worker — never started"));
+// The factory constructs through deps.createWorker — the ONLY worker
+// construction path the seam offers a consumer (finding 16: a consumer
+// importing @temporalio/worker itself pairs the server's connection with
+// a second native bridge and its pollers die at boot). This proof never
+// runs; it pins that the capability's option surface stays sufficient
+// for a consumer-shaped worker.
+const workerFactory: WorkerFactory = (deps) =>
+  deps.createWorker({
+    taskQueue: "consumer-extension-queue",
+    activities: { consumerActivity: async (): Promise<void> => {} },
+    workflows: { workflowsPath: "compile-proof-workflows-never-resolved" },
+  });
 
 /**
  * A consumer-shaped model-catalog provider built the way the cloud's


### PR DESCRIPTION
## Summary

- `WorkerFactoryDeps` no longer hands worker factories a raw `NativeConnection`. Deps are now `{ createWorker, client }`: the `createWorker(options)` capability builds every worker through THIS package's `@temporalio/worker` instance with connection, namespace, and the decode-only codec chain pre-wired — the one enforced site of the manager's choke-point invariant (previously ten copy-pasted conditionals).
- Root cause being fixed (stigmer-cloud C4 readout, finding 16): a composition consuming `@stigmer/server` via `file:` loads a second physical copy of `@temporalio/worker`; pairing the server's `NativeConnection` with the consumer copy's `Worker.create` panics the native bridge ("there is no reactor running") and every extension queue's pollers die at boot while the workers report RUNNING. The capability makes the wrong pairing impossible to write.
- The three OSS factories (agent-execution, workflow-execution, schedule) migrate to the capability — one construction path for OSS and extensions alike.
- `bundleWorkflowCode` is re-exported from `@stigmer/server` so bundle-prebuilding extension factories need no `@temporalio/worker` of their own.
- Worker-death observability: worker start is logged with its task-queue identity, and a `run()` rejection now logs at ERROR with the same identity (a permanent death re-dies on every recreate while the worker reports RUNNING — the log line is the only signal). The Go-inherited reconnect-recreates recovery model is unchanged.
- The extension-consumer compile proof now constructs its factory through `deps.createWorker` instead of dodging `Worker.create` — the gap that let finding 16 pass the proof.

## Verification

- `make test-server`: 2008 passed / 57 skipped — includes new pins: capability wiring (connection/namespace/codec reach `Worker.create`), codec-less shape, ERROR-level death log with queue identity.
- `make test-extension-consumer`: compile proof green with zero `@temporalio/worker` dependency of its own.
- All four local conformance rosters byte-identical to main (Node 22.22.1): local 498, local-execution 160, local-postgres 498, local-postgres-execution 160 — the execution rosters boot real workers through the capability.
- Live composition proof (stigmer-cloud spike stack): 8 workers, one webpack stamp, live pollers on every extension queue, first-ever end-to-end COMPLETED runs of all extension workflow types. Companion PR: stigmer-cloud (cross-linked after creation).

Made with [Cursor](https://cursor.com)