### PR TITLE
feat(backend/stigmer-server): Stage 4 — direct-handler authorization + the summary read scope (C2)

### DIFF
--- a/backend/services/stigmer-server/docs/authorization-coverage.md
+++ b/backend/services/stigmer-server/docs/authorization-coverage.md
@@ -5,8 +5,8 @@ This document is the ratified coverage inventory for the stigmer-server authoriz
 How to read the tables:
 
 - **Annotation** is what the method's proto declares: a `config` summary (`permission` on `resource_kind`, the `field_path` or literal `resource_id` the target is resolved from, and whether `error_msg` is set), `is_public` (50057), `is_skip_authorization` (50058), or `none` (no option at all — the apply RPCs and the gRPC health service).
-- **Handler** is what the server actually runs: `chain-with-Authorize` means the handler builds a `newPipeline(...)` whose FIRST `.addStep` is `newAuthorizeStep(<its own method descriptor>, authorizer)`; `direct: <posture>` means no pipeline is built and the Authorize step never runs for that method.
-- The two columns are independent facts. A method can carry a `config` annotation and still be a direct handler — for such methods the annotation is declared but not evaluated by the Authorize step today. Every such method is called out in the "annotated but direct" list before the notes section.
+- **Handler** is what the server actually runs: `chain-with-Authorize` means the handler builds a `newPipeline(...)` whose FIRST `.addStep` is `newAuthorizeStep(<its own method descriptor>, authorizer)`; `direct: <posture>` means no pipeline is built. A direct handler marked `authorizeDirect` evaluates its annotation through the SAME exported evaluation the step runs (`authorizeDirect` in `src/pipeline/steps/authorize.ts` — identical skip arms, target resolution, and decision mapping; C2 Stage 4, 20260827.10), placed per the Java baseline's handler order (noted per row where it differs from authorize-first).
+- The two columns are independent facts. A method can carry a `config` annotation and be a direct handler — since C2 Stage 4 nearly all such methods evaluate the annotation via `authorizeDirect`; the dispositions of the full set are recorded in the "Config-annotated methods served by direct handlers" section before the notes.
 - Authorize step semantics (verified in `src/pipeline/steps/authorize.ts`): the step returns immediately for the `internal` caller class, then for `is_public`, then for `is_skip_authorization`, then for methods with no `config` option; only a present `config` reaches the composed Authorizer. So even on chain methods, a skip/public annotation means the Authorizer is never consulted — the step's presence still gives C1/C2 the uniform interception point.
 
 Verification notes: every registration map in `src/boot/compose.ts`'s routes closure was cross-checked against its controller file and its proto service definition; every `newAuthorizeStep` call site was checked for descriptor/RPC agreement (all ten lifecycle RPCs pass their own descriptor through the shared `runLifecyclePipeline` builder; memory `confirm`/`reject` pass their own descriptors through the shared `runTransition` helper); a mechanical scan confirmed `newAuthorizeStep` is the first `.addStep` of every `newPipeline` in the server (zero exceptions).
@@ -15,9 +15,9 @@ Verification notes: every registration map in `src/boot/compose.ts`'s routes clo
 
 - Registered services: 29 (28 Stigmer services + the standard gRPC health service; ApiKey command + query added by O3, 20260827.06).
 - Registered RPC methods: 233.
-- Handler classes: 179 `chain-with-Authorize`, 54 `direct`.
+- Handler classes: 179 `chain-with-Authorize`, 54 `direct` (17 of which evaluate their annotation via `authorizeDirect` — C2 Stage 4).
 - Annotation classes: 139 `config`, 74 `is_skip_authorization`, 2 `is_public`, 18 `none` (15 apply RPCs + 3 health methods).
-- Config-annotated methods served by direct handlers (annotation declared, Authorize step not running): 30 — enumerated before the notes section.
+- Config-annotated methods served by direct handlers: 30, dispositioned at the C2 Stage-4 gate (17 `authorizeDirect`, 9 on the composed channel runtime, 1 deliberate skip, 3 recorded-gap stubs) — the full table before the notes section.
 
 ## 1. Health (`grpc.health.v1.Health`, `src/transport/health.ts`)
 
@@ -131,7 +131,7 @@ All six RPCs are chains, and the proto deliberately marks every one `is_skip_aut
 | SessionCommandController.apply | none | chain-with-Authorize |
 | SessionCommandController.create | config: can_create_session on organization (field metadata.org), error_msg yes | chain-with-Authorize |
 | SessionCommandController.update | config: can_edit on session (field metadata.id), error_msg yes | chain-with-Authorize |
-| SessionCommandController.updateSubject | config: can_edit on session (field id), error_msg yes | direct: field-level read-modify-write on the server (no pipeline by design — ports Go update_subject.go); annotated but Authorize does not run |
+| SessionCommandController.updateSubject | config: can_edit on session (field id), error_msg yes | direct: field-level read-modify-write (ports Go update_subject.go); authorizeDirect AFTER the load — the Java load-before-authorize order (#224) |
 | SessionCommandController.delete | config: can_delete on session (field value), error_msg yes | chain-with-Authorize |
 | SessionQueryController.get | config: can_view on session (field value), error_msg yes | chain-with-Authorize |
 | SessionQueryController.list | is_skip_authorization | chain-with-Authorize |
@@ -254,14 +254,14 @@ The conversation surface is a cloud capability; OSS serves edition stubs, all di
 | AgentExecutionQueryController.get | config: can_view on agent_execution (field value), error_msg yes | chain-with-Authorize |
 | AgentExecutionQueryController.list | is_skip_authorization | chain-with-Authorize |
 | AgentExecutionQueryController.listBySession | is_skip_authorization | chain-with-Authorize |
-| AgentExecutionQueryController.subscribe | config: can_view on agent_execution (field value), error_msg yes | direct: stream subscribe over broker (register-before-snapshot; server-stream generator cannot run inside the pipeline executor) |
-| AgentExecutionQueryController.getArtifactDownloadUrl | config: can_view on agent_execution (field execution_id), error_msg yes | direct: key-prefix / attachment-membership ownership check, then time-limited URL mint |
-| AgentExecutionQueryController.getArtifactContent | config: can_view on agent_execution (field execution_id), error_msg yes | direct: key-prefix ownership check, CAS-blob integrity check, truncated bytes in response |
+| AgentExecutionQueryController.subscribe | config: can_view on agent_execution (field value), error_msg yes | direct: stream subscribe over broker (register-before-snapshot; server-stream generator cannot run inside the pipeline executor); authorizeDirect once at subscription start |
+| AgentExecutionQueryController.getArtifactDownloadUrl | config: can_view on agent_execution (field execution_id), error_msg yes | direct: authorizeDirect, then key-prefix / attachment-membership ownership check, then time-limited URL mint |
+| AgentExecutionQueryController.getArtifactContent | config: can_view on agent_execution (field execution_id), error_msg yes | direct: authorizeDirect, then key-prefix ownership check, CAS-blob integrity check, truncated bytes in response |
 | AgentExecutionQueryController.getExecutionUsageReport | config: can_view on agent_execution (field execution_id), error_msg yes | chain-with-Authorize (usage.ts) |
 | AgentExecutionQueryController.getSessionUsageReport | config: can_view on session (field session_id), error_msg yes | chain-with-Authorize (usage.ts) |
 | AgentExecutionQueryController.getAgentUsageReport | config: can_view on organization (field org_id), error_msg yes | chain-with-Authorize (usage.ts) |
 | AgentExecutionQueryController.getOrgUsageReport | config: can_view on organization (field org_id), error_msg yes | chain-with-Authorize (usage.ts) |
-| AgentExecutionQueryController.getExecutionSummary | is_skip_authorization | direct: full-scan store aggregate for the dashboard (a direct handler in Go as well) |
+| AgentExecutionQueryController.getExecutionSummary | is_skip_authorization | direct: full-scan store aggregate for the dashboard (a direct handler in Go as well); a composed ExecutionReadScope narrows it to authorized ids ∩ requested org (C2 Stage 4) |
 
 ## 17. Workflow (`src/domain/workflow/controller.ts`)
 
@@ -272,12 +272,12 @@ The conversation surface is a cloud capability; OSS serves edition stubs, all di
 | WorkflowCommandController.update | config: can_edit on workflow (field metadata.id), error_msg yes | chain-with-Authorize |
 | WorkflowCommandController.updateVisibility | config: can_edit on workflow (field resource_id), error_msg yes | chain-with-Authorize |
 | WorkflowCommandController.delete | config: can_delete on workflow (field value), error_msg yes | chain-with-Authorize |
-| WorkflowCommandController.validateSpec | config: can_create_workflow on organization (field metadata.org), error_msg yes | direct: validation-only, nothing persisted (Layer-2 validator over the domain-owned registry store) |
+| WorkflowCommandController.validateSpec | config: can_create_workflow on organization (field metadata.org), error_msg yes | direct: validation-only, nothing persisted (Layer-2 validator over the domain-owned registry store); annotation DELIBERATELY not evaluated — matches the Java handler's documented "no persist, no authorize" posture (C2 Stage-4 gate ruling; the annotation mismatch is recorded, not an omission) |
 | WorkflowCommandController.tagVersion | config: can_edit on workflow (field workflow_id), error_msg yes | chain-with-Authorize |
 | WorkflowQueryController.get | config: can_view on workflow (field value), error_msg yes | chain-with-Authorize |
 | WorkflowQueryController.getByReference | is_skip_authorization | direct: branching slug/org read (Go's own direct-handler note) |
 | WorkflowQueryController.listVersions | is_skip_authorization | chain-with-Authorize |
-| WorkflowQueryController.getVersion | config: can_view on workflow (field workflow_id), error_msg yes | direct: live-then-audit version read |
+| WorkflowQueryController.getVersion | config: can_view on workflow (field workflow_id), error_msg yes | direct: authorizeDirect, then live-then-audit version read. DELIBERATE divergence from the Java edition (C2 Stage-4 gate ruling): Java declares the annotation but never evaluates it (a cross-org version-read gap; its javadoc claims framework enforcement that does not exist) — the annotation is the contract and this server enforces it |
 
 ## 18. WorkflowInstance (`src/domain/workflowinstance/controller.ts`)
 
@@ -313,10 +313,10 @@ The conversation surface is a cloud capability; OSS serves edition stubs, all di
 | WorkflowExecutionQueryController.get | config: can_view on workflow_execution (field value), error_msg yes | chain-with-Authorize |
 | WorkflowExecutionQueryController.list | is_skip_authorization | direct: full-scan store read (malformed rows skipped) |
 | WorkflowExecutionQueryController.listByWorkflow | is_skip_authorization | direct: full-scan store read filtered by workflow |
-| WorkflowExecutionQueryController.subscribe | config: can_view on workflow_execution (field execution_id), error_msg yes | direct: stream subscribe over broker |
-| WorkflowExecutionQueryController.getEventLog | config: can_view on workflow_execution (field execution_id), error_msg yes | direct: cursor-paginated read over the event side table (no existence check by contract) |
-| WorkflowExecutionQueryController.subscribeEvents | config: can_view on workflow_execution (field execution_id), error_msg yes | direct: event-log replay + poll stream (existence-checked NotFound before streaming) |
-| WorkflowExecutionQueryController.getExecutionSummary | is_skip_authorization | direct: full-scan store aggregate for the dashboard |
+| WorkflowExecutionQueryController.subscribe | config: can_view on workflow_execution (field execution_id), error_msg yes | direct: stream subscribe over broker; authorizeDirect once at subscription start |
+| WorkflowExecutionQueryController.getEventLog | config: can_view on workflow_execution (field execution_id), error_msg yes | direct: authorizeDirect, then cursor-paginated read over the event side table (no existence check by contract) |
+| WorkflowExecutionQueryController.subscribeEvents | config: can_view on workflow_execution (field execution_id), error_msg yes | direct: authorizeDirect at subscription start, then event-log replay + poll stream (existence-checked NotFound before streaming) |
+| WorkflowExecutionQueryController.getExecutionSummary | is_skip_authorization | direct: full-scan store aggregate for the dashboard; a composed ExecutionReadScope narrows it to authorized ids ∩ requested org, empty set = the default instance (C2 Stage 4) |
 | WorkflowExecutionQueryController.listPendingApprovals | is_skip_authorization | direct: scan of IN_PROGRESS executions for waiting-approval tasks |
 
 ## 20. McpServer (`src/domain/mcpserver/controller.ts` + connect.ts, start-connect.ts, initiate-oauth-connect.ts, complete-oauth-connect.ts, disconnect-oauth.ts, get-oauth-grant-status.ts)
@@ -328,16 +328,16 @@ The conversation surface is a cloud capability; OSS serves edition stubs, all di
 | McpServerCommandController.update | config: can_edit on mcp_server (field metadata.id), error_msg yes | chain-with-Authorize |
 | McpServerCommandController.updateVisibility | config: can_edit on mcp_server (field resource_id), error_msg yes | chain-with-Authorize |
 | McpServerCommandController.delete | config: can_delete on mcp_server (field resource_id), error_msg yes | chain-with-Authorize |
-| McpServerCommandController.connect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: blocking connect flow over the engine seam (ephemeral ExecutionContext, decrypt-lane token mint, runner workflow start) |
-| McpServerCommandController.startConnect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: async connect lane over the engine seam |
-| McpServerCommandController.initiateOAuthConnect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: OAuth authorize-URL mint (refuses FAILED_PRECONDITION without a configured redirect URI) |
-| McpServerCommandController.completeOAuthConnect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: OAuth code exchange + grant persistence |
-| McpServerCommandController.disconnectOAuth | config: can_connect on mcp_server (field resource_id), error_msg yes | direct: grant teardown |
+| McpServerCommandController.connect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: blocking connect flow over the engine seam (ephemeral ExecutionContext, decrypt-lane token mint, runner workflow start); authorizeDirect AFTER the load (#224) |
+| McpServerCommandController.startConnect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: async connect lane over the engine seam; authorizeDirect AFTER the load (#224) |
+| McpServerCommandController.initiateOAuthConnect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: OAuth authorize-URL mint (refuses FAILED_PRECONDITION without a configured redirect URI); authorizeDirect AFTER the load (#224) |
+| McpServerCommandController.completeOAuthConnect | config: can_connect on mcp_server (field mcp_server_id), error_msg yes | direct: OAuth code exchange + grant persistence; authorizeDirect against the PENDING RECORD's server id (target override — the Java confused-deputy discipline; the single-use state is burned before a denial lands) |
+| McpServerCommandController.disconnectOAuth | config: can_connect on mcp_server (field resource_id), error_msg yes | direct: grant teardown; authorizeDirect after input validation (no load step — the Java order) |
 | McpServerCommandController.setOrgOAuthApp | config: can_create_oauth_app on organization (field org), error_msg yes | direct: OSS stub — throws Unimplemented (org OAuth-app overrides are cloud-only) |
 | McpServerCommandController.deleteOrgOAuthApp | config: can_create_oauth_app on organization (field org), error_msg yes | direct: OSS stub — throws Unimplemented |
 | McpServerQueryController.get | config: can_view on mcp_server (field value), error_msg yes | chain-with-Authorize |
 | McpServerQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
-| McpServerQueryController.getOAuthGrantStatus | config: can_view on mcp_server (field resource_id), error_msg yes | direct: grant-store read |
+| McpServerQueryController.getOAuthGrantStatus | config: can_view on mcp_server (field resource_id), error_msg yes | direct: authorizeDirect after input validation, then grant-store read |
 | McpServerQueryController.getOrgOAuthApp | config: can_view on mcp_server (field resource_id), error_msg yes | direct: OSS stub — throws Unimplemented |
 
 ## 21. Skill (`src/domain/skill/controller.ts` + push.ts)
@@ -360,11 +360,11 @@ The conversation surface is a cloud capability; OSS serves edition stubs, all di
 | Method | Annotation | Handler |
 |---|---|---|
 | ArtifactCommandController.create | is_skip_authorization | direct: content-addressed blob write + metadata row persist |
-| ArtifactCommandController.delete | config: can_edit on artifact (field value), error_msg yes | direct: soft delete — storage_state transition, never a row removal |
+| ArtifactCommandController.delete | config: can_edit on artifact (field value), error_msg yes | direct: soft delete — storage_state transition, never a row removal; authorizeDirect AFTER the load (#224) |
 | ArtifactQueryController.get | config: can_view on artifact (field value), error_msg yes | chain-with-Authorize |
 | ArtifactQueryController.listByExecution | is_skip_authorization | chain-with-Authorize |
-| ArtifactQueryController.getDownloadUrl | config: can_view on artifact (field value), error_msg yes | direct: time-limited URL mint against the blob store |
-| ArtifactQueryController.getContent | config: can_view on artifact (field artifact_id), error_msg yes | direct: truncated bytes in the response (512KB default cap) |
+| ArtifactQueryController.getDownloadUrl | config: can_view on artifact (field value), error_msg yes | direct: time-limited URL mint against the blob store; authorizeDirect AFTER the load (#224) |
+| ArtifactQueryController.getContent | config: can_view on artifact (field artifact_id), error_msg yes | direct: truncated bytes in the response (512KB default cap); authorizeDirect AFTER the load (#224) |
 
 ## 23. Project (`src/domain/project/controller.ts`)
 
@@ -406,16 +406,27 @@ The conversation surface is a cloud capability; OSS serves edition stubs, all di
 
 ## Config-annotated methods served by direct handlers
 
-These 30 methods declare a `(ai.stigmer.commons.rpc.config)` annotation but run no pipeline, so the Authorize step never evaluates them on this server. C1/C2 must decide per method whether the cloud edition enforces the annotation in its own handler (several already do — the cloud conversation/install handlers are real) or whether the method needs to move onto a chain.
+These 30 methods declare a `(ai.stigmer.commons.rpc.config)` annotation and run no pipeline. All 30 were dispositioned at the C2 Stage-4 gate (20260827.10); the enforcement state per bucket:
+
+**Evaluated via `authorizeDirect` (17)** — the exported Authorize evaluation, called by the handler itself at the Java baseline's position (each table row notes load-first `#224` order where it applies):
 
 - Session: updateSubject
+- AgentExecution: subscribe, getArtifactDownloadUrl, getArtifactContent
+- Workflow: getVersion (a ruled DELIBERATE divergence — the Java edition never evaluates this annotation; see the table row)
+- WorkflowExecution: subscribe, getEventLog, subscribeEvents
+- McpServer: connect, startConnect, initiateOAuthConnect, completeOAuthConnect, disconnectOAuth, getOAuthGrantStatus
+- Artifact: delete, getDownloadUrl, getContent
+
+**Enforced by the composed channel runtime (9)** — this server's handlers delegate whole-method to `drivers.channelRuntime` (DD-004); the OSS default serves the byte-pinned refusal/stub postures with nothing to protect, and the cloud runtime's served arms gate on the composed Authorizer as their first act (its own suite pins the deny paths). The install pair is an interim stub on both sides until the C3 installer stage, which owes the can_edit arm when it lands:
+
 - AgentChannel: initiateInstall, completeInstall
 - ChannelConversation: getConversation, getTimeline, getMediaDownloadUrl, reply, takeOver, handBack, clearAttention
-- AgentExecution: subscribe, getArtifactDownloadUrl, getArtifactContent
-- Workflow: validateSpec, getVersion
-- WorkflowExecution: subscribe, getEventLog, subscribeEvents
-- McpServer: connect, startConnect, initiateOAuthConnect, completeOAuthConnect, disconnectOAuth, setOrgOAuthApp, deleteOrgOAuthApp, getOAuthGrantStatus, getOrgOAuthApp
-- Artifact: delete, getDownloadUrl, getContent
+
+**Deliberately not evaluated (1)** — Workflow.validateSpec: matches the Java handler's documented "no persist, no authorize" posture (nothing loaded or persisted); the annotation mismatch is a recorded ruling, not an omission.
+
+**Recorded-gap stubs (3)** — the org-OAuth-app (BYOA) surface answers UNIMPLEMENTED on this server (stigmer/stigmer#558) and is cloud-real in Java with dual authorization; the feature port is an unowned convergence gap recorded in the program's parent project, and enforcing an annotation on an Unimplemented stub protects nothing:
+
+- McpServer: setOrgOAuthApp, deleteOrgOAuthApp, getOrgOAuthApp
 
 ## Descriptor mismatches found
 

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -819,6 +819,7 @@ export async function composeServer(
       logger,
       authorizer,
       authorizationLifecycle,
+      executionReadScope: extensions.drivers.executionReadScope,
       broker: agentExecutionStreamBroker,
       engineState: executionEngineState,
       modelRegistry: modelCatalog,
@@ -866,6 +867,7 @@ export async function composeServer(
       logger,
       authorizer,
       authorizationLifecycle,
+      executionReadScope: extensions.drivers.executionReadScope,
       gateSteps: extensions.gateSteps,
       engineState: workflowExecutionEngineState,
       broker: workflowExecutionStreamBroker,
@@ -901,6 +903,7 @@ export async function composeServer(
       connect: {
         store,
         logger,
+        authorizer,
         engineState: mcpServerEngineState,
         environmentReader: {
           list: (request) =>

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/artifacts.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/artifacts.test.ts
@@ -24,17 +24,33 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import { LocalArtifactStorage } from "../../../artifactstorage/artifact-storage.js";
 import { createLogger } from "../../../boot/logger.js";
+import { newPermissiveSingleTeamAuthorizer } from "../../../pipeline/steps/authorize.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import { SqliteStore } from "../../../store/sqlite/store.js";
 import type { Store } from "../../../store/interface.js";
 
 import type { ArtifactRpcDeps } from "../artifacts.js";
 import {
   detectContentType,
-  getArtifactContent,
-  getArtifactDownloadUrl,
+  getArtifactContent as getArtifactContentRpc,
+  getArtifactDownloadUrl as getArtifactDownloadUrlRpc,
   osMimeTypeByExtension,
   uploadAttachment,
 } from "../artifacts.js";
+
+// The two read RPCs now evaluate their can_view annotations (C2 Stage 4);
+// these direct-call tests exercise them under the OSS permissive
+// authorizer with one fixed caller — the authorize.test.ts suite owns the
+// deny/not-found arms.
+const testCaller = testCallerIdentity();
+const getArtifactContent = (
+  deps: ArtifactRpcDeps,
+  req: Parameters<typeof getArtifactContentRpc>[1],
+) => getArtifactContentRpc(deps, req, testCaller);
+const getArtifactDownloadUrl = (
+  deps: ArtifactRpcDeps,
+  req: Parameters<typeof getArtifactDownloadUrlRpc>[1],
+) => getArtifactDownloadUrlRpc(deps, req, testCaller);
 
 const silentLogger = createLogger({
   level: "error",
@@ -56,6 +72,7 @@ beforeAll(() => {
       path.join(dir, "artifacts"),
       "http://localhost:7235",
     ),
+    authorizer: newPermissiveSingleTeamAuthorizer(),
   };
 });
 

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/read-authorization.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/read-authorization.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Pins the C2 Stage-4 enforcement on this domain's three config-annotated
+ * direct read surfaces (subscribe, getArtifactDownloadUrl,
+ * getArtifactContent): each evaluates its OWN annotation through
+ * authorizeDirect, and a denying authorizer answers PERMISSION_DENIED
+ * with the method's byte-pinned error_msg — before any store, broker, or
+ * blob-storage touch. The exact copy doubles as the descriptor-mismatch
+ * guard. The decision mapping itself is pinned in
+ * pipeline/steps/__tests__/authorize.test.ts.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { HandlerContext } from "@connectrpc/connect";
+import { Code, ConnectError, createContextValues } from "@connectrpc/connect";
+import { describe, expect, it } from "vitest";
+
+import {
+  AgentExecutionIdSchema,
+  GetArtifactContentRequestSchema,
+  GetArtifactDownloadUrlRequestSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+
+import type { ArtifactStorage } from "../../../artifactstorage/artifact-storage.js";
+import { createLogger } from "../../../boot/logger.js";
+import type { Authorizer } from "../../../extensions/authorizer.js";
+import { callerIdentityKey } from "../../../pipeline/interceptors/auth.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
+import type { Store } from "../../../store/interface.js";
+
+import { getArtifactContent, getArtifactDownloadUrl } from "../artifacts.js";
+import type { StreamBroker } from "../stream-broker.js";
+import { subscribeExecution } from "../subscribe.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const denyingAuthorizer: Authorizer = {
+  authorize: () => Promise.resolve({ kind: "deny", reason: "" }),
+};
+
+const untouchableStore = new Proxy({} as Store, {
+  get(_target, prop) {
+    throw new Error(`store.${String(prop)} reached despite the denial`);
+  },
+});
+
+const untouchableBroker = new Proxy({} as StreamBroker, {
+  get(_target, prop) {
+    throw new Error(`broker.${String(prop)} reached despite the denial`);
+  },
+});
+
+const untouchableStorage = new Proxy({} as ArtifactStorage, {
+  get(_target, prop) {
+    throw new Error(`storage.${String(prop)} reached despite the denial`);
+  },
+});
+
+function handlerContext(): HandlerContext {
+  const values = createContextValues();
+  values.set(callerIdentityKey, testCallerIdentity());
+  return { signal: new AbortController().signal, values } as HandlerContext;
+}
+
+async function expectDenied(run: () => Promise<unknown>, copy: string) {
+  const error = await run().catch((e: unknown) => e);
+  expect(error).toBeInstanceOf(ConnectError);
+  expect((error as ConnectError).code).toBe(Code.PermissionDenied);
+  expect((error as ConnectError).rawMessage).toBe(copy);
+}
+
+const artifactDeps = {
+  store: untouchableStore,
+  logger: silentLogger,
+  artifactStorage: untouchableStorage,
+  authorizer: denyingAuthorizer,
+};
+
+describe("read-surface authorization (C2 Stage 4)", () => {
+  it("subscribe denies with its annotation copy before touching store or broker", async () => {
+    await expectDenied(
+      () =>
+        subscribeExecution(
+          {
+            store: untouchableStore,
+            logger: silentLogger,
+            broker: untouchableBroker,
+            authorizer: denyingAuthorizer,
+          },
+          create(AgentExecutionIdSchema, { value: "aexec_01denied" }),
+          handlerContext(),
+        ).next(),
+      "unauthorized to subscribe to agent execution",
+    );
+  });
+
+  it("getArtifactDownloadUrl denies with its annotation copy before the load", async () => {
+    await expectDenied(
+      () =>
+        getArtifactDownloadUrl(
+          artifactDeps,
+          create(GetArtifactDownloadUrlRequestSchema, {
+            executionId: "aexec_01denied",
+            storageKey: "artifacts/aexec_01denied/report.txt",
+          }),
+          testCallerIdentity(),
+        ),
+      "unauthorized to download artifact from agent execution",
+    );
+  });
+
+  it("getArtifactContent denies with its annotation copy before the ownership check", async () => {
+    await expectDenied(
+      () =>
+        getArtifactContent(
+          artifactDeps,
+          create(GetArtifactContentRequestSchema, {
+            executionId: "aexec_01denied",
+            storageKey: "artifacts/aexec_01denied/report.txt",
+          }),
+          testCallerIdentity(),
+        ),
+      "unauthorized to read artifact content from agent execution",
+    );
+  });
+});

--- a/backend/services/stigmer-server/src/domain/agentexecution/artifacts.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/artifacts.ts
@@ -46,12 +46,17 @@ import {
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { create } from "@bufbuild/protobuf";
 
+import { AgentExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/query_pb";
+
 import type { Logger } from "../../boot/logger.js";
 import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import {
   internalError,
   invalidArgumentError,
 } from "../../pipeline/errors.js";
+import { authorizeDirect } from "../../pipeline/steps/authorize.js";
 import type { Store } from "../../store/interface.js";
 import { casBlobContentMismatch } from "./filereview/cas-blob.js";
 
@@ -59,6 +64,13 @@ export interface ArtifactRpcDeps {
   readonly store: Store;
   readonly logger: Logger;
   readonly artifactStorage: ArtifactStorage;
+  /**
+   * The composed authorization seam — the two artifact READ surfaces
+   * evaluate their can_view annotations before the ownership checks (the
+   * Java handler order; C2 Stage 4). uploadAttachment stays checkless by
+   * annotation (is_skip_authorization — the storage_key is the capability).
+   */
+  readonly authorizer: Authorizer;
 }
 
 /**
@@ -206,6 +218,7 @@ export function validateAttachmentFilename(name: string): void {
 export async function getArtifactContent(
   deps: ArtifactRpcDeps,
   req: GetArtifactContentRequest,
+  identity: CallerIdentity,
 ): Promise<GetArtifactContentResponse> {
   if (req.executionId === "") {
     throw invalidArgumentError("execution_id is required");
@@ -213,6 +226,14 @@ export async function getArtifactContent(
   if (req.storageKey === "") {
     throw invalidArgumentError("storage_key is required");
   }
+  // The annotation's can_view check (validate → authorize → ownership,
+  // the Java AgentExecutionGetArtifactContentHandler order; C2 Stage 4).
+  await authorizeDirect(
+    AgentExecutionQueryController.method.getArtifactContent,
+    deps.authorizer,
+    identity,
+    req,
+  );
 
   // Ownership is checked on the NORMALIZED key and the normalized key is
   // what gets served: the storage layer path-cleans `.`/`..` segments, so
@@ -385,6 +406,7 @@ function fileExtension(name: string): string {
 export async function getArtifactDownloadUrl(
   deps: ArtifactRpcDeps,
   req: GetArtifactDownloadUrlRequest,
+  identity: CallerIdentity,
 ): Promise<GetArtifactDownloadUrlResponse> {
   if (req.executionId === "") {
     throw invalidArgumentError("execution_id is required");
@@ -392,6 +414,14 @@ export async function getArtifactDownloadUrl(
   if (req.storageKey === "") {
     throw invalidArgumentError("storage_key is required");
   }
+  // The annotation's can_view check (validate → authorize → ownership,
+  // the Java AgentExecutionGetArtifactDownloadUrlHandler order; C2 Stage 4).
+  await authorizeDirect(
+    AgentExecutionQueryController.method.getArtifactDownloadUrl,
+    deps.authorizer,
+    identity,
+    req,
+  );
 
   // Load BEFORE the key check: the attachment arm needs spec.attachments,
   // and this doubles as the existence check.

--- a/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
@@ -30,6 +30,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ExecutionReadScope } from "../../extensions/execution-read-scope.js";
 import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
 import { stepsForSlot } from "../../extensions/gate-slots.js";
@@ -144,6 +145,8 @@ export interface AgentExecutionControllerDeps {
   readonly authorizer: Authorizer;
   /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
   readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
+  /** The composed summary read scope — undefined = the OSS full scan (C2 Stage 4). */
+  readonly executionReadScope: ExecutionReadScope | undefined;
   /**
    * The shared broadcast fabric for subscribe streams. ONE instance spans
    * both routers (serving + in-process) — see stream-broker.ts; the
@@ -217,6 +220,7 @@ export function registerAgentExecutionServices(
     store: deps.store,
     logger: deps.logger,
     artifactStorage: deps.artifactStorage,
+    authorizer: deps.authorizer,
   };
   router.service(AgentExecutionCommandController, {
     create: (execution, ctx) => createExecution(deps, execution, ctx),
@@ -245,8 +249,10 @@ export function registerAgentExecutionServices(
     list: (req, ctx) => list(deps, req, ctx),
     listBySession: (req, ctx) => listBySession(deps, req, ctx),
     subscribe: (id, ctx) => subscribeExecution(deps, id, ctx),
-    getArtifactDownloadUrl: (req) => getArtifactDownloadUrl(artifactDeps, req),
-    getArtifactContent: (req) => getArtifactContent(artifactDeps, req),
+    getArtifactDownloadUrl: (req, ctx) =>
+      getArtifactDownloadUrl(artifactDeps, req, callerIdentityOf(ctx)),
+    getArtifactContent: (req, ctx) =>
+      getArtifactContent(artifactDeps, req, callerIdentityOf(ctx)),
     getExecutionUsageReport: (req, ctx) =>
       getExecutionUsageReport(deps, req, callerIdentityOf(ctx)),
     getSessionUsageReport: (req, ctx) =>
@@ -255,7 +261,8 @@ export function registerAgentExecutionServices(
       getAgentUsageReport(deps, req, callerIdentityOf(ctx)),
     getOrgUsageReport: (req, ctx) =>
       getOrgUsageReport(deps, req, callerIdentityOf(ctx)),
-    getExecutionSummary: (req) => getExecutionSummary(deps, req),
+    getExecutionSummary: (req, ctx) =>
+      getExecutionSummary(deps, req, callerIdentityOf(ctx)),
   });
 }
 

--- a/backend/services/stigmer-server/src/domain/agentexecution/subscribe.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/subscribe.ts
@@ -40,11 +40,16 @@ import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecutio
 import type { AgentExecutionId } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
+import { AgentExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/query_pb";
+
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import {
   invalidArgumentError,
   notFoundError,
 } from "../../pipeline/errors.js";
+import { authorizeDirect } from "../../pipeline/steps/authorize.js";
 import type { Store } from "../../store/interface.js";
 
 import { isTranscriptTerminalPhase } from "./phases.js";
@@ -54,6 +59,8 @@ export interface SubscribeDeps {
   readonly store: Store;
   readonly logger: Logger;
   readonly broker: StreamBroker;
+  /** The composed authorization seam — the pre-stream check below (C2 Stage 4). */
+  readonly authorizer: Authorizer;
 }
 
 export async function* subscribeExecution(
@@ -65,6 +72,17 @@ export async function* subscribeExecution(
   if (executionId.value === "") {
     throw invalidArgumentError("execution id is required");
   }
+  // The annotation's can_view check, once at subscription start — the
+  // Java AgentExecutionSubscribeHandler order (validate → authorize).
+  // The composed authorizer's guest-isolation arm rides this same check
+  // (the G2 per-visitor cookie match), matching Java's GuestVisitorScope
+  // filter on this stream. C2 Stage 4.
+  await authorizeDirect(
+    AgentExecutionQueryController.method.subscribe,
+    deps.authorizer,
+    callerIdentityOf(context),
+    executionId,
+  );
   const id = executionId.value;
   deps.logger.info("Starting execution subscription", { executionId: id });
 

--- a/backend/services/stigmer-server/src/domain/agentexecution/usage.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/usage.ts
@@ -66,6 +66,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { ExecutionReadScope } from "../../extensions/execution-read-scope.js";
 import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
@@ -82,6 +83,8 @@ export interface UsageReportDeps {
   readonly logger: Logger;
   /** The composed authorization seam — the Authorize step at position 1 of every chain calls it (O2, DD-007 §3). */
   readonly authorizer: Authorizer;
+  /** The composed summary read scope — undefined = the OSS full scan (C2 Stage 4). */
+  readonly executionReadScope: ExecutionReadScope | undefined;
 }
 
 // Context keys for inter-step communication — Go's key strings, verbatim.
@@ -777,13 +780,36 @@ function requireReport<T>(value: unknown, message: string): T {
 // a direct handler in Go as well — no pipeline). Cost is deliberately
 // absent from this shape (AD-DASH-005: the dashboard sources cost from
 // getOrgUsageReport to prevent double-counting).
+//
+// With a composed ExecutionReadScope (C2 Stage 4), the scan narrows to
+// the caller's authorized ids ∩ the requested org and an empty set
+// answers the default instance — the Java
+// AgentExecutionGetExecutionSummaryHandler baseline; see the twin's
+// header (workflowexecution/get-execution-summary.ts) for the full
+// rationale. No scope composed = this full scan, byte-identical.
 // ---------------------------------------------------------------------------
 
 export async function getExecutionSummary(
   deps: UsageReportDeps,
   req: GetAgentExecutionSummaryRequest,
+  identity: CallerIdentity,
 ): Promise<AgentExecutionSummary> {
-  const executions = await loadAllAgentExecutions(deps.store, deps.logger);
+  let executions = await loadAllAgentExecutions(deps.store, deps.logger);
+
+  if (deps.executionReadScope !== undefined) {
+    const authorizedIds = await deps.executionReadScope.authorizedExecutionIds(
+      identity,
+      ApiResourceKind.agent_execution,
+    );
+    if (authorizedIds.size === 0) {
+      return create(AgentExecutionSummarySchema);
+    }
+    executions = executions.filter(
+      (execution) =>
+        authorizedIds.has(execution.metadata?.id ?? "") &&
+        execution.metadata?.org === req.org,
+    );
+  }
 
   const cutoffMs = resolveAgentTimeCutoffMs(req.timeWindow);
 

--- a/backend/services/stigmer-server/src/domain/artifact/controller.ts
+++ b/backend/services/stigmer-server/src/domain/artifact/controller.ts
@@ -63,7 +63,10 @@ import { newPipeline } from "../../pipeline/pipeline.js";
 import type { CallerIdentity } from "../../extensions/identity.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
-import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import {
+  authorizeDirect,
+  newAuthorizeStep,
+} from "../../pipeline/steps/authorize.js";
 import {
   generateId,
   setAuditFieldsForCreate,
@@ -106,8 +109,9 @@ export function registerArtifactServices(
   router.service(ArtifactQueryController, {
     get: (id, ctx) => get(deps, id, ctx),
     listByExecution: (req, ctx) => listByExecution(deps, req, ctx),
-    getDownloadUrl: (id) => getDownloadUrl(deps, id),
-    getContent: (req) => getContent(deps, req),
+    getDownloadUrl: (id, ctx) =>
+      getDownloadUrl(deps, id, callerIdentityOf(ctx)),
+    getContent: (req, ctx) => getContent(deps, req, callerIdentityOf(ctx)),
   });
 }
 
@@ -301,6 +305,16 @@ async function deleteArtifact(
 
   const artifact = await loadArtifactOrNotFound(deps, resourceId);
 
+  // The annotation's can_edit check AFTER the load — the Java
+  // ArtifactDeleteHandler order (load-before-authorize, stigmer#224).
+  // C2 Stage 4.
+  await authorizeDirect(
+    ArtifactCommandController.method.delete,
+    deps.authorizer,
+    identity,
+    id,
+  );
+
   deps.logger.info("soft-deleting artifact", {
     artifactId: resourceId,
     previousState: ArtifactStorageState[artifact.status?.storageState ?? 0],
@@ -476,6 +490,7 @@ async function listByExecution(
 async function getDownloadUrl(
   deps: ArtifactControllerDeps,
   id: ArtifactId,
+  identity: CallerIdentity,
 ): Promise<ArtifactDownloadUrl> {
   const resourceId = id.value;
   if (resourceId === "") {
@@ -483,6 +498,17 @@ async function getDownloadUrl(
   }
 
   const artifact = await loadArtifactOrNotFound(deps, resourceId);
+
+  // The annotation's can_view check AFTER the load — the Java
+  // ArtifactGetDownloadUrlHandler order (load-before-authorize,
+  // stigmer#224). C2 Stage 4.
+  await authorizeDirect(
+    ArtifactQueryController.method.getDownloadUrl,
+    deps.authorizer,
+    identity,
+    id,
+  );
+
   const contentHash = requireLiveBlob(artifact, resourceId);
 
   deps.logger.info("generating download URL for artifact", {
@@ -524,6 +550,7 @@ async function getDownloadUrl(
 async function getContent(
   deps: ArtifactControllerDeps,
   req: GetArtifactContentRequest,
+  identity: CallerIdentity,
 ): Promise<GetArtifactContentResponse> {
   const artifactId = req.artifactId;
   if (artifactId === "") {
@@ -531,6 +558,17 @@ async function getContent(
   }
 
   const artifact = await loadArtifactOrNotFound(deps, artifactId);
+
+  // The annotation's can_view check AFTER the load — the Java
+  // ArtifactGetContentHandler order (load-before-authorize, stigmer#224).
+  // C2 Stage 4.
+  await authorizeDirect(
+    ArtifactQueryController.method.getContent,
+    deps.authorizer,
+    identity,
+    req,
+  );
+
   const contentHash = requireLiveBlob(artifact, artifactId);
 
   let maxBytes = req.maxBytes;

--- a/backend/services/stigmer-server/src/domain/mcpserver/__tests__/connect-authorization.test.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/__tests__/connect-authorization.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Pins the C2 Stage-4 enforcement on the six config-annotated connect
+ * lanes (connect, startConnect, initiateOAuthConnect,
+ * completeOAuthConnect, disconnectOAuth, getOAuthGrantStatus): each
+ * evaluates its OWN annotation through authorizeDirect, and a denying
+ * authorizer answers PERMISSION_DENIED with the method's byte-pinned
+ * error_msg. Java-parity orders are asserted structurally:
+ *
+ *   - connect/startConnect/initiateOAuthConnect authorize AFTER the load
+ *     (stigmer#224 — a missing server answers NOT_FOUND even to a caller
+ *     the authorizer would deny);
+ *   - completeOAuthConnect authorizes against the PENDING RECORD's server
+ *     id, and the single-use state is burned before the denial lands (the
+ *     Java discipline — asserted via the consumed-state refusal on retry);
+ *   - disconnectOAuth/getOAuthGrantStatus authorize before any grant
+ *     lookup (the grant store is untouchable under denial).
+ */
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import {
+  CompleteOAuthConnectInputSchema,
+  ConnectInputSchema,
+  DisconnectOAuthInputSchema,
+  GetOAuthGrantStatusInputSchema,
+  InitiateOAuthConnectInputSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import type { Authorizer, AuthzCheck } from "../../../extensions/authorizer.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
+import { SqliteStore } from "../../../store/sqlite/store.js";
+
+import { connect } from "../connect.js";
+import type { McpServerConnectDeps } from "../connect.js";
+import { completeOAuthConnect } from "../complete-oauth-connect.js";
+import { disconnectOAuth } from "../disconnect-oauth.js";
+import { getOAuthGrantStatus } from "../get-oauth-grant-status.js";
+import { initiateOAuthConnect } from "../initiate-oauth-connect.js";
+import { startConnect } from "../start-connect.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const caller = testCallerIdentity();
+
+/** Records every check and denies — the arm + target assertions read it. */
+function denyingAuthorizer(): { authorizer: Authorizer; checks: AuthzCheck[] } {
+  const checks: AuthzCheck[] = [];
+  return {
+    checks,
+    authorizer: {
+      authorize(_caller, check) {
+        checks.push(check);
+        return Promise.resolve({ kind: "deny", reason: "" });
+      },
+    },
+  };
+}
+
+let dir: string;
+let store: SqliteStore;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), "mcps-authz-test-"));
+  store = SqliteStore.open(path.join(dir, "stigmer.db"));
+});
+
+afterEach(() => {
+  store.close();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function seedServer(id: string): Promise<void> {
+  await store.saveResource(
+    ApiResourceKind.mcp_server,
+    id,
+    McpServerSchema,
+    create(McpServerSchema, {
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "McpServer",
+      metadata: { id, name: id, org: "test-org" },
+    }),
+  );
+}
+
+function deps(authorizer: Authorizer): McpServerConnectDeps {
+  // Only the members a lane touches BEFORE its authorize call are real;
+  // everything after the denial is unreachable and throws if touched.
+  const unreachable = <T extends object>(name: string): T =>
+    new Proxy({} as T, {
+      get(_target, prop) {
+        throw new Error(`${name}.${String(prop)} reached despite the denial`);
+      },
+    });
+  return {
+    store,
+    logger: silentLogger,
+    authorizer,
+    engineState: () => ({
+      connected: true,
+      engine: unreachable("engine"),
+    }),
+    environmentReader: unreachable("environmentReader"),
+    executionContext: unreachable("executionContext"),
+    runnerAuth: unreachable("runnerAuth"),
+    managedEnv: unreachable("managedEnv"),
+    oauthGrants: unreachable("oauthGrants"),
+    pendingOAuthStates: store.pendingOAuthStates,
+    secretService: unreachable("secretService"),
+    oauthRedirectUri: "http://localhost:7233/oauth/callback",
+  };
+}
+
+async function expectDenied(run: () => Promise<unknown>, copy: string) {
+  const error = await run().catch((e: unknown) => e);
+  expect(error).toBeInstanceOf(ConnectError);
+  expect((error as ConnectError).code).toBe(Code.PermissionDenied);
+  expect((error as ConnectError).rawMessage).toBe(copy);
+}
+
+describe("connect-lane authorization (C2 Stage 4)", () => {
+  it("connect: a missing server answers NOT_FOUND even under denial (load-first, #224); an existing one denies with the annotation copy", async () => {
+    const { authorizer } = denyingAuthorizer();
+    const missing = await connect(
+      deps(authorizer),
+      create(ConnectInputSchema, { mcpServerId: "mcps_missing", org: "o" }),
+      caller,
+    ).catch((e: unknown) => e);
+    expect((missing as ConnectError).code).toBe(Code.NotFound);
+
+    await seedServer("mcps_denied");
+    await expectDenied(
+      () =>
+        connect(
+          deps(authorizer),
+          create(ConnectInputSchema, { mcpServerId: "mcps_denied", org: "o" }),
+          caller,
+        ),
+      "unauthorized to connect to mcp server",
+    );
+  });
+
+  it("startConnect denies with the shared connect annotation copy after the load", async () => {
+    const { authorizer } = denyingAuthorizer();
+    await seedServer("mcps_denied");
+    await expectDenied(
+      () =>
+        startConnect(
+          deps(authorizer),
+          create(ConnectInputSchema, { mcpServerId: "mcps_denied", org: "o" }),
+          caller,
+        ),
+      "unauthorized to connect to mcp server",
+    );
+  });
+
+  it("initiateOAuthConnect denies with its annotation copy after the load", async () => {
+    const { authorizer } = denyingAuthorizer();
+    await seedServer("mcps_denied");
+    await expectDenied(
+      () =>
+        initiateOAuthConnect(
+          deps(authorizer),
+          create(InitiateOAuthConnectInputSchema, {
+            mcpServerId: "mcps_denied",
+          }),
+          caller,
+        ),
+      "unauthorized to initiate oauth connect for mcp server",
+    );
+  });
+
+  it("completeOAuthConnect authorizes the PENDING RECORD's id and burns the state before the denial", async () => {
+    const { authorizer, checks } = denyingAuthorizer();
+    await store.pendingOAuthStates.save({
+      state: "state-123",
+      codeVerifier: "",
+      clientId: "",
+      clientSecret: "",
+      tokenEndpoint: "",
+      mcpServerId: "mcps_pending",
+      identityAccountId: "",
+      targetEnvVar: "",
+      authMethod: "mcp_oauth",
+      tokenAuthMethod: "",
+      redirectUri: "",
+      org: "test-org",
+      createdAt: 0,
+    });
+
+    await expectDenied(
+      () =>
+        completeOAuthConnect(
+          deps(authorizer),
+          create(CompleteOAuthConnectInputSchema, {
+            mcpServerId: "mcps_pending",
+            state: "state-123",
+            authorizationCode: "code",
+          }),
+          caller,
+        ),
+      "unauthorized to complete oauth connect for mcp server",
+    );
+    // The target of record is the server-side pending state's id.
+    expect(checks[0].resourceId).toBe("mcps_pending");
+    // The single-use state was consumed before the denial (Java parity):
+    // a retry refuses on the missing state, not on authorization.
+    const retry = await completeOAuthConnect(
+      deps(authorizer),
+      create(CompleteOAuthConnectInputSchema, {
+        mcpServerId: "mcps_pending",
+        state: "state-123",
+        authorizationCode: "code",
+      }),
+      caller,
+    ).catch((e: unknown) => e);
+    expect((retry as ConnectError).code).toBe(Code.FailedPrecondition);
+  });
+
+  it("disconnectOAuth denies with its annotation copy before any grant lookup", async () => {
+    const { authorizer } = denyingAuthorizer();
+    await expectDenied(
+      () =>
+        disconnectOAuth(
+          deps(authorizer),
+          create(DisconnectOAuthInputSchema, {
+            resourceId: "mcps_denied",
+            org: "o",
+          }),
+          caller,
+        ),
+      "unauthorized to disconnect oauth for mcp server",
+    );
+  });
+
+  it("getOAuthGrantStatus denies with its annotation copy before any grant lookup", async () => {
+    const { authorizer } = denyingAuthorizer();
+    await expectDenied(
+      () =>
+        getOAuthGrantStatus(
+          deps(authorizer),
+          create(GetOAuthGrantStatusInputSchema, {
+            resourceId: "mcps_denied",
+            org: "o",
+          }),
+          caller,
+        ),
+      "unauthorized to view oauth status for mcp server",
+    );
+  });
+});

--- a/backend/services/stigmer-server/src/domain/mcpserver/__tests__/connect.test.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/__tests__/connect.test.ts
@@ -31,16 +31,21 @@ import { SecretService } from "../../../encryption/encryption.js";
 import { newExecutionScopedRunnerCredentialProvider } from "../../../runnerauth/runner-credential-provider.js";
 import { RunnerAuthService } from "../../../runnerauth/runnerauth.js";
 import { SqliteStore } from "../../../store/sqlite/store.js";
+import { newPermissiveSingleTeamAuthorizer } from "../../../pipeline/steps/authorize.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import {
   ASYNC_CONNECT_TIMEOUT,
   CONNECT_TIMEOUT,
   buildConnectFailureMessage,
-  connect,
+  connect as connectRpc,
   startBestEffortConnect,
 } from "../connect.js";
 import type { McpServerConnectDeps } from "../connect.js";
 import { ManagedEnvironmentService } from "../oauth/managed-env.js";
-import { RUNNER_QUEUE_WARNING, startConnect } from "../start-connect.js";
+import {
+  RUNNER_QUEUE_WARNING,
+  startConnect as startConnectRpc,
+} from "../start-connect.js";
 import type {
   ConnectRunOutcome,
   ConnectWorkflowInput,
@@ -126,6 +131,20 @@ afterEach(() => {
   rmSync(dir, { recursive: true, force: true });
 });
 
+// The connect lanes now evaluate their can_connect/can_view annotations
+// (C2 Stage 4); these direct-call tests exercise them under the OSS
+// permissive authorizer with one fixed caller — authorize.test.ts owns
+// the deny/not-found arms.
+const testCaller = testCallerIdentity();
+const connect = (
+  deps: McpServerConnectDeps,
+  input: Parameters<typeof connectRpc>[1],
+) => connectRpc(deps, input, testCaller);
+const startConnect = (
+  deps: McpServerConnectDeps,
+  input: Parameters<typeof startConnectRpc>[1],
+) => startConnectRpc(deps, input, testCaller);
+
 function makeHarness(options: FakeEngineOptions = {}): Harness {
   const engine = fakeEngine(options);
   const harness: Harness = {
@@ -135,6 +154,7 @@ function makeHarness(options: FakeEngineOptions = {}): Harness {
     deps: {
       store,
       logger: silentLogger,
+      authorizer: newPermissiveSingleTeamAuthorizer(),
       engineState: () => ({ connected: true, engine }),
       environmentReader: {
         list: async () => {

--- a/backend/services/stigmer-server/src/domain/mcpserver/complete-oauth-connect.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/complete-oauth-connect.ts
@@ -23,6 +23,7 @@ import type { EnvironmentValue as EnvironmentSpecValue } from "@stigmer/protos/a
 import { EnvironmentValueSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/spec_pb";
 import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
 import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
 import type {
   CompleteOAuthConnectInput,
   CompleteOAuthConnectOutput,
@@ -31,6 +32,7 @@ import { CompleteOAuthConnectOutputSchema } from "@stigmer/protos/ai/stigmer/age
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { SecretService } from "../../encryption/encryption.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import {
   failedPreconditionError,
   internalError,
@@ -38,6 +40,7 @@ import {
   notFoundError,
   unavailableError,
 } from "../../pipeline/errors.js";
+import { authorizeDirect } from "../../pipeline/steps/authorize.js";
 import type { PendingOAuthState } from "../../store/interface.js";
 import type { McpServerConnectDeps } from "./connect.js";
 import { exchangeCode } from "./oauth/token.js";
@@ -45,6 +48,7 @@ import { exchangeCode } from "./oauth/token.js";
 export async function completeOAuthConnect(
   deps: McpServerConnectDeps,
   input: CompleteOAuthConnectInput,
+  identity: CallerIdentity,
 ): Promise<CompleteOAuthConnectOutput> {
   const mcpServerId = input.mcpServerId;
   if (mcpServerId === "") {
@@ -79,6 +83,20 @@ export async function completeOAuthConnect(
       "state parameter does not match the requested mcp_server_id",
     );
   }
+
+  // The annotation's can_connect check against the PENDING RECORD's
+  // server id — the Java McpServerCompleteOAuthConnectHandler discipline
+  // (the server-side state is the truth; a caller-supplied id would be a
+  // confused-deputy target). As in Java, the single-use state is already
+  // burned when a denial lands — the denied caller costs the user one
+  // re-initiate. C2 Stage 4.
+  await authorizeDirect(
+    McpServerCommandController.method.completeOAuthConnect,
+    deps.authorizer,
+    identity,
+    input,
+    { resourceId: pendingState.mcpServerId },
+  );
 
   // Unseal the handshake secrets that initiateOAuthConnect sealed at rest
   // (oss#394), at the last moment before their only use. The row was

--- a/backend/services/stigmer-server/src/domain/mcpserver/connect.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/connect.ts
@@ -35,12 +35,16 @@ import type { ExecutionValue } from "@stigmer/protos/ai/stigmer/agentic/executio
 import { ExecutionValueSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/spec_pb";
 import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
 import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
 import type { ConnectInput } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
 import type { ApiResourceDeleteInputSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/io_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { TokenEndpointAuthMethod } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/spec_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import { authorizeDirect } from "../../pipeline/steps/authorize.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import {
   failedPreconditionError,
@@ -188,6 +192,12 @@ export interface ConnectExecutionContextClient {
 export interface McpServerConnectDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /**
+   * The composed authorization seam — every connect-family lane evaluates
+   * its can_connect/can_view annotation (the Java handlers' bespoke
+   * authorize steps carry the same config; C2 Stage 4).
+   */
+  readonly authorizer: Authorizer;
   readonly engineState: McpServerEngineStateProvider;
   readonly environmentReader: ConnectEnvironmentReader;
   readonly executionContext: ConnectExecutionContextClient;
@@ -224,6 +234,7 @@ interface PreparedConnect {
 export async function connect(
   deps: McpServerConnectDeps,
   input: ConnectInput,
+  identity: CallerIdentity,
 ): Promise<McpServer> {
   const engineState = deps.engineState();
   if (!engineState.connected) {
@@ -250,6 +261,16 @@ export async function connect(
   } catch {
     throw notFoundError("mcp_server", mcpServerId);
   }
+
+  // The annotation's can_connect check AFTER the load — the Java
+  // McpServerConnectHandler order (load-before-authorize, stigmer#224).
+  // C2 Stage 4.
+  await authorizeDirect(
+    McpServerCommandController.method.connect,
+    deps.authorizer,
+    identity,
+    input,
+  );
 
   const prepared = await prepareConnect(deps, mcpServer, input);
 

--- a/backend/services/stigmer-server/src/domain/mcpserver/controller.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/controller.ts
@@ -137,11 +137,16 @@ export function registerMcpServerServices(
     update: (server, ctx) => update(deps, server, ctx),
     updateVisibility: (input, ctx) => updateVisibility(deps, input, ctx),
     delete: (input, ctx) => deleteMcpServer(deps, input, ctx),
-    connect: (input) => connect(deps.connect, input),
-    startConnect: (input) => startConnect(deps.connect, input),
-    initiateOAuthConnect: (input) => initiateOAuthConnect(deps.connect, input),
-    completeOAuthConnect: (input) => completeOAuthConnect(deps.connect, input),
-    disconnectOAuth: (input) => disconnectOAuth(deps.connect, input),
+    connect: (input, ctx) =>
+      connect(deps.connect, input, callerIdentityOf(ctx)),
+    startConnect: (input, ctx) =>
+      startConnect(deps.connect, input, callerIdentityOf(ctx)),
+    initiateOAuthConnect: (input, ctx) =>
+      initiateOAuthConnect(deps.connect, input, callerIdentityOf(ctx)),
+    completeOAuthConnect: (input, ctx) =>
+      completeOAuthConnect(deps.connect, input, callerIdentityOf(ctx)),
+    disconnectOAuth: (input, ctx) =>
+      disconnectOAuth(deps.connect, input, callerIdentityOf(ctx)),
     setOrgOAuthApp: () => {
       throw orgOAuthAppUnimplemented("SetOrgOAuthApp");
     },
@@ -152,7 +157,8 @@ export function registerMcpServerServices(
   router.service(McpServerQueryController, {
     get: (id, ctx) => get(deps, id, ctx),
     getByReference: (ref, ctx) => getByReference(deps, ref, ctx),
-    getOAuthGrantStatus: (input) => getOAuthGrantStatus(deps.connect, input),
+    getOAuthGrantStatus: (input, ctx) =>
+      getOAuthGrantStatus(deps.connect, input, callerIdentityOf(ctx)),
     getOrgOAuthApp: () => {
       throw orgOAuthAppUnimplemented("GetOrgOAuthApp");
     },

--- a/backend/services/stigmer-server/src/domain/mcpserver/disconnect-oauth.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/disconnect-oauth.ts
@@ -27,12 +27,17 @@ import type {
 } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
 import { DisconnectOAuthOutputSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
 
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
+
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
+import { authorizeDirect } from "../../pipeline/steps/authorize.js";
 import type { McpServerConnectDeps } from "./connect.js";
 
 export async function disconnectOAuth(
   deps: McpServerConnectDeps,
   input: DisconnectOAuthInput,
+  identity: CallerIdentity,
 ): Promise<DisconnectOAuthOutput> {
   const resourceId = input.resourceId;
   if (resourceId === "") {
@@ -42,6 +47,16 @@ export async function disconnectOAuth(
   if (org === "") {
     throw invalidArgumentError("org is required");
   }
+  // The annotation's can_connect check (validate → authorize, the Java
+  // McpServerDisconnectOAuthHandler order — no load step; on the
+  // multi-tenant edition an unresolvable id answers through the
+  // authorizer's ruled uniform posture). C2 Stage 4.
+  await authorizeDirect(
+    McpServerCommandController.method.disconnectOAuth,
+    deps.authorizer,
+    identity,
+    input,
+  );
 
   // OSS mode: single user, empty identity_account_id.
   let grant;

--- a/backend/services/stigmer-server/src/domain/mcpserver/get-oauth-grant-status.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/get-oauth-grant-status.ts
@@ -23,7 +23,11 @@ import {
   OAuthConnectionHealth,
 } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
 
+import { McpServerQueryController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/query_pb";
+
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
+import { authorizeDirect } from "../../pipeline/steps/authorize.js";
 import type { OAuthGrant } from "../../store/interface.js";
 import type { McpServerConnectDeps } from "./connect.js";
 import { REFRESH_EXPIRY_BUFFER_SECONDS } from "./oauth/refresh.js";
@@ -31,6 +35,7 @@ import { REFRESH_EXPIRY_BUFFER_SECONDS } from "./oauth/refresh.js";
 export async function getOAuthGrantStatus(
   deps: McpServerConnectDeps,
   input: GetOAuthGrantStatusInput,
+  identity: CallerIdentity,
 ): Promise<GetOAuthGrantStatusOutput> {
   if (input.resourceId === "") {
     throw invalidArgumentError("resource_id is required");
@@ -38,6 +43,14 @@ export async function getOAuthGrantStatus(
   if (input.org === "") {
     throw invalidArgumentError("org is required");
   }
+  // The annotation's can_view check (validate → authorize, the Java
+  // McpServerGetOAuthGrantStatusHandler order — no load step). C2 Stage 4.
+  await authorizeDirect(
+    McpServerQueryController.method.getOAuthGrantStatus,
+    deps.authorizer,
+    identity,
+    input,
+  );
 
   let grant: OAuthGrant | undefined;
   try {

--- a/backend/services/stigmer-server/src/domain/mcpserver/initiate-oauth-connect.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/initiate-oauth-connect.ts
@@ -16,6 +16,7 @@ import { randomBytes } from "node:crypto";
 
 import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
 import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
 import type {
   InitiateOAuthConnectInput,
   InitiateOAuthConnectOutput,
@@ -29,12 +30,14 @@ import {
 
 import type { Logger } from "../../boot/logger.js";
 import type { SecretService } from "../../encryption/encryption.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import {
   failedPreconditionError,
   internalError,
   invalidArgumentError,
   notFoundError,
 } from "../../pipeline/errors.js";
+import { authorizeDirect } from "../../pipeline/steps/authorize.js";
 import type { PendingOAuthState } from "../../store/interface.js";
 import { resolveOAuthAppRef } from "../oauthapp/refresolution.js";
 import { tokenAuthMethodFromSpec } from "./connect.js";
@@ -49,6 +52,7 @@ import type { AuthorizeRejection } from "./oauth/preflight.js";
 export async function initiateOAuthConnect(
   deps: McpServerConnectDeps,
   input: InitiateOAuthConnectInput,
+  identity: CallerIdentity,
 ): Promise<InitiateOAuthConnectOutput> {
   if (deps.oauthRedirectUri === "") {
     throw failedPreconditionError(
@@ -71,6 +75,16 @@ export async function initiateOAuthConnect(
   } catch {
     throw notFoundError("mcp_server", mcpServerId);
   }
+
+  // The annotation's can_connect check AFTER the load — the Java
+  // McpServerInitiateOAuthConnectHandler order (load-before-authorize,
+  // stigmer#224). C2 Stage 4.
+  await authorizeDirect(
+    McpServerCommandController.method.initiateOAuthConnect,
+    deps.authorizer,
+    identity,
+    input,
+  );
 
   const auth = mcpServer.spec?.auth;
   if (auth === undefined) {

--- a/backend/services/stigmer-server/src/domain/mcpserver/start-connect.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/start-connect.ts
@@ -26,16 +26,19 @@
  */
 import type { McpServer } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
 import { McpServerSchema } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/api_pb";
+import { McpServerCommandController } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/command_pb";
 import type { ConnectInput } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/io_pb";
 import { ConnectPhase } from "@stigmer/protos/ai/stigmer/agentic/mcpserver/v1/status_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
+import type { CallerIdentity } from "../../extensions/identity.js";
 import {
   failedPreconditionError,
   internalError,
   invalidArgumentError,
   notFoundError,
 } from "../../pipeline/errors.js";
+import { authorizeDirect } from "../../pipeline/steps/authorize.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import {
   persistConnectFailure,
@@ -64,6 +67,7 @@ export const RUNNER_QUEUE_WARNING =
 export async function startConnect(
   deps: McpServerConnectDeps,
   input: ConnectInput,
+  identity: CallerIdentity,
 ): Promise<McpServer> {
   const engineState = deps.engineState();
   if (!engineState.connected) {
@@ -90,6 +94,16 @@ export async function startConnect(
   } catch {
     throw notFoundError("mcp_server", mcpServerId);
   }
+
+  // The annotation's can_connect check AFTER the load — the Java
+  // McpServerStartConnectHandler order (the connect handler's shared
+  // load/authorize steps, stigmer#224). C2 Stage 4.
+  await authorizeDirect(
+    McpServerCommandController.method.startConnect,
+    deps.authorizer,
+    identity,
+    input,
+  );
 
   const connectStatus = mcpServer.status?.connectStatus;
   if (connectStatus?.phase === ConnectPhase.connecting) {

--- a/backend/services/stigmer-server/src/domain/session/controller.ts
+++ b/backend/services/stigmer-server/src/domain/session/controller.ts
@@ -51,7 +51,10 @@ import { newPipeline } from "../../pipeline/pipeline.js";
 import type { CallerIdentity } from "../../extensions/identity.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
-import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import {
+  authorizeDirect,
+  newAuthorizeStep,
+} from "../../pipeline/steps/authorize.js";
 import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import {
   newBuildNewStateStep,
@@ -370,6 +373,10 @@ async function deleteSession(
  * index best-effort. Because the read-modify-write happens entirely on
  * the server, concurrent callers (e.g., GenerateSessionSubject and
  * sandbox_manager) cannot overwrite each other's unrelated fields.
+ *
+ * The annotation's can_edit check runs AFTER the load — the Java
+ * SessionUpdateSubjectHandler order (load-before-authorize, stigmer#224:
+ * a missing id answers NOT_FOUND, never PERMISSION_DENIED). C2 Stage 4.
  */
 async function updateSubject(
   deps: SessionControllerDeps,
@@ -394,6 +401,13 @@ async function updateSubject(
     }
     throw internalError(error, "failed to load session");
   }
+
+  await authorizeDirect(
+    SessionCommandController.method.updateSubject,
+    deps.authorizer,
+    identity,
+    req,
+  );
 
   if (session.spec === undefined) {
     session.spec = create(SessionSpecSchema, {});

--- a/backend/services/stigmer-server/src/domain/workflow/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflow/controller.ts
@@ -65,9 +65,13 @@ import {
 } from "../../pipeline/errors.js";
 import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
-import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import {
+  authorizeDirect,
+  newAuthorizeStep,
+} from "../../pipeline/steps/authorize.js";
 import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import {
   newAuthorizeVisibilityTransitionStep,
@@ -174,6 +178,12 @@ export function registerWorkflowServices(
     update: (workflow, ctx) => update(deps, workflow, ctx),
     updateVisibility: (input, ctx) => updateVisibility(deps, input, ctx),
     delete: (id, ctx) => deleteWorkflow(deps, id, ctx),
+    // validateSpec deliberately evaluates NO authorization despite its
+    // can_create_workflow annotation — the Java handler's documented
+    // "no persist, no authorize" posture, ruled matched at the C2 Stage 4
+    // gate (nothing is loaded or persisted; the caller only gets a
+    // verdict on their own submitted spec). The annotation mismatch is
+    // recorded in docs/authorization-coverage.md.
     validateSpec: (workflow) => validateSpec(deps, workflow),
     tagVersion: (input, ctx) => tagVersion(deps, input, ctx),
   });
@@ -181,7 +191,7 @@ export function registerWorkflowServices(
     get: (id, ctx) => get(deps, id, ctx),
     getByReference: (ref) => getByReference(deps, ref),
     listVersions: (input, ctx) => listVersions(deps, input, ctx),
-    getVersion: (input) => getVersion(deps, input),
+    getVersion: (input, ctx) => getVersion(deps, input, callerIdentityOf(ctx)),
   });
 }
 
@@ -1105,6 +1115,7 @@ function decodePageToken(token: string): number {
 async function getVersion(
   deps: WorkflowControllerDeps,
   req: GetWorkflowVersionInput,
+  identity: CallerIdentity,
 ): Promise<WorkflowVersionEntry> {
   if (req.workflowId === "") {
     throw invalidArgumentError("workflow_id is required");
@@ -1112,6 +1123,17 @@ async function getVersion(
   if (req.versionHash === "") {
     throw invalidArgumentError("version_hash is required");
   }
+  // The annotation's can_view check. DELIBERATE divergence from the Java
+  // edition, ruled at the C2 Stage 4 gate: the Java handler declares the
+  // annotation but never evaluates it (its javadoc claims framework
+  // enforcement that does not exist) — a cross-org version-read gap. The
+  // annotation is the contract; the composition enforces it.
+  await authorizeDirect(
+    WorkflowQueryController.method.getVersion,
+    deps.authorizer,
+    identity,
+    req,
+  );
 
   // First check the current (live) workflow — avoids an audit lookup for
   // the common case of recent executions.

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/read-authorization.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/read-authorization.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Pins the C2 Stage-4 enforcement on this domain's three config-annotated
+ * direct read surfaces (subscribe, subscribeEvents, getEventLog): each
+ * evaluates its OWN annotation through authorizeDirect BEFORE any store
+ * or broker touch, and a denying authorizer answers PERMISSION_DENIED
+ * with the method's byte-pinned error_msg. The exact copy doubles as the
+ * descriptor-mismatch guard (a handler passing another method's
+ * descriptor would answer the wrong copy). The deny/not-found/unavailable
+ * mapping itself is pinned in pipeline/steps/__tests__/authorize.test.ts.
+ */
+import { create } from "@bufbuild/protobuf";
+import type { HandlerContext } from "@connectrpc/connect";
+import { Code, ConnectError, createContextValues } from "@connectrpc/connect";
+import { describe, expect, it } from "vitest";
+
+import {
+  GetEventLogRequestSchema,
+  SubscribeEventsRequestSchema,
+  SubscribeWorkflowExecutionRequestSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import type { Authorizer } from "../../../extensions/authorizer.js";
+import { callerIdentityKey } from "../../../pipeline/interceptors/auth.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
+import type { Store } from "../../../store/interface.js";
+
+import { getEventLog } from "../get-event-log.js";
+import type { StreamBroker } from "../stream-broker.js";
+import { subscribeEvents } from "../subscribe-events.js";
+import { subscribeExecution } from "../subscribe.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const denyingAuthorizer: Authorizer = {
+  authorize: () => Promise.resolve({ kind: "deny", reason: "" }),
+};
+
+/** A store that fails the test if the denied request ever reaches it. */
+const untouchableStore = new Proxy({} as Store, {
+  get(_target, prop) {
+    throw new Error(`store.${String(prop)} reached despite the denial`);
+  },
+});
+
+const untouchableBroker = new Proxy({} as StreamBroker, {
+  get(_target, prop) {
+    throw new Error(`broker.${String(prop)} reached despite the denial`);
+  },
+});
+
+function handlerContext(): HandlerContext {
+  const values = createContextValues();
+  values.set(callerIdentityKey, testCallerIdentity());
+  return { signal: new AbortController().signal, values } as HandlerContext;
+}
+
+async function expectDenied(run: () => Promise<unknown>, copy: string) {
+  const error = await run().catch((e: unknown) => e);
+  expect(error).toBeInstanceOf(ConnectError);
+  expect((error as ConnectError).code).toBe(Code.PermissionDenied);
+  expect((error as ConnectError).rawMessage).toBe(copy);
+}
+
+describe("read-surface authorization (C2 Stage 4)", () => {
+  it("subscribe denies with its annotation copy before touching store or broker", async () => {
+    await expectDenied(
+      () =>
+        subscribeExecution(
+          {
+            store: untouchableStore,
+            logger: silentLogger,
+            broker: untouchableBroker,
+            authorizer: denyingAuthorizer,
+          },
+          create(SubscribeWorkflowExecutionRequestSchema, {
+            executionId: "wfe_01denied",
+          }),
+          handlerContext(),
+        ).next(),
+      "unauthorized to get workflow execution stream",
+    );
+  });
+
+  it("subscribeEvents denies with its annotation copy before the existence check", async () => {
+    await expectDenied(
+      () =>
+        subscribeEvents(
+          {
+            store: untouchableStore,
+            logger: silentLogger,
+            authorizer: denyingAuthorizer,
+          },
+          create(SubscribeEventsRequestSchema, { executionId: "wfe_01denied" }),
+          handlerContext(),
+        ).next(),
+      "unauthorized to subscribe to workflow execution events",
+    );
+  });
+
+  it("getEventLog denies with its annotation copy before the store read", async () => {
+    await expectDenied(
+      () =>
+        getEventLog(
+          {
+            store: untouchableStore,
+            logger: silentLogger,
+            authorizer: denyingAuthorizer,
+          },
+          create(GetEventLogRequestSchema, { executionId: "wfe_01denied" }),
+          testCallerIdentity(),
+        ),
+      "unauthorized to get workflow execution event log",
+    );
+  });
+
+  it("the internal caller class skips the check on all three (in-process parity)", async () => {
+    // The denying authorizer must never be consulted; the handlers then
+    // proceed into their store reads — the throwing store proves BOTH.
+    const internal = testCallerIdentity({ callerClass: "internal" });
+    const values = createContextValues();
+    values.set(callerIdentityKey, internal);
+    const ctx = {
+      signal: new AbortController().signal,
+      values,
+    } as HandlerContext;
+
+    const subscribeError = await subscribeExecution(
+      {
+        store: untouchableStore,
+        logger: silentLogger,
+        broker: untouchableBroker,
+        authorizer: denyingAuthorizer,
+      },
+      create(SubscribeWorkflowExecutionRequestSchema, {
+        executionId: "wfe_01internal",
+      }),
+      ctx,
+    )
+      .next()
+      .catch((e: unknown) => e);
+    expect((subscribeError as Error).message).toContain(
+      "reached despite the denial",
+    );
+
+    // getEventLog wraps its store fault as the sanitized Internal — the
+    // wrapped copy (not a denial) is the store-was-reached proof.
+    const eventLogError = await getEventLog(
+      {
+        store: untouchableStore,
+        logger: silentLogger,
+        authorizer: denyingAuthorizer,
+      },
+      create(GetEventLogRequestSchema, { executionId: "wfe_01internal" }),
+      internal,
+    ).catch((e: unknown) => e);
+    expect((eventLogError as ConnectError).code).toBe(Code.Internal);
+    expect((eventLogError as ConnectError).rawMessage).toBe(
+      "failed to query execution events",
+    );
+  });
+});

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/subscribe.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/subscribe.test.ts
@@ -9,6 +9,7 @@
  */
 import { clone, create } from "@bufbuild/protobuf";
 import type { HandlerContext } from "@connectrpc/connect";
+import { createContextValues } from "@connectrpc/connect";
 import { describe, expect, it } from "vitest";
 
 import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
@@ -17,6 +18,9 @@ import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecu
 import { SubscribeWorkflowExecutionRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
 
 import { createLogger } from "../../../boot/logger.js";
+import { callerIdentityKey } from "../../../pipeline/interceptors/auth.js";
+import { newPermissiveSingleTeamAuthorizer } from "../../../pipeline/steps/authorize.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
 import type { Store } from "../../../store/interface.js";
 
 import { StreamBroker } from "../stream-broker.js";
@@ -60,7 +64,9 @@ function hookedSnapshotStore(
 }
 
 function handlerContext(signal: AbortSignal): HandlerContext {
-  return { signal } as HandlerContext;
+  const values = createContextValues();
+  values.set(callerIdentityKey, testCallerIdentity());
+  return { signal, values } as HandlerContext;
 }
 
 /**
@@ -104,7 +110,12 @@ describe("subscribe (subscribe_test.go case-for-case)", () => {
 
     const frames = await collectFrames(
       subscribeExecution(
-        { store, logger: silentLogger, broker },
+        {
+          store,
+          logger: silentLogger,
+          broker,
+          authorizer: newPermissiveSingleTeamAuthorizer(),
+        },
         create(SubscribeWorkflowExecutionRequestSchema, { executionId: id }),
         handlerContext(abortController.signal),
       ),
@@ -135,7 +146,12 @@ describe("subscribe (subscribe_test.go case-for-case)", () => {
 
     const frames = await collectFrames(
       subscribeExecution(
-        { store, logger: silentLogger, broker },
+        {
+          store,
+          logger: silentLogger,
+          broker,
+          authorizer: newPermissiveSingleTeamAuthorizer(),
+        },
         create(SubscribeWorkflowExecutionRequestSchema, { executionId: id }),
         handlerContext(abortController.signal),
       ),
@@ -159,7 +175,12 @@ describe("subscribe (subscribe_test.go case-for-case)", () => {
     const abortController = new AbortController();
     await collectFrames(
       subscribeExecution(
-        { store, logger: silentLogger, broker },
+        {
+          store,
+          logger: silentLogger,
+          broker,
+          authorizer: newPermissiveSingleTeamAuthorizer(),
+        },
         create(SubscribeWorkflowExecutionRequestSchema, { executionId: id }),
         handlerContext(abortController.signal),
       ),

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/summary-read-scope.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/summary-read-scope.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Pins the ExecutionReadScope arm of BOTH getExecutionSummary handlers
+ * (C2 Stage 4 — the multi-tenant tenant-isolation port):
+ *
+ *   - a composed scope narrows the aggregation to authorized ids ∩ the
+ *     requested org (the Java GetExecutionSummary baseline);
+ *   - an EMPTY authorized set answers the proto DEFAULT INSTANCE — the
+ *     conformance-pinned multi-tenant zero shape (workflow: success_rate
+ *     0 and NO cost summary — the exact opposite of the OSS -1 sentinel
+ *     and always-present zero cost) falls out of the scoping;
+ *   - NO scope composed = the full scan, org NOT consulted (the OSS
+ *     single-user semantics, byte-identity guarded here as well as by
+ *     the conformance rosters).
+ */
+import { create, toBinary } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase as AgentExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { GetAgentExecutionSummaryRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/enum_pb";
+import { GetExecutionSummaryRequestSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import type { ExecutionReadScope } from "../../../extensions/execution-read-scope.js";
+import { testCallerIdentity } from "../../../pipeline/__tests__/support.js";
+import { newPermissiveSingleTeamAuthorizer } from "../../../pipeline/steps/authorize.js";
+import type { Store } from "../../../store/interface.js";
+
+import { getExecutionSummary as getAgentSummary } from "../../agentexecution/usage.js";
+import { getExecutionSummary as getWorkflowSummary } from "../get-execution-summary.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const caller = testCallerIdentity();
+
+function scopeOf(ids: ReadonlyArray<string>): ExecutionReadScope {
+  return {
+    authorizedExecutionIds: () => Promise.resolve(new Set(ids)),
+  };
+}
+
+/** A store whose listResources answers the given serialized rows. */
+function listOnlyStore(rows: Uint8Array[]): Store {
+  return { listResources: () => Promise.resolve(rows) } as unknown as Store;
+}
+
+function workflowExecRow(id: string, org: string, phase: ExecutionPhase) {
+  return toBinary(
+    WorkflowExecutionSchema,
+    create(WorkflowExecutionSchema, {
+      metadata: { id, name: id, slug: id, org },
+      status: { phase },
+    }),
+  );
+}
+
+function agentExecRow(id: string, org: string, phase: AgentExecutionPhase) {
+  return toBinary(
+    AgentExecutionSchema,
+    create(AgentExecutionSchema, {
+      metadata: { id, name: id, org },
+      status: { phase },
+    }),
+  );
+}
+
+describe("workflow getExecutionSummary read scope", () => {
+  const rows = [
+    workflowExecRow("wfe_mine_done", "acme", ExecutionPhase.EXECUTION_COMPLETED),
+    workflowExecRow("wfe_mine_run", "acme", ExecutionPhase.EXECUTION_IN_PROGRESS),
+    // Authorized but in ANOTHER org — the org intersection must drop it.
+    workflowExecRow("wfe_other_org", "rival", ExecutionPhase.EXECUTION_FAILED),
+    // In the org but NOT authorized — the id set must drop it.
+    workflowExecRow("wfe_not_mine", "acme", ExecutionPhase.EXECUTION_FAILED),
+  ];
+
+  function deps(scope: ExecutionReadScope | undefined) {
+    return {
+      store: listOnlyStore(rows),
+      logger: silentLogger,
+      executionReadScope: scope,
+    };
+  }
+
+  it("narrows to authorized ids ∩ the requested org", async () => {
+    const summary = await getWorkflowSummary(
+      deps(scopeOf(["wfe_mine_done", "wfe_mine_run", "wfe_other_org"])),
+      create(GetExecutionSummaryRequestSchema, { org: "acme" }),
+      caller,
+    );
+    expect(summary.totalCount).toBe(2);
+    expect(summary.activeCount).toBe(1);
+    // One terminal (completed) — a real 100%, not the -1 sentinel.
+    expect(summary.successRate).toBe(1);
+  });
+
+  it("an empty authorized set answers the default instance — the multi-tenant zero shape", async () => {
+    const summary = await getWorkflowSummary(
+      deps(scopeOf([])),
+      create(GetExecutionSummaryRequestSchema, { org: "acme" }),
+      caller,
+    );
+    expect(summary.successRate).toBe(0);
+    expect(summary.totalCost).toBeUndefined();
+    expect(summary.totalCount).toBe(0);
+    expect(summary.avgDuration).toBeUndefined();
+  });
+
+  it("no scope composed = the full scan; org is NOT consulted (OSS byte-identity)", async () => {
+    const summary = await getWorkflowSummary(
+      deps(undefined),
+      create(GetExecutionSummaryRequestSchema, { org: "acme" }),
+      caller,
+    );
+    // All four rows counted, the rival org's included; and the OSS zero
+    // pins hold: the -1 sentinel family and the ALWAYS-present cost
+    // summary.
+    expect(summary.totalCount).toBe(4);
+    expect(summary.totalCost).toBeDefined();
+  });
+});
+
+describe("agent getExecutionSummary read scope", () => {
+  const rows = [
+    agentExecRow("aexec_mine", "acme", AgentExecutionPhase.EXECUTION_IN_PROGRESS),
+    agentExecRow("aexec_other_org", "rival", AgentExecutionPhase.EXECUTION_IN_PROGRESS),
+    agentExecRow("aexec_not_mine", "acme", AgentExecutionPhase.EXECUTION_IN_PROGRESS),
+  ];
+
+  function deps(scope: ExecutionReadScope | undefined) {
+    return {
+      store: listOnlyStore(rows),
+      logger: silentLogger,
+      authorizer: newPermissiveSingleTeamAuthorizer(),
+      executionReadScope: scope,
+    };
+  }
+
+  it("narrows to authorized ids ∩ the requested org", async () => {
+    const summary = await getAgentSummary(
+      deps(scopeOf(["aexec_mine", "aexec_other_org"])),
+      create(GetAgentExecutionSummaryRequestSchema, { org: "acme" }),
+      caller,
+    );
+    expect(summary.activeCount).toBe(1);
+  });
+
+  it("an empty authorized set answers the default instance", async () => {
+    const summary = await getAgentSummary(
+      deps(scopeOf([])),
+      create(GetAgentExecutionSummaryRequestSchema, { org: "acme" }),
+      caller,
+    );
+    expect(summary.activeCount).toBe(0);
+    expect(summary.phaseCounts).toEqual({});
+    expect(summary.avgDuration).toBeUndefined();
+  });
+
+  it("no scope composed = the full scan across orgs (OSS byte-identity)", async () => {
+    const summary = await getAgentSummary(
+      deps(undefined),
+      create(GetAgentExecutionSummaryRequestSchema, { org: "acme" }),
+      caller,
+    );
+    expect(summary.activeCount).toBe(3);
+  });
+
+  it("the scope receives the kind it is scoping (agent_execution here)", async () => {
+    const kinds: ApiResourceKind[] = [];
+    const recordingScope: ExecutionReadScope = {
+      authorizedExecutionIds: (_caller, kind) => {
+        kinds.push(kind);
+        return Promise.resolve(new Set<string>());
+      },
+    };
+    await getAgentSummary(
+      deps(recordingScope),
+      create(GetAgentExecutionSummaryRequestSchema, { org: "acme" }),
+      caller,
+    );
+    expect(kinds).toEqual([ApiResourceKind.agent_execution]);
+  });
+});

--- a/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
@@ -39,6 +39,7 @@ import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
 import type { ResolvedGateSteps } from "../../extensions/gate-slots.js";
 import { stepsForSlot } from "../../extensions/gate-slots.js";
+import type { ExecutionReadScope } from "../../extensions/execution-read-scope.js";
 import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
@@ -130,6 +131,8 @@ export interface WorkflowExecutionControllerDeps {
   readonly authorizer: Authorizer;
   /** The composed tuple-lifecycle driver — undefined = the shared steps no-op (C2). */
   readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
+  /** The composed summary read scope — undefined = the OSS full scan (C2 Stage 4). */
+  readonly executionReadScope: ExecutionReadScope | undefined;
   /**
    * The merged slot registrations (O1/O4; DD-006 §2). This domain
    * carries `sandbox-acquisition:gate` on the create and recover chains
@@ -225,9 +228,10 @@ export function registerWorkflowExecutionServices(
     list: (req) => list(deps, req),
     listByWorkflow: (req) => listByWorkflow(deps, req),
     subscribe: (req, ctx) => subscribeExecution(deps, req, ctx),
-    getEventLog: (req) => getEventLog(deps, req),
+    getEventLog: (req, ctx) => getEventLog(deps, req, callerIdentityOf(ctx)),
     subscribeEvents: (req, ctx) => subscribeEvents(deps, req, ctx),
-    getExecutionSummary: (req) => getExecutionSummary(deps, req),
+    getExecutionSummary: (req, ctx) =>
+      getExecutionSummary(deps, req, callerIdentityOf(ctx)),
     listPendingApprovals: (req) => listPendingApprovals(deps, req),
   });
 }

--- a/backend/services/stigmer-server/src/domain/workflowexecution/get-event-log.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/get-event-log.ts
@@ -21,8 +21,13 @@ import type {
   GetEventLogResponse,
 } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
 
+import { WorkflowExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/query_pb";
+
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { internalError, invalidArgumentError } from "../../pipeline/errors.js";
+import { authorizeDirect } from "../../pipeline/steps/authorize.js";
 import type { Store, WorkflowExecutionEventRecord } from "../../store/interface.js";
 
 import { DEFAULT_EVENT_PAGE_SIZE, MAX_EVENT_PAGE_SIZE } from "./constants.js";
@@ -30,6 +35,8 @@ import { DEFAULT_EVENT_PAGE_SIZE, MAX_EVENT_PAGE_SIZE } from "./constants.js";
 export interface EventLogDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the annotation check below (C2 Stage 4). */
+  readonly authorizer: Authorizer;
 }
 
 /** The proto enum's value NAME — exactly Go's WorkflowEventType.String(). */
@@ -40,10 +47,21 @@ export function eventTypeName(eventType: WorkflowEventType): string {
 export async function getEventLog(
   deps: EventLogDeps,
   req: GetEventLogRequest,
+  identity: CallerIdentity,
 ): Promise<GetEventLogResponse> {
   if (req.executionId === "") {
     throw invalidArgumentError("execution_id is required");
   }
+  // The annotation's can_view check (validate → authorize, the Java
+  // WorkflowExecutionGetEventLogHandler order; C2 Stage 4). The
+  // no-existence-check empty-page contract below is unchanged for
+  // authorized callers.
+  await authorizeDirect(
+    WorkflowExecutionQueryController.method.getEventLog,
+    deps.authorizer,
+    identity,
+    req,
+  );
 
   let pageSize = req.pageSize;
   if (pageSize <= 0) {

--- a/backend/services/stigmer-server/src/domain/workflowexecution/get-execution-summary.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/get-execution-summary.ts
@@ -10,6 +10,16 @@
  * deliberately absent when nothing completed (an average over nothing is
  * not 0).
  *
+ * With a composed ExecutionReadScope (C2 Stage 4 — the multi-tenant
+ * edition), the scan narrows to the caller's authorized ids intersected
+ * with the requested org (the Java GetExecutionSummary baseline: without
+ * the org filter a member of several organizations sees every org's
+ * numbers on every dashboard), and an EMPTY authorized set answers the
+ * proto default instance — the conformance-pinned multi-tenant zero shape
+ * (success_rate 0, NO cost summary) falls out of the scoping, never a
+ * special case. No scope composed = the full scan above, byte-identical
+ * (the request's org deliberately not consulted — single-user semantics).
+ *
  * Tie order in the two ranked lists is not wire-stable in Go (map
  * iteration feeds a stable sort), so ties here — deterministic first-seen
  * order — are not a wire divergence (the #6 sort-stability precedent).
@@ -35,7 +45,11 @@ import type {
   WorkflowFailureRank,
 } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
 
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
 import type { Logger } from "../../boot/logger.js";
+import type { ExecutionReadScope } from "../../extensions/execution-read-scope.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import type { Store } from "../../store/interface.js";
 
 import { parseRfc3339Ms } from "./execution-filter.js";
@@ -46,17 +60,37 @@ const RANK_LIMIT = 10;
 export interface SummaryDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed summary read scope — undefined = the OSS full scan (C2 Stage 4). */
+  readonly executionReadScope: ExecutionReadScope | undefined;
 }
 
 export async function getExecutionSummary(
   deps: SummaryDeps,
   req: GetExecutionSummaryRequest,
+  identity: CallerIdentity,
 ): Promise<ExecutionSummary> {
-  const executions = await loadAllWorkflowExecutions(
+  let executions = await loadAllWorkflowExecutions(
     deps.store,
     deps.logger,
     "failed to list workflow executions for summary",
   );
+
+  if (deps.executionReadScope !== undefined) {
+    const authorizedIds = await deps.executionReadScope.authorizedExecutionIds(
+      identity,
+      ApiResourceKind.workflow_execution,
+    );
+    if (authorizedIds.size === 0) {
+      // The Java baseline's empty arm: the default instance, before any
+      // aggregation — success_rate 0 and NO cost summary by construction.
+      return create(ExecutionSummarySchema);
+    }
+    executions = executions.filter(
+      (execution) =>
+        authorizedIds.has(execution.metadata?.id ?? "") &&
+        execution.metadata?.org === req.org,
+    );
+  }
 
   const cutoffMs = resolveTimeCutoffMs(req.timeWindow);
   const workflowFilter = req.workflowId;

--- a/backend/services/stigmer-server/src/domain/workflowexecution/subscribe-events.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/subscribe-events.ts
@@ -33,12 +33,17 @@ import type { WorkflowExecutionEvent } from "@stigmer/protos/ai/stigmer/agentic/
 import type { SubscribeEventsRequest } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
+import { WorkflowExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/query_pb";
+
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import {
   internalError,
   invalidArgumentError,
   notFoundError,
 } from "../../pipeline/errors.js";
+import { authorizeDirect } from "../../pipeline/steps/authorize.js";
 import type {
   Store,
   WorkflowExecutionEventRecord,
@@ -54,6 +59,8 @@ import { isWorkflowTerminalPhase } from "./subscribe.js";
 export interface SubscribeEventsDeps {
   readonly store: Store;
   readonly logger: Logger;
+  /** The composed authorization seam — the pre-stream check below (C2 Stage 4). */
+  readonly authorizer: Authorizer;
 }
 
 export async function* subscribeEvents(
@@ -64,6 +71,14 @@ export async function* subscribeEvents(
   if (request.executionId === "") {
     throw invalidArgumentError("execution_id is required");
   }
+  // The annotation's can_view check, once at subscription start (the
+  // pre-stream Authorize evaluation — see subscribe.ts; C2 Stage 4).
+  await authorizeDirect(
+    WorkflowExecutionQueryController.method.subscribeEvents,
+    deps.authorizer,
+    callerIdentityOf(context),
+    request,
+  );
   const executionId = request.executionId;
 
   // Verify the execution exists (the opposite of getEventLog's contract).

--- a/backend/services/stigmer-server/src/domain/workflowexecution/subscribe.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/subscribe.ts
@@ -35,8 +35,13 @@ import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecu
 import type { SubscribeWorkflowExecutionRequest } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/io_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
+import { WorkflowExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/query_pb";
+
 import type { Logger } from "../../boot/logger.js";
+import type { Authorizer } from "../../extensions/authorizer.js";
+import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { invalidArgumentError, notFoundError } from "../../pipeline/errors.js";
+import { authorizeDirect } from "../../pipeline/steps/authorize.js";
 import type { Store } from "../../store/interface.js";
 
 import type { StreamBroker } from "./stream-broker.js";
@@ -45,6 +50,8 @@ export interface SubscribeDeps {
   readonly store: Store;
   readonly logger: Logger;
   readonly broker: StreamBroker;
+  /** The composed authorization seam — the pre-stream check below (C2 Stage 4). */
+  readonly authorizer: Authorizer;
 }
 
 /**
@@ -70,6 +77,16 @@ export async function* subscribeExecution(
   if (request.executionId === "") {
     throw invalidArgumentError("execution_id is required");
   }
+  // The annotation's can_view check, once at subscription start — the
+  // stream cannot run inside the pipeline executor, so the Authorize
+  // evaluation runs here directly (the Java subscribe handlers' validate →
+  // authorize order; C2 Stage 4).
+  await authorizeDirect(
+    WorkflowExecutionQueryController.method.subscribe,
+    deps.authorizer,
+    callerIdentityOf(context),
+    request,
+  );
   const id = request.executionId;
   deps.logger.info("Starting workflow execution subscription", {
     executionId: id,

--- a/backend/services/stigmer-server/src/extensions/__tests__/direct-handler-authorization.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/direct-handler-authorization.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Pins the C2 Stage-4 enforcement END TO END for the direct handlers whose
+ * domain suites run through full composed servers (session updateSubject,
+ * workflow getVersion, artifact delete/getDownloadUrl/getContent): one
+ * composed server with a DENYING extension Authorizer, probed over the
+ * wire. This proves the whole path — transport → registered handler →
+ * authorizeDirect → the composed Authorizer — not just the handler
+ * function, and each method's byte-pinned annotation copy doubles as the
+ * descriptor-mismatch guard. Denials must also be side-effect free: the
+ * denied writes leave the stored rows untouched.
+ *
+ * The streaming/connect lanes' enforcement is pinned in their domain
+ * suites (workflowexecution/agentexecution read-authorization.test.ts,
+ * mcpserver connect-authorization.test.ts); the decision mapping itself
+ * in pipeline/steps/__tests__/authorize.test.ts.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import type { Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { ArtifactSchema } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/api_pb";
+import { ArtifactCommandController } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/command_pb";
+import { ArtifactStorageState } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/enum_pb";
+import { ArtifactQueryController } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/query_pb";
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { SessionCommandController } from "@stigmer/protos/ai/stigmer/agentic/session/v1/command_pb";
+import { WorkflowQueryController } from "@stigmer/protos/ai/stigmer/agentic/workflow/v1/query_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { loadConfig } from "../../boot/config.js";
+import { composeServer } from "../../boot/compose.js";
+import type { ComposedServer } from "../../boot/compose.js";
+import { createLogger } from "../../boot/logger.js";
+import type { ServerExtension } from "../registry.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+describe("direct-handler authorization (composed server, denying authorizer)", () => {
+  let server: ComposedServer;
+  let dir: string;
+  let transport: Transport;
+
+  const denyEverything: ServerExtension = {
+    name: "deny-everything",
+    authorizer: {
+      authorize: () => Promise.resolve({ kind: "deny", reason: "" }),
+    },
+  };
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "direct-authz-test-"));
+    server = await composeServer({
+      config: loadConfig({
+        STIGMER_MODEL_REGISTRY_REFRESH: "off",
+        TEMPORAL_HOST_PORT: "127.0.0.1:1",
+        DB_PATH: path.join(dir, "stigmer.db"),
+        STORAGE_PATH: path.join(dir, "storage"),
+        ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      }),
+      logger: silentLogger,
+      extensions: [denyEverything],
+      portOverride: 0,
+      host: "127.0.0.1",
+    });
+    const port = await server.start();
+    transport = createGrpcTransport({ baseUrl: `http://127.0.0.1:${port}` });
+
+    // Seed the load-first targets directly through the store — the write
+    // path is not under test and the denying authorizer would refuse it.
+    await server.store.saveResource(
+      ApiResourceKind.session,
+      "ses_01authztarget",
+      SessionSchema,
+      create(SessionSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Session",
+        metadata: { id: "ses_01authztarget", name: "target", org: "acme" },
+        spec: { agentInstanceId: "ain_01x", subject: "original" },
+      }),
+    );
+    await server.store.saveResource(
+      ApiResourceKind.artifact,
+      "art_01authztarget",
+      ArtifactSchema,
+      create(ArtifactSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "Artifact",
+        metadata: { id: "art_01authztarget", name: "target", org: "acme" },
+        status: {
+          contentHash: "0".repeat(64),
+          storageState: ArtifactStorageState.storage_state_stored,
+        },
+      }),
+    );
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function expectDenied(run: () => Promise<unknown>, copy: string) {
+    const error = await run().catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.PermissionDenied);
+    expect((error as ConnectError).rawMessage).toBe(copy);
+  }
+
+  it("session updateSubject denies with its annotation copy and leaves the row unchanged", async () => {
+    const command = createClient(SessionCommandController, transport);
+    await expectDenied(
+      () =>
+        command.updateSubject({ id: "ses_01authztarget", subject: "stolen" }),
+      "unauthorized to update session subject",
+    );
+    const stored = await server.store.getResource(
+      ApiResourceKind.session,
+      "ses_01authztarget",
+      SessionSchema,
+    );
+    expect(stored.spec?.subject).toBe("original");
+  });
+
+  it("session updateSubject on a MISSING id answers NotFound even under denial (load-first, #224)", async () => {
+    const command = createClient(SessionCommandController, transport);
+    const error = await command
+      .updateSubject({ id: "ses_doesnotexist", subject: "anything" })
+      .catch((e: unknown) => e);
+    expect((error as ConnectError).code).toBe(Code.NotFound);
+    expect((error as ConnectError).rawMessage).toBe(
+      "session not found: ses_doesnotexist",
+    );
+  });
+
+  it("workflow getVersion denies with its annotation copy (the ruled Java-gap divergence)", async () => {
+    const query = createClient(WorkflowQueryController, transport);
+    await expectDenied(
+      () =>
+        query.getVersion({
+          workflowId: "wfl_01any",
+          versionHash: "a".repeat(64),
+        }),
+      "unauthorized to get workflow version",
+    );
+  });
+
+  it("artifact delete denies with its annotation copy and leaves the storage state unchanged", async () => {
+    const command = createClient(ArtifactCommandController, transport);
+    await expectDenied(
+      () => command.delete({ value: "art_01authztarget" }),
+      "unauthorized to delete artifact",
+    );
+    const stored = await server.store.getResource(
+      ApiResourceKind.artifact,
+      "art_01authztarget",
+      ArtifactSchema,
+    );
+    expect(stored.status?.storageState).toBe(
+      ArtifactStorageState.storage_state_stored,
+    );
+  });
+
+  it("artifact getDownloadUrl and getContent deny with their annotation copies", async () => {
+    const query = createClient(ArtifactQueryController, transport);
+    await expectDenied(
+      () => query.getDownloadUrl({ value: "art_01authztarget" }),
+      "unauthorized to download artifact",
+    );
+    await expectDenied(
+      () => query.getContent({ artifactId: "art_01authztarget" }),
+      "unauthorized to read artifact content",
+    );
+  });
+});

--- a/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
@@ -238,6 +238,18 @@ describe("resolveExtensions — merge semantics", () => {
     ]);
     expect(resolved.drivers.channelRuntime).toBe(runtime);
   });
+
+  it("keeps the declared ExecutionReadScope as the resolved singleton (C2 Stage 4)", () => {
+    const scope = {
+      authorizedExecutionIds: () => Promise.resolve(new Set<string>()),
+    };
+    const resolved = resolveExtensions([
+      { name: "iam", drivers: { executionReadScope: scope } },
+    ]);
+    expect(resolved.drivers.executionReadScope).toBe(scope);
+    // The empty state resolves explicitly, never a missing key.
+    expect(resolveExtensions([]).drivers.executionReadScope).toBeUndefined();
+  });
 });
 
 describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
@@ -259,6 +271,20 @@ describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
       ]),
     ).toThrowError(
       /extension 'second-authz' registers an Authorizer, but 'first-authz' already did/,
+    );
+  });
+
+  it("throws on a second ExecutionReadScope, naming both units", () => {
+    const scope = {
+      authorizedExecutionIds: () => Promise.resolve(new Set<string>()),
+    };
+    expect(() =>
+      resolveExtensions([
+        { name: "scope-a", drivers: { executionReadScope: scope } },
+        { name: "scope-b", drivers: { executionReadScope: scope } },
+      ]),
+    ).toThrowError(
+      /extension 'scope-b' registers an ExecutionReadScope, but 'scope-a' already did/,
     );
   });
 

--- a/backend/services/stigmer-server/src/extensions/drivers.ts
+++ b/backend/services/stigmer-server/src/extensions/drivers.ts
@@ -13,6 +13,8 @@
  *     landed with C2 (20260827.10, rulings Q2/Q7)
  *   - channel runtime (DD-004's serving seam) — landed with C3
  *     (20260827.11, plan-gate ruling Q1)
+ *   - execution read scope (the summary tenant-isolation fork) — landed
+ *     with C2 Stage 4 (20260827.10, gate ruling)
  *
  * Merge rules (enforced by resolveExtensions, DD-006 §2b): the two
  * provider kinds are single-instance points — a second declaring unit is
@@ -29,6 +31,7 @@ import type { ChannelRuntime } from "../domain/agentchannel/channel-runtime.js";
 import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
 import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
 import type { SandboxProvisionerFactory } from "../sandbox/provisioner.js";
+import type { ExecutionReadScope } from "./execution-read-scope.js";
 import type { OrganizationDirectory } from "./organization-directory.js";
 import type { ResourceAuthorizationLifecycle } from "./resource-authorization.js";
 
@@ -90,4 +93,11 @@ export interface ExtensionDrivers {
    * (src/domain/agentchannel/channel-runtime.ts carries the contract).
    */
   readonly channelRuntime?: ChannelRuntime;
+  /**
+   * The execution read scope (C2 Stage 4; single-instance point). When
+   * composed, both getExecutionSummary handlers aggregate only the
+   * caller's authorized executions intersected with the requested org;
+   * when absent, the OSS full scan — byte-identical.
+   */
+  readonly executionReadScope?: ExecutionReadScope;
 }

--- a/backend/services/stigmer-server/src/extensions/execution-read-scope.ts
+++ b/backend/services/stigmer-server/src/extensions/execution-read-scope.ts
@@ -1,0 +1,49 @@
+/**
+ * The execution-read-scope extension point (convergence program C2,
+ * 20260827.10; Stage-4 gate ruling). The two dashboard summary reads —
+ * AgentExecutionQueryController.getExecutionSummary and
+ * WorkflowExecutionQueryController.getExecutionSummary — are deliberate
+ * direct full-scan aggregates on OSS (single-user: everything is yours,
+ * the request's org is not even consulted). On a multi-tenant edition the
+ * same scan aggregates OTHER tenants' executions into the dashboard
+ * numbers, so the cloud baseline (the Java GetExecutionSummary handlers)
+ * scopes the aggregation to the caller's authorized id set intersected
+ * with the requested org, and answers the proto DEFAULT INSTANCE when the
+ * authorized set is empty — which is exactly the conformance-pinned
+ * multi-tenant zero shape (success_rate 0, no cost summary), falling out
+ * of the scoping rather than being special-cased.
+ *
+ * This port is the ONE seam for that fork (the organizationDirectory
+ * precedent — never a second registration of an OSS-served RPC):
+ *
+ *   - No scope composed = the OSS full scan, byte-identical (the four
+ *     conformance rosters pin it).
+ *   - A composed scope answers the caller's authorized execution ids for
+ *     the kind; the SUMMARY HANDLERS own everything else — the org
+ *     intersection, the empty-set default instance, and the aggregation
+ *     itself stay OSS-owned and edition-neutral.
+ *
+ * The scope receives whatever identity the call carries, including the
+ * in-process `internal` class — the driver owns that arm's semantics
+ * (the Java baseline propagates the original caller through in-process
+ * calls, so a composed driver normally never sees `internal` on this
+ * lane).
+ */
+import type { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { CallerIdentity } from "./identity.js";
+
+/** The scope contract (single-instance point, ExtensionDrivers.executionReadScope). */
+export interface ExecutionReadScope {
+  /**
+   * The execution ids `caller` may read for `kind` (the Java baseline:
+   * FGA listAuthorizedResourceIds on can_view). An empty set is a real
+   * answer — the summary handlers map it to the default instance without
+   * touching the store. `kind` is agent_execution or workflow_execution;
+   * a scope may throw on any other kind (a consumer bug by contract).
+   */
+  authorizedExecutionIds(
+    caller: CallerIdentity,
+    kind: ApiResourceKind,
+  ): Promise<ReadonlySet<string>>;
+}

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -38,6 +38,7 @@ import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_inf
 import type { ArtifactStorageDriverFactory } from "../artifactstorage/artifact-storage.js";
 import { BUILT_IN_STORAGE_TYPES } from "../artifactstorage/artifact-storage.js";
 import type { ChannelRuntime } from "../domain/agentchannel/channel-runtime.js";
+import type { ExecutionReadScope } from "./execution-read-scope.js";
 import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
 import type { PipelineStep } from "../pipeline/pipeline.js";
 import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
@@ -166,6 +167,8 @@ export interface ResolvedExtensionDrivers {
    * that defines its semantics, not with this data holder).
    */
   readonly channelRuntime: ChannelRuntime | undefined;
+  /** The C2 Stage-4 summary read scope — undefined = the OSS full scan. */
+  readonly executionReadScope: ExecutionReadScope | undefined;
 }
 
 /**
@@ -201,6 +204,8 @@ export function resolveExtensions(
   let organizationDirectoryDeclaredBy: string | undefined;
   let channelRuntime: ChannelRuntime | undefined;
   let channelRuntimeDeclaredBy: string | undefined;
+  let executionReadScope: ExecutionReadScope | undefined;
+  let executionReadScopeDeclaredBy: string | undefined;
   const artifactStorageDrivers = new Map<
     string,
     ArtifactStorageDriverFactory
@@ -301,6 +306,16 @@ export function resolveExtensions(
       channelRuntimeDeclaredBy = unit.name;
     }
 
+    if (unit.drivers?.executionReadScope !== undefined) {
+      if (executionReadScopeDeclaredBy !== undefined) {
+        throw new Error(
+          `extension '${unit.name}' registers an ExecutionReadScope, but '${executionReadScopeDeclaredBy}' already did — exactly one may be composed`,
+        );
+      }
+      executionReadScope = unit.drivers.executionReadScope;
+      executionReadScopeDeclaredBy = unit.name;
+    }
+
     if (unit.drivers?.artifactStorageDrivers !== undefined) {
       for (const [name, factory] of unit.drivers.artifactStorageDrivers) {
         if ((BUILT_IN_STORAGE_TYPES as ReadonlyArray<string>).includes(name)) {
@@ -384,6 +399,7 @@ export function resolveExtensions(
       artifactStorageDrivers,
       sandboxProvisionerDrivers,
       channelRuntime,
+      executionReadScope,
     },
     services,
     workers,

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -91,6 +91,7 @@ export type {
 } from "./extensions/resource-authorization.js";
 export type { OrganizationDirectory } from "./extensions/organization-directory.js";
 export { ALL_ORGANIZATIONS } from "./extensions/organization-directory.js";
+export type { ExecutionReadScope } from "./extensions/execution-read-scope.js";
 export {
   diffVisibilityShapes,
   visibilityShapesFor,

--- a/backend/services/stigmer-server/src/pipeline/steps/__tests__/authorize.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/__tests__/authorize.test.ts
@@ -30,6 +30,7 @@ import { testCallerIdentity } from "../../__tests__/support.js";
 import { RequestContext } from "../../request-context.js";
 import {
   AUTHORIZATION_UNAVAILABLE_MESSAGE,
+  authorizeDirect,
   newAuthorizeStep,
   newPermissiveSingleTeamAuthorizer,
 } from "../authorize.js";
@@ -275,6 +276,77 @@ describe("check-target resolution (never a throw — byte-identity)", () => {
         resourceId: "stigmer",
       },
     ]);
+  });
+});
+
+describe("authorizeDirect (the direct-handler arm, C2 Stage 4)", () => {
+  // The step delegates to authorizeDirect, so the arms above already pin
+  // the shared evaluation; these pin what is SPECIFIC to the direct
+  // entry: no RequestContext, and the target override.
+
+  it("denies with the annotation copy from a bare identity + input (no pipeline)", async () => {
+    const { authorizer } = fakeAuthorizer({ kind: "deny", reason: "" });
+    const error = await authorizeDirect(
+      AgentCommandController.method.create,
+      authorizer,
+      testCallerIdentity(),
+      create(AgentSchema, { metadata: { name: "a", org: "acme" } }),
+    ).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.PermissionDenied);
+    expect((error as ConnectError).rawMessage).toBe(
+      "unauthorized to create agent in this organization",
+    );
+  });
+
+  it("skips for the internal caller class without consulting the authorizer", async () => {
+    const { authorizer, checks } = fakeAuthorizer({
+      kind: "deny",
+      reason: "must not be called",
+    });
+    await expect(
+      authorizeDirect(
+        AgentCommandController.method.create,
+        authorizer,
+        testCallerIdentity({ callerClass: "internal" }),
+        create(AgentSchema, { metadata: { name: "a", org: "acme" } }),
+      ),
+    ).resolves.toBeUndefined();
+    expect(checks).toHaveLength(0);
+  });
+
+  it("the target override replaces field_path resolution — the completeOAuthConnect lane", async () => {
+    const { authorizer, checks } = fakeAuthorizer({ kind: "allow" });
+    await authorizeDirect(
+      AgentCommandController.method.create,
+      authorizer,
+      testCallerIdentity(),
+      // The request names one org; the override (server-side state in the
+      // real lane) names another. The CHECK must carry the override.
+      create(AgentSchema, { metadata: { name: "a", org: "caller-supplied" } }),
+      { resourceId: "server-side-truth" },
+    );
+    expect(checks).toEqual([
+      {
+        permission: IamPermission.can_create_agent,
+        resourceKind: ApiResourceKind.organization,
+        resourceId: "server-side-truth",
+      },
+    ]);
+  });
+
+  it("the ruling-Q1 not-found arm maps identically from the direct entry", async () => {
+    const { authorizer } = fakeAuthorizer({ kind: "not-found" });
+    const error = await authorizeDirect(
+      AgentCommandController.method.create,
+      authorizer,
+      testCallerIdentity(),
+      create(AgentSchema, { metadata: { name: "a", org: "acme" } }),
+    ).catch((e: unknown) => e);
+    expect((error as ConnectError).code).toBe(Code.NotFound);
+    expect((error as ConnectError).rawMessage).toBe(
+      "Organization not found: acme",
+    );
   });
 });
 

--- a/backend/services/stigmer-server/src/pipeline/steps/authorize.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/authorize.ts
@@ -34,6 +34,19 @@
  * A thrown resolution would be a NEW wire behavior on requests that are
  * legal today (byte-identity forbids it); an implementation that wants to
  * refuse empty ids does so as a deny, visibly.
+ *
+ * `authorizeDirect` is the SAME evaluation exported for the direct
+ * handlers — the config-annotated methods that deliberately run no
+ * pipeline (streams cannot run in the pipeline executor; the rest are
+ * ported direct forms, docs/authorization-coverage.md). One evaluation,
+ * two entry shapes; a direct handler calls it after its own input
+ * validation and before any load or side effect, mirroring the Java
+ * edition's validate → authorize handler order (C2 Stage 4 ruling,
+ * 20260827.10). The optional target override serves the one lane whose
+ * true target is server-side state rather than caller input
+ * (completeOAuthConnect authorizes the PENDING RECORD's server id — a
+ * caller-supplied id would be a confused-deputy hole, the Java
+ * McpServerCompleteOAuthConnectHandler discipline).
  */
 import { Code, ConnectError } from "@connectrpc/connect";
 import type { DescMethod, DescMessage, Message } from "@bufbuild/protobuf";
@@ -52,6 +65,7 @@ import type {
   AuthzCheck,
   AuthzDecision,
 } from "../../extensions/authorizer.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
 import { getKindName } from "../apiresource-meta.js";
 import { internalError, notFoundError } from "../errors.js";
 import type { PipelineStep } from "../pipeline.js";
@@ -94,74 +108,94 @@ export function newAuthorizeStep<Desc extends DescMessage>(
 ): PipelineStep<Desc> {
   return {
     name: "Authorize",
-    async execute(ctx: RequestContext<Desc>): Promise<void> {
-      if (ctx.callerIdentity.callerClass === "internal") {
-        return;
-      }
-      if (
-        getOption(method, is_public) ||
-        getOption(method, is_skip_authorization)
-      ) {
-        return;
-      }
-      if (!hasOption(method, rpcAuthorizationConfig)) {
-        return;
-      }
-      const config = getOption(method, rpcAuthorizationConfig);
-
-      const check: AuthzCheck = {
-        permission: config.permission,
-        resourceKind: resolveResourceKind(ctx.input, config),
-        resourceId: resolveResourceId(ctx.input, config),
-      };
-      const decision = await runAuthorizer(authorizer, ctx, check);
-      switch (decision.kind) {
-        case "allow":
-          return;
-        case "deny":
-          throw new ConnectError(
-            config.errorMsg !== ""
-              ? config.errorMsg
-              : decision.reason !== ""
-                ? decision.reason
-                : AUTHORIZATION_DENIED_FALLBACK_MESSAGE,
-            Code.PermissionDenied,
-          );
-        case "not-found": {
-          // The ruling-Q1 arm: the exact copy the load-first chain would
-          // answer for the missing id (LoadTarget's notFoundError), so
-          // the wire cannot distinguish which step spoke.
-          if (
-            check.resourceId === "" ||
-            check.resourceKind === ApiResourceKind.api_resource_kind_unknown
-          ) {
-            throw internalError(
-              new Error(
-                "authorizer answered not-found for a non-resource-scoped check",
-              ),
-              AUTHORIZATION_UNAVAILABLE_MESSAGE,
-            );
-          }
-          throw notFoundError(
-            getKindName(check.resourceKind),
-            check.resourceId,
-          );
-        }
-        case "unavailable":
-          throw internalError(
-            decision.cause,
-            AUTHORIZATION_UNAVAILABLE_MESSAGE,
-          );
-        default: {
-          const exhaustive: never = decision;
-          throw internalError(
-            new Error(`unknown decision ${JSON.stringify(exhaustive)}`),
-            AUTHORIZATION_UNAVAILABLE_MESSAGE,
-          );
-        }
-      }
+    execute(ctx: RequestContext<Desc>): Promise<void> {
+      return authorizeDirect(method, authorizer, ctx.callerIdentity, ctx.input);
     },
   };
+}
+
+/**
+ * The one lane whose authorization target is server-side state rather
+ * than a request field (see the module header). `resourceId` replaces the
+ * annotation's `field_path`/`resource_id` resolution; everything else —
+ * skip arms, kind, permission, copy — still comes from the annotation.
+ */
+export interface AuthorizeTargetOverride {
+  readonly resourceId: string;
+}
+
+/**
+ * The Authorize evaluation for direct handlers: identical skip arms,
+ * target resolution, and decision-to-wire mapping as the pipeline step
+ * (which delegates here). Throws the mapped ConnectError on any
+ * non-allow arm; resolves on allow and on every skip arm.
+ */
+export async function authorizeDirect(
+  method: DescMethod,
+  authorizer: Authorizer,
+  identity: CallerIdentity,
+  input: Message,
+  override?: AuthorizeTargetOverride,
+): Promise<void> {
+  if (identity.callerClass === "internal") {
+    return;
+  }
+  if (
+    getOption(method, is_public) ||
+    getOption(method, is_skip_authorization)
+  ) {
+    return;
+  }
+  if (!hasOption(method, rpcAuthorizationConfig)) {
+    return;
+  }
+  const config = getOption(method, rpcAuthorizationConfig);
+
+  const check: AuthzCheck = {
+    permission: config.permission,
+    resourceKind: resolveResourceKind(input, config),
+    resourceId: override?.resourceId ?? resolveResourceId(input, config),
+  };
+  const decision = await runAuthorizer(authorizer, identity, check);
+  switch (decision.kind) {
+    case "allow":
+      return;
+    case "deny":
+      throw new ConnectError(
+        config.errorMsg !== ""
+          ? config.errorMsg
+          : decision.reason !== ""
+            ? decision.reason
+            : AUTHORIZATION_DENIED_FALLBACK_MESSAGE,
+        Code.PermissionDenied,
+      );
+    case "not-found": {
+      // The ruling-Q1 arm: the exact copy the load-first chain would
+      // answer for the missing id (LoadTarget's notFoundError), so
+      // the wire cannot distinguish which step spoke.
+      if (
+        check.resourceId === "" ||
+        check.resourceKind === ApiResourceKind.api_resource_kind_unknown
+      ) {
+        throw internalError(
+          new Error(
+            "authorizer answered not-found for a non-resource-scoped check",
+          ),
+          AUTHORIZATION_UNAVAILABLE_MESSAGE,
+        );
+      }
+      throw notFoundError(getKindName(check.resourceKind), check.resourceId);
+    }
+    case "unavailable":
+      throw internalError(decision.cause, AUTHORIZATION_UNAVAILABLE_MESSAGE);
+    default: {
+      const exhaustive: never = decision;
+      throw internalError(
+        new Error(`unknown decision ${JSON.stringify(exhaustive)}`),
+        AUTHORIZATION_UNAVAILABLE_MESSAGE,
+      );
+    }
+  }
 }
 
 /**
@@ -169,13 +203,13 @@ export function newAuthorizeStep<Desc extends DescMessage>(
  * normalized into the unavailable arm so a buggy implementation can never
  * soften an outage into a denial by accident.
  */
-async function runAuthorizer<Desc extends DescMessage>(
+async function runAuthorizer(
   authorizer: Authorizer,
-  ctx: RequestContext<Desc>,
+  identity: CallerIdentity,
   check: AuthzCheck,
 ): Promise<AuthzDecision> {
   try {
-    return await authorizer.authorize(ctx.callerIdentity, check);
+    return await authorizer.authorize(identity, check);
   } catch (error) {
     return {
       kind: "unavailable",

--- a/test/conformance/src/suites/agentexecution.conformance.test.ts
+++ b/test/conformance/src/suites/agentexecution.conformance.test.ts
@@ -308,8 +308,10 @@ describe("AgentExecution conformance — zero-record read surfaces (CW-7)", () =
       Code.InvalidArgument,
       "subscribe with an empty id",
     );
-    // Single-user arm: the multi-tenant edition answers PermissionDenied
-    // for an unresolvable id (authorization fail-closed, no existence leak).
+    // Single-user arm here; on the multi-tenant edition an unresolvable id
+    // answers the SAME NotFound through the authorizer's deny-path
+    // existence probe (the ruled uniform Q1 posture, C2 Stage 4) — pinned
+    // with an outsider caller in the direct-handler-authorization suite.
     if (target.capabilities.multiTenant) return;
     await expectGrpcCode(
       () =>

--- a/test/conformance/src/suites/direct-handler-authorization.conformance.test.ts
+++ b/test/conformance/src/suites/direct-handler-authorization.conformance.test.ts
@@ -1,0 +1,251 @@
+// Direct-handler authorization conformance (C2 Stage 4, 20260827.10).
+//
+// The config-annotated methods served by DIRECT handlers evaluate their
+// annotations since Stage 4 (docs/authorization-coverage.md carries the
+// per-method dispositions). This suite pins the OUTSIDER contract on the
+// multi-tenant edition — a second provisioned identity with no grants on
+// the owner's resources:
+//
+//   - a write/read against an EXISTING foreign resource refuses
+//     PERMISSION_DENIED with the method's byte-pinned annotation
+//     error_msg (the copy doubles as the descriptor-mismatch guard), and
+//     a denied write is side-effect free;
+//   - an UNKNOWN id on the authorize-first family answers NOT_FOUND via
+//     the authorizer's deny-path existence probe — the ruled UNIFORM Q1
+//     posture (DD-007 not-found arm; the Java edition answers
+//     PERMISSION_DENIED on these lanes, an artifact of its missing load
+//     steps — divergence ruled and recorded at the Stage-4 gate);
+//   - the load-first family (updateSubject, the artifact trio, the MCP
+//     connect trio) keeps its handler-owned NotFound copy for unknown
+//     ids, outsider or not — the load fires before the check (#224).
+//
+// Single-user targets skip: one implicit caller, isolation untestable by
+// construction (the organization suite's outsider precedent).
+import { Code } from "@connectrpc/connect";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import type { ConformanceClients } from "../harness/clients";
+import { createTarget, type TargetProfile } from "../targets";
+import { FixtureTracker } from "../harness/fixtures";
+import { expectGrpcCode } from "../contract/errors";
+import { collectStream } from "../support/collect-stream";
+import { makeAgent } from "../support/agents";
+import { makeMcpServer } from "../support/mcpservers";
+import { makeSession } from "../support/sessions";
+import { makeWorkflow } from "../support/workflows";
+import { uniqueName } from "../support/naming";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+function multiTenantOnly(): boolean {
+  return target.capabilities.multiTenant;
+}
+
+async function outsiderClients(): Promise<ConformanceClients> {
+  if (target.provisionIdentity === undefined) {
+    throw new Error(
+      `target "${target.name}" declares multiTenant but provides no provisionIdentity()`,
+    );
+  }
+  return target.provisionIdentity();
+}
+
+describe("direct-handler authorization — outsider denials (multi-tenant only)", () => {
+  it("session updateSubject refuses an outsider with the annotation copy; the subject survives", async (ctx) => {
+    if (!multiTenantOnly()) return ctx.skip();
+    const { org } = await target.provisionTenancy();
+    const outsider = await outsiderClients();
+
+    const agent = await clients.agentCommand.create(
+      makeAgent({ org, name: uniqueName("authz-agent") }),
+    );
+    fixtures.defer(() =>
+      clients.agentCommand.delete({ value: agent.metadata!.id }),
+    );
+    const session = await clients.sessionCommand.create(
+      makeSession({
+        org,
+        name: uniqueName("authz-session"),
+        agentInstanceId: agent.status!.defaultInstanceId,
+        subject: "owner's subject",
+      }),
+    );
+    fixtures.defer(() =>
+      clients.sessionCommand.delete({ value: session.metadata!.id }),
+    );
+
+    const denied = await expectGrpcCode(
+      () =>
+        outsider.sessionCommand.updateSubject({
+          id: session.metadata!.id,
+          subject: "hijacked",
+        }),
+      Code.PermissionDenied,
+      "outsider updateSubject on a foreign session",
+    );
+    expect(denied.rawMessage).toBe("unauthorized to update session subject");
+    // The denied write left the row untouched.
+    const after = await clients.sessionQuery.get({
+      value: session.metadata!.id,
+    });
+    expect(after.spec?.subject).toBe("owner's subject");
+  });
+
+  it("workflow getVersion refuses an outsider with the annotation copy (the ruled Java-gap divergence)", async (ctx) => {
+    if (!multiTenantOnly()) return ctx.skip();
+    const { org } = await target.provisionTenancy();
+    const outsider = await outsiderClients();
+
+    const workflow = await clients.workflowCommand.create(
+      makeWorkflow({ org, name: uniqueName("authz-wf") }),
+    );
+    fixtures.defer(() =>
+      clients.workflowCommand.delete({ value: workflow.metadata!.id }),
+    );
+
+    const denied = await expectGrpcCode(
+      () =>
+        outsider.workflowQuery.getVersion({
+          workflowId: workflow.metadata!.id,
+          versionHash: workflow.status!.versionHash,
+        }),
+      Code.PermissionDenied,
+      "outsider getVersion on a foreign workflow",
+    );
+    expect(denied.rawMessage).toBe("unauthorized to get workflow version");
+  });
+
+  it("the MCP connect lanes refuse an outsider with their annotation copies", async (ctx) => {
+    if (!multiTenantOnly()) return ctx.skip();
+    const { org } = await target.provisionTenancy();
+    const outsider = await outsiderClients();
+
+    const server = await clients.mcpServerCommand.create(
+      makeMcpServer({ org, name: uniqueName("authz-mcp") }),
+    );
+    fixtures.defer(() =>
+      clients.mcpServerCommand.delete({ resourceId: server.metadata!.id }),
+    );
+    const id = server.metadata!.id;
+
+    const lanes: ReadonlyArray<[string, () => Promise<unknown>, string]> = [
+      [
+        "connect",
+        () => outsider.mcpServerCommand.connect({ mcpServerId: id, org }),
+        "unauthorized to connect to mcp server",
+      ],
+      [
+        "startConnect",
+        () => outsider.mcpServerCommand.startConnect({ mcpServerId: id, org }),
+        "unauthorized to connect to mcp server",
+      ],
+      [
+        "initiateOAuthConnect",
+        () =>
+          outsider.mcpServerCommand.initiateOAuthConnect({ mcpServerId: id }),
+        "unauthorized to initiate oauth connect for mcp server",
+      ],
+      [
+        "getOAuthGrantStatus",
+        () =>
+          outsider.mcpServerQuery.getOAuthGrantStatus({ resourceId: id, org }),
+        "unauthorized to view oauth status for mcp server",
+      ],
+      [
+        "disconnectOAuth",
+        () =>
+          outsider.mcpServerCommand.disconnectOAuth({ resourceId: id, org }),
+        "unauthorized to disconnect oauth for mcp server",
+      ],
+    ];
+    for (const [lane, op, copy] of lanes) {
+      const denied = await expectGrpcCode(
+        op,
+        Code.PermissionDenied,
+        `outsider ${lane} on a foreign server`,
+      );
+      expect(denied.rawMessage, `${lane} annotation copy`).toBe(copy);
+    }
+  });
+
+  it("the authorize-first read lanes answer NOT_FOUND for unknown ids — the ruled uniform Q1 posture", async (ctx) => {
+    if (!multiTenantOnly()) return ctx.skip();
+    const outsider = await outsiderClients();
+
+    await expectGrpcCode(
+      () =>
+        outsider.workflowExecutionQuery.getEventLog({
+          executionId: "wfe_01conformancemissing",
+        }),
+      Code.NotFound,
+      "outsider getEventLog on an unknown execution",
+    );
+    await expectGrpcCode(
+      () =>
+        collectStream((signal) =>
+          outsider.workflowExecutionQuery.subscribe(
+            { executionId: "wfe_01conformancemissing" },
+            { signal },
+          ),
+        ),
+      Code.NotFound,
+      "outsider subscribe on an unknown workflow execution",
+    );
+    await expectGrpcCode(
+      () =>
+        collectStream((signal) =>
+          outsider.workflowExecutionQuery.subscribeEvents(
+            { executionId: "wfe_01conformancemissing" },
+            { signal },
+          ),
+        ),
+      Code.NotFound,
+      "outsider subscribeEvents on an unknown workflow execution",
+    );
+    await expectGrpcCode(
+      () =>
+        collectStream((signal) =>
+          outsider.agentExecutionQuery.subscribe(
+            { value: "aexec_01conformancemissing" },
+            { signal },
+          ),
+        ),
+      Code.NotFound,
+      "outsider subscribe on an unknown agent execution",
+    );
+    await expectGrpcCode(
+      () =>
+        outsider.agentExecutionQuery.getArtifactDownloadUrl({
+          executionId: "aexec_01conformancemissing",
+          storageKey: "artifacts/aexec_01conformancemissing/f.txt",
+        }),
+      Code.NotFound,
+      "outsider getArtifactDownloadUrl on an unknown execution",
+    );
+    await expectGrpcCode(
+      () =>
+        outsider.agentExecutionQuery.getArtifactContent({
+          executionId: "aexec_01conformancemissing",
+          storageKey: "artifacts/aexec_01conformancemissing/f.txt",
+        }),
+      Code.NotFound,
+      "outsider getArtifactContent on an unknown execution",
+    );
+  });
+});

--- a/test/conformance/src/suites/direct-handler-authorization.conformance.test.ts
+++ b/test/conformance/src/suites/direct-handler-authorization.conformance.test.ts
@@ -158,7 +158,10 @@ describe("direct-handler authorization — outsider denials (multi-tenant only)"
       [
         "initiateOAuthConnect",
         () =>
-          outsider.mcpServerCommand.initiateOAuthConnect({ mcpServerId: id }),
+          outsider.mcpServerCommand.initiateOAuthConnect({
+            mcpServerId: id,
+            org,
+          }),
         "unauthorized to initiate oauth connect for mcp server",
       ],
       [

--- a/test/conformance/src/suites/workflowexecution.conformance.test.ts
+++ b/test/conformance/src/suites/workflowexecution.conformance.test.ts
@@ -140,9 +140,11 @@ describe("WorkflowExecution conformance — zero-record read surfaces (Class A)"
       "getEventLog without an execution id",
     );
 
-    // The unknown-id arm is single-user-posture only: the multi-tenant
-    // edition's authorization fails closed on an unresolvable id
-    // (PermissionDenied — no existence leak), never reaching the handler's
+    // The unknown-id arm is single-user-posture only: on the multi-tenant
+    // edition the annotation check runs first and an unresolvable id
+    // answers NOT_FOUND through the authorizer's deny-path existence probe
+    // (the ruled uniform Q1 posture, C2 Stage 4 — pinned in the
+    // direct-handler-authorization suite), never reaching the handler's
     // no-existence-check behavior.
     if (!target.capabilities.multiTenant) {
       const page = await clients.workflowExecutionQuery.getEventLog({
@@ -175,10 +177,11 @@ describe("WorkflowExecution conformance — zero-record read surfaces (Class A)"
       "subscribeEvents with an empty id",
     );
 
-    // The unknown-id NotFound arms hold where the caller can see everything
-    // (single-user); the multi-tenant edition answers PermissionDenied for
-    // an unresolvable id instead (authorization fail-closed, no existence
-    // leak) — the same split as getEventLog above.
+    // The unknown-id NotFound arms hold on BOTH postures since C2 Stage 4
+    // (multi-tenant: the deny-path existence probe answers the same
+    // NOT_FOUND — the ruled uniform Q1 posture), but the multi-tenant arm
+    // is pinned with an OUTSIDER caller in the direct-handler-authorization
+    // suite; here the single-user arm keeps its original pin.
     if (target.capabilities.multiTenant) return;
     await expectGrpcCode(
       () =>


### PR DESCRIPTION
## Summary

C2 Stage 4 (20260827.10), the last C2 stage — the 30 config-annotated direct-handler dispositions ruled at the Stage-4 gate, plus the summary tenant-isolation seam:

- **`authorizeDirect`** — the Authorize step's evaluation exported for handlers that run no pipeline (single source of truth; the step delegates to it). 17 direct handlers now evaluate their annotations at the Java baseline's per-method order: load-first (#224) where Java loads (session updateSubject, the artifact trio, the MCP connect trio), the pre-stream check on the three subscribe lanes, and completeOAuthConnect authorizing the PENDING RECORD's server id with the state burned before a denial (the Java confused-deputy discipline).
- **Ruled divergences, recorded**: Workflow.getVersion enforces its annotation although the Java handler never evaluates it (a Java gap — its javadoc claims framework enforcement that does not exist); validateSpec matches Java's deliberate skip; the org-OAuth-app stub trio stays a recorded program gap. Unknown ids on the authorize-first lanes answer the uniform Q1 NOT_FOUND via the deny-path probe (Java answers PERMISSION_DENIED there — an artifact of its missing load steps; ruled + suite comments updated).
- **`ExecutionReadScope`** — a new single-instance driver point (the organizationDirectory precedent): both getExecutionSummary dashboards narrow to the caller's authorized executions ∩ the requested org when composed; the empty set answers the default instance, so the multi-tenant zero shape falls out of the scoping. No driver = the full scan, byte-identical.
- **Evidence**: per-domain deny-path suites pin every enforcement with its byte-pinned annotation copy (the descriptor-mismatch guard); a composed-server end-to-end suite (denying-authorizer extension over the wire); the new multiTenant-gated outsider conformance suite (`direct-handler-authorization.conformance.test.ts`) — the durable cross-edition instrument. `docs/authorization-coverage.md` carries the full disposition table.

## Verification

- Units: 2036 passed, typecheck clean (Node 22.22.1).
- All four OSS conformance rosters byte-identical, zero failures: local 498, local-execution 160, local-postgres 498, local-postgres-execution 160 (the new outsider tests skip on single-user targets by construction).
- Measured with the cloud composition (stigmer-cloud PR pair): **cloud conformance 471 passed / 0 failed / 36 skipped** — the first fully green cloud run.

Merge order: this PR first; the stigmer-cloud PR re-pins the submodule to the squash commit (the C1 precedent).

Made with [Cursor](https://cursor.com)