### PR TITLE
feat(backend/stigmer-server): add OAuthGrantStore.deleteByResourceId + the by-resource grant index

### DIFF
--- a/backend/services/stigmer-server/src/store/__tests__/store-contract.ts
+++ b/backend/services/stigmer-server/src/store/__tests__/store-contract.ts
@@ -95,19 +95,32 @@ export function describeStoreContract(
       const org = makeOrganization({ id: "acme" });
       await fx.store.saveResource(KIND, "acme", OrganizationSchema, org);
 
-      const loaded = await fx.store.getResource(KIND, "acme", OrganizationSchema);
+      const loaded = await fx.store.getResource(
+        KIND,
+        "acme",
+        OrganizationSchema,
+      );
       expect(loaded.metadata?.name).toBe("Acme");
     });
 
     it("saveResource upserts on kind+id", async () => {
-      await fx.store.saveResource(KIND, "acme", OrganizationSchema, makeOrganization());
+      await fx.store.saveResource(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        makeOrganization(),
+      );
       await fx.store.saveResource(
         KIND,
         "acme",
         OrganizationSchema,
         makeOrganization({ description: "second write" }),
       );
-      const loaded = await fx.store.getResource(KIND, "acme", OrganizationSchema);
+      const loaded = await fx.store.getResource(
+        KIND,
+        "acme",
+        OrganizationSchema,
+      );
       expect(loaded.spec?.description).toBe("second write");
       expect(await fx.store.listResources(KIND)).toHaveLength(1);
     });
@@ -122,7 +135,9 @@ export function describeStoreContract(
     });
 
     it("deleteResource is a silent no-op for a missing resource", async () => {
-      await expect(fx.store.deleteResource(KIND, "ghost")).resolves.toBeUndefined();
+      await expect(
+        fx.store.deleteResource(KIND, "ghost"),
+      ).resolves.toBeUndefined();
     });
 
     it("listResources returns an empty array (never undefined) for an empty kind", async () => {
@@ -130,17 +145,42 @@ export function describeStoreContract(
     });
 
     it("deleteResourcesByKind and ByIdPrefix return the deleted counts", async () => {
-      await fx.store.saveResource(KIND, "acme", OrganizationSchema, makeOrganization({ id: "acme" }));
-      await fx.store.saveResource(KIND, "beta", OrganizationSchema, makeOrganization({ id: "beta" }));
-      await fx.store.saveResource(KIND, "acme-2", OrganizationSchema, makeOrganization({ id: "acme-2" }));
+      await fx.store.saveResource(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        makeOrganization({ id: "acme" }),
+      );
+      await fx.store.saveResource(
+        KIND,
+        "beta",
+        OrganizationSchema,
+        makeOrganization({ id: "beta" }),
+      );
+      await fx.store.saveResource(
+        KIND,
+        "acme-2",
+        OrganizationSchema,
+        makeOrganization({ id: "acme-2" }),
+      );
 
       expect(await fx.store.deleteResourcesByIdPrefix(KIND, "acme")).toBe(2);
       expect(await fx.store.deleteResourcesByKind(KIND)).toBe(1);
     });
 
     it("deleteResourcesByIdPrefix treats LIKE metacharacters in the prefix literally", async () => {
-      await fx.store.saveResource(KIND, "a_c", OrganizationSchema, makeOrganization({ id: "a_c" }));
-      await fx.store.saveResource(KIND, "abc", OrganizationSchema, makeOrganization({ id: "abc" }));
+      await fx.store.saveResource(
+        KIND,
+        "a_c",
+        OrganizationSchema,
+        makeOrganization({ id: "a_c" }),
+      );
+      await fx.store.saveResource(
+        KIND,
+        "abc",
+        OrganizationSchema,
+        makeOrganization({ id: "abc" }),
+      );
 
       // "a_c" must match only the literal id — an unescaped LIKE '_' would
       // also delete "abc".
@@ -151,7 +191,12 @@ export function describeStoreContract(
 
   describe("updateResource (atomic RMW)", () => {
     it("applies the mutation and returns the persisted message", async () => {
-      await fx.store.saveResource(KIND, "acme", OrganizationSchema, makeOrganization());
+      await fx.store.saveResource(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        makeOrganization(),
+      );
 
       const updated = await fx.store.updateResource(
         KIND,
@@ -163,7 +208,11 @@ export function describeStoreContract(
       );
       expect(updated.spec?.description).toBe("mutated");
 
-      const reloaded = await fx.store.getResource(KIND, "acme", OrganizationSchema);
+      const reloaded = await fx.store.getResource(
+        KIND,
+        "acme",
+        OrganizationSchema,
+      );
       expect(reloaded.spec?.description).toBe("mutated");
     });
 
@@ -181,7 +230,11 @@ export function describeStoreContract(
         }),
       ).rejects.toThrow("modify failed");
 
-      const reloaded = await fx.store.getResource(KIND, "acme", OrganizationSchema);
+      const reloaded = await fx.store.getResource(
+        KIND,
+        "acme",
+        OrganizationSchema,
+      );
       expect(reloaded.spec?.description).toBe("original");
       // The rolled-back transaction must not leave the connection wedged.
       await expect(
@@ -212,7 +265,11 @@ export function describeStoreContract(
           org.spec!.description += "|second";
         }),
       ]);
-      const reloaded = await fx.store.getResource(KIND, "acme", OrganizationSchema);
+      const reloaded = await fx.store.getResource(
+        KIND,
+        "acme",
+        OrganizationSchema,
+      );
       // Order is driver-relative (sqlite serializes globally, Postgres
       // per-row); the CONTRACT is that neither write is lost.
       expect(["|first|second", "|second|first"]).toContain(
@@ -221,8 +278,18 @@ export function describeStoreContract(
     });
 
     it("parallel updates to DIFFERENT resources both land", async () => {
-      await fx.store.saveResource(KIND, "acme", OrganizationSchema, makeOrganization({ id: "acme" }));
-      await fx.store.saveResource(KIND, "beta", OrganizationSchema, makeOrganization({ id: "beta" }));
+      await fx.store.saveResource(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        makeOrganization({ id: "acme" }),
+      );
+      await fx.store.saveResource(
+        KIND,
+        "beta",
+        OrganizationSchema,
+        makeOrganization({ id: "beta" }),
+      );
 
       await Promise.all([
         fx.store.updateResource(KIND, "acme", OrganizationSchema, (org) => {
@@ -242,7 +309,12 @@ export function describeStoreContract(
 
   describe("field and label queries", () => {
     it("findByField matches camelCase paths with snake_case fallback (Go's two-probe lookup)", async () => {
-      await fx.store.saveResource(KIND, "acme", OrganizationSchema, makeOrganization({ id: "acme" }));
+      await fx.store.saveResource(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        makeOrganization({ id: "acme" }),
+      );
       await fx.store.saveResource(
         KIND,
         "beta",
@@ -270,12 +342,24 @@ export function describeStoreContract(
 
     it("findByField throws ResourceNotFoundError naming the predicate", async () => {
       await expect(
-        fx.store.findByField(KIND, "spec.description", "none", OrganizationSchema),
-      ).rejects.toThrow("resource not found: organization where spec.description=none");
+        fx.store.findByField(
+          KIND,
+          "spec.description",
+          "none",
+          OrganizationSchema,
+        ),
+      ).rejects.toThrow(
+        "resource not found: organization where spec.description=none",
+      );
     });
 
     it("findAllByField preserves the Go quirk: ALL rows of the kind, unfiltered (DD-001)", async () => {
-      await fx.store.saveResource(KIND, "acme", OrganizationSchema, makeOrganization({ id: "acme" }));
+      await fx.store.saveResource(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        makeOrganization({ id: "acme" }),
+      );
       await fx.store.saveResource(
         KIND,
         "beta",
@@ -283,7 +367,11 @@ export function describeStoreContract(
         makeOrganization({ id: "beta", description: "only-this-one" }),
       );
 
-      const rows = await fx.store.findAllByField(KIND, "spec.description", "only-this-one");
+      const rows = await fx.store.findAllByField(
+        KIND,
+        "spec.description",
+        "only-this-one",
+      );
       // Two rows despite the predicate matching one — the caller filters,
       // exactly as every Go call site did.
       expect(rows).toHaveLength(2);
@@ -294,13 +382,19 @@ export function describeStoreContract(
         KIND,
         "acme",
         OrganizationSchema,
-        makeOrganization({ id: "acme", labels: { "stigmer.ai/system": "true" } }),
+        makeOrganization({
+          id: "acme",
+          labels: { "stigmer.ai/system": "true" },
+        }),
       );
       await fx.store.saveResource(
         KIND,
         "beta",
         OrganizationSchema,
-        makeOrganization({ id: "beta", labels: { "stigmer.ai/system": "false" } }),
+        makeOrganization({
+          id: "beta",
+          labels: { "stigmer.ai/system": "false" },
+        }),
       );
 
       const matches = await fx.store.findAllByLabel(
@@ -316,11 +410,28 @@ export function describeStoreContract(
   describe("audit operations", () => {
     it("archives snapshots and lists them newest first with authoritative tags", async () => {
       const org = makeOrganization();
-      await fx.store.saveAudit(KIND, "acme", OrganizationSchema, org, "hash-1", "");
-      await fx.store.saveAudit(KIND, "acme", OrganizationSchema, org, "hash-2", "latest");
+      await fx.store.saveAudit(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        org,
+        "hash-1",
+        "",
+      );
+      await fx.store.saveAudit(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        org,
+        "hash-2",
+        "latest",
+      );
 
       const records = await fx.store.listAuditRecords(KIND, "acme");
-      expect(records.map((record) => record.versionHash)).toEqual(["hash-2", "hash-1"]);
+      expect(records.map((record) => record.versionHash)).toEqual([
+        "hash-2",
+        "hash-1",
+      ]);
       expect(records[0]!.tag).toBe("latest");
 
       expect(await fx.store.countAuditEntries(KIND, "acme")).toBe(2);
@@ -330,12 +441,29 @@ export function describeStoreContract(
 
     it("getAuditByHash / getAuditByTag round-trip the snapshot", async () => {
       const org = makeOrganization({ description: "snapshotted" });
-      await fx.store.saveAudit(KIND, "acme", OrganizationSchema, org, "hash-1", "stable");
+      await fx.store.saveAudit(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        org,
+        "hash-1",
+        "stable",
+      );
 
-      const byHash = await fx.store.getAuditByHash(KIND, "acme", "hash-1", OrganizationSchema);
+      const byHash = await fx.store.getAuditByHash(
+        KIND,
+        "acme",
+        "hash-1",
+        OrganizationSchema,
+      );
       expect(byHash.spec?.description).toBe("snapshotted");
 
-      const byTag = await fx.store.getAuditByTag(KIND, "acme", "stable", OrganizationSchema);
+      const byTag = await fx.store.getAuditByTag(
+        KIND,
+        "acme",
+        "stable",
+        OrganizationSchema,
+      );
       expect(byTag.spec?.description).toBe("snapshotted");
     });
 
@@ -355,45 +483,99 @@ export function describeStoreContract(
 
     it("setAuditTag moves the tag atomically — single holder (#341)", async () => {
       const org = makeOrganization();
-      await fx.store.saveAudit(KIND, "acme", OrganizationSchema, org, "hash-1", "stable");
-      await fx.store.saveAudit(KIND, "acme", OrganizationSchema, org, "hash-2", "");
+      await fx.store.saveAudit(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        org,
+        "hash-1",
+        "stable",
+      );
+      await fx.store.saveAudit(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        org,
+        "hash-2",
+        "",
+      );
 
       await fx.store.setAuditTag(KIND, "acme", "hash-2", "stable");
 
       const records = await fx.store.listAuditRecords(KIND, "acme");
-      const byHash = new Map(records.map((record) => [record.versionHash, record.tag]));
+      const byHash = new Map(
+        records.map((record) => [record.versionHash, record.tag]),
+      );
       expect(byHash.get("hash-2")).toBe("stable");
       expect(byHash.get("hash-1"), "the prior holder is cleared").toBe("");
     });
 
     it("setAuditTag with a missing target rolls back — the prior holder keeps the tag", async () => {
       const org = makeOrganization();
-      await fx.store.saveAudit(KIND, "acme", OrganizationSchema, org, "hash-1", "stable");
+      await fx.store.saveAudit(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        org,
+        "hash-1",
+        "stable",
+      );
 
       await expect(
         fx.store.setAuditTag(KIND, "acme", "missing-hash", "stable"),
       ).rejects.toThrow(AuditNotFoundError);
 
       const record = await fx.store.getAuditRecordByTag(KIND, "acme", "stable");
-      expect(record.versionHash, "a missing target never orphans the tag").toBe("hash-1");
+      expect(record.versionHash, "a missing target never orphans the tag").toBe(
+        "hash-1",
+      );
     });
 
     it("duplicate rows for one hash are legal — newest wins (stigmer-cloud#191)", async () => {
       await fx.store.saveAudit(
-        KIND, "acme", OrganizationSchema, makeOrganization({ description: "older" }), "hash-x", "",
+        KIND,
+        "acme",
+        OrganizationSchema,
+        makeOrganization({ description: "older" }),
+        "hash-x",
+        "",
       );
       await fx.store.saveAudit(
-        KIND, "acme", OrganizationSchema, makeOrganization({ description: "newer" }), "hash-x", "",
+        KIND,
+        "acme",
+        OrganizationSchema,
+        makeOrganization({ description: "newer" }),
+        "hash-x",
+        "",
       );
 
-      const record = await fx.store.getAuditByHash(KIND, "acme", "hash-x", OrganizationSchema);
+      const record = await fx.store.getAuditByHash(
+        KIND,
+        "acme",
+        "hash-x",
+        OrganizationSchema,
+      );
       expect(record.spec?.description).toBe("newer");
     });
 
     it("deleteAuditByResourceId removes the resource's records and reports the count", async () => {
       const org = makeOrganization();
-      await fx.store.saveAudit(KIND, "acme", OrganizationSchema, org, "hash-1", "");
-      await fx.store.saveAudit(KIND, "acme", OrganizationSchema, org, "hash-2", "");
+      await fx.store.saveAudit(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        org,
+        "hash-1",
+        "",
+      );
+      await fx.store.saveAudit(
+        KIND,
+        "acme",
+        OrganizationSchema,
+        org,
+        "hash-2",
+        "",
+      );
       expect(await fx.store.deleteAuditByResourceId(KIND, "acme")).toBe(2);
       expect(await fx.store.countAuditEntries(KIND, "acme")).toBe(0);
     });
@@ -402,12 +584,18 @@ export function describeStoreContract(
   describe("workflow execution events", () => {
     it("append is insert-or-skip, first-writer-wins (oss#308 contract)", async () => {
       expect(
-        await fx.store.appendWorkflowExecutionEvents("wfe_1", [event(1), event(2)]),
+        await fx.store.appendWorkflowExecutionEvents("wfe_1", [
+          event(1),
+          event(2),
+        ]),
       ).toBe(2);
       // A retried batch re-sends the same sequence numbers: idempotent
       // no-op for the duplicates, the new event still lands.
       expect(
-        await fx.store.appendWorkflowExecutionEvents("wfe_1", [event(1), event(3)]),
+        await fx.store.appendWorkflowExecutionEvents("wfe_1", [
+          event(1),
+          event(3),
+        ]),
       ).toBe(1);
       expect(await fx.store.getMaxEventSequence("wfe_1")).toBe(3);
     });
@@ -419,22 +607,52 @@ export function describeStoreContract(
         event(3, "task_started", "step-b"),
       ]);
 
-      const afterFirst = await fx.store.getWorkflowExecutionEvents("wfe_1", 1, "", "", 0);
+      const afterFirst = await fx.store.getWorkflowExecutionEvents(
+        "wfe_1",
+        1,
+        "",
+        "",
+        0,
+      );
       expect(afterFirst.map((row) => row.sequenceNumber)).toEqual([2, 3]);
 
-      const started = await fx.store.getWorkflowExecutionEvents("wfe_1", 0, "task_started", "", 0);
+      const started = await fx.store.getWorkflowExecutionEvents(
+        "wfe_1",
+        0,
+        "task_started",
+        "",
+        0,
+      );
       expect(started.map((row) => row.sequenceNumber)).toEqual([1, 3]);
 
-      const stepA = await fx.store.getWorkflowExecutionEvents("wfe_1", 0, "", "step-a", 0);
+      const stepA = await fx.store.getWorkflowExecutionEvents(
+        "wfe_1",
+        0,
+        "",
+        "step-a",
+        0,
+      );
       expect(stepA.map((row) => row.sequenceNumber)).toEqual([1, 2]);
 
-      const limited = await fx.store.getWorkflowExecutionEvents("wfe_1", 0, "", "", 2);
+      const limited = await fx.store.getWorkflowExecutionEvents(
+        "wfe_1",
+        0,
+        "",
+        "",
+        2,
+      );
       expect(limited).toHaveLength(2);
     });
 
     it("round-trips event payload bytes and stamps createdAt", async () => {
       await fx.store.appendWorkflowExecutionEvents("wfe_1", [event(7)]);
-      const rows = await fx.store.getWorkflowExecutionEvents("wfe_1", 0, "", "", 0);
+      const rows = await fx.store.getWorkflowExecutionEvents(
+        "wfe_1",
+        0,
+        "",
+        "",
+        0,
+      );
       expect(rows).toHaveLength(1);
       expect(Array.from(rows[0]!.data)).toEqual([7]);
       expect(rows[0]!.createdAt).not.toBe("");
@@ -443,7 +661,9 @@ export function describeStoreContract(
     it("empty batches and unknown executions are calm no-ops", async () => {
       expect(await fx.store.appendWorkflowExecutionEvents("wfe_1", [])).toBe(0);
       expect(await fx.store.getMaxEventSequence("ghost")).toBe(0);
-      expect(await fx.store.getWorkflowExecutionEvents("ghost", 0, "", "", 0)).toEqual([]);
+      expect(
+        await fx.store.getWorkflowExecutionEvents("ghost", 0, "", "", 0),
+      ).toEqual([]);
     });
   });
 
@@ -462,7 +682,11 @@ export function describeStoreContract(
 
     it("upsert converges retried writes onto the fire-identity row", async () => {
       await fx.store.upsertScheduleRun(baseRun);
-      await fx.store.upsertScheduleRun({ ...baseRun, outcome: "completed", completedAt: "2026-08-20T00:00:05Z" });
+      await fx.store.upsertScheduleRun({
+        ...baseRun,
+        outcome: "completed",
+        completedAt: "2026-08-20T00:00:05Z",
+      });
 
       const { runs, total } = await fx.store.listScheduleRuns("sch_1", 0, 0);
       expect(total).toBe(1);
@@ -470,11 +694,17 @@ export function describeStoreContract(
     });
 
     it("terminal rows are never downgraded by a replayed 'started' write", async () => {
-      await fx.store.upsertScheduleRun({ ...baseRun, outcome: "completed", completedAt: "2026-08-20T00:00:05Z" });
+      await fx.store.upsertScheduleRun({
+        ...baseRun,
+        outcome: "completed",
+        completedAt: "2026-08-20T00:00:05Z",
+      });
       await fx.store.upsertScheduleRun(baseRun); // the replay
 
       const { runs } = await fx.store.listScheduleRuns("sch_1", 0, 0);
-      expect(runs[0]!.outcome, "the verdict survives the replay").toBe("completed");
+      expect(runs[0]!.outcome, "the verdict survives the replay").toBe(
+        "completed",
+      );
       expect(runs[0]!.completedAt).toBe("2026-08-20T00:00:05Z");
     });
 
@@ -489,7 +719,11 @@ export function describeStoreContract(
       });
 
       await fx.store.markLatestScheduleRunTerminal(
-        "sch_1", "cron", "failed", "boom", "2026-08-20T00:01:00Z",
+        "sch_1",
+        "cron",
+        "failed",
+        "boom",
+        "2026-08-20T00:01:00Z",
       );
 
       const { runs } = await fx.store.listScheduleRuns("sch_1", 0, 0);
@@ -502,7 +736,13 @@ export function describeStoreContract(
 
     it("marking with no non-terminal row is a silent no-op", async () => {
       await expect(
-        fx.store.markLatestScheduleRunTerminal("sch_ghost", "cron", "failed", "", "t"),
+        fx.store.markLatestScheduleRunTerminal(
+          "sch_ghost",
+          "cron",
+          "failed",
+          "",
+          "t",
+        ),
       ).resolves.toBeUndefined();
     });
 
@@ -648,7 +888,11 @@ export function describeStoreContract(
       await fx.store.upsertSearchIndex(
         ApiResourceKind.agent,
         "agt-public",
-        entry({ name: "searchable beta", org: "globex", visibility: "visibility_public" }),
+        entry({
+          name: "searchable beta",
+          org: "globex",
+          visibility: "visibility_public",
+        }),
       );
       await fx.store.upsertSearchIndex(
         ApiResourceKind.agent,
@@ -726,8 +970,16 @@ export function describeStoreContract(
     });
 
     it("upsert replaces the indexed document; deleteSearchIndex and clearSearchIndex remove", async () => {
-      await fx.store.upsertSearchIndex(KIND, "acme", entry({ name: "original name" }));
-      await fx.store.upsertSearchIndex(KIND, "acme", entry({ name: "renamed thing" }));
+      await fx.store.upsertSearchIndex(
+        KIND,
+        "acme",
+        entry({ name: "original name" }),
+      );
+      await fx.store.upsertSearchIndex(
+        KIND,
+        "acme",
+        entry({ name: "renamed thing" }),
+      );
 
       const stale = await fx.store.querySearchIndex({
         kinds: ["organization"],
@@ -763,7 +1015,11 @@ export function describeStoreContract(
       });
       expect(afterDelete.totalCount).toBe(0);
 
-      await fx.store.upsertSearchIndex(KIND, "acme", entry({ name: "back again" }));
+      await fx.store.upsertSearchIndex(
+        KIND,
+        "acme",
+        entry({ name: "back again" }),
+      );
       await fx.store.clearSearchIndex();
       const afterClear = await fx.store.querySearchIndex({
         kinds: ["organization"],
@@ -786,7 +1042,9 @@ export function describeStoreContract(
       await fx.store.bootstrapState.set("seedpack_version", "1.1.0");
       await fx.store.bootstrapState.set("bootstrap_status", "completed");
 
-      expect(await fx.store.bootstrapState.get("seedpack_version")).toBe("1.1.0");
+      expect(await fx.store.bootstrapState.get("seedpack_version")).toBe(
+        "1.1.0",
+      );
       expect(await fx.store.bootstrapState.getAll()).toEqual(
         new Map([
           ["seedpack_version", "1.1.0"],
@@ -806,13 +1064,21 @@ export function describeStoreContract(
   describe("signal dedupe (two-phase hold)", () => {
     it("claims a fresh key, reports the holder on a duplicate claim", async () => {
       const first = await fx.store.signalDedupe.claim(
-        "acme", "key-1", "wfe_1", "resume", IN_FLIGHT_CLAIM_TTL_MS,
+        "acme",
+        "key-1",
+        "wfe_1",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
       );
       expect(first.status).toBe("SUCCESS");
       expect(first.record).toBeUndefined();
 
       const second = await fx.store.signalDedupe.claim(
-        "acme", "key-1", "wfe_2", "resume", IN_FLIGHT_CLAIM_TTL_MS,
+        "acme",
+        "key-1",
+        "wfe_2",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
       );
       expect(second.status).toBe("DUPLICATE");
       // The caller branches on the HOLDER's state: CLAIMED = in-flight
@@ -822,19 +1088,39 @@ export function describeStoreContract(
     });
 
     it("keys are org-scoped: the same idempotency key in another org claims freely", async () => {
-      await fx.store.signalDedupe.claim("acme", "key-1", "wfe_1", "resume", IN_FLIGHT_CLAIM_TTL_MS);
+      await fx.store.signalDedupe.claim(
+        "acme",
+        "key-1",
+        "wfe_1",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
+      );
       const other = await fx.store.signalDedupe.claim(
-        "globex", "key-1", "wfe_9", "resume", IN_FLIGHT_CLAIM_TTL_MS,
+        "globex",
+        "key-1",
+        "wfe_9",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
       );
       expect(other.status).toBe("SUCCESS");
     });
 
     it("markDelivered flips the status and extends the hold to the 24h window", async () => {
-      await fx.store.signalDedupe.claim("acme", "key-1", "wfe_1", "resume", IN_FLIGHT_CLAIM_TTL_MS);
+      await fx.store.signalDedupe.claim(
+        "acme",
+        "key-1",
+        "wfe_1",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
+      );
       await fx.store.signalDedupe.markDelivered("acme", "key-1");
 
       const dup = await fx.store.signalDedupe.claim(
-        "acme", "key-1", "wfe_2", "resume", IN_FLIGHT_CLAIM_TTL_MS,
+        "acme",
+        "key-1",
+        "wfe_2",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
       );
       expect(dup.status).toBe("DUPLICATE");
       expect(dup.record?.status).toBe("DELIVERED");
@@ -845,39 +1131,78 @@ export function describeStoreContract(
     });
 
     it("markDelivered on a missing or already-delivered key is a tolerant no-op", async () => {
-      await expect(fx.store.signalDedupe.markDelivered("acme", "ghost")).resolves.toBeUndefined();
-      await fx.store.signalDedupe.claim("acme", "key-1", "wfe_1", "resume", IN_FLIGHT_CLAIM_TTL_MS);
+      await expect(
+        fx.store.signalDedupe.markDelivered("acme", "ghost"),
+      ).resolves.toBeUndefined();
+      await fx.store.signalDedupe.claim(
+        "acme",
+        "key-1",
+        "wfe_1",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
+      );
       await fx.store.signalDedupe.markDelivered("acme", "key-1");
-      await expect(fx.store.signalDedupe.markDelivered("acme", "key-1")).resolves.toBeUndefined();
+      await expect(
+        fx.store.signalDedupe.markDelivered("acme", "key-1"),
+      ).resolves.toBeUndefined();
     });
 
     it("release frees a CLAIMED key immediately but never a DELIVERED one", async () => {
-      await fx.store.signalDedupe.claim("acme", "key-1", "wfe_1", "resume", IN_FLIGHT_CLAIM_TTL_MS);
+      await fx.store.signalDedupe.claim(
+        "acme",
+        "key-1",
+        "wfe_1",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
+      );
       await fx.store.signalDedupe.release("acme", "key-1");
       const reclaimed = await fx.store.signalDedupe.claim(
-        "acme", "key-1", "wfe_2", "resume", IN_FLIGHT_CLAIM_TTL_MS,
+        "acme",
+        "key-1",
+        "wfe_2",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
       );
-      expect(reclaimed.status, "a released key is claimable at once").toBe("SUCCESS");
+      expect(reclaimed.status, "a released key is claimable at once").toBe(
+        "SUCCESS",
+      );
 
       await fx.store.signalDedupe.markDelivered("acme", "key-1");
       await fx.store.signalDedupe.release("acme", "key-1"); // guarded no-op
       const stillBlocked = await fx.store.signalDedupe.claim(
-        "acme", "key-1", "wfe_3", "resume", IN_FLIGHT_CLAIM_TTL_MS,
+        "acme",
+        "key-1",
+        "wfe_3",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
       );
-      expect(stillBlocked.status, "a delivered key survives a misplaced release").toBe("DUPLICATE");
+      expect(
+        stillBlocked.status,
+        "a delivered key survives a misplaced release",
+      ).toBe("DUPLICATE");
     });
 
     it("an expired hold self-heals: the next claim cleans it up and wins", async () => {
       // Crash recovery path: a claim whose delivery died holds only the
       // short TTL. Simulate the lapse by aging the row directly.
-      await fx.store.signalDedupe.claim("acme", "key-1", "wfe_1", "resume", IN_FLIGHT_CLAIM_TTL_MS);
+      await fx.store.signalDedupe.claim(
+        "acme",
+        "key-1",
+        "wfe_1",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
+      );
       await fx.forceDedupeExpiry(
         "acme:key-1",
         new Date(Date.now() - 1000).toISOString(),
       );
 
       const reclaimed = await fx.store.signalDedupe.claim(
-        "acme", "key-1", "wfe_2", "resume", IN_FLIGHT_CLAIM_TTL_MS,
+        "acme",
+        "key-1",
+        "wfe_2",
+        "resume",
+        IN_FLIGHT_CLAIM_TTL_MS,
       );
       expect(reclaimed.status).toBe("SUCCESS");
     });
@@ -909,15 +1234,55 @@ export function describeStoreContract(
       await fx.store.oauthGrants.upsert({ ...grant, clientId: "client-2" });
       const second = await fx.store.oauthGrants.find("ida_1", "mcp_1", "acme");
       expect(second!.clientId).toBe("client-2");
-      expect(second!.createdAt, "createdAt survives the upsert").toBe(first!.createdAt);
+      expect(second!.createdAt, "createdAt survives the upsert").toBe(
+        first!.createdAt,
+      );
     });
 
     it("find returns undefined (not an error) when absent; delete removes by composite key", async () => {
-      expect(await fx.store.oauthGrants.find("ida_x", "mcp_x", "acme")).toBeUndefined();
+      expect(
+        await fx.store.oauthGrants.find("ida_x", "mcp_x", "acme"),
+      ).toBeUndefined();
 
       await fx.store.oauthGrants.upsert(grant);
       await fx.store.oauthGrants.delete("ida_1", "mcp_1", "acme");
-      expect(await fx.store.oauthGrants.find("ida_1", "mcp_1", "acme")).toBeUndefined();
+      expect(
+        await fx.store.oauthGrants.find("ida_1", "mcp_1", "acme"),
+      ).toBeUndefined();
+    });
+
+    it("deleteByResourceId sweeps every identity's grants for the resource and no others", async () => {
+      // Two identities granted the same resource (re-install by a second
+      // caller leaves one row per identity — the sweep must take both),
+      // plus one grant on a different resource that must survive.
+      await fx.store.oauthGrants.upsert(grant);
+      await fx.store.oauthGrants.upsert({
+        ...grant,
+        identityAccountId: "ida_2",
+      });
+      await fx.store.oauthGrants.upsert({ ...grant, resourceId: "mcp_other" });
+
+      const swept = await fx.store.oauthGrants.deleteByResourceId(
+        "mcp_1",
+        "acme",
+      );
+      expect(swept, "both identities' grants counted").toBe(2);
+      expect(
+        await fx.store.oauthGrants.find("ida_1", "mcp_1", "acme"),
+      ).toBeUndefined();
+      expect(
+        await fx.store.oauthGrants.find("ida_2", "mcp_1", "acme"),
+      ).toBeUndefined();
+      expect(
+        await fx.store.oauthGrants.find("ida_1", "mcp_other", "acme"),
+        "other resources' grants survive",
+      ).toBeDefined();
+
+      const rerun = await fx.store.oauthGrants.deleteByResourceId(
+        "mcp_1",
+        "acme",
+      );
+      expect(rerun, "idempotent re-sweep answers zero, not an error").toBe(0);
     });
   });
 
@@ -941,7 +1306,8 @@ export function describeStoreContract(
     it("getAndDelete redeems a state exactly once", async () => {
       await fx.store.pendingOAuthStates.save(state);
 
-      const redeemed = await fx.store.pendingOAuthStates.getAndDelete("state-1");
+      const redeemed =
+        await fx.store.pendingOAuthStates.getAndDelete("state-1");
       expect(redeemed?.codeVerifier).toBe("enc:v1:sealed-verifier");
       expect(redeemed?.org).toBe("acme");
 
@@ -956,12 +1322,19 @@ export function describeStoreContract(
         createdAt: Math.floor(Date.now() / 1000) - 11 * 60,
       });
 
-      expect(await fx.store.pendingOAuthStates.getAndDelete("state-1")).toBeUndefined();
-      expect(await fx.countPendingOAuthStates(), "the expired row is gone").toBe(0);
+      expect(
+        await fx.store.pendingOAuthStates.getAndDelete("state-1"),
+      ).toBeUndefined();
+      expect(
+        await fx.countPendingOAuthStates(),
+        "the expired row is gone",
+      ).toBe(0);
     });
 
     it("unknown states return undefined; cleanupExpired reports the count removed", async () => {
-      expect(await fx.store.pendingOAuthStates.getAndDelete("ghost")).toBeUndefined();
+      expect(
+        await fx.store.pendingOAuthStates.getAndDelete("ghost"),
+      ).toBeUndefined();
 
       await fx.store.pendingOAuthStates.save(state); // fresh
       await fx.store.pendingOAuthStates.save({
@@ -971,7 +1344,9 @@ export function describeStoreContract(
       });
 
       expect(await fx.store.pendingOAuthStates.cleanupExpired()).toBe(1);
-      expect(await fx.store.pendingOAuthStates.getAndDelete("state-1")).toBeDefined();
+      expect(
+        await fx.store.pendingOAuthStates.getAndDelete("state-1"),
+      ).toBeDefined();
     });
   });
 
@@ -980,9 +1355,15 @@ export function describeStoreContract(
       await fx.store.close();
       await fx.store.close(); // second close is a no-op, as in Go
 
-      await expect(fx.store.listResources(KIND)).rejects.toThrow("store is closed");
-      await expect(fx.store.bootstrapState.get("k")).rejects.toThrow("store is closed");
-      await expect(fx.store.signalDedupe.release("o", "k")).rejects.toThrow("store is closed");
+      await expect(fx.store.listResources(KIND)).rejects.toThrow(
+        "store is closed",
+      );
+      await expect(fx.store.bootstrapState.get("k")).rejects.toThrow(
+        "store is closed",
+      );
+      await expect(fx.store.signalDedupe.release("o", "k")).rejects.toThrow(
+        "store is closed",
+      );
     });
   });
 }

--- a/backend/services/stigmer-server/src/store/interface.ts
+++ b/backend/services/stigmer-server/src/store/interface.ts
@@ -320,7 +320,7 @@ export interface SignalDedupeStore {
 export interface OAuthGrant {
   readonly identityAccountId: string;
   readonly resourceId: string;
-  /** e.g. "mcp_server", "workflow". */
+  /** e.g. "mcp_server", "workflow", "agent_channel". */
   readonly resourceKind: string;
   readonly orgId: string;
   /** Unix seconds. */
@@ -351,6 +351,15 @@ export interface OAuthGrantStore {
     resourceId: string,
     orgId: string,
   ): Promise<void>;
+  /**
+   * Deletes every grant for a resource regardless of the granting
+   * identity (the Java delete-cascade's OAuthGrantRepo.deleteByResourceId,
+   * consumed by the cloud channel teardown): re-installs by different
+   * callers leave one row per identity and a resource teardown must sweep
+   * them all. Returns the deleted count (the cascade logs it); zero is a
+   * normal state, not an error — teardown is idempotent.
+   */
+  deleteByResourceId(resourceId: string, orgId: string): Promise<number>;
 }
 
 /**
@@ -559,10 +568,7 @@ export interface Store {
   ): Promise<number>;
 
   /** Count of audit records; 0 (not an error) when none exist. */
-  countAuditEntries(
-    kind: ApiResourceKind,
-    resourceId: string,
-  ): Promise<number>;
+  countAuditEntries(kind: ApiResourceKind, resourceId: string): Promise<number>;
 
   /**
    * Version hash of the most recent audit record (archived_at DESC, id

--- a/backend/services/stigmer-server/src/store/postgres/__tests__/migrations.test.ts
+++ b/backend/services/stigmer-server/src/store/postgres/__tests__/migrations.test.ts
@@ -76,22 +76,35 @@ describe.skipIf(testDatabaseAdminUrl() === undefined)(
              AND indexname = 'idx_wfee_created_at'`,
         );
         expect(sweepIndex.rowCount, "the v2 sweep index exists").toBe(1);
+
+        // v3's index: the by-resource grant teardown (see migrateToV3).
+        const grantIndex = await client.query(
+          `SELECT indexname FROM pg_indexes
+           WHERE tablename = 'oauth_grant'
+             AND indexname = 'idx_oauth_grant_resource'`,
+        );
+        expect(grantIndex.rowCount, "the v3 grant-teardown index exists").toBe(
+          1,
+        );
       } finally {
         await client.end();
       }
     });
 
-    it("a v1 database resumes the chain on reopen: v2's sweep index arrives", async () => {
+    it("a v1 database resumes the chain on reopen: the v2/v3 indexes arrive", async () => {
       const store = await PostgresStore.open(db.databaseUrl);
       await store.close();
 
-      // Rewind to a v1 database: drop exactly what v2 created and its
-      // version row — the state any pre-v2 deployment is actually in.
+      // Rewind to a v1 database: drop exactly what v2+v3 created and their
+      // version rows — the state any pre-v2 deployment is actually in.
       const client = new pg.Client({ connectionString: db.databaseUrl });
       await client.connect();
       try {
         await client.query(`DROP INDEX idx_wfee_created_at`);
-        await client.query(`DELETE FROM schema_version WHERE version = 2`);
+        await client.query(`DROP INDEX idx_oauth_grant_resource`);
+        await client.query(
+          `DELETE FROM schema_version WHERE version IN (2, 3)`,
+        );
 
         const reopened = await PostgresStore.open(db.databaseUrl);
         await reopened.close();
@@ -102,6 +115,13 @@ describe.skipIf(testDatabaseAdminUrl() === undefined)(
              AND indexname = 'idx_wfee_created_at'`,
         );
         expect(sweepIndex.rowCount, "reopen applied v2 mid-chain").toBe(1);
+
+        const grantIndex = await client.query(
+          `SELECT indexname FROM pg_indexes
+           WHERE tablename = 'oauth_grant'
+             AND indexname = 'idx_oauth_grant_resource'`,
+        );
+        expect(grantIndex.rowCount, "reopen applied v3 mid-chain").toBe(1);
 
         const version = await client.query(
           `SELECT COALESCE(MAX(version), 0) AS version FROM schema_version`,

--- a/backend/services/stigmer-server/src/store/postgres/migrations.ts
+++ b/backend/services/stigmer-server/src/store/postgres/migrations.ts
@@ -40,9 +40,10 @@ import type { PoolClient } from "pg";
 
 export const SCHEMA_VERSION_1 = 1;
 export const SCHEMA_VERSION_2 = 2;
+export const SCHEMA_VERSION_3 = 3;
 
 /** Target version for new databases. */
-export const CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_2;
+export const CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_3;
 
 /**
  * Advisory lock key for the migration chain. Arbitrary but stable 64-bit
@@ -74,6 +75,7 @@ export async function runMigrations(client: PoolClient): Promise<void> {
     > = [
       [SCHEMA_VERSION_1, migrateToV1],
       [SCHEMA_VERSION_2, migrateToV2],
+      [SCHEMA_VERSION_3, migrateToV3],
     ];
 
     for (const [version, migrate] of chain) {
@@ -274,5 +276,23 @@ async function migrateToV1(client: PoolClient): Promise<void> {
 async function migrateToV2(client: PoolClient): Promise<void> {
   await client.query(`
     CREATE INDEX idx_wfee_created_at ON workflow_execution_events (created_at);
+  `);
+}
+
+/**
+ * v3: the by-resource grant sweep's index.
+ *
+ * OAuthGrantStore.deleteByResourceId (the cloud channel teardown's arm)
+ * deletes every oauth_grant row for a resource regardless of granting
+ * identity; the primary key leads with identity_account_id, so the sweep
+ * would otherwise seq-scan a table M1 later fills with the Java edition's
+ * accumulated grants. The Java edition carries the identical index
+ * (idx_oauth_grant_resource) for the identical delete cascade — the same
+ * v2 doctrine: a query pattern owned by a cloud extension does not exempt
+ * the index.
+ */
+async function migrateToV3(client: PoolClient): Promise<void> {
+  await client.query(`
+    CREATE INDEX idx_oauth_grant_resource ON oauth_grant (resource_id, org_id);
   `);
 }

--- a/backend/services/stigmer-server/src/store/postgres/store.ts
+++ b/backend/services/stigmer-server/src/store/postgres/store.ts
@@ -235,7 +235,9 @@ export class PostgresStore implements Store {
     const rows = await this.listResources(kind);
     const match = scanForFieldMatch(rows, schema, fieldPath, value);
     if (match === undefined) {
-      throw new ResourceNotFoundError(`${kindName} where ${fieldPath}=${value}`);
+      throw new ResourceNotFoundError(
+        `${kindName} where ${fieldPath}=${value}`,
+      );
     }
     return match;
   }
@@ -300,7 +302,13 @@ export class PostgresStore implements Store {
     await this.open().query(
       `INSERT INTO resource_audit (kind, resource_id, data, version_hash, tag, archived_at)
        VALUES ($1, $2, $3, $4, $5, now())`,
-      [apiResourceKindName(kind), resourceId, Buffer.from(data), versionHash, tag],
+      [
+        apiResourceKindName(kind),
+        resourceId,
+        Buffer.from(data),
+        versionHash,
+        tag,
+      ],
     );
   }
 
@@ -310,7 +318,11 @@ export class PostgresStore implements Store {
     versionHash: string,
     schema: Desc,
   ): Promise<MessageShape<Desc>> {
-    const record = await this.getAuditRecordByHash(kind, resourceId, versionHash);
+    const record = await this.getAuditRecordByHash(
+      kind,
+      resourceId,
+      versionHash,
+    );
     return fromBinary(schema, record.data);
   }
 
@@ -646,9 +658,7 @@ export class PostgresStore implements Store {
     );
 
     return {
-      total: Number(
-        (totalResult.rows[0] as { total: string | number }).total,
-      ),
+      total: Number((totalResult.rows[0] as { total: string | number }).total),
       runs: (
         result.rows as Array<{
           schedule_id: string;
@@ -1201,6 +1211,15 @@ class PostgresOAuthGrantStore implements OAuthGrantStore {
       [identityAccountId, resourceId, orgId],
     );
   }
+
+  async deleteByResourceId(resourceId: string, orgId: string): Promise<number> {
+    const result = await this.open().query(
+      `DELETE FROM oauth_grant
+       WHERE resource_id = $1 AND org_id = $2`,
+      [resourceId, orgId],
+    );
+    return result.rowCount ?? 0;
+  }
 }
 
 // =============================================================================
@@ -1308,5 +1327,8 @@ class PostgresPendingOAuthStateStore implements PendingOAuthStateStore {
 
 /** Escapes LIKE metacharacters so a prefix matches literally. */
 function escapeLikePattern(value: string): string {
-  return value.replaceAll("\\", "\\\\").replaceAll("%", "\\%").replaceAll("_", "\\_");
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("%", "\\%")
+    .replaceAll("_", "\\_");
 }

--- a/backend/services/stigmer-server/src/store/sqlite/__tests__/migrations.test.ts
+++ b/backend/services/stigmer-server/src/store/sqlite/__tests__/migrations.test.ts
@@ -81,7 +81,7 @@ describe("fresh database", () => {
     const rows = db
       .prepare(`SELECT version FROM schema_version ORDER BY version`)
       .all() as Array<{ version: number }>;
-    expect(rows.map((row) => row.version)).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(rows.map((row) => row.version)).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
   });
 
   it("re-opening an already-migrated database is a no-op", async () => {
@@ -101,7 +101,7 @@ describe("fresh database", () => {
 });
 
 describe("Go-created v6 database adoption (DD-002 fixture)", () => {
-  it("migrates 6 → 7 preserving every row, including the out-of-chain tables", async () => {
+  it("migrates 6 → current preserving every row, including the out-of-chain tables", async () => {
     const fixture = materializeGoFixture();
     cleanups.push(() => fixture.cleanup());
 
@@ -116,7 +116,7 @@ describe("Go-created v6 database adoption (DD-002 fixture)", () => {
     const db = new DatabaseSync(fixture.dbPath);
     cleanups.push(() => db.close());
 
-    expect(getSchemaVersion(db)).toBe(7);
+    expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
 
     // Every Go-written row survives adoption untouched.
     const org = db
@@ -130,7 +130,9 @@ describe("Go-created v6 database adoption (DD-002 fixture)", () => {
     expect(audit).toEqual({ version_hash: "hash-v1", tag: "stable" });
 
     const bootstrap = db
-      .prepare(`SELECT value FROM bootstrap_state WHERE key = 'seedpack_version'`)
+      .prepare(
+        `SELECT value FROM bootstrap_state WHERE key = 'seedpack_version'`,
+      )
       .get() as { value: string };
     expect(bootstrap.value).toBe("1.1.0");
 
@@ -154,12 +156,16 @@ describe("Go-created v6 database adoption (DD-002 fixture)", () => {
     expect(dedupe.status).toBe("DELIVERED");
 
     const grant = db
-      .prepare(`SELECT client_id FROM oauth_grant WHERE identity_account_id = 'ida_fixture'`)
+      .prepare(
+        `SELECT client_id FROM oauth_grant WHERE identity_account_id = 'ida_fixture'`,
+      )
       .get() as { client_id: string };
     expect(grant.client_id).toBe("client-1");
 
     const pending = db
-      .prepare(`SELECT code_verifier, org FROM pending_oauth_state WHERE state = 'state-fixture'`)
+      .prepare(
+        `SELECT code_verifier, org FROM pending_oauth_state WHERE state = 'state-fixture'`,
+      )
       .get() as { code_verifier: string; org: string };
     expect(pending.code_verifier).toBe("enc:v1:sealed");
     expect(pending.org).toBe("acme");
@@ -181,12 +187,10 @@ describe("Go-created v6 database adoption (DD-002 fixture)", () => {
     const store = SqliteStore.open(fixture.dbPath);
     cleanups.push(() => store.close());
 
-    const { OrganizationSchema } = await import(
-      "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb"
-    );
-    const { ApiResourceKind } = await import(
-      "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb"
-    );
+    const { OrganizationSchema } =
+      await import("@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb");
+    const { ApiResourceKind } =
+      await import("@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb");
     const org = await store.getResource(
       ApiResourceKind.organization,
       "acme",
@@ -240,7 +244,7 @@ describe("v7 column reconciliation", () => {
       )
       .get() as { state: string; org: string; token_auth_method: string };
     expect(row).toEqual({ state: "old-state", org: "", token_auth_method: "" });
-    expect(getSchemaVersion(db)).toBe(7);
+    expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
   });
 });
 
@@ -281,7 +285,7 @@ describe("legacy pre-v2 database", () => {
     // Hash/tag stay empty for migrated rows (unknowable without the type).
     expect(audit.version_hash).toBe("");
     expect(audit.tag).toBe("");
-    expect(getSchemaVersion(db)).toBe(7);
+    expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
   });
 });
 

--- a/backend/services/stigmer-server/src/store/sqlite/migrations.ts
+++ b/backend/services/stigmer-server/src/store/sqlite/migrations.ts
@@ -1,7 +1,8 @@
 /**
  * Versioned schema migrations — ports the inline chain in
- * backend/libs/go/store/sqlite/store.go (v1–v6, DDL character-faithful) and
- * adds v7, the OD-3 consolidation (D2 §3).
+ * backend/libs/go/store/sqlite/store.go (v1–v6, DDL character-faithful),
+ * adds v7, the OD-3 consolidation (D2 §3), and v8, the by-resource
+ * oauth_grant index (the channel teardown's query pattern, C3 Stage 6).
  *
  * Schema continuity across cutover is the design point: a database the Go
  * server created at any version migrates forward through the SAME steps Go
@@ -39,9 +40,11 @@ export const SCHEMA_VERSION_5 = 5;
 export const SCHEMA_VERSION_6 = 6;
 /** v7: OD-3 consolidation of the out-of-chain tables (this port's addition). */
 export const SCHEMA_VERSION_7 = 7;
+/** v8: the by-resource grant-teardown index (the C3 channel installer). */
+export const SCHEMA_VERSION_8 = 8;
 
 /** Target version for new databases. */
-export const CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_7;
+export const CURRENT_SCHEMA_VERSION = SCHEMA_VERSION_8;
 
 /** Applies all pending migrations in order. */
 export function runMigrations(db: DatabaseSync): void {
@@ -62,6 +65,7 @@ export function runMigrations(db: DatabaseSync): void {
     [SCHEMA_VERSION_5, migrateToV5],
     [SCHEMA_VERSION_6, migrateToV6],
     [SCHEMA_VERSION_7, migrateToV7],
+    [SCHEMA_VERSION_8, migrateToV8],
   ];
 
   for (const [version, migrate] of chain) {
@@ -265,7 +269,7 @@ function migrateToV6(db: DatabaseSync): void {
 
 /**
  * v7: OD-3 consolidation. DDL copied verbatim from the Go consumer stores
- * (signal_dedupe_store.go createTable; grant_store.go / 
+ * (signal_dedupe_store.go createTable; grant_store.go /
  * pending_state_store.go ensureTable) — IF NOT EXISTS adopts a live
  * database's existing tables and data untouched.
  */
@@ -335,4 +339,21 @@ function migrateToV7(db: DatabaseSync): void {
       // Column already exists — the CREATE above or a prior Go boot added it.
     }
   }
+}
+
+/**
+ * v8: the by-resource grant sweep's index.
+ *
+ * OAuthGrantStore.deleteByResourceId (the cloud channel teardown's arm)
+ * deletes every grant for a resource regardless of granting identity; the
+ * primary key leads with identity_account_id, so without this index the
+ * sweep scans. The Java edition carries the identical index
+ * (idx_oauth_grant_resource) for the identical delete cascade, and the
+ * postgres chain's v2 ratified the doctrine: a query pattern owned by a
+ * cloud extension does not exempt the index.
+ */
+function migrateToV8(db: DatabaseSync): void {
+  db.exec(`
+    CREATE INDEX IF NOT EXISTS idx_oauth_grant_resource ON oauth_grant(resource_id, org_id);
+  `);
 }

--- a/backend/services/stigmer-server/src/store/sqlite/store.ts
+++ b/backend/services/stigmer-server/src/store/sqlite/store.ts
@@ -245,7 +245,9 @@ export class SqliteStore implements Store {
       value,
     );
     if (match === undefined) {
-      throw new ResourceNotFoundError(`${kindName} where ${fieldPath}=${value}`);
+      throw new ResourceNotFoundError(
+        `${kindName} where ${fieldPath}=${value}`,
+      );
     }
     return match;
   }
@@ -328,7 +330,11 @@ export class SqliteStore implements Store {
     versionHash: string,
     schema: Desc,
   ): Promise<MessageShape<Desc>> {
-    const record = await this.getAuditRecordByHash(kind, resourceId, versionHash);
+    const record = await this.getAuditRecordByHash(
+      kind,
+      resourceId,
+      versionHash,
+    );
     return fromBinary(schema, record.data);
   }
 
@@ -661,7 +667,9 @@ export class SqliteStore implements Store {
     const effectiveOffset = offset < 0 ? 0 : offset;
 
     const totalRow = db
-      .prepare(`SELECT COUNT(*) AS total FROM schedule_runs WHERE schedule_id = ?`)
+      .prepare(
+        `SELECT COUNT(*) AS total FROM schedule_runs WHERE schedule_id = ?`,
+      )
       .get(scheduleId) as { total: number };
 
     const rows = db
@@ -970,7 +978,15 @@ class SqliteSignalDedupeStore implements SignalDedupeStore {
       db.prepare(
         `INSERT INTO signal_dedupe (id, org, idempotency_key, execution_id, signal_name, status, created_at, expires_at)
          VALUES (?, ?, ?, ?, ?, 'CLAIMED', ?, ?)`,
-      ).run(id, org, idempotencyKey, executionId, signalName, createdAt, expiresAt);
+      ).run(
+        id,
+        org,
+        idempotencyKey,
+        executionId,
+        signalName,
+        createdAt,
+        expiresAt,
+      );
     } catch (error) {
       if (!isUniqueConstraintError(error)) {
         throw error;
@@ -1191,6 +1207,16 @@ class SqliteOAuthGrantStore implements OAuthGrantStore {
          WHERE identity_account_id = ? AND resource_id = ? AND org_id = ?`,
       )
       .run(identityAccountId, resourceId, orgId);
+  }
+
+  async deleteByResourceId(resourceId: string, orgId: string): Promise<number> {
+    const result = this.open()
+      .prepare(
+        `DELETE FROM oauth_grant
+         WHERE resource_id = ? AND org_id = ?`,
+      )
+      .run(resourceId, orgId);
+    return Number(result.changes);
   }
 }
 


### PR DESCRIPTION
## Summary
Adds the by-resource delete arm to the OSS store's `oauthGrants` sub-store — `deleteByResourceId(resourceId, orgId)` — plus the index that serves it (SQLite v8, Postgres v3: `idx_oauth_grant_resource`). This is the seam the cloud channel teardown consumes (C3 Stage 6, the Slack OAuth installer): channel deletion must sweep every grant for the channel regardless of which identity installed it, exactly the Java `OAuthGrantRepo.deleteByResourceId` cascade.

## Context
The `oauth_grant` store is resource-agnostic by design ("resourceId can refer to any kind that requires OAuth credentials"), but its only delete was exact-key `(identity, resource, org)`. Re-installs by different callers leave one row per identity, so a resource teardown needs the by-resource sweep. Ruled at the C3 Stage 6 plan gate (Q2a: one home for all grants — no cloud-side twin table).

## Changes
- `store/interface.ts`: `OAuthGrantStore.deleteByResourceId(resourceId, orgId): Promise<number>` (returns the deleted count the cascade logs); `resourceKind` doc gains `"agent_channel"`.
- `store/sqlite/store.ts`, `store/postgres/store.ts`: the driver implementations.
- `store/sqlite/migrations.ts` v8, `store/postgres/migrations.ts` v3: `idx_oauth_grant_resource ON oauth_grant (resource_id, org_id)` — the PK leads with `identity_account_id`, so the sweep would otherwise scan; the Java edition carries the identical index, and the postgres chain's v2 ratified the doctrine (a cloud-extension query pattern does not exempt the index).
- Shared store-contract suite: the sweep pins both-identities deletion, other-resource survival, the count, and idempotent re-sweep; migration tests updated for the new chain tails.

## Breaking changes
- None (additive interface method; new migration versions apply idempotently).

## Test plan
- Shared store contract against BOTH drivers: SQLite 52 tests, Postgres 53 tests green (throwaway `postgres:16-alpine`).
- Migration suites green both drivers (fresh replay, mid-chain resume, idempotent reopen).
- Full unit suite: 2009 passed / 58 skipped (150 files); `tsc --noEmit` clean.

## Risks
- Minimal: additive method + index-only migrations. Rollback = revert; the index is inert weight if unused.

Made with [Cursor](https://cursor.com)