### PR TITLE
feat(backend/stigmer-server): serving-chain error boundary + VisitorErrorPolicy seam

### DIFF
--- a/.cursor/rules/backend/ts-server-guidelines.mdc
+++ b/.cursor/rules/backend/ts-server-guidelines.mdc
@@ -160,6 +160,14 @@ eventually violate creatively.
 - Log the real error; the wire carries the sanitized message. Never log
   secrets — the redaction doctrine (`***REDACTED***`, `enc:v1:`) extends to
   logs and Temporal payloads.
+- **The serving chain's error boundary is a net, not a license**
+  (20260830.03, ruling Q2 — `pipeline/interceptors/error-boundary.ts`): a
+  raw non-ConnectError escaping any handler is structurally converted to
+  the sanitized `"internal server error"` before the wire, and a composed
+  VisitorErrorPolicy rewrites leak-prone descriptions for anonymous
+  callers. Direct handlers STILL self-sanitize with
+  `internalError(cause, "failed to <do thing>")` — authored copy beats the
+  generic net, and the boundary exists for the path someone forgot.
 
 ## Tests ship with the feature
 

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -102,6 +102,7 @@ import { SqliteSearchQueryStore } from "../query/search/query-store.js";
 import { newSearchableResourceRegistry } from "../query/search/registry.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
 import { createVerifierChainInterceptor } from "../pipeline/interceptors/auth.js";
+import { createErrorBoundaryInterceptor } from "../pipeline/interceptors/error-boundary.js";
 import { newPermissiveSingleTeamAuthorizer } from "../pipeline/steps/authorize.js";
 import { newExecutionScopedRunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
 import { RunnerAuthService } from "../runnerauth/runnerauth.js";
@@ -1037,10 +1038,17 @@ export async function composeServer(
     // chassis over the composed verifiers (O2; zero verifiers = the
     // trusted-local posture, byte-identical wire behavior). The in-process
     // transport above carries its own position-1 source — the internal
-    // caller class only it can mint (ruling Q4).
+    // caller class only it can mint (ruling Q4). Position 0 is the error
+    // boundary (20260830.03): the raw-error conversion net plus the
+    // composed visitor sanitizer — SERVING chain only, so in-process
+    // hops keep full diagnostics by construction.
     interceptors: buildInterceptorChain(
       logger,
       createVerifierChainInterceptor(identityVerifiers, logger, authEnabled),
+      createErrorBoundaryInterceptor(
+        logger,
+        extensions.drivers.visitorErrorPolicy,
+      ),
     ),
     taskKindRegistryLane: registryLanes.taskKindRegistryLane,
     modelRegistryLane: registryLanes.modelRegistryLane,

--- a/backend/services/stigmer-server/src/extensions/drivers.ts
+++ b/backend/services/stigmer-server/src/extensions/drivers.ts
@@ -16,6 +16,8 @@
  *   - list read scope (the list-shaped tenant-isolation fork) — landed
  *     with 20260830.01.sp.list-read-scoping, generalizing C2 Stage 4's
  *     ExecutionReadScope (absorbed, gate ruling Q2)
+ *   - visitor error policy (the transport-boundary sanitizer's
+ *     edition semantics) — landed with 20260830.03, gate ruling Q1
  *
  * Merge rules (enforced by resolveExtensions, DD-006 §2b): the two
  * provider kinds are single-instance points — a second declaring unit is
@@ -30,6 +32,7 @@
 import type { ArtifactStorageDriverFactory } from "../artifactstorage/artifact-storage.js";
 import type { ChannelRuntime } from "../domain/agentchannel/channel-runtime.js";
 import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
+import type { VisitorErrorPolicy } from "../pipeline/interceptors/error-boundary.js";
 import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
 import type { SandboxProvisionerFactory } from "../sandbox/provisioner.js";
 import type { ListReadScope } from "./list-read-scope.js";
@@ -103,4 +106,12 @@ export interface ExtensionDrivers {
    * the enumeration verb. When absent, the OSS full scan — byte-identical.
    */
   readonly listReadScope?: ListReadScope;
+  /**
+   * The visitor error policy (20260830.03; single-instance point) — the
+   * edition semantics of the serving chain's error boundary: WHO is on
+   * the anonymous surface and WHAT copy replaces a leak-prone
+   * description. When absent, the boundary runs only its structural
+   * raw-error conversion — OSS wire behavior otherwise byte-identical.
+   */
+  readonly visitorErrorPolicy?: VisitorErrorPolicy;
 }

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -40,6 +40,7 @@ import { BUILT_IN_STORAGE_TYPES } from "../artifactstorage/artifact-storage.js";
 import type { ChannelRuntime } from "../domain/agentchannel/channel-runtime.js";
 import type { ListReadScope } from "./list-read-scope.js";
 import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
+import type { VisitorErrorPolicy } from "../pipeline/interceptors/error-boundary.js";
 import type { PipelineStep } from "../pipeline/pipeline.js";
 import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
 import type { SandboxProvisionerFactory } from "../sandbox/provisioner.js";
@@ -169,6 +170,11 @@ export interface ResolvedExtensionDrivers {
   readonly channelRuntime: ChannelRuntime | undefined;
   /** The 20260830.01 list read scope — undefined = the OSS full scan. */
   readonly listReadScope: ListReadScope | undefined;
+  /**
+   * The 20260830.03 visitor error policy — undefined = the error
+   * boundary runs only its structural raw-error conversion.
+   */
+  readonly visitorErrorPolicy: VisitorErrorPolicy | undefined;
 }
 
 /**
@@ -206,6 +212,8 @@ export function resolveExtensions(
   let channelRuntimeDeclaredBy: string | undefined;
   let listReadScope: ListReadScope | undefined;
   let listReadScopeDeclaredBy: string | undefined;
+  let visitorErrorPolicy: VisitorErrorPolicy | undefined;
+  let visitorErrorPolicyDeclaredBy: string | undefined;
   const artifactStorageDrivers = new Map<
     string,
     ArtifactStorageDriverFactory
@@ -316,6 +324,16 @@ export function resolveExtensions(
       listReadScopeDeclaredBy = unit.name;
     }
 
+    if (unit.drivers?.visitorErrorPolicy !== undefined) {
+      if (visitorErrorPolicyDeclaredBy !== undefined) {
+        throw new Error(
+          `extension '${unit.name}' registers a VisitorErrorPolicy, but '${visitorErrorPolicyDeclaredBy}' already did — exactly one may be composed`,
+        );
+      }
+      visitorErrorPolicy = unit.drivers.visitorErrorPolicy;
+      visitorErrorPolicyDeclaredBy = unit.name;
+    }
+
     if (unit.drivers?.artifactStorageDrivers !== undefined) {
       for (const [name, factory] of unit.drivers.artifactStorageDrivers) {
         if ((BUILT_IN_STORAGE_TYPES as ReadonlyArray<string>).includes(name)) {
@@ -400,6 +418,7 @@ export function resolveExtensions(
       sandboxProvisionerDrivers,
       channelRuntime,
       listReadScope,
+      visitorErrorPolicy,
     },
     services,
     workers,

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -99,8 +99,12 @@ export type {
 // chain's error boundary consumes (drivers.visitorErrorPolicy) — the
 // composition supplies WHO is on the anonymous surface and WHAT copy
 // replaces a leak-prone description; the boundary owns the mechanism
-// (code set, code preservation, ref format, details-drop).
+// (code set, code preservation, ref format, details-drop). The factory
+// rides the callerIdentityKey precedent: production wiring stays
+// compose.ts's job, but a composition's OWN tests must drive its policy
+// through the REAL boundary mechanism, never a re-derivation.
 export type { VisitorErrorPolicy } from "./pipeline/interceptors/error-boundary.js";
+export { createErrorBoundaryInterceptor } from "./pipeline/interceptors/error-boundary.js";
 export {
   diffVisibilityShapes,
   visibilityShapesFor,

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -95,6 +95,12 @@ export type {
   ListReadScope,
   ListEntryMeta,
 } from "./extensions/list-read-scope.js";
+// The 20260830.03 seam: the visitor-sanitization policy the serving
+// chain's error boundary consumes (drivers.visitorErrorPolicy) — the
+// composition supplies WHO is on the anonymous surface and WHAT copy
+// replaces a leak-prone description; the boundary owns the mechanism
+// (code set, code preservation, ref format, details-drop).
+export type { VisitorErrorPolicy } from "./pipeline/interceptors/error-boundary.js";
 export {
   diffVisibilityShapes,
   visibilityShapesFor,

--- a/backend/services/stigmer-server/src/pipeline/chain.ts
+++ b/backend/services/stigmer-server/src/pipeline/chain.ts
@@ -1,7 +1,11 @@
 /**
- * The server's interceptor chain, in the ratified order (D2 §2):
+ * The server's interceptor chain, in the ratified order (D2 §2; position
+ * 0 added by 20260830.03, gate ruling Q1):
  *
- *   1. identity source  — REQUIRED parameter, outermost (DD-004; O2)
+ *   0. error boundary   — SERVING chain only, optional parameter
+ *                         (interceptors/error-boundary.ts: the raw-error
+ *                         conversion net + the visitor sanitizer seam)
+ *   1. identity source  — REQUIRED parameter (DD-004; O2)
  *   2. logging          — level-tiered per outcome
  *   3. protovalidate    — boundary validation before any handler
  *   4. apiresource      — kind context from the service option
@@ -15,7 +19,10 @@
  * own interceptor mints (interceptors/auth.ts owns both sources and the
  * spoofing-impossible invariant). The parameter is required — a chain
  * without an identity source is a compile error, never a silently
- * unauthenticated transport.
+ * unauthenticated transport. Position 0 deliberately exists ONLY on the
+ * serving chain: in-process hops are exempt from sanitization by
+ * construction — the outer handler needs the full inner diagnostic (the
+ * Java InProcessCallContextHolder exemption, structurally).
  */
 import type { Interceptor } from "@connectrpc/connect";
 
@@ -27,8 +34,10 @@ import { createProtovalidateInterceptor } from "./interceptors/protovalidate.js"
 export function buildInterceptorChain(
   logger: Logger,
   identitySource: Interceptor,
+  errorBoundary?: Interceptor,
 ): Interceptor[] {
   return [
+    ...(errorBoundary === undefined ? [] : [errorBoundary]),
     identitySource,
     createLoggingInterceptor(logger),
     createProtovalidateInterceptor(),

--- a/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/error-boundary.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/error-boundary.test.ts
@@ -13,11 +13,7 @@
  * message crosses verbatim (the Java wire suite's pre-fix-red pattern).
  */
 import { describe, expect, it } from "vitest";
-import {
-  Code,
-  ConnectError,
-  createContextValues,
-} from "@connectrpc/connect";
+import { Code, ConnectError, createContextValues } from "@connectrpc/connect";
 import type { Interceptor } from "@connectrpc/connect";
 import type { DescMethod } from "@bufbuild/protobuf";
 
@@ -54,7 +50,9 @@ const MEMBER: CallerIdentity = {
 };
 
 /** A guest-only policy with fixed copy — the cloud shape in miniature. */
-function guestPolicy(copy = "This agent is currently unavailable."): VisitorErrorPolicy {
+function guestPolicy(
+  copy = "This agent is currently unavailable.",
+): VisitorErrorPolicy {
   return {
     eligible: (identity) => identity?.callerClass === "guest",
     replacementCopy: () => Promise.resolve(copy),
@@ -180,7 +178,10 @@ describe("arm 2: the visitor rewrite", () => {
   it("rewrites a leak-prone description for an eligible caller, preserving the code and appending the ref", async () => {
     const error = await runFailing(
       createErrorBoundaryInterceptor(silentLogger, guestPolicy()),
-      new ConnectError("pg: connection refused at 10.0.3.7:5432", Code.Unavailable),
+      new ConnectError(
+        "pg: connection refused at 10.0.3.7:5432",
+        Code.Unavailable,
+      ),
       { identity: GUEST },
     );
     expect(error.code).toBe(Code.Unavailable);
@@ -236,7 +237,10 @@ describe("arm 2: the visitor rewrite", () => {
       MEMBER,
       { ...MEMBER, callerClass: "schedule" } satisfies CallerIdentity,
     ]) {
-      const thrown = new ConnectError("step Persist failed: disk full", Code.Internal);
+      const thrown = new ConnectError(
+        "step Persist failed: disk full",
+        Code.Internal,
+      );
       const error = await runFailing(
         createErrorBoundaryInterceptor(silentLogger, guestPolicy()),
         thrown,

--- a/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/error-boundary.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/error-boundary.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Pins the error boundary (20260830.03, all gate rulings as recommended):
+ * the structural raw-error conversion (Q2 — a non-ConnectError from any
+ * handler becomes the pipeline's sanitized Internal, never
+ * Unknown-with-raw-message), the policy-driven visitor rewrite (the six
+ * leak-prone codes, code ALWAYS preserved, ref format byte-pinned,
+ * details and metadata dropped), the pass-through arms (deliberate
+ * refusal codes untouched byte-identically; non-eligible callers keep
+ * full diagnostics — the cloud's schedule-caller arm rides this), the
+ * fail-safe arms (eligibility throw → sanitize; copy rejection → the
+ * fallback copy, never the original), the mid-stream guard, and the
+ * NEGATIVE CONTROL: the same call WITHOUT the boundary proves the raw
+ * message crosses verbatim (the Java wire suite's pre-fix-red pattern).
+ */
+import { describe, expect, it } from "vitest";
+import {
+  Code,
+  ConnectError,
+  createContextValues,
+} from "@connectrpc/connect";
+import type { Interceptor } from "@connectrpc/connect";
+import type { DescMethod } from "@bufbuild/protobuf";
+
+import { ApiKeyQueryController } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/query_pb";
+import { PlatformQueryController } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+
+import type { CallerIdentity } from "../../../extensions/identity.js";
+import { callerIdentityKey } from "../auth.js";
+import {
+  createErrorBoundaryInterceptor,
+  supportRefSuffix,
+} from "../error-boundary.js";
+import type { VisitorErrorPolicy } from "../error-boundary.js";
+
+const silentLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+const GUEST: CallerIdentity = {
+  identityId: "ida_guest",
+  callerClass: "guest",
+  issuer: "stigmer",
+  rawToken: "tok",
+};
+
+const MEMBER: CallerIdentity = {
+  identityId: "ida_member",
+  callerClass: "user",
+  issuer: "stigmer",
+  rawToken: "tok",
+};
+
+/** A guest-only policy with fixed copy — the cloud shape in miniature. */
+function guestPolicy(copy = "This agent is currently unavailable."): VisitorErrorPolicy {
+  return {
+    eligible: (identity) => identity?.callerClass === "guest",
+    replacementCopy: () => Promise.resolve(copy),
+  };
+}
+
+interface RunOptions {
+  identity?: CallerIdentity;
+  method?: DescMethod;
+}
+
+/**
+ * Drives the boundary with a unary-shaped request whose handler throws.
+ * Returns the error that would reach the wire.
+ */
+async function runFailing(
+  interceptor: Interceptor,
+  thrown: unknown,
+  options: RunOptions = {},
+): Promise<ConnectError> {
+  const contextValues = createContextValues();
+  if (options.identity !== undefined) {
+    contextValues.set(callerIdentityKey, options.identity);
+  }
+  const next = () => Promise.reject(thrown);
+  try {
+    await interceptor(next as never)({
+      header: new Headers(),
+      contextValues,
+      method: options.method ?? ApiKeyQueryController.method.get,
+      service: ApiKeyQueryController,
+      stream: false,
+    } as never);
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    return error as ConnectError;
+  }
+  throw new Error("expected the interceptor to rethrow");
+}
+
+/** Drives the boundary with a stream response that fails mid-iteration. */
+async function runFailingStream(
+  interceptor: Interceptor,
+  thrown: unknown,
+  identity?: CallerIdentity,
+): Promise<{ received: string[]; error: ConnectError }> {
+  const contextValues = createContextValues();
+  if (identity !== undefined) {
+    contextValues.set(callerIdentityKey, identity);
+  }
+  async function* failingMessages(): AsyncIterable<string> {
+    yield "first";
+    throw thrown;
+  }
+  const next = () =>
+    Promise.resolve({ stream: true, message: failingMessages() });
+  const response = (await interceptor(next as never)({
+    header: new Headers(),
+    contextValues,
+    method: ApiKeyQueryController.method.get,
+    service: ApiKeyQueryController,
+    stream: false,
+  } as never)) as { stream: true; message: AsyncIterable<string> };
+  const received: string[] = [];
+  try {
+    for await (const message of response.message) {
+      received.push(message);
+    }
+  } catch (error) {
+    expect(error).toBeInstanceOf(ConnectError);
+    return { received, error: error as ConnectError };
+  }
+  throw new Error("expected the guarded stream to rethrow");
+}
+
+/** The byte-pinned ref shape: " (ref: <8 hex chars>)" at the end. */
+const REF_PATTERN = /^(.*) \(ref: [0-9a-f]{8}\)$/;
+
+describe("arm 1: structural raw-error conversion (ruling Q2)", () => {
+  it("converts a raw Error to the pipeline's sanitized Internal", async () => {
+    const error = await runFailing(
+      createErrorBoundaryInterceptor(silentLogger),
+      new Error("ENOENT: /var/lib/stigmer/secrets.db"),
+    );
+    expect(error.code).toBe(Code.Internal);
+    expect(error.rawMessage).toBe("internal server error");
+  });
+
+  it("converts thrown non-Error values the same way", async () => {
+    const error = await runFailing(
+      createErrorBoundaryInterceptor(silentLogger),
+      "string thrown from a handler",
+    );
+    expect(error.code).toBe(Code.Internal);
+    expect(error.rawMessage).toBe("internal server error");
+  });
+
+  it("NEGATIVE CONTROL: without the boundary, the raw message crosses verbatim", async () => {
+    // The pre-fix wiring: connect-node's default conversion — proves the
+    // leak the boundary closes (the Java wire suite's control pattern).
+    const raw = new Error("ENOENT: /var/lib/stigmer/secrets.db");
+    const withoutBoundary = ConnectError.from(raw);
+    expect(withoutBoundary.code).toBe(Code.Unknown);
+    expect(withoutBoundary.rawMessage).toContain(
+      "ENOENT: /var/lib/stigmer/secrets.db",
+    );
+  });
+
+  it("passes ConnectErrors through byte-identically with no policy", async () => {
+    const thrown = new ConnectError(
+      "agent 'my-agent' not found",
+      Code.NotFound,
+    );
+    const error = await runFailing(
+      createErrorBoundaryInterceptor(silentLogger),
+      thrown,
+    );
+    expect(error).toBe(thrown);
+  });
+});
+
+describe("arm 2: the visitor rewrite", () => {
+  it("rewrites a leak-prone description for an eligible caller, preserving the code and appending the ref", async () => {
+    const error = await runFailing(
+      createErrorBoundaryInterceptor(silentLogger, guestPolicy()),
+      new ConnectError("pg: connection refused at 10.0.3.7:5432", Code.Unavailable),
+      { identity: GUEST },
+    );
+    expect(error.code).toBe(Code.Unavailable);
+    const match = REF_PATTERN.exec(error.rawMessage);
+    expect(match?.[1]).toBe("This agent is currently unavailable.");
+    expect(error.rawMessage).not.toContain("10.0.3.7");
+  });
+
+  it("rewrites all six leak-prone codes and no others", async () => {
+    const leaky = [
+      Code.Internal,
+      Code.Unknown,
+      Code.DataLoss,
+      Code.Unavailable,
+      Code.DeadlineExceeded,
+      Code.Unimplemented,
+    ];
+    for (const code of leaky) {
+      const error = await runFailing(
+        createErrorBoundaryInterceptor(silentLogger, guestPolicy()),
+        new ConnectError("internals", code),
+        { identity: GUEST },
+      );
+      expect(error.code).toBe(code);
+      expect(error.rawMessage).toMatch(REF_PATTERN);
+    }
+    const passThrough = [
+      Code.NotFound,
+      Code.AlreadyExists,
+      Code.InvalidArgument,
+      Code.FailedPrecondition,
+      Code.PermissionDenied,
+      Code.ResourceExhausted,
+      Code.Unauthenticated,
+      Code.Aborted,
+      Code.OutOfRange,
+      Code.Canceled,
+    ];
+    for (const code of passThrough) {
+      const thrown = new ConnectError("authored refusal copy", code);
+      const error = await runFailing(
+        createErrorBoundaryInterceptor(silentLogger, guestPolicy()),
+        thrown,
+        { identity: GUEST },
+      );
+      // Byte-identical pass-through: the SAME instance, trailers intact.
+      expect(error).toBe(thrown);
+    }
+  });
+
+  it("keeps full diagnostics for non-eligible callers (the org-member and schedule arms)", async () => {
+    for (const identity of [
+      MEMBER,
+      { ...MEMBER, callerClass: "schedule" } satisfies CallerIdentity,
+    ]) {
+      const thrown = new ConnectError("step Persist failed: disk full", Code.Internal);
+      const error = await runFailing(
+        createErrorBoundaryInterceptor(silentLogger, guestPolicy()),
+        thrown,
+        { identity },
+      );
+      expect(error).toBe(thrown);
+    }
+  });
+
+  it("consults the policy even with NO stamped identity (the Java no-context pin)", async () => {
+    // An is_public-shaped policy answers on the method alone — the arm
+    // that must hold when position 1 itself failed before stamping.
+    const publicOnly: VisitorErrorPolicy = {
+      eligible: (_identity, method) =>
+        method.name === PlatformQueryController.method.getServerInfo.name,
+      replacementCopy: () =>
+        Promise.resolve("Something went wrong on our side."),
+    };
+    const error = await runFailing(
+      createErrorBoundaryInterceptor(silentLogger, publicOnly),
+      new ConnectError("verifier chain wiring fault", Code.Internal),
+      { method: PlatformQueryController.method.getServerInfo },
+    );
+    expect(error.code).toBe(Code.Internal);
+    expect(error.rawMessage).toMatch(REF_PATTERN);
+    expect(error.rawMessage).toContain("Something went wrong on our side.");
+  });
+
+  it("sanitizes the RAW-error arm for eligible callers too (raw → Internal → visitor copy)", async () => {
+    const error = await runFailing(
+      createErrorBoundaryInterceptor(silentLogger, guestPolicy()),
+      new Error("raw driver detail"),
+      { identity: GUEST },
+    );
+    expect(error.code).toBe(Code.Internal);
+    expect(error.rawMessage).toMatch(REF_PATTERN);
+    expect(error.rawMessage).not.toContain("raw driver detail");
+  });
+
+  it("drops details and metadata on sanitize (the Java trailers-drop)", async () => {
+    const thrown = new ConnectError("internals", Code.Internal);
+    thrown.metadata.set("x-debug-hint", "table=oauth_grant");
+    const error = await runFailing(
+      createErrorBoundaryInterceptor(silentLogger, guestPolicy()),
+      thrown,
+      { identity: GUEST },
+    );
+    expect(error).not.toBe(thrown);
+    expect(error.details).toHaveLength(0);
+    expect([...error.metadata.keys()]).toHaveLength(0);
+  });
+});
+
+describe("fail-safe arms", () => {
+  it("a throwing eligibility check fails toward sanitizing", async () => {
+    const broken: VisitorErrorPolicy = {
+      eligible: () => {
+        throw new Error("policy bug");
+      },
+      replacementCopy: () => Promise.resolve("neutral copy"),
+    };
+    const error = await runFailing(
+      createErrorBoundaryInterceptor(silentLogger, broken),
+      new ConnectError("internals", Code.Internal),
+      { identity: GUEST },
+    );
+    expect(error.rawMessage).toContain("neutral copy");
+    expect(error.rawMessage).not.toContain("internals");
+  });
+
+  it("a rejecting copy resolution falls back to the sanitized-Internal copy, never the original", async () => {
+    const failingCopy: VisitorErrorPolicy = {
+      eligible: () => true,
+      replacementCopy: () => Promise.reject(new Error("share store down")),
+    };
+    const error = await runFailing(
+      createErrorBoundaryInterceptor(silentLogger, failingCopy),
+      new ConnectError("internals", Code.Unavailable),
+      { identity: GUEST },
+    );
+    expect(error.code).toBe(Code.Unavailable);
+    const match = REF_PATTERN.exec(error.rawMessage);
+    expect(match?.[1]).toBe("internal server error");
+  });
+});
+
+describe("the stream guard", () => {
+  it("sanitizes a raw mid-stream error (arm 1)", async () => {
+    const { received, error } = await runFailingStream(
+      createErrorBoundaryInterceptor(silentLogger),
+      new Error("mid-stream driver detail"),
+    );
+    expect(received).toEqual(["first"]);
+    expect(error.code).toBe(Code.Internal);
+    expect(error.rawMessage).toBe("internal server error");
+  });
+
+  it("rewrites a leak-prone mid-stream ConnectError for an eligible caller (arm 2)", async () => {
+    const { received, error } = await runFailingStream(
+      createErrorBoundaryInterceptor(silentLogger, guestPolicy()),
+      new ConnectError("broker connection lost: 10.0.3.7", Code.Unavailable),
+      GUEST,
+    );
+    expect(received).toEqual(["first"]);
+    expect(error.code).toBe(Code.Unavailable);
+    expect(error.rawMessage).toMatch(REF_PATTERN);
+    expect(error.rawMessage).not.toContain("10.0.3.7");
+  });
+});
+
+describe("the ref format", () => {
+  it("is the Java byte-pinned suffix shape", () => {
+    expect(supportRefSuffix("9c1b2a3d")).toBe(" (ref: 9c1b2a3d)");
+  });
+});

--- a/backend/services/stigmer-server/src/pipeline/interceptors/error-boundary.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/error-boundary.ts
@@ -1,0 +1,242 @@
+/**
+ * Error-boundary interceptor — the serving chain's position 0, the TS
+ * port of the cloud Java VisitorErrorSanitizerInterceptor posture (cloud
+ * DD-005 of 20260810.02, shipped for stigmer-cloud#242; ported by
+ * convergence entry 20260830.03.sp.visitor-error-sanitizer, all six gate
+ * rulings as recommended).
+ *
+ * Two arms, one structural guarantee each:
+ *
+ *   1. RAW-ERROR CONVERSION (always on, gate ruling Q2): a non-ConnectError
+ *      escaping any handler — the direct handlers whose internalError
+ *      wrapping is per-site discipline, not structure — becomes the
+ *      pipeline executor's exact sanitized Internal
+ *      ("internal server error") instead of connect-node's default
+ *      Unknown-with-raw-message conversion. This closes the
+ *      leak-by-default class for direct handlers the way
+ *      pipeline.ts closes it for chains (stigmer#478's sibling). The
+ *      guidelines' self-sanitize discipline still applies — a handler's
+ *      own "failed to <do thing>" copy beats this generic net.
+ *
+ *   2. VISITOR SANITIZATION (policy-driven, empty by default): when a
+ *      composition registers a VisitorErrorPolicy, descriptions of the
+ *      six leak-prone codes are rewritten for callers the policy deems
+ *      on the anonymous surface (the cloud: guest / channel / is_public),
+ *      the code ALWAYS preserved so SDK retry semantics stay honest, a
+ *      minted support ref appended in the Java byte-pinned format, and
+ *      the original description kept operator-visible via the boundary
+ *      WARN (log-based correlation — the TS serving path has no OTel
+ *      span to stamp, gate ruling Q3). The sanitized error is a FRESH
+ *      ConnectError: details and metadata never survive sanitization
+ *      (the Java trailers-drop, and rethrownStatusError's metadata
+ *      lesson).
+ *
+ * Placement contract: OUTERMOST on the SERVING chain only (chain.ts).
+ * Outermost keeps the Java pin "sanitizes even with no identity context"
+ * (identity is read from contextValues at error time — stamped by
+ * position 1 when the error rose from inside it, absent when position 1
+ * itself refused) and covers identity-chassis faults; the logging
+ * interceptor sits inside, so operators keep the ORIGINAL error at error
+ * level while the wire carries the rewrite. The in-process chain never
+ * composes this interceptor — in-process hops are exempt by
+ * construction (the outer handler needs the full inner diagnostic), the
+ * TS rendering of the Java InProcessCallContextHolder exemption.
+ *
+ * Streams: mid-iteration errors bypass a plain `await next(request)`
+ * wrapper, so stream responses are re-wrapped with a guarded iterable —
+ * without it, server-stream errors would escape both arms.
+ */
+import { randomBytes } from "node:crypto";
+import { Code, ConnectError } from "@connectrpc/connect";
+import type {
+  Interceptor,
+  StreamRequest,
+  UnaryRequest,
+} from "@connectrpc/connect";
+import type { DescMethod } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../boot/logger.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import { internalError } from "../errors.js";
+import { INTERNAL_FALLBACK_MESSAGE } from "../pipeline.js";
+import { callerIdentityKey } from "./auth.js";
+
+/**
+ * The codes whose descriptions may carry internals — the deny-leaky
+ * matrix ratified by cloud DD-005 (20260810.02) and byte-pinned across
+ * editions. Deliberate-refusal codes (PermissionDenied,
+ * FailedPrecondition, ResourceExhausted, …) pass through untouched:
+ * their descriptions are authored copy, including owner-customized
+ * refusal messages and machine tokens brokers branch on.
+ */
+const SANITIZED_CODES: ReadonlySet<Code> = new Set([
+  Code.Internal,
+  Code.Unknown,
+  Code.DataLoss,
+  Code.Unavailable,
+  Code.DeadlineExceeded,
+  Code.Unimplemented,
+]);
+
+/**
+ * The visitor-sanitization policy a composition registers through
+ * ExtensionDrivers.visitorErrorPolicy (single-instance point). The
+ * boundary owns the mechanism — the code set, code preservation, the
+ * ref format, details/metadata dropping, the boundary WARN; the policy
+ * owns the edition semantics — WHO is on the anonymous surface and WHAT
+ * copy replaces the description.
+ */
+export interface VisitorErrorPolicy {
+  /**
+   * Whether this caller+method pair is on the anonymous surface (the
+   * cloud rule: guest or channel caller class, or an is_public method).
+   * Synchronous and cheap — it runs on every boundary error. `identity`
+   * is undefined when the error rose from position 1 before stamping
+   * (the Java "no interceptor context" arm — an is_public rule must
+   * still answer there). A throw is treated as eligible: over-sanitizing
+   * an org member's diagnostics is recoverable, leaking internals to a
+   * visitor is not.
+   */
+  eligible(identity: CallerIdentity | undefined, method: DescMethod): boolean;
+  /**
+   * The replacement description (WITHOUT the support ref — the boundary
+   * appends it). Runs only on the error path, so per-call resolution
+   * work (the cloud's per-share owner copy) is admissible. A rejection
+   * falls back to the pipeline's sanitized-Internal copy — never the
+   * original description.
+   */
+  replacementCopy(
+    identity: CallerIdentity | undefined,
+    method: DescMethod,
+  ): Promise<string>;
+}
+
+/**
+ * The Java supportRef format, byte-pinned (gate ruling Q3):
+ * `" (ref: <8 hex chars>)"`. Java derives the ref from the first 8 of
+ * the trace id; the TS serving path has no trace id, so the boundary
+ * mints one on the error path and the boundary WARN is the correlation
+ * point.
+ */
+export function supportRefSuffix(ref: string): string {
+  return ` (ref: ${ref})`;
+}
+
+function mintSupportRef(): string {
+  return randomBytes(4).toString("hex");
+}
+
+/**
+ * Builds the boundary for the serving chain. `policy` is the composed
+ * VisitorErrorPolicy or undefined (the OSS default) — arm 1 runs either
+ * way, arm 2 only with a policy.
+ */
+export function createErrorBoundaryInterceptor(
+  logger: Logger,
+  policy?: VisitorErrorPolicy,
+): Interceptor {
+  return (next) => async (request) => {
+    let response;
+    try {
+      response = await next(request);
+    } catch (error) {
+      throw await boundaryError(error, request, logger, policy);
+    }
+    if (response.stream) {
+      return {
+        ...response,
+        message: guardStreamMessages(response.message, request, logger, policy),
+      };
+    }
+    return response;
+  };
+}
+
+/** Re-raises mid-stream errors through the same two boundary arms. */
+async function* guardStreamMessages<T>(
+  messages: AsyncIterable<T>,
+  request: UnaryRequest | StreamRequest,
+  logger: Logger,
+  policy: VisitorErrorPolicy | undefined,
+): AsyncIterable<T> {
+  try {
+    yield* messages;
+  } catch (error) {
+    throw await boundaryError(error, request, logger, policy);
+  }
+}
+
+async function boundaryError(
+  error: unknown,
+  request: UnaryRequest | StreamRequest,
+  logger: Logger,
+  policy: VisitorErrorPolicy | undefined,
+): Promise<ConnectError> {
+  const procedure = `/${request.service.typeName}/${request.method.name}`;
+
+  // Arm 1: the structural raw-error conversion (Q2). The logging
+  // interceptor inside already recorded unary failures; this line is the
+  // only record for mid-stream and identity-chassis raws, and it names
+  // the conversion the operator would otherwise not know happened.
+  let connectError: ConnectError;
+  if (error instanceof ConnectError) {
+    connectError = error;
+  } else {
+    logger.error("unhandled non-ConnectError at the transport boundary", {
+      procedure,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    connectError = internalError(error, INTERNAL_FALLBACK_MESSAGE);
+  }
+
+  // Arm 2: the visitor rewrite — only with a composed policy, only on
+  // the leak-prone codes.
+  if (policy === undefined || !SANITIZED_CODES.has(connectError.code)) {
+    return connectError;
+  }
+  const identity = request.contextValues.get(callerIdentityKey);
+  let eligible: boolean;
+  try {
+    eligible = policy.eligible(identity, request.method);
+  } catch (policyFault) {
+    // Fail toward sanitizing: the recoverable direction (see the
+    // contract's eligible() doc).
+    logger.error("visitor error policy eligibility check threw", {
+      procedure,
+      error:
+        policyFault instanceof Error ? policyFault.message : String(policyFault),
+    });
+    eligible = true;
+  }
+  if (!eligible) {
+    return connectError;
+  }
+
+  let copy: string;
+  try {
+    copy = await policy.replacementCopy(identity, request.method);
+  } catch (policyFault) {
+    logger.warn("visitor error copy resolution failed, using fallback", {
+      procedure,
+      error:
+        policyFault instanceof Error ? policyFault.message : String(policyFault),
+    });
+    copy = INTERNAL_FALLBACK_MESSAGE;
+  }
+
+  const ref = mintSupportRef();
+  // The correlation point (Q3): the visitor holds the ref, this line
+  // holds the original description — the log-based rendering of the
+  // Java span attribute + boundary WARN pair.
+  logger.warn("sanitized a visitor-facing error", {
+    procedure,
+    code: Code[connectError.code],
+    callerClass: identity?.callerClass ?? "(unstamped)",
+    ref,
+    error: connectError.rawMessage,
+  });
+  // A FRESH error: same code (never changed — SDK retry semantics stay
+  // honest), rewritten description + ref, and NO inherited details or
+  // metadata (the Java trailers-drop; rethrownStatusError's lesson).
+  return new ConnectError(copy + supportRefSuffix(ref), connectError.code);
+}

--- a/backend/services/stigmer-server/src/pipeline/interceptors/error-boundary.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/error-boundary.ts
@@ -204,7 +204,9 @@ async function boundaryError(
     logger.error("visitor error policy eligibility check threw", {
       procedure,
       error:
-        policyFault instanceof Error ? policyFault.message : String(policyFault),
+        policyFault instanceof Error
+          ? policyFault.message
+          : String(policyFault),
     });
     eligible = true;
   }
@@ -219,7 +221,9 @@ async function boundaryError(
     logger.warn("visitor error copy resolution failed, using fallback", {
       procedure,
       error:
-        policyFault instanceof Error ? policyFault.message : String(policyFault),
+        policyFault instanceof Error
+          ? policyFault.message
+          : String(policyFault),
     });
     copy = INTERNAL_FALLBACK_MESSAGE;
   }


### PR DESCRIPTION
## Summary

Adds a structural error boundary at position 0 of the SERVING interceptor chain — the TS port of the cloud Java `VisitorErrorSanitizerInterceptor` posture (cloud DD-005 of 20260810.02) — plus the `visitorErrorPolicy` driver sub-kind so a composition supplies the visitor-sanitization semantics. Convergence entry `20260830.03.sp.visitor-error-sanitizer` (parent worklist item 11), all six plan-gate rulings as recommended.

## Context

A raw `Error` thrown from any DIRECT handler (54 of 233 methods) reached the wire as `Unknown` carrying the raw message via connect-node's default conversion — the leak-by-default shape DD-005 rejected, and stigmer#478's direct-handler sibling (the pipeline executor's collapse covers pipeline chains only). The composition additionally needs Java's visitor sanitization (guest/channel/is_public callers must never see leak-prone descriptions) and a support ref, but the serving chain had no interceptor extension point.

## Changes

- `pipeline/interceptors/error-boundary.ts` (new): arm 1 (always on) converts raw non-ConnectErrors to the pipeline's exact sanitized Internal (`"internal server error"`); arm 2 (policy-driven, empty by default) rewrites the six leak-prone codes (INTERNAL/UNKNOWN/DATA_LOSS/UNAVAILABLE/DEADLINE_EXCEEDED/UNIMPLEMENTED) for callers the composed `VisitorErrorPolicy` deems anonymous — code always preserved, the Java `" (ref: <8 hex>)"` format byte-pinned (minted on the error path only), details/metadata dropped on sanitize, the original description kept operator-visible via the boundary WARN. Stream responses are guarded by wrapping the iterable — mid-stream errors sanitize too.
- `pipeline/chain.ts`: the documented optional position-0 parameter — SERVING chain only; the in-process chain never composes it, so in-process hops keep full diagnostics by construction (the Java `InProcessCallContextHolder` exemption, structurally).
- `extensions/drivers.ts` + `extensions/registry.ts`: the `visitorErrorPolicy` single-instance driver sub-kind (loud-fail on duplicates).
- `index.ts`: exports the `VisitorErrorPolicy` type and `createErrorBoundaryInterceptor` (the composition test seam — the `callerIdentityKey` precedent).
- `ts-server-guidelines.mdc`: the Errors section gains the "net, not a license" rule — direct handlers still self-sanitize; the boundary exists for the path someone forgot.

## Implementation notes

- OUTERMOST placement (ruling Q1) preserves the Java pin "sanitizes even with no identity context" (identity is read from contextValues on the error path; absent when position 1 itself refused) and keeps the logging interceptor inside — operators log the ORIGINAL error, the wire carries the rewrite.
- The sanitized error is a FRESH ConnectError (same code, new description, no inherited details/metadata) — the Java trailers-drop and `rethrownStatusError`'s NGHTTP2 metadata lesson.
- Fail-safe direction (ruling contract): a throwing eligibility check sanitizes; a rejecting copy resolution falls back to `"internal server error"` — never the original description.

## Breaking changes

- None on any tested surface. The one deliberate behavior change (ruling Q2): a raw non-ConnectError that previously crossed as `Unknown` + raw message now crosses as `Internal` + `"internal server error"` — buggy paths only; all four conformance rosters are byte-identical.

## Test plan

- 15 new unit arms incl. the NEGATIVE CONTROL (without the boundary the raw message crosses verbatim), the stream arm, org-member/schedule pass-through, the no-identity is_public arm, both fail-safe arms, and the details/metadata drop pin. Full server suite: 2085 passed.
- All four conformance rosters byte-identical: `local` 499/13, `local-postgres` 499/13, `local-execution` 160/1, `local-postgres-execution` 160/1.
- The cloud composition readout (companion stigmer-cloud PR): 480/0/36 — exact baseline parity.

## Risks

- Low: the boundary is pass-through for every ConnectError when no policy is composed. Rollback = revert (no data or schema surface).

## Checklist

- [x] Docs updated (guidelines rule)
- [x] Tests added
- [x] Backward compatible (rosters byte-identical)

Made with [Cursor](https://cursor.com)