### PR TITLE
fix(backend/stigmer-server): C2 close-out — enforce the channel install pair's can_edit and the anonymous share-profile audience contract

### DIFF
--- a/backend/services/stigmer-server/docs/authorization-coverage.md
+++ b/backend/services/stigmer-server/docs/authorization-coverage.md
@@ -161,8 +161,8 @@ All six RPCs are chains, and the proto deliberately marks every one `is_skip_aut
 | AgentChannelCommandController.apply | none | chain-with-Authorize |
 | AgentChannelCommandController.create | is_skip_authorization | chain-with-Authorize |
 | AgentChannelCommandController.update | config: can_edit on agent_channel (field metadata.id), error_msg yes | chain-with-Authorize |
-| AgentChannelCommandController.initiateInstall | config: can_edit on agent_channel (field resource_id), error_msg yes | direct: OSS stub — loads the channel (NOT_FOUND contract matches cloud), then refuses FAILED_PRECONDITION (install unavailable on this edition) |
-| AgentChannelCommandController.completeInstall | config: can_edit on agent_channel (field resource_id), error_msg yes | direct: OSS stub — same load-then-refuse FAILED_PRECONDITION |
+| AgentChannelCommandController.initiateInstall | config: can_edit on agent_channel (field resource_id), error_msg yes | direct: `authorizeDirect` AFTER the load (the Java LoadChannel-then-authorize order — missing ids answer NOT_FOUND for everyone), then refuse FAILED_PRECONDITION on the storing edition or delegate to `drivers.channelRuntime` (C2 close-out, 20260827.10 — the interim stub's owed can_edit arm) |
+| AgentChannelCommandController.completeInstall | config: can_edit on agent_channel (field resource_id), error_msg yes | direct: same load → `authorizeDirect` → refuse-or-delegate |
 | AgentChannelCommandController.delete | config: can_delete on agent_channel (field value), error_msg yes | chain-with-Authorize |
 | AgentChannelQueryController.get | config: can_view on agent_channel (field value), error_msg yes | chain-with-Authorize |
 | AgentChannelQueryController.getByReference | is_skip_authorization | chain-with-Authorize |
@@ -408,18 +408,18 @@ The conversation surface is a cloud capability; OSS serves edition stubs, all di
 
 These 30 methods declare a `(ai.stigmer.commons.rpc.config)` annotation and run no pipeline. All 30 were dispositioned at the C2 Stage-4 gate (20260827.10); the enforcement state per bucket:
 
-**Evaluated via `authorizeDirect` (17)** — the exported Authorize evaluation, called by the handler itself at the Java baseline's position (each table row notes load-first `#224` order where it applies):
+**Evaluated via `authorizeDirect` (19)** — the exported Authorize evaluation, called by the handler itself at the Java baseline's position (each table row notes load-first `#224` order where it applies):
 
 - Session: updateSubject
+- AgentChannel: initiateInstall, completeInstall (moved here at the C2 close-out — the Stage-4 "rides the C3 installer stage" deferral shipped without the arm on either side; the OSS lane now enforces after its load, so every composed runtime receives a pre-authorized caller)
 - AgentExecution: subscribe, getArtifactDownloadUrl, getArtifactContent
 - Workflow: getVersion (a ruled DELIBERATE divergence — the Java edition never evaluates this annotation; see the table row)
 - WorkflowExecution: subscribe, getEventLog, subscribeEvents
 - McpServer: connect, startConnect, initiateOAuthConnect, completeOAuthConnect, disconnectOAuth, getOAuthGrantStatus
 - Artifact: delete, getDownloadUrl, getContent
 
-**Enforced by the composed channel runtime (9)** — this server's handlers delegate whole-method to `drivers.channelRuntime` (DD-004); the OSS default serves the byte-pinned refusal/stub postures with nothing to protect, and the cloud runtime's served arms gate on the composed Authorizer as their first act (its own suite pins the deny paths). The install pair is an interim stub on both sides until the C3 installer stage, which owes the can_edit arm when it lands:
+**Enforced by the composed channel runtime (7)** — this server's handlers delegate whole-method to `drivers.channelRuntime` (DD-004); the OSS default serves the byte-pinned refusal/stub postures with nothing to protect, and the cloud runtime's served arms gate on the composed Authorizer as their first act (its own suite pins the deny paths):
 
-- AgentChannel: initiateInstall, completeInstall
 - ChannelConversation: getConversation, getTimeline, getMediaDownloadUrl, reply, takeOver, handBack, clearAttention
 
 **Deliberately not evaluated (1)** — Workflow.validateSpec: matches the Java handler's documented "no persist, no authorize" posture (nothing loaded or persisted); the annotation mismatch is a recorded ruling, not an omission.

--- a/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentchannel/controller.ts
@@ -60,7 +60,10 @@ import { newPipeline } from "../../pipeline/pipeline.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
-import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import {
+  authorizeDirect,
+  newAuthorizeStep,
+} from "../../pipeline/steps/authorize.js";
 import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
@@ -318,6 +321,18 @@ async function initiateInstall(
   ctx: HandlerContext,
 ): Promise<InitiateChannelInstallOutput> {
   const channel = await loadChannelForInstall(deps, ctx, input.resourceId);
+  // can_edit AFTER the load (the Java LoadChannel-then-authorize order,
+  // #224 discipline): a missing id answers NOT_FOUND for everyone; only
+  // an existing channel can produce the annotation's denial. Enforced at
+  // the OSS lane so every composed runtime receives a pre-authorized
+  // caller (C2 close-out — the interim stub the coverage doc recorded as
+  // owing this arm shipped without it on both sides).
+  await authorizeDirect(
+    AgentChannelCommandController.method.initiateInstall,
+    deps.authorizer,
+    callerIdentityOf(ctx),
+    input,
+  );
   if (deps.channelRuntime === undefined) {
     throw failedPreconditionError(INSTALL_UNAVAILABLE_MESSAGE);
   }
@@ -339,6 +354,14 @@ async function completeInstall(
   ctx: HandlerContext,
 ): Promise<AgentChannel> {
   const channel = await loadChannelForInstall(deps, ctx, input.resourceId);
+  // Same load-then-authorize order as initiateInstall — the two halves
+  // of one flow carry the identical can_edit annotation.
+  await authorizeDirect(
+    AgentChannelCommandController.method.completeInstall,
+    deps.authorizer,
+    callerIdentityOf(ctx),
+    input,
+  );
   if (deps.channelRuntime === undefined) {
     throw failedPreconditionError(INSTALL_UNAVAILABLE_MESSAGE);
   }

--- a/backend/services/stigmer-server/src/domain/agentshare/__tests__/agentshare.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentshare/__tests__/agentshare.test.ts
@@ -635,6 +635,34 @@ describe("audience and the member resolution lane", () => {
     const profile = await query.getSharedProfileForMember(ref);
     expect(profile.slug).toBe(agent.metadata!.slug);
   });
+
+  it("the ANONYMOUS path collapses an org-audience share to the uniform NotFound (C2 close-out — the proto's audience contract)", async () => {
+    const agent = await createTestAgent(uniqueName("Org Audience Anon Agent"), ORG);
+    await shares.create({
+      ...shareFor(agent, true),
+      spec: { ...shareFor(agent, true).spec, audience: AgentShareAudience.org },
+    });
+
+    // Byte-identical with the missing/disabled/rotated refusals — a
+    // members-only share URL must teach an anonymous visitor nothing.
+    const err = await grpcError(() =>
+      query.getSharedProfile({ org: ORG, slug: agent.metadata!.slug }),
+    );
+    expect(err.code).toBe(Code.NotFound);
+    expect(err.rawMessage).toBe(`Agent not found: ${agent.metadata!.slug}`);
+
+    // Flipping back to public restores anonymous resolution — the same
+    // immediate-revocation latency as disabling the share.
+    const stored = await query.getByAgent({ agentId: agent.metadata!.id });
+    const share = stored.items[0];
+    share.spec!.audience = AgentShareAudience.public;
+    await shares.update(share);
+    const profile = await query.getSharedProfile({
+      org: ORG,
+      slug: agent.metadata!.slug,
+    });
+    expect(profile.slug).toBe(agent.metadata!.slug);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/backend/services/stigmer-server/src/domain/agentshare/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentshare/controller.ts
@@ -823,10 +823,14 @@ function newLoadShareForMemberProfileStep(
 }
 
 /**
- * Gates on spec.enabled plus the live link token, then projects the
- * trimmed public profile. A disabled share and a locked link with a wrong
- * or absent token are both indistinguishable from a nonexistent share —
- * a rotated (killed) link must look exactly like one that never existed.
+ * Gates on spec.enabled, the audience, and the live link token, then
+ * projects the trimmed public profile. A disabled share, an org-audience
+ * share, and a locked link with a wrong or absent token are ALL
+ * indistinguishable from a nonexistent share — a rotated (killed) link
+ * must look exactly like one that never existed, and a members-only
+ * share URL must leak nothing to non-members (they resolve via
+ * getSharedProfileForMember instead). Check order mirrors the cloud
+ * AgentShareGetSharedProfileHandler: exists → enabled → audience → token.
  */
 function newProjectSharedProfileStep(store: Store): PipelineStep<ProfileDesc> {
   return {
@@ -836,6 +840,15 @@ function newProjectSharedProfileStep(store: Store): PipelineStep<ProfileDesc> {
       const req = ctx.input;
 
       if (share.spec?.enabled !== true) {
+        throw sharedNotFound(req.slug);
+      }
+      // The audience arm (SharingAudiencePolicy.admitsGuests): only an
+      // EXPLICIT org audience refuses — unspecified means public by
+      // contract (shares created before the audience field existed are
+      // anyone-with-link shares). Closes the recorded C2 close-out gap:
+      // this anonymous lane resolved org-audience shares the proto
+      // contract says must collapse.
+      if (share.spec.audience === AgentShareAudience.org) {
         throw sharedNotFound(req.slug);
       }
       if (

--- a/backend/services/stigmer-server/src/extensions/__tests__/direct-handler-authorization.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/direct-handler-authorization.test.ts
@@ -1,7 +1,8 @@
 /**
  * Pins the C2 Stage-4 enforcement END TO END for the direct handlers whose
  * domain suites run through full composed servers (session updateSubject,
- * workflow getVersion, artifact delete/getDownloadUrl/getContent): one
+ * workflow getVersion, artifact delete/getDownloadUrl/getContent, and the
+ * channel install pair added at the C2 close-out): one
  * composed server with a DENYING extension Authorizer, probed over the
  * wire. This proves the whole path — transport → registered handler →
  * authorizeDirect → the composed Authorizer — not just the handler
@@ -24,6 +25,8 @@ import type { Transport } from "@connectrpc/connect";
 import { createGrpcTransport } from "@connectrpc/connect-node";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { AgentChannelSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
+import { AgentChannelCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/command_pb";
 import { ArtifactSchema } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/api_pb";
 import { ArtifactCommandController } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/command_pb";
 import { ArtifactStorageState } from "@stigmer/protos/ai/stigmer/agentic/artifact/v1/enum_pb";
@@ -100,6 +103,16 @@ describe("direct-handler authorization (composed server, denying authorizer)", (
           contentHash: "0".repeat(64),
           storageState: ArtifactStorageState.storage_state_stored,
         },
+      }),
+    );
+    await server.store.saveResource(
+      ApiResourceKind.agent_channel,
+      "ach_01authztarget",
+      AgentChannelSchema,
+      create(AgentChannelSchema, {
+        apiVersion: "agentic.stigmer.ai/v1",
+        kind: "AgentChannel",
+        metadata: { id: "ach_01authztarget", name: "target", org: "acme" },
       }),
     );
   });
@@ -179,6 +192,36 @@ describe("direct-handler authorization (composed server, denying authorizer)", (
     await expectDenied(
       () => query.getContent({ artifactId: "art_01authztarget" }),
       "unauthorized to read artifact content",
+    );
+  });
+
+  it("channel initiateInstall and completeInstall deny with their annotation copy (C2 close-out — the arm both sides deferred)", async () => {
+    const command = createClient(AgentChannelCommandController, transport);
+    // PermissionDenied — NOT the storing edition's FailedPrecondition —
+    // proves the authorization runs before the refuse-or-delegate split.
+    await expectDenied(
+      () => command.initiateInstall({ resourceId: "ach_01authztarget" }),
+      "unauthorized to install agent channel",
+    );
+    await expectDenied(
+      () =>
+        command.completeInstall({
+          resourceId: "ach_01authztarget",
+          state: "some-state",
+          code: "some-code",
+        }),
+      "unauthorized to install agent channel",
+    );
+  });
+
+  it("channel install on a MISSING id answers NotFound even under denial (load-first)", async () => {
+    const command = createClient(AgentChannelCommandController, transport);
+    const error = await command
+      .initiateInstall({ resourceId: "ach_doesnotexist" })
+      .catch((e: unknown) => e);
+    expect((error as ConnectError).code).toBe(Code.NotFound);
+    expect((error as ConnectError).rawMessage).toBe(
+      "AgentChannel not found: ach_doesnotexist",
     );
   });
 });

--- a/test/conformance/src/suites/agentshare.conformance.test.ts
+++ b/test/conformance/src/suites/agentshare.conformance.test.ts
@@ -290,6 +290,31 @@ describe("AgentShare conformance — the anonymous resolution lane", () => {
     expect(afterDelete.rawMessage).toBe(sharedNotFoundMessage(dangling.metadata!.slug));
   });
 
+  it("collapses an org-audience share to the SAME NotFound — members-only URLs teach anonymous visitors nothing", async () => {
+    const { org } = await target.provisionTenancy();
+    const agent = await createAgentFixture(org);
+    await createShareFixture(org, agent.metadata!.slug, {
+      audience: AgentShareAudience.org,
+    });
+
+    // The proto's audience contract: org-audience shares resolve only via
+    // getSharedProfileForMember; the anonymous lane answers the uniform
+    // refusal, byte-identical with a share that never existed.
+    const refused = await expectGrpcCode(
+      () => clients.agentShareQuery.getSharedProfile({ org, slug: agent.metadata!.slug }),
+      Code.NotFound,
+      "getSharedProfile on an org-audience share",
+    );
+    expect(refused.rawMessage).toBe(sharedNotFoundMessage(agent.metadata!.slug));
+
+    // The member lane still resolves it — the refusal is audience, not state.
+    const profile = await clients.agentShareQuery.getSharedProfileForMember({
+      org,
+      slug: agent.metadata!.slug,
+    });
+    expect(profile.slug).toBe(agent.metadata?.slug);
+  });
+
   it("a stale token on an UNLOCKED link stays harmless", async () => {
     const { org } = await target.provisionTenancy();
     const agent = await createAgentFixture(org);

--- a/test/conformance/src/suites/direct-handler-authorization.conformance.test.ts
+++ b/test/conformance/src/suites/direct-handler-authorization.conformance.test.ts
@@ -30,6 +30,7 @@ import { FixtureTracker } from "../harness/fixtures";
 import { expectGrpcCode } from "../contract/errors";
 import { collectStream } from "../support/collect-stream";
 import { makeAgent } from "../support/agents";
+import { makeSlackAgentChannel } from "../support/agentchannels";
 import { makeMcpServer } from "../support/mcpservers";
 import { makeSession } from "../support/sessions";
 import { makeWorkflow } from "../support/workflows";
@@ -185,6 +186,50 @@ describe("direct-handler authorization — outsider denials (multi-tenant only)"
       );
       expect(denied.rawMessage, `${lane} annotation copy`).toBe(copy);
     }
+  });
+
+  it("the channel install pair refuses an outsider with its annotation copy (C2 close-out — the arm both editions declare)", async (ctx) => {
+    if (!multiTenantOnly()) return ctx.skip();
+    const { org } = await target.provisionTenancy();
+    const outsider = await outsiderClients();
+
+    const agent = await clients.agentCommand.create(
+      makeAgent({ org, name: uniqueName("authz-channel-agent") }),
+    );
+    fixtures.defer(() =>
+      clients.agentCommand.delete({ value: agent.metadata!.id }),
+    );
+    const channel = await clients.agentChannelCommand.create(
+      makeSlackAgentChannel(org, uniqueName("authz-channel"), agent.metadata!.slug),
+    );
+    fixtures.defer(() =>
+      clients.agentChannelCommand.delete({ value: channel.metadata!.id }),
+    );
+
+    const initiateDenied = await expectGrpcCode(
+      () =>
+        outsider.agentChannelCommand.initiateInstall({
+          resourceId: channel.metadata!.id,
+        }),
+      Code.PermissionDenied,
+      "outsider initiateInstall on a foreign channel",
+    );
+    expect(initiateDenied.rawMessage).toBe(
+      "unauthorized to install agent channel",
+    );
+    const completeDenied = await expectGrpcCode(
+      () =>
+        outsider.agentChannelCommand.completeInstall({
+          resourceId: channel.metadata!.id,
+          state: "outsider-state",
+          code: "outsider-code",
+        }),
+      Code.PermissionDenied,
+      "outsider completeInstall on a foreign channel",
+    );
+    expect(completeDenied.rawMessage).toBe(
+      "unauthorized to install agent channel",
+    );
   });
 
   it("the authorize-first read lanes answer NOT_FOUND for unknown ids — the ruled uniform Q1 posture", async (ctx) => {


### PR DESCRIPTION
## Summary
The C2 close-out readout's two owner-ruled OSS fixes: the channel install pair (`initiateInstall`/`completeInstall`) now evaluates its declared `can_edit` annotation via `authorizeDirect`, and the anonymous `getSharedProfile` lane now collapses org-audience shares per the proto's audience contract.

## Context
The close-out evidence pass (project 20260827.10, session 5) found the install pair enforced by NOBODY — C2 Stage 4 deferred the arm to "C3 Stage 5" and C3's installers shipped believing the OSS chain had already authorized (it loaded and delegated, nothing more). Any authenticated caller could drive the install flow on any tenant's channel. Separately, the anonymous share-profile lane resolved org-audience (members-only) shares that Java collapses to NOT_FOUND — an OSS contract bug the proto documents (session-3 disposition 1, owner-ruled fix).

## Changes
- `domain/agentchannel/controller.ts`: `authorizeDirect` on both install lanes AFTER the load (the Java LoadChannel-then-authorize order — missing ids answer NOT_FOUND for everyone; only existing channels can produce the denial). Composed runtimes now receive a pre-authorized caller.
- `domain/agentshare/controller.ts`: the `ProjectSharedProfile` audience arm at the Java handler's exact position (exists → enabled → audience → token). Only an EXPLICIT org audience refuses — unspecified stays public by contract (pre-audience shares keep their anyone-with-link behavior). Same uniform NotFound; the member lane is untouched.
- `docs/authorization-coverage.md`: the install pair moves from the channel-runtime bucket into `authorizeDirect` (17→19 / 9→7); rows updated.
- Tests: the composed denying-authorizer suite gains the install deny arms + the load-first NotFound-under-denial pin; the agentshare unit suite gains the anonymous org-audience collapse + the public-flip restoration; conformance gains the agentshare audience pin (runs on every target — Java already conforms) and the multiTenant outsider install-pair probes.

## Implementation notes
- Enforcement lives at the OSS lane, not in each composed runtime driver — one mechanism (`authorizeDirect`, the Stage-4 pattern), no per-driver discipline to drift.
- OSS wire behavior on the default permissive authorizer is unchanged for the install pair (allow → the storing edition's FailedPrecondition exactly as before). The audience arm is a deliberate, owner-ruled OSS-observable change: org-audience shares stop resolving anonymously, matching the cloud edition and the proto contract.

## Breaking changes
- None for composed/cloud behavior. OSS self-hosts with org-audience shares (an explicitly-set minority state) will see the anonymous lane refuse them — the documented contract, previously unenforced.

## Test plan
- OSS units 2041 passed; typecheck clean.
- Rosters: local 499 passed (+1, the new audience pin), local-execution 160, local-postgres 499 — byte-identical elsewhere.
- The measured cloud conformance run against the composition at this pin: **473 passed / 0 failed / 36 skipped** (Stage 4's 471 + the two new arms; the outsider install probes executed for real).

## Risks
- Minimal: both arms are deny-path additions behind existing load contracts; rollback is a revert.

Part of the C2 close-out (20260827.10.sp.iam-lifecycle-extension); merges before its stigmer-cloud pair, which re-pins the submodule.

Made with [Cursor](https://cursor.com)