### PR TITLE
feat(backend/stigmer-server): versioned secret-codec seam + sweep store primitives

### DIFF
--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -93,7 +93,17 @@ import {
   uploadUrl as skillUploadUrl,
 } from "../domain/skill/transfer/handler.js";
 import { UploadSlots } from "../domain/skill/transfer/slots.js";
-import { SecretService } from "../encryption/encryption.js";
+import {
+  DEFAULT_WRITE_VERSION,
+  ENCRYPTION_KEY_ENV_VAR,
+  ENCRYPTION_KEY_FILE_NAME,
+  ENCRYPTION_WRITE_VERSION_ENV_VAR,
+  SecretService,
+  StaticKeySecretCodec,
+} from "../encryption/encryption.js";
+import type { SecretCodec } from "../encryption/codec.js";
+import { getOrCreateNamedKey } from "../encryption/key-manager.js";
+import { V1_VERSION } from "../encryption/v1-codec.js";
 import { registerActivityServices } from "../query/activity/controller.js";
 import { ActivityHandler } from "../query/activity/handler.js";
 import { registerSearchServices } from "../query/search/controller.js";
@@ -261,7 +271,7 @@ export async function composeServer(
   // invariants; Go server.go:277-293):
   //
   //   - Encryption key failure → WARN and continue with a keyless
-  //     pass-through service. Plaintext at rest is tolerable (the write
+  //     pass-through v1 codec. Plaintext at rest is tolerable (the write
   //     steps WARN per request, oss#394); refusing to boot over it is not.
   //   - Runner-token key failure → FATAL (throw). The EC read RPCs redact
   //     by default, so a server that cannot mint runner tokens would hand
@@ -270,16 +280,46 @@ export async function composeServer(
   //     (The verify side is live: the executioncontext decrypt lane. The
   //     mint side — the platform exchange RPC — arrives with its
   //     sub-project.)
-  let secretService: SecretService;
+  //
+  // The versioned-codec seam (20260830.04 Stage 1, ruling Q2): the
+  // built-in v1 codec installs HERE, never in the registry (the
+  // default-lives-with-the-consumer doctrine), and merges with the
+  // extension-registered codecs. The write version resolves FAIL-FAST:
+  // naming a version with no codec is a boot throw (deliberately outside
+  // the WARN-degrade catch — only the KEY ladder degrades; a
+  // misconfigured write version must never silently write v1). The env
+  // vars stay off ServerConfig, the key-manager posture: no config entry
+  // exists before the code that reads it.
+  let v1Key: Buffer | undefined;
   try {
-    secretService = SecretService.fromEnv();
+    v1Key = getOrCreateNamedKey(
+      ENCRYPTION_KEY_ENV_VAR,
+      ENCRYPTION_KEY_FILE_NAME,
+    );
   } catch (error) {
     logger.warn(
       "Failed to initialize encryption - secret values will be stored in plaintext",
       { error: error instanceof Error ? error.message : String(error) },
     );
-    secretService = SecretService.create(undefined);
+    v1Key = undefined;
   }
+  const secretCodecs = new Map<string, SecretCodec>([
+    [V1_VERSION, new StaticKeySecretCodec(v1Key)],
+    ...extensions.drivers.secretCodecs,
+  ]);
+  // Blank normalizes to the default — a rollback lever must be robust to
+  // sloppy unsetting (the cloud EncryptionConfig contract).
+  const writeVersionValue = process.env[ENCRYPTION_WRITE_VERSION_ENV_VAR] ?? "";
+  const secretService = SecretService.withCodecs({
+    codecs: secretCodecs,
+    writeVersion:
+      writeVersionValue === "" ? DEFAULT_WRITE_VERSION : writeVersionValue,
+  });
+  logger.info("secret encryption configured", {
+    writeVersion:
+      writeVersionValue === "" ? DEFAULT_WRITE_VERSION : writeVersionValue,
+    registeredCodecs: [...secretCodecs.keys()].sort(),
+  });
   const runnerAuthService = RunnerAuthService.fromEnv();
   // The runner-credential seam (§6c, O5): the composed provider, or the
   // OSS execution-scoped default over the service above. The concrete

--- a/backend/services/stigmer-server/src/domain/channelapp/__tests__/channelapp.test.ts
+++ b/backend/services/stigmer-server/src/domain/channelapp/__tests__/channelapp.test.ts
@@ -37,7 +37,11 @@ import { loadConfig } from "../../../boot/config.js";
 import { composeServer } from "../../../boot/compose.js";
 import type { ComposedServer } from "../../../boot/compose.js";
 import { createLogger } from "../../../boot/logger.js";
-import { SecretService, isCiphertextShaped } from "../../../encryption/encryption.js";
+import {
+  EncryptionScope,
+  SecretService,
+  isCiphertextShaped,
+} from "../../../encryption/encryption.js";
 import {
   PROVIDER_IMMUTABLE_MESSAGE,
   REDACTED_MARKER,
@@ -47,7 +51,11 @@ import {
   plaintextRequiredMessage,
 } from "../constants.js";
 
-const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
 
 // A real 32-byte key so encrypt/redact round-trips are exercised for real
 // (the Go harness posture); the same key decrypts stored values below.
@@ -70,7 +78,10 @@ let dir: string;
 beforeAll(async () => {
   dir = mkdtempSync(path.join(tmpdir(), "channelapp-domain-test-"));
   vi.stubEnv("STIGMER_ENCRYPTION_KEY", TEST_KEY_B64);
-  vi.stubEnv("STIGMER_RUNNER_TOKEN_KEY", Buffer.alloc(32, 8).toString("base64"));
+  vi.stubEnv(
+    "STIGMER_RUNNER_TOKEN_KEY",
+    Buffer.alloc(32, 8).toString("base64"),
+  );
   server = await composeServer({
     config: loadConfig({
       STIGMER_MODEL_REGISTRY_REFRESH: "off",
@@ -143,7 +154,11 @@ function newWhatsAppApp(name: string, org: string = ORG) {
 }
 
 async function readStored(id: string): Promise<ChannelApp> {
-  return server.store.getResource(ApiResourceKind.channel_app, id, ChannelAppSchema);
+  return server.store.getResource(
+    ApiResourceKind.channel_app,
+    id,
+    ChannelAppSchema,
+  );
 }
 
 async function grpcError(run: () => Promise<unknown>): Promise<ConnectError> {
@@ -175,7 +190,10 @@ describe("provider-arm redact/encrypt tripwire (#324 regression guard)", () => {
     slack: {
       newApp: (name) => newSlackApp(name),
       secretsOf: (app) => {
-        const slack = app.spec?.providerConfig.case === "slack" ? app.spec.providerConfig.value : undefined;
+        const slack =
+          app.spec?.providerConfig.case === "slack"
+            ? app.spec.providerConfig.value
+            : undefined;
         return {
           client_secret: slack?.clientSecret ?? "",
           signing_secret: slack?.signingSecret ?? "",
@@ -185,7 +203,10 @@ describe("provider-arm redact/encrypt tripwire (#324 regression guard)", () => {
     whatsapp: {
       newApp: (name) => newWhatsAppApp(name),
       secretsOf: (app) => {
-        const wa = app.spec?.providerConfig.case === "whatsapp" ? app.spec.providerConfig.value : undefined;
+        const wa =
+          app.spec?.providerConfig.case === "whatsapp"
+            ? app.spec.providerConfig.value
+            : undefined;
         return {
           app_secret: wa?.appSecret ?? "",
           access_token: wa?.accessToken ?? "",
@@ -199,13 +220,20 @@ describe("provider-arm redact/encrypt tripwire (#324 regression guard)", () => {
     // The tripwire proper: the case table must cover every provider_config
     // arm. Adding a provider arm to the proto fails here until the arm has
     // redaction, encryption, and a case entry (the Go tripwire's posture).
-    const oneof = ChannelAppSpecSchema.oneofs.find((o) => o.name === "provider_config");
+    const oneof = ChannelAppSpecSchema.oneofs.find(
+      (o) => o.name === "provider_config",
+    );
     expect(oneof).toBeDefined();
     const armNames = oneof!.fields.map((f) => f.name);
     for (const arm of armNames) {
-      expect(cases, `provider arm "${arm}" has no redaction/encryption coverage`).toHaveProperty(arm);
+      expect(
+        cases,
+        `provider arm "${arm}" has no redaction/encryption coverage`,
+      ).toHaveProperty(arm);
     }
-    expect(Object.keys(cases).length, "remove stale case entries").toBe(armNames.length);
+    expect(Object.keys(cases).length, "remove stale case entries").toBe(
+      armNames.length,
+    );
   });
 
   for (const [arm, tc] of Object.entries(cases)) {
@@ -217,15 +245,21 @@ describe("provider-arm redact/encrypt tripwire (#324 regression guard)", () => {
 
       const created = await command.create(tc.newApp(name));
       for (const [field, value] of Object.entries(tc.secretsOf(created))) {
-        expect(value, `${field} must be redacted in the create response`).toBe(REDACTED_MARKER);
+        expect(value, `${field} must be redacted in the create response`).toBe(
+          REDACTED_MARKER,
+        );
       }
 
       const stored = await readStored(created.metadata!.id);
       for (const [field, value] of Object.entries(tc.secretsOf(stored))) {
-        expect(isCiphertextShaped(value), `stored ${field} must be encrypted`).toBe(true);
-        expect(secrets.decrypt(value), `stored ${field} must decrypt to the original`).toBe(
-          plaintexts[field],
-        );
+        expect(
+          isCiphertextShaped(value),
+          `stored ${field} must be encrypted`,
+        ).toBe(true);
+        expect(
+          await secrets.decrypt(value),
+          `stored ${field} must decrypt to the original`,
+        ).toBe(plaintexts[field]);
       }
     });
   }
@@ -237,20 +271,29 @@ describe("provider-arm redact/encrypt tripwire (#324 regression guard)", () => {
 
 describe("channelapp create", () => {
   it("encrypts at rest, redacts the response, stamps the chapp id", async () => {
-    const created = await command.create(newSlackApp(uniqueName("Acme Support App")));
+    const created = await command.create(
+      newSlackApp(uniqueName("Acme Support App")),
+    );
 
     expect(created.metadata?.id).toMatch(/^chapp/);
     expect(created.spec?.providerConfig.case).toBe("slack");
-    const slack = created.spec!.providerConfig.case === "slack" ? created.spec!.providerConfig.value : undefined;
+    const slack =
+      created.spec!.providerConfig.case === "slack"
+        ? created.spec!.providerConfig.value
+        : undefined;
     expect(slack?.clientSecret).toBe(REDACTED_MARKER);
     expect(slack?.signingSecret).toBe(REDACTED_MARKER);
 
     const stored = await readStored(created.metadata!.id);
     const storedSlack =
-      stored.spec?.providerConfig.case === "slack" ? stored.spec.providerConfig.value : undefined;
+      stored.spec?.providerConfig.case === "slack"
+        ? stored.spec.providerConfig.value
+        : undefined;
     expect(isCiphertextShaped(storedSlack?.clientSecret ?? "")).toBe(true);
     expect(isCiphertextShaped(storedSlack?.signingSecret ?? "")).toBe(true);
-    expect(secrets.decrypt(storedSlack!.clientSecret)).toBe("shh-client-secret");
+    expect(await secrets.decrypt(storedSlack!.clientSecret)).toBe(
+      "shh-client-secret",
+    );
   });
 
   it("refuses the redaction marker on create", async () => {
@@ -270,7 +313,8 @@ describe("channelapp create", () => {
 describe("ciphertext-shaped secrets are refused (oss#395)", () => {
   it("slack create", async () => {
     const app = newSlackApp(uniqueName("Acme Slack App"));
-    app.spec.providerConfig.value.clientSecret = "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=";
+    app.spec.providerConfig.value.clientSecret =
+      "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=";
 
     const err = await grpcError(() => command.create(app));
     expect(err.code).toBe(Code.InvalidArgument);
@@ -294,7 +338,8 @@ describe("ciphertext-shaped secrets are refused (oss#395)", () => {
     (update.metadata as Record<string, string>).id = created.metadata!.id;
     (update.metadata as Record<string, string>).slug = created.metadata!.slug;
     update.spec.providerConfig.value.clientSecret = REDACTED_MARKER;
-    update.spec.providerConfig.value.signingSecret = "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=";
+    update.spec.providerConfig.value.signingSecret =
+      "enc:v1:Zm9yZ2VkLWNpcGhlcnRleHQ=";
 
     const err = await grpcError(() => command.update(update));
     expect(err.code).toBe(Code.InvalidArgument);
@@ -319,13 +364,18 @@ describe("update marker preserves per field", () => {
     await command.update(update);
 
     const stored = await readStored(created.metadata!.id);
-    const slack = stored.spec?.providerConfig.case === "slack" ? stored.spec.providerConfig.value : undefined;
-    expect(secrets.decrypt(slack!.clientSecret), "marker must preserve the ORIGINAL client_secret").toBe(
-      "shh-client-secret",
-    );
-    expect(secrets.decrypt(slack!.signingSecret), "plaintext must rotate to the new value").toBe(
-      "rotated-signing-secret",
-    );
+    const slack =
+      stored.spec?.providerConfig.case === "slack"
+        ? stored.spec.providerConfig.value
+        : undefined;
+    expect(
+      await secrets.decrypt(slack!.clientSecret),
+      "marker must preserve the ORIGINAL client_secret",
+    ).toBe("shh-client-secret");
+    expect(
+      await secrets.decrypt(slack!.signingSecret),
+      "plaintext must rotate to the new value",
+    ).toBe("rotated-signing-secret");
   });
 
   it("whatsapp: rotates the access token, keeps app_secret and verify_token", async () => {
@@ -341,10 +391,13 @@ describe("update marker preserves per field", () => {
     await command.update(update);
 
     const stored = await readStored(created.metadata!.id);
-    const wa = stored.spec?.providerConfig.case === "whatsapp" ? stored.spec.providerConfig.value : undefined;
-    expect(secrets.decrypt(wa!.appSecret)).toBe("shh-app-secret");
-    expect(secrets.decrypt(wa!.accessToken)).toBe("rotated-access-token");
-    expect(secrets.decrypt(wa!.verifyToken)).toBe("shh-verify-token");
+    const wa =
+      stored.spec?.providerConfig.case === "whatsapp"
+        ? stored.spec.providerConfig.value
+        : undefined;
+    expect(await secrets.decrypt(wa!.appSecret)).toBe("shh-app-secret");
+    expect(await secrets.decrypt(wa!.accessToken)).toBe("rotated-access-token");
+    expect(await secrets.decrypt(wa!.verifyToken)).toBe("shh-verify-token");
   });
 
   it("marker with no stored value is InvalidArgument (adversarial arm)", async () => {
@@ -364,7 +417,14 @@ describe("update marker preserves per field", () => {
       spec: {
         providerConfig: {
           case: "slack",
-          value: { clientId: "1.2", clientSecret: secrets.encrypt("x"), signingSecret: "" },
+          value: {
+            clientId: "1.2",
+            clientSecret: await secrets.encrypt(
+              "x",
+              EncryptionScope.forOrganization(ORG),
+            ),
+            signingSecret: "",
+          },
         },
       },
     });
@@ -393,15 +453,24 @@ describe("update marker preserves per field", () => {
 
 describe("apply round-trips with markers", () => {
   it("get → apply back verbatim preserves both stored secrets", async () => {
-    const created = await command.apply(newSlackApp(uniqueName("Acme Support App")));
+    const created = await command.apply(
+      newSlackApp(uniqueName("Acme Support App")),
+    );
 
     const fetched = await query.get({ value: created.metadata!.id });
     await command.apply(fetched);
 
     const stored = await readStored(created.metadata!.id);
-    const slack = stored.spec?.providerConfig.case === "slack" ? stored.spec.providerConfig.value : undefined;
-    expect(secrets.decrypt(slack!.clientSecret)).toBe("shh-client-secret");
-    expect(secrets.decrypt(slack!.signingSecret)).toBe("shh-signing-secret");
+    const slack =
+      stored.spec?.providerConfig.case === "slack"
+        ? stored.spec.providerConfig.value
+        : undefined;
+    expect(await secrets.decrypt(slack!.clientSecret)).toBe(
+      "shh-client-secret",
+    );
+    expect(await secrets.decrypt(slack!.signingSecret)).toBe(
+      "shh-signing-secret",
+    );
   });
 });
 
@@ -412,11 +481,15 @@ describe("apply round-trips with markers", () => {
 describe("queries redact secrets", () => {
   it("slack: get, getByReference, and listByOrg redact; org filter holds", async () => {
     const org = "acme-slack-queries";
-    const created = await command.create(newSlackApp(uniqueName("Acme Support App"), org));
+    const created = await command.create(
+      newSlackApp(uniqueName("Acme Support App"), org),
+    );
 
     const fetched = await query.get({ value: created.metadata!.id });
     const fetchedSlack =
-      fetched.spec?.providerConfig.case === "slack" ? fetched.spec.providerConfig.value : undefined;
+      fetched.spec?.providerConfig.case === "slack"
+        ? fetched.spec.providerConfig.value
+        : undefined;
     expect(fetchedSlack?.clientSecret).toBe(REDACTED_MARKER);
     expect(fetchedSlack?.signingSecret).toBe(REDACTED_MARKER);
 
@@ -426,7 +499,9 @@ describe("queries redact secrets", () => {
       slug: created.metadata!.slug,
     });
     const byRefSlack =
-      byRef.spec?.providerConfig.case === "slack" ? byRef.spec.providerConfig.value : undefined;
+      byRef.spec?.providerConfig.case === "slack"
+        ? byRef.spec.providerConfig.value
+        : undefined;
     expect(byRefSlack?.clientSecret).toBe(REDACTED_MARKER);
 
     const list = await query.listByOrg({ org });
@@ -443,21 +518,31 @@ describe("queries redact secrets", () => {
 
   it("whatsapp: all three secrets redact; app_id is public and stays", async () => {
     const org = "acme-wa-queries";
-    const created = await command.create(newWhatsAppApp(uniqueName("Clinic Meta App"), org));
+    const created = await command.create(
+      newWhatsAppApp(uniqueName("Clinic Meta App"), org),
+    );
 
     const fetched = await query.get({ value: created.metadata!.id });
-    const wa = fetched.spec?.providerConfig.case === "whatsapp" ? fetched.spec.providerConfig.value : undefined;
+    const wa =
+      fetched.spec?.providerConfig.case === "whatsapp"
+        ? fetched.spec.providerConfig.value
+        : undefined;
     expect(wa?.appSecret).toBe(REDACTED_MARKER);
     expect(wa?.accessToken).toBe(REDACTED_MARKER);
     expect(wa?.verifyToken).toBe(REDACTED_MARKER);
-    expect(wa?.appId, "app_id is public and must NOT be redacted").toBe("108954");
+    expect(wa?.appId, "app_id is public and must NOT be redacted").toBe(
+      "108954",
+    );
 
     const byRef = await query.getByReference({
       org,
       kind: ApiResourceKind.channel_app,
       slug: created.metadata!.slug,
     });
-    const byRefWa = byRef.spec?.providerConfig.case === "whatsapp" ? byRef.spec.providerConfig.value : undefined;
+    const byRefWa =
+      byRef.spec?.providerConfig.case === "whatsapp"
+        ? byRef.spec.providerConfig.value
+        : undefined;
     expect(byRefWa?.appSecret).toBe(REDACTED_MARKER);
 
     const list = await query.listByOrg({ org });
@@ -506,7 +591,9 @@ describe("provider arm is immutable on update", () => {
 
 describe("delete is blocked while referenced", () => {
   it("names a referencing channel; deletion succeeds after unreferencing, redacted", async () => {
-    const created = await command.create(newSlackApp(uniqueName("Acme Support App")));
+    const created = await command.create(
+      newSlackApp(uniqueName("Acme Support App")),
+    );
 
     // Seed a referencing channel directly — the referential check reads
     // stored state, not the channel pipeline (the Go test's posture).
@@ -532,21 +619,36 @@ describe("delete is blocked while referenced", () => {
       channel,
     );
 
-    const err = await grpcError(() => command.delete({ resourceId: created.metadata!.id }));
+    const err = await grpcError(() =>
+      command.delete({ resourceId: created.metadata!.id }),
+    );
     expect(err.code).toBe(Code.FailedPrecondition);
     expect(err.rawMessage).toBe(
-      deleteBlockedByChannelMessage(ORG, created.metadata!.slug, "support-bot-slack"),
+      deleteBlockedByChannelMessage(
+        ORG,
+        created.metadata!.slug,
+        "support-bot-slack",
+      ),
     );
 
-    await server.store.deleteResource(ApiResourceKind.agent_channel, channel.metadata!.id);
+    await server.store.deleteResource(
+      ApiResourceKind.agent_channel,
+      channel.metadata!.id,
+    );
     const deleted = await command.delete({ resourceId: created.metadata!.id });
     const slack =
-      deleted.spec?.providerConfig.case === "slack" ? deleted.spec.providerConfig.value : undefined;
-    expect(slack?.clientSecret, "the delete response must be redacted").toBe(REDACTED_MARKER);
+      deleted.spec?.providerConfig.case === "slack"
+        ? deleted.spec.providerConfig.value
+        : undefined;
+    expect(slack?.clientSecret, "the delete response must be redacted").toBe(
+      REDACTED_MARKER,
+    );
   });
 
   it("a pre-normalization app_ref with no org still guards its app", async () => {
-    const created = await command.create(newSlackApp(uniqueName("Acme Support App")));
+    const created = await command.create(
+      newSlackApp(uniqueName("Acme Support App")),
+    );
 
     const channel = create(AgentChannelSchema, {
       metadata: {
@@ -569,9 +671,14 @@ describe("delete is blocked while referenced", () => {
       channel,
     );
 
-    const err = await grpcError(() => command.delete({ resourceId: created.metadata!.id }));
+    const err = await grpcError(() =>
+      command.delete({ resourceId: created.metadata!.id }),
+    );
     expect(err.code).toBe(Code.FailedPrecondition);
 
-    await server.store.deleteResource(ApiResourceKind.agent_channel, channel.metadata!.id);
+    await server.store.deleteResource(
+      ApiResourceKind.agent_channel,
+      channel.metadata!.id,
+    );
   });
 });

--- a/backend/services/stigmer-server/src/domain/channelapp/steps.ts
+++ b/backend/services/stigmer-server/src/domain/channelapp/steps.ts
@@ -28,6 +28,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { SecretService } from "../../encryption/encryption.js";
+import { EncryptionScope } from "../../encryption/encryption.js";
 import { isCiphertextShaped } from "../../encryption/encryption.js";
 import {
   failedPreconditionError,
@@ -146,12 +147,12 @@ function newEncryptChannelAppSecretsStep(
    * and returns before the ciphertext-shape rejection, which therefore
    * only ever sees raw client input (oss#395).
    */
-  function resolveSecret(
+  async function resolveSecret(
     ctx: RequestContext<ChannelAppDesc>,
     fieldName: string,
     requestValue: string,
     readExisting: (existing: ChannelApp) => string,
-  ): string {
+  ): Promise<string> {
     if (requestValue === "") {
       return requestValue;
     }
@@ -167,12 +168,20 @@ function newEncryptChannelAppSecretsStep(
     }
 
     if (!secretService.isEnabled()) {
-      logger.warn(`Encryption disabled: ${fieldName} will be stored in plaintext`);
+      logger.warn(
+        `Encryption disabled: ${fieldName} will be stored in plaintext`,
+      );
       return requestValue;
     }
 
     try {
-      return secretService.encrypt(requestValue);
+      // Tenancy-only scope, the pre-v3 write posture: channelapp is an
+      // org-scoped kind, so metadata.org is validated non-empty before
+      // this step.
+      return await secretService.encrypt(
+        requestValue,
+        EncryptionScope.forOrganization(ctx.newState.metadata?.org ?? ""),
+      );
     } catch (error) {
       throw internalError(error, `failed to encrypt ${fieldName}`);
     }
@@ -205,12 +214,12 @@ function newEncryptChannelAppSecretsStep(
 
   return {
     name: "EncryptChannelAppSecrets",
-    execute(ctx: RequestContext<ChannelAppDesc>): void {
+    async execute(ctx: RequestContext<ChannelAppDesc>): Promise<void> {
       const provider = ctx.newState.spec?.providerConfig;
       switch (provider?.case) {
         case "slack": {
           const slack = provider.value;
-          slack.clientSecret = resolveSecret(
+          slack.clientSecret = await resolveSecret(
             ctx,
             "client_secret",
             slack.clientSecret,
@@ -219,7 +228,7 @@ function newEncryptChannelAppSecretsStep(
                 ? existing.spec.providerConfig.value.clientSecret
                 : "",
           );
-          slack.signingSecret = resolveSecret(
+          slack.signingSecret = await resolveSecret(
             ctx,
             "signing_secret",
             slack.signingSecret,
@@ -232,7 +241,7 @@ function newEncryptChannelAppSecretsStep(
         }
         case "whatsapp": {
           const whatsapp = provider.value;
-          whatsapp.appSecret = resolveSecret(
+          whatsapp.appSecret = await resolveSecret(
             ctx,
             "app_secret",
             whatsapp.appSecret,
@@ -241,7 +250,7 @@ function newEncryptChannelAppSecretsStep(
                 ? existing.spec.providerConfig.value.appSecret
                 : "",
           );
-          whatsapp.accessToken = resolveSecret(
+          whatsapp.accessToken = await resolveSecret(
             ctx,
             "access_token",
             whatsapp.accessToken,
@@ -250,7 +259,7 @@ function newEncryptChannelAppSecretsStep(
                 ? existing.spec.providerConfig.value.accessToken
                 : "",
           );
-          whatsapp.verifyToken = resolveSecret(
+          whatsapp.verifyToken = await resolveSecret(
             ctx,
             "verify_token",
             whatsapp.verifyToken,
@@ -360,7 +369,11 @@ export function newCheckNoReferencingChannelsStep(
 
         if (refOrg === org && ref.slug === slug) {
           throw failedPreconditionError(
-            deleteBlockedByChannelMessage(org, slug, channel.metadata?.name ?? ""),
+            deleteBlockedByChannelMessage(
+              org,
+              slug,
+              channel.metadata?.name ?? "",
+            ),
           );
         }
       }

--- a/backend/services/stigmer-server/src/domain/environment/constants.ts
+++ b/backend/services/stigmer-server/src/domain/environment/constants.ts
@@ -10,9 +10,13 @@
  * Environment-returning boundary — Go steps.RedactedMarker, pinned by the
  * conformance suite and mirrored by the cloud edition. A client sending it
  * BACK on a write means "keep the existing secret" (the round-trip
- * contract; see preserveRedactedSecrets).
+ * contract; see preserveRedactedSecrets). The definition moved to the
+ * encryption facade with the codec seam (20260830.04 Stage 1 — reencrypt
+ * refuses the marker, and domain → encryption is the dependency
+ * direction); re-exported here for the historical importers, byte
+ * unchanged.
  */
-export const REDACTED_MARKER = "***REDACTED***";
+export { REDACTED_MARKER } from "../../encryption/encryption.js";
 
 /** Label marking a user's personal environment — Go personalLabelKey. */
 export const PERSONAL_LABEL_KEY = "stigmer.ai/personal";

--- a/backend/services/stigmer-server/src/domain/environment/resolution/__tests__/resolution.test.ts
+++ b/backend/services/stigmer-server/src/domain/environment/resolution/__tests__/resolution.test.ts
@@ -18,13 +18,21 @@ import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environmen
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import { createLogger } from "../../../../boot/logger.js";
-import { SecretService } from "../../../../encryption/encryption.js";
+import {
+  EncryptionScope,
+  SecretService,
+} from "../../../../encryption/encryption.js";
 import { SqliteStore } from "../../../../store/sqlite/store.js";
 import type { Store } from "../../../../store/interface.js";
 import { RuntimeResolutionService } from "../resolution.js";
 
-const silentLogger = createLogger({ level: "error", pretty: false, write: () => {} });
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
 const KEY = Buffer.alloc(32, 7);
+const SCOPE = EncryptionScope.forOrganization("acme");
 
 let dir: string;
 let store: Store;
@@ -38,7 +46,10 @@ beforeAll(async () => {
   service = new RuntimeResolutionService(store, secretService, silentLogger);
 
   await seed("resolved", "acme", {
-    API_KEY: { value: secretService.encrypt("real-key"), isSecret: true },
+    API_KEY: {
+      value: await secretService.encrypt("real-key", SCOPE),
+      isSecret: true,
+    },
     LEGACY: { value: "pre-oss405-plaintext", isSecret: true },
     REGION: { value: "us-east-1", isSecret: false },
   });
@@ -68,11 +79,18 @@ async function seed(
       ),
     },
   });
-  await store.saveResource(ApiResourceKind.environment, id, EnvironmentSchema, env);
+  await store.saveResource(
+    ApiResourceKind.environment,
+    id,
+    EnvironmentSchema,
+    env,
+  );
   return id;
 }
 
-async function connectError(run: () => Promise<unknown>): Promise<ConnectError> {
+async function connectError(
+  run: () => Promise<unknown>,
+): Promise<ConnectError> {
   try {
     await run();
     throw new Error("expected the call to fail");
@@ -105,7 +123,9 @@ describe("resolveByReference", () => {
       "env_resolved",
       EnvironmentSchema,
     );
-    expect(stored.spec?.data["API_KEY"]?.value.startsWith("enc:v1:")).toBe(true);
+    expect(stored.spec?.data["API_KEY"]?.value.startsWith("enc:v1:")).toBe(
+      true,
+    );
   });
 
   it("accepts an unspecified kind (unknown = no assertion), rejects a wrong one", async () => {
@@ -115,18 +135,28 @@ describe("resolveByReference", () => {
     expect(viaUnknown.metadata?.id).toBe("env_resolved");
 
     const error = await connectError(() =>
-      service.resolveByReference(ref("resolved", "acme", ApiResourceKind.agent)),
+      service.resolveByReference(
+        ref("resolved", "acme", ApiResourceKind.agent),
+      ),
     );
     expect(error.code).toBe(Code.InvalidArgument);
-    expect(error.rawMessage).toBe("kind mismatch: expected environment, got agent");
+    expect(error.rawMessage).toBe(
+      "kind mismatch: expected environment, got agent",
+    );
   });
 
   it("requires a slug and an org (org-scoped kind — no cross-tenant resolution)", async () => {
-    const noSlug = await connectError(() => service.resolveByReference(ref("", "acme")));
+    const noSlug = await connectError(() =>
+      service.resolveByReference(ref("", "acme")),
+    );
     expect(noSlug.code).toBe(Code.InvalidArgument);
-    expect(noSlug.rawMessage).toBe("environment reference with slug is required");
+    expect(noSlug.rawMessage).toBe(
+      "environment reference with slug is required",
+    );
 
-    const noOrg = await connectError(() => service.resolveByReference(ref("resolved", "")));
+    const noOrg = await connectError(() =>
+      service.resolveByReference(ref("resolved", "")),
+    );
     expect(noOrg.code).toBe(Code.InvalidArgument);
   });
 
@@ -140,17 +170,28 @@ describe("resolveByReference", () => {
 
   it("WARNs and DROPS an undecryptable key, keeping the rest (per-key skip)", async () => {
     await seed("partially-broken", "acme", {
-      GOOD: { value: secretService.encrypt("good-value"), isSecret: true },
-      BROKEN: { value: "enc:v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", isSecret: true },
+      GOOD: {
+        value: await secretService.encrypt("good-value", SCOPE),
+        isSecret: true,
+      },
+      BROKEN: {
+        value: "enc:v1:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        isSecret: true,
+      },
     });
-    const env = await service.resolveByReference(ref("partially-broken", "acme"));
+    const env = await service.resolveByReference(
+      ref("partially-broken", "acme"),
+    );
     expect(env.spec?.data["GOOD"]?.value).toBe("good-value");
     expect(env.spec?.data["BROKEN"]).toBeUndefined();
   });
 
   it("fails LOUD when ciphertext exists but no key is configured (never a credential-less run)", async () => {
     await seed("keyless-victim", "acme", {
-      SEALED: { value: secretService.encrypt("sealed"), isSecret: true },
+      SEALED: {
+        value: await secretService.encrypt("sealed", SCOPE),
+        isSecret: true,
+      },
     });
     const keyless = new RuntimeResolutionService(
       store,

--- a/backend/services/stigmer-server/src/domain/environment/resolution/resolution.ts
+++ b/backend/services/stigmer-server/src/domain/environment/resolution/resolution.ts
@@ -26,7 +26,7 @@ import type { ApiResourceReference } from "@stigmer/protos/ai/stigmer/commons/ap
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 
 import type { Logger } from "../../../boot/logger.js";
-import { EncryptionDisabledError } from "../../../encryption/encryption.js";
+import { EncryptionUnavailableError } from "../../../encryption/encryption.js";
 import type { SecretService } from "../../../encryption/encryption.js";
 import {
   internalError,
@@ -59,13 +59,16 @@ export class RuntimeResolutionService {
    * org-scoped kind — so a ref that resolves through the RPC surface
    * resolves identically here, and vice versa.
    *
-   * Error doctrine (the cloud service's, in this edition's taxonomy):
-   *   - Undecryptable ciphertext (tampered/truncated/wrong-key) is scoped
-   *     to one value: WARN and drop that key (the cloud's per-key skip).
-   *   - EncryptionDisabledError propagates: the stored ciphertext may be
-   *     perfectly valid (key file lost), and skipping it would start the
-   *     execution silently missing a credential — a confusing downstream
-   *     failure instead of a clear one here.
+   * Error doctrine (the cloud service's two-armed taxonomy, errors.ts):
+   *   - The value-scoped arm (InvalidCiphertextError family —
+   *     tampered/truncated/wrong-key) is scoped to one value: WARN and
+   *     drop that key (the cloud's per-key skip).
+   *   - The infrastructure arm (EncryptionUnavailableError, incl. its
+   *     keyless EncryptionDisabledError case) propagates: the stored
+   *     ciphertext may be perfectly valid (key file lost, codec's key
+   *     provider unreachable, version with no codec here), and skipping
+   *     it would start the execution silently missing a credential — a
+   *     confusing downstream failure instead of a clear one here.
    *   - An unresolvable reference is NotFound, same as the RPC path — the
    *     execution-context builders treat that as an authoring error that
    *     fails the create (never a silent run without credentials).
@@ -105,16 +108,18 @@ export class RuntimeResolutionService {
       throw notFoundError("environment", ref.slug);
     }
 
-    this.decryptSecretValues(env);
+    await this.decryptSecretValues(env);
     return env;
   }
 
   /**
    * Decrypts every encrypted is_secret value in place. Plaintext legacy
    * rows pass through decrypt unchanged, so pre-oss#405 stores resolve
-   * without migration.
+   * without migration. Values decrypt one at a time, deliberately NOT
+   * through the batch verb: decryptAll fails as a whole, and this lane's
+   * contract is per-key skip for value-scoped failures.
    */
-  private decryptSecretValues(env: Environment): void {
+  private async decryptSecretValues(env: Environment): Promise<void> {
     const data = env.spec?.data;
     if (data === undefined || Object.keys(data).length === 0) {
       return;
@@ -127,9 +132,9 @@ export class RuntimeResolutionService {
       }
 
       try {
-        value.value = this.secretService.decrypt(value.value);
+        value.value = await this.secretService.decrypt(value.value);
       } catch (error) {
-        if (error instanceof EncryptionDisabledError) {
+        if (error instanceof EncryptionUnavailableError) {
           throw internalError(
             error,
             `environment ${environmentId} holds encrypted secret '${key}' but no encryption key is configured`,

--- a/backend/services/stigmer-server/src/domain/environment/steps.ts
+++ b/backend/services/stigmer-server/src/domain/environment/steps.ts
@@ -38,6 +38,7 @@ import type {
 import type { Logger } from "../../boot/logger.js";
 import { isCiphertextShaped } from "../../encryption/encryption.js";
 import type { SecretService } from "../../encryption/encryption.js";
+import { EncryptionScope } from "../../encryption/encryption.js";
 import {
   internalError,
   invalidArgumentError,
@@ -157,7 +158,9 @@ export function newEncryptSecretValuesStep(
 ): PipelineStep<typeof EnvironmentSchema> {
   return {
     name: "EncryptSecretValues",
-    execute(ctx: RequestContext<typeof EnvironmentSchema>): void {
+    async execute(
+      ctx: RequestContext<typeof EnvironmentSchema>,
+    ): Promise<void> {
       const env = ctx.newState;
       const data = env.spec?.data;
       if (data === undefined || Object.keys(data).length === 0) {
@@ -179,7 +182,14 @@ export function newEncryptSecretValuesStep(
           continue;
         }
         try {
-          value.value = secretService.encrypt(value.value);
+          // Tenancy-only scope, the pre-v3 write posture: environment is
+          // an org-scoped kind, so metadata.org is validated non-empty
+          // long before this step. The v1 codec ignores the scope; a
+          // vault-backed write codec keys the per-org KEK by it.
+          value.value = await secretService.encrypt(
+            value.value,
+            EncryptionScope.forOrganization(env.metadata?.org ?? ""),
+          );
         } catch (error) {
           throw internalError(
             error,
@@ -307,9 +317,9 @@ export function newExtractAndDecryptSingleKeyStep(
 ): PipelineStep<typeof EnvironmentSecretValueInputSchema> {
   return {
     name: "ExtractAndDecryptSingleKey",
-    execute(
+    async execute(
       ctx: RequestContext<typeof EnvironmentSecretValueInputSchema>,
-    ): void {
+    ): Promise<void> {
       const key = ctx.input.key;
 
       const env = ctx.get(TARGET_RESOURCE_KEY) as Environment | undefined;
@@ -328,7 +338,7 @@ export function newExtractAndDecryptSingleKeyStep(
       if (envValue.isSecret && envValue.value !== "") {
         let decrypted: string;
         try {
-          decrypted = secretService.decrypt(envValue.value);
+          decrypted = await secretService.decrypt(envValue.value);
         } catch (error) {
           logger.error("Failed to decrypt secret value", {
             key,
@@ -414,7 +424,10 @@ export function newMergeVariablesAndPersistStep(
           } else {
             let encrypted: string;
             try {
-              encrypted = secretService.encrypt(value.value);
+              encrypted = await secretService.encrypt(
+                value.value,
+                EncryptionScope.forOrganization(env.metadata?.org ?? ""),
+              );
             } catch (error) {
               throw internalError(
                 error,

--- a/backend/services/stigmer-server/src/domain/executioncontext/__tests__/executioncontext.test.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/__tests__/executioncontext.test.ts
@@ -48,6 +48,7 @@ import type { ComposedServer } from "../../../boot/compose.js";
 import { createLogger } from "../../../boot/logger.js";
 import {
   ENCRYPTED_PREFIX,
+  EncryptionScope,
   SecretService,
 } from "../../../encryption/encryption.js";
 import { SqliteStore } from "../../../store/sqlite/store.js";
@@ -581,8 +582,9 @@ describe("executioncontext domain (encryption keyless, runner auth enabled)", ()
       }),
     );
     const stored = await storedRow(ts, created.metadata!.id);
-    stored.spec!.data["HELD_SECRET"]!.value = keyed.encrypt(
+    stored.spec!.data["HELD_SECRET"]!.value = await keyed.encrypt(
       "the-real-credential",
+      EncryptionScope.forOrganization("test-org"),
     );
     await ts.server.store.saveResource(
       ApiResourceKind.execution_context,

--- a/backend/services/stigmer-server/src/domain/executioncontext/__tests__/resolve-values-capability.test.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/__tests__/resolve-values-capability.test.ts
@@ -15,7 +15,10 @@ import { describe, expect, it } from "vitest";
 import { ExecutionContextSchema } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
 
 import { createLogger } from "../../../boot/logger.js";
-import { SecretService } from "../../../encryption/encryption.js";
+import {
+  EncryptionScope,
+  SecretService,
+} from "../../../encryption/encryption.js";
 import { InvalidTokenError } from "../../../runnerauth/runnerauth.js";
 import type { RunnerCredentialProvider } from "../../../runnerauth/runner-credential-provider.js";
 import { resolveValuesForCaller } from "../resolve-values-for-caller.js";
@@ -59,13 +62,16 @@ function providerWith(
   };
 }
 
-function executionContext() {
+async function executionContext() {
   return create(ExecutionContextSchema, {
     spec: {
       executionId: "aexec_cap1",
       data: {
         API_KEY: {
-          value: secretService.encrypt("s3cret"),
+          value: await secretService.encrypt(
+            "s3cret",
+            EncryptionScope.forOrganization("test-org"),
+          ),
           isSecret: true,
         },
       },
@@ -76,7 +82,7 @@ function executionContext() {
 describe("resolveValuesForCaller (capability delegation — C4)", () => {
   it("decrypts when the capability answers true, passing token and execution id", async () => {
     const provider = providerWith(async () => true);
-    const ec = executionContext();
+    const ec = await executionContext();
     await resolveValuesForCaller(
       { logger: silentLogger, secretService, runnerAuthService: provider },
       ctxWithBearer("sandbox-token"),
@@ -88,7 +94,7 @@ describe("resolveValuesForCaller (capability delegation — C4)", () => {
 
   it("redacts when the capability answers false", async () => {
     const provider = providerWith(async () => false);
-    const ec = executionContext();
+    const ec = await executionContext();
     await resolveValuesForCaller(
       { logger: silentLogger, secretService, runnerAuthService: provider },
       ctxWithBearer("someone-elses-token"),
@@ -99,7 +105,7 @@ describe("resolveValuesForCaller (capability delegation — C4)", () => {
 
   it("redacts without consulting the capability when no bearer token is presented", async () => {
     const provider = providerWith(async () => true);
-    const ec = executionContext();
+    const ec = await executionContext();
     await resolveValuesForCaller(
       { logger: silentLogger, secretService, runnerAuthService: provider },
       ctxWithBearer(""),
@@ -113,7 +119,7 @@ describe("resolveValuesForCaller (capability delegation — C4)", () => {
     const provider = providerWith(async () => {
       throw new Error("policy backend unavailable");
     });
-    const ec = executionContext();
+    const ec = await executionContext();
     await resolveValuesForCaller(
       { logger: silentLogger, secretService, runnerAuthService: provider },
       ctxWithBearer("sandbox-token"),

--- a/backend/services/stigmer-server/src/domain/executioncontext/constants.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/constants.ts
@@ -24,12 +24,14 @@ export function ciphertextShapedMessage(key: string): string {
 }
 
 /**
- * Internal copy for an encrypt failure at write — Go
- * encrypt_secret_values.go (no "variable" wording, unlike environment).
+ * Internal copy for an encrypt failure at write. Replaced the ported
+ * per-key `failed to encrypt secret value for '<key>'` (Go
+ * encrypt_secret_values.go) when EC sealing became one batch through the
+ * v2-capped verb (20260830.04 Stage 1) — a batch failure has no single
+ * failing key. Unreachable for the local v1 codec; a vault-backed write
+ * codec reaches it on KEK-provider failure, with the real error logged.
  */
-export function encryptFailureMessage(key: string): string {
-  return `failed to encrypt secret value for '${key}'`;
-}
+export const ENCRYPT_BATCH_FAILURE_MESSAGE = "failed to encrypt secret values";
 
 /**
  * Internal copy for the fail-loud decrypt arm: the row holds ciphertext

--- a/backend/services/stigmer-server/src/domain/executioncontext/resolve-values-for-caller.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/resolve-values-for-caller.ts
@@ -30,14 +30,19 @@
  * must survive every future verifier: a runner token is NEVER an
  * authentication credential.
  *
- * # Decrypt error doctrine (the oss#405 runtime-resolution doctrine)
+ * # Decrypt error doctrine (the oss#405 runtime-resolution doctrine,
+ * # arms per the two-armed taxonomy in encryption/errors.ts)
  *
- *   - Undecryptable ciphertext (tampered/truncated/wrong-key) is scoped
- *     to one value: WARN and drop that key rather than failing the read.
- *   - EncryptionDisabledError fails the request: the stored ciphertext
- *     may be perfectly valid (key file lost), and dropping it would start
- *     the execution silently missing a credential — a confusing
- *     downstream failure instead of a clear one here.
+ *   - The value-scoped arm (InvalidCiphertextError family —
+ *     tampered/truncated/wrong-key) is scoped to one value: WARN and
+ *     drop that key rather than failing the read.
+ *   - The infrastructure arm (EncryptionUnavailableError, incl. its
+ *     keyless EncryptionDisabledError case) fails the request: the
+ *     stored ciphertext may be perfectly valid (key file lost, codec's
+ *     key provider unreachable, version with no codec here), and
+ *     dropping it would start the execution silently missing a
+ *     credential — a confusing downstream failure instead of a clear one
+ *     here.
  *   - Legacy pre-oss#535 plaintext rows pass through undecorated (decrypt
  *     only runs on isEncrypted values), so old stores serve without
  *     migration.
@@ -47,7 +52,7 @@ import type { HandlerContext } from "@connectrpc/connect";
 import type { ExecutionContext } from "@stigmer/protos/ai/stigmer/agentic/executioncontext/v1/api_pb";
 
 import type { Logger } from "../../boot/logger.js";
-import { EncryptionDisabledError } from "../../encryption/encryption.js";
+import { EncryptionUnavailableError } from "../../encryption/encryption.js";
 import type { SecretService } from "../../encryption/encryption.js";
 import { internalError } from "../../pipeline/errors.js";
 import { parseBearerToken } from "../../pipeline/interceptors/auth.js";
@@ -79,7 +84,7 @@ export async function resolveValuesForCaller(
   ec: ExecutionContext,
 ): Promise<void> {
   if (await runnerMayDecrypt(deps, ctx, ec)) {
-    decryptSecretValues(deps, ec);
+    await decryptSecretValues(deps, ec);
     return;
   }
   redactExecutionContextSecrets(ec);
@@ -194,21 +199,24 @@ function bearerToken(ctx: HandlerContext): string {
  * is_secret value in place, per the doctrine documented on the module
  * header.
  */
-function decryptSecretValues(
+async function decryptSecretValues(
   deps: ResolveValuesDeps,
   ec: ExecutionContext,
-): void {
+): Promise<void> {
   const executionId = ec.spec?.executionId ?? "";
   const data = ec.spec?.data ?? {};
+  // One value at a time, deliberately NOT the batch verb: decryptAll
+  // fails as a whole, and this lane's contract is per-key skip for
+  // value-scoped failures.
   for (const [key, value] of Object.entries(data)) {
     if (!value.isSecret || !deps.secretService.isEncrypted(value.value)) {
       continue;
     }
 
     try {
-      value.value = deps.secretService.decrypt(value.value);
+      value.value = await deps.secretService.decrypt(value.value);
     } catch (error) {
-      if (error instanceof EncryptionDisabledError) {
+      if (error instanceof EncryptionUnavailableError) {
         throw internalError(
           error,
           encryptionKeyMissingMessage(executionId, key),

--- a/backend/services/stigmer-server/src/domain/executioncontext/steps.ts
+++ b/backend/services/stigmer-server/src/domain/executioncontext/steps.ts
@@ -32,6 +32,7 @@ import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
 import type { Logger } from "../../boot/logger.js";
 import { isCiphertextShaped } from "../../encryption/encryption.js";
 import type { SecretService } from "../../encryption/encryption.js";
+import { EncryptionScope } from "../../encryption/encryption.js";
 import type { Authorizer, AuthzDecision } from "../../extensions/authorizer.js";
 import {
   internalError,
@@ -43,7 +44,10 @@ import type { RequestContext } from "../../pipeline/request-context.js";
 import { TARGET_RESOURCE_KEY } from "../../pipeline/steps/load-target.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
-import { ciphertextShapedMessage, encryptFailureMessage } from "./constants.js";
+import {
+  ENCRYPT_BATCH_FAILURE_MESSAGE,
+  ciphertextShapedMessage,
+} from "./constants.js";
 
 /**
  * RejectCiphertextShapedValues — Go rejectCiphertextShapedStep: refuses
@@ -93,6 +97,16 @@ export function newRejectCiphertextShapedStep(): PipelineStep<
  * oss#394 convention). Non-secret values are never touched: the read
  * paths gate decryption on is_secret, so encrypting a non-secret value
  * would strand it as unreadable ciphertext.
+ *
+ * Seals as ONE batch through the v2-capped verb — the Java service's
+ * encryptAllV2 lane (vault project DD-005): EC values are ephemeral, on
+ * the runner's latency-budgeted read path, so a vault-backed write codec
+ * must spend one batched KEK round trip here, never one per value, and a
+ * future v3 write flip must not drag these unlocatable rows with it.
+ * Under the v1-only OSS default the batch is behaviorally identical to
+ * the per-value loop it replaced, except that an encrypt failure (never
+ * observed for local AES-GCM) reports without the failing key name —
+ * disclosed with the codec seam (20260830.04 Stage 1).
  */
 export function newEncryptSecretValuesStep(
   secretService: SecretService,
@@ -100,7 +114,9 @@ export function newEncryptSecretValuesStep(
 ): PipelineStep<typeof ExecutionContextSchema> {
   return {
     name: "EncryptSecretValues",
-    execute(ctx: RequestContext<typeof ExecutionContextSchema>): void {
+    async execute(
+      ctx: RequestContext<typeof ExecutionContextSchema>,
+    ): Promise<void> {
       const ec = ctx.newState;
       const data = ec.spec?.data;
       if (data === undefined || Object.keys(data).length === 0) {
@@ -117,14 +133,30 @@ export function newEncryptSecretValuesStep(
         return;
       }
 
+      const toSeal = new Map<string, string>();
       for (const [key, value] of Object.entries(data)) {
         if (!value.isSecret || value.value === "") {
           continue;
         }
-        try {
-          value.value = secretService.encrypt(value.value);
-        } catch (error) {
-          throw internalError(error, encryptFailureMessage(key));
+        toSeal.set(key, value.value);
+      }
+      if (toSeal.size === 0) {
+        return;
+      }
+
+      let sealed: Map<string, string>;
+      try {
+        sealed = await secretService.encryptAllAtMostV2(
+          toSeal,
+          EncryptionScope.forOrganization(ec.metadata?.org ?? ""),
+        );
+      } catch (error) {
+        throw internalError(error, ENCRYPT_BATCH_FAILURE_MESSAGE);
+      }
+      for (const [key, value] of Object.entries(data)) {
+        const sealedValue = sealed.get(key);
+        if (sealedValue !== undefined) {
+          value.value = sealedValue;
         }
       }
     },

--- a/backend/services/stigmer-server/src/domain/mcpserver/__tests__/seal-unseal.test.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/__tests__/seal-unseal.test.ts
@@ -24,7 +24,9 @@ const silentLogger = createLogger({
 const enabled = SecretService.create(Buffer.alloc(32, 7));
 const disabled = SecretService.create(undefined);
 
-function pendingState(overrides?: Partial<PendingOAuthState>): PendingOAuthState {
+function pendingState(
+  overrides?: Partial<PendingOAuthState>,
+): PendingOAuthState {
   return {
     state: "state-1",
     codeVerifier: "verifier-plaintext",
@@ -44,16 +46,20 @@ function pendingState(overrides?: Partial<PendingOAuthState>): PendingOAuthState
 }
 
 describe("sealPendingOAuthState (enabled encryption)", () => {
-  it("encrypts the code_verifier and a non-empty client_secret at rest", () => {
-    const sealed = sealPendingOAuthState(enabled, silentLogger, pendingState());
+  it("encrypts the code_verifier and a non-empty client_secret at rest", async () => {
+    const sealed = await sealPendingOAuthState(
+      enabled,
+      silentLogger,
+      pendingState(),
+    );
     expect(sealed.codeVerifier).toMatch(/^enc:v1:/);
     expect(sealed.clientSecret).toMatch(/^enc:v1:/);
     // Everything else rides unchanged.
     expect(sealed.tokenEndpoint).toBe("https://auth.example.com/token");
   });
 
-  it("keeps the DCR path's empty client_secret EMPTY — never ciphertext-of-empty (oss#394)", () => {
-    const sealed = sealPendingOAuthState(
+  it("keeps the DCR path's empty client_secret EMPTY — never ciphertext-of-empty (oss#394)", async () => {
+    const sealed = await sealPendingOAuthState(
       enabled,
       silentLogger,
       pendingState({ clientSecret: "", authMethod: "mcp_oauth" }),
@@ -62,30 +68,42 @@ describe("sealPendingOAuthState (enabled encryption)", () => {
     expect(sealed.clientSecret).toBe("");
   });
 
-  it("passes plaintext through with disabled encryption (the WARN-degrade posture)", () => {
-    const sealed = sealPendingOAuthState(disabled, silentLogger, pendingState());
+  it("passes plaintext through with disabled encryption (the WARN-degrade posture)", async () => {
+    const sealed = await sealPendingOAuthState(
+      disabled,
+      silentLogger,
+      pendingState(),
+    );
     expect(sealed.codeVerifier).toBe("verifier-plaintext");
     expect(sealed.clientSecret).toBe("vendor-secret");
   });
 });
 
 describe("unsealPendingOAuthState", () => {
-  it("round-trips the sealed secrets back to their exact plaintexts", () => {
-    const sealed = sealPendingOAuthState(enabled, silentLogger, pendingState());
-    const unsealed = unsealPendingOAuthState(enabled, sealed);
+  it("round-trips the sealed secrets back to their exact plaintexts", async () => {
+    const sealed = await sealPendingOAuthState(
+      enabled,
+      silentLogger,
+      pendingState(),
+    );
+    const unsealed = await unsealPendingOAuthState(enabled, sealed);
     expect(unsealed.codeVerifier).toBe("verifier-plaintext");
     expect(unsealed.clientSecret).toBe("vendor-secret");
   });
 
-  it("passes legacy plaintext rows through unchanged (pre-sealing shapes)", () => {
-    const unsealed = unsealPendingOAuthState(enabled, pendingState());
+  it("passes legacy plaintext rows through unchanged (pre-sealing shapes)", async () => {
+    const unsealed = await unsealPendingOAuthState(enabled, pendingState());
     expect(unsealed.codeVerifier).toBe("verifier-plaintext");
     expect(unsealed.clientSecret).toBe("vendor-secret");
   });
 
-  it("fails loudly on a sealed row when the key has vanished (before any token exchange)", () => {
-    const sealed = sealPendingOAuthState(enabled, silentLogger, pendingState());
-    expect(() => unsealPendingOAuthState(disabled, sealed)).toThrow(
+  it("fails loudly on a sealed row when the key has vanished (before any token exchange)", async () => {
+    const sealed = await sealPendingOAuthState(
+      enabled,
+      silentLogger,
+      pendingState(),
+    );
+    await expect(unsealPendingOAuthState(disabled, sealed)).rejects.toThrow(
       /^failed to decrypt code_verifier: /,
     );
   });

--- a/backend/services/stigmer-server/src/domain/mcpserver/complete-oauth-connect.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/complete-oauth-connect.ts
@@ -104,7 +104,10 @@ export async function completeOAuthConnect(
   // failure costs the user one re-initiate — the same posture as the
   // expiry refusal; the error message points them there.
   try {
-    pendingState = unsealPendingOAuthState(deps.secretService, pendingState);
+    pendingState = await unsealPendingOAuthState(
+      deps.secretService,
+      pendingState,
+    );
   } catch (error) {
     deps.logger.error("Failed to decrypt pending OAuth state secrets", {
       mcp_server_id: mcpServerId,
@@ -253,13 +256,13 @@ export async function completeOAuthConnect(
  * (loudly, before any token-exchange attempt) rather than sending
  * ciphertext to the vendor's token endpoint.
  */
-export function unsealPendingOAuthState(
+export async function unsealPendingOAuthState(
   secretService: SecretService,
   state: PendingOAuthState,
-): PendingOAuthState {
+): Promise<PendingOAuthState> {
   let verifier: string;
   try {
-    verifier = secretService.decrypt(state.codeVerifier);
+    verifier = await secretService.decrypt(state.codeVerifier);
   } catch (error) {
     throw new Error(
       `failed to decrypt code_verifier: ${error instanceof Error ? error.message : String(error)}`,
@@ -268,7 +271,7 @@ export function unsealPendingOAuthState(
 
   let secret: string;
   try {
-    secret = secretService.decrypt(state.clientSecret);
+    secret = await secretService.decrypt(state.clientSecret);
   } catch (error) {
     throw new Error(
       `failed to decrypt client_secret: ${error instanceof Error ? error.message : String(error)}`,
@@ -308,10 +311,13 @@ async function resolveOrCreateManagedEnvironment(
   }
 
   if (existingGrant !== undefined && existingGrant.environmentId !== "") {
-    deps.logger.info("Reusing existing managed environment for OAuth re-connect", {
-      mcp_server_id: mcpServerId,
-      environment_id: existingGrant.environmentId,
-    });
+    deps.logger.info(
+      "Reusing existing managed environment for OAuth re-connect",
+      {
+        mcp_server_id: mcpServerId,
+        environment_id: existingGrant.environmentId,
+      },
+    );
     return existingGrant.environmentId;
   }
 

--- a/backend/services/stigmer-server/src/domain/mcpserver/connect.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/connect.ts
@@ -296,7 +296,12 @@ export async function connect(
     // learns the outcome from this RPC's response either way.
     if (!run.attached) {
       try {
-        await persistConnectStarting(deps.store, mcpServerId, run.workflowId, "");
+        await persistConnectStarting(
+          deps.store,
+          mcpServerId,
+          run.workflowId,
+          "",
+        );
       } catch (error) {
         deps.logger.warn(
           "Failed to record CONNECTING on connect_status (non-fatal)",
@@ -324,7 +329,12 @@ export async function connect(
         outcome.failure,
         CONNECT_TIMEOUT,
       );
-      await persistConnectFailure(deps.store, deps.logger, mcpServerId, failure);
+      await persistConnectFailure(
+        deps.store,
+        deps.logger,
+        mcpServerId,
+        failure,
+      );
       throw failure;
     }
 
@@ -885,10 +895,13 @@ export async function refreshOAuthTokenIfNeeded(
   try {
     grant = await deps.oauthGrants.find("", mcpServerId, callerOrg);
   } catch (error) {
-    deps.logger.warn("Failed to load OAuth grant for pre-flight check (non-fatal)", {
-      mcp_server_id: mcpServerId,
-      error: error instanceof Error ? error.message : String(error),
-    });
+    deps.logger.warn(
+      "Failed to load OAuth grant for pre-flight check (non-fatal)",
+      {
+        mcp_server_id: mcpServerId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
     return;
   }
   if (grant === undefined) {
@@ -1040,7 +1053,7 @@ export async function loadOAuthAppClientCredentials(
 
   let secret = app.spec?.clientSecret ?? "";
   if (deps.secretService.isEncrypted(secret)) {
-    secret = deps.secretService.decrypt(secret);
+    secret = await deps.secretService.decrypt(secret);
   }
   return { clientSecret: secret, tokenAuthMethod };
 }
@@ -1105,10 +1118,13 @@ export async function startBestEffortConnect(
       CONNECT_TIMEOUT.ms,
     );
   } catch (error) {
-    deps.logger.warn("Failed to start best-effort connect workflow (non-fatal)", {
-      mcp_server_id: mcpServerId,
-      error: error instanceof Error ? error.message : String(error),
-    });
+    deps.logger.warn(
+      "Failed to start best-effort connect workflow (non-fatal)",
+      {
+        mcp_server_id: mcpServerId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
     return;
   }
 
@@ -1171,10 +1187,13 @@ export async function startBestEffortConnect(
       );
       return;
     }
-    deps.logger.warn("Failed to persist best-effort connect result (non-fatal)", {
-      mcp_server_id: mcpServerId,
-      error: error instanceof Error ? error.message : String(error),
-    });
+    deps.logger.warn(
+      "Failed to persist best-effort connect result (non-fatal)",
+      {
+        mcp_server_id: mcpServerId,
+        error: error instanceof Error ? error.message : String(error),
+      },
+    );
     return;
   }
 

--- a/backend/services/stigmer-server/src/domain/mcpserver/initiate-oauth-connect.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/initiate-oauth-connect.ts
@@ -30,6 +30,7 @@ import {
 
 import type { Logger } from "../../boot/logger.js";
 import type { SecretService } from "../../encryption/encryption.js";
+import { EncryptionScope } from "../../encryption/encryption.js";
 import type { CallerIdentity } from "../../extensions/identity.js";
 import {
   failedPreconditionError,
@@ -124,7 +125,11 @@ export async function initiateOAuthConnect(
   // reaches the store.
   let sealed: PendingOAuthState;
   try {
-    sealed = sealPendingOAuthState(deps.secretService, deps.logger, pendingState);
+    sealed = await sealPendingOAuthState(
+      deps.secretService,
+      deps.logger,
+      pendingState,
+    );
   } catch (error) {
     throw internalError(error, "failed to encrypt OAuth handshake secrets");
   }
@@ -238,7 +243,8 @@ async function initiateDcr(
   } catch (probeError) {
     deps.logger.debug("authorize pre-flight probe inconclusive; proceeding", {
       mcp_server_id: mcpServer.metadata?.id ?? "",
-      error: probeError instanceof Error ? probeError.message : String(probeError),
+      error:
+        probeError instanceof Error ? probeError.message : String(probeError),
     });
   }
   if (rejection !== undefined) {
@@ -311,7 +317,7 @@ async function initiateVendorOAuth(
   let clientSecret = oauthApp.spec?.clientSecret ?? "";
   if (deps.secretService.isEncrypted(clientSecret)) {
     try {
-      clientSecret = deps.secretService.decrypt(clientSecret);
+      clientSecret = await deps.secretService.decrypt(clientSecret);
     } catch (error) {
       throw internalError(error, "failed to decrypt OAuthApp client secret");
     }
@@ -439,11 +445,11 @@ function generateState(): string {
  * while enabled throws so the caller fails the request instead of
  * persisting plaintext.
  */
-export function sealPendingOAuthState(
+export async function sealPendingOAuthState(
   secretService: SecretService,
   logger: Logger,
   state: PendingOAuthState,
-): PendingOAuthState {
+): Promise<PendingOAuthState> {
   if (!secretService.isEnabled()) {
     logger.warn(
       "Encryption disabled: pending OAuth state secrets will be stored in plaintext",
@@ -451,9 +457,15 @@ export function sealPendingOAuthState(
     return state;
   }
 
+  // Tenancy-only scope from the row's own org (proto-required min_len 1
+  // on the initiate input, so never empty here) — the handshake ephemera
+  // seal under the caller's org exactly like the durable rows they
+  // snapshot from.
+  const scope = EncryptionScope.forOrganization(state.org);
+
   let sealedVerifier: string;
   try {
-    sealedVerifier = secretService.encrypt(state.codeVerifier);
+    sealedVerifier = await secretService.encrypt(state.codeVerifier, scope);
   } catch (error) {
     throw new Error(
       `failed to encrypt code_verifier: ${error instanceof Error ? error.message : String(error)}`,
@@ -463,7 +475,7 @@ export function sealPendingOAuthState(
   let sealedSecret = state.clientSecret;
   if (state.clientSecret !== "") {
     try {
-      sealedSecret = secretService.encrypt(state.clientSecret);
+      sealedSecret = await secretService.encrypt(state.clientSecret, scope);
     } catch (error) {
       throw new Error(
         `failed to encrypt client_secret: ${error instanceof Error ? error.message : String(error)}`,

--- a/backend/services/stigmer-server/src/domain/oauthapp/steps.ts
+++ b/backend/services/stigmer-server/src/domain/oauthapp/steps.ts
@@ -16,6 +16,7 @@ import type { OAuthApp } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb
 import type { Logger } from "../../boot/logger.js";
 import { isCiphertextShaped } from "../../encryption/encryption.js";
 import type { SecretService } from "../../encryption/encryption.js";
+import { EncryptionScope } from "../../encryption/encryption.js";
 import {
   failedPreconditionError,
   internalError,
@@ -92,7 +93,7 @@ function newEncryptClientSecretStep(
 ): PipelineStep<typeof OAuthAppSchema> {
   return {
     name: "EncryptClientSecret",
-    execute(ctx: RequestContext<typeof OAuthAppSchema>): void {
+    async execute(ctx: RequestContext<typeof OAuthAppSchema>): Promise<void> {
       const app = ctx.newState;
       if (app.spec === undefined) {
         return;
@@ -119,7 +120,13 @@ function newEncryptClientSecretStep(
       }
 
       try {
-        app.spec.clientSecret = secretService.encrypt(clientSecret);
+        // Tenancy-only scope, the pre-v3 write posture: oauthapp is an
+        // org-scoped kind, so metadata.org is validated non-empty before
+        // this step.
+        app.spec.clientSecret = await secretService.encrypt(
+          clientSecret,
+          EncryptionScope.forOrganization(app.metadata?.org ?? ""),
+        );
       } catch (error) {
         throw internalError(error, "failed to encrypt client_secret");
       }
@@ -173,9 +180,10 @@ function preserveExistingSecret(
  * deleted is read from ExistingResource). Generic over the delete input
  * Desc, like the shared delete steps.
  */
-export function newCheckNoReferencingMcpServersStep<
-  Desc extends DescMessage,
->(store: Store, logger: Logger): PipelineStep<Desc> {
+export function newCheckNoReferencingMcpServersStep<Desc extends DescMessage>(
+  store: Store,
+  logger: Logger,
+): PipelineStep<Desc> {
   return {
     name: "CheckNoReferencingMcpServers",
     async execute(ctx: RequestContext<Desc>): Promise<void> {

--- a/backend/services/stigmer-server/src/encryption/__tests__/codec-seam.test.ts
+++ b/backend/services/stigmer-server/src/encryption/__tests__/codec-seam.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Pins the versioned-codec seam (20260830.04 Stage 1, rulings Q2/Q7):
+ * read dispatch on the value's own version token, fail-fast write-version
+ * resolution, the facade-owned policy layer (idempotent pass-through,
+ * unprefixed pass-through, unknown-version refusal on the unavailable
+ * arm), the batch verbs and their loop fallbacks, the v2-capped
+ * executioncontext lane (the Java encryptAllV2 pin, generalized),
+ * reencrypt's three load-bearing rules (upward-only, round-trip-verified,
+ * marker-refused, plaintext-sealed), versionOf, and EncryptionScope's
+ * validation invariants (the Java EncryptionScopeTest cases). The v1
+ * wire format itself is pinned by encryption.test.ts.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { SecretCodec } from "../codec.js";
+import {
+  ENCRYPTED_PREFIX,
+  EncryptionScope,
+  EncryptionUnavailableError,
+  InvalidCiphertextError,
+  REDACTED_MARKER,
+  SecretService,
+  StaticKeySecretCodec,
+} from "../encryption.js";
+
+const KEY = Buffer.alloc(32, 7);
+const SCOPE = EncryptionScope.forOrganization("test-org");
+
+/**
+ * A reversible fake "v2": base64 payload behind its own prefix, plus call
+ * counters so the tests can prove WHICH codec served a verb and whether
+ * the native batch (vs the loop fallback) ran.
+ */
+function fakeV2(): SecretCodec & {
+  encryptCalls: number;
+  batchEncryptCalls: number;
+  batchDecryptCalls: number;
+} {
+  const codec = {
+    version: "v2",
+    encryptCalls: 0,
+    batchEncryptCalls: 0,
+    batchDecryptCalls: 0,
+    encrypt(plaintext: string): Promise<string> {
+      codec.encryptCalls += 1;
+      return Promise.resolve(
+        `enc:v2:${Buffer.from(plaintext, "utf8").toString("base64")}`,
+      );
+    },
+    decrypt(encrypted: string): Promise<string> {
+      return Promise.resolve(
+        Buffer.from(encrypted.slice("enc:v2:".length), "base64").toString(
+          "utf8",
+        ),
+      );
+    },
+    encryptAll(
+      plaintexts: ReadonlyMap<string, string>,
+    ): Promise<Map<string, string>> {
+      codec.batchEncryptCalls += 1;
+      const out = new Map<string, string>();
+      for (const [k, v] of plaintexts) {
+        out.set(k, `enc:v2:${Buffer.from(v, "utf8").toString("base64")}`);
+      }
+      return Promise.resolve(out);
+    },
+    decryptAll(
+      encrypted: ReadonlyMap<string, string>,
+    ): Promise<Map<string, string>> {
+      codec.batchDecryptCalls += 1;
+      const out = new Map<string, string>();
+      for (const [k, v] of encrypted) {
+        out.set(
+          k,
+          Buffer.from(v.slice("enc:v2:".length), "base64").toString("utf8"),
+        );
+      }
+      return Promise.resolve(out);
+    },
+  };
+  return codec;
+}
+
+/** A v1+v2 facade writing the given version. */
+function facadeWith(v2: SecretCodec, writeVersion: string): SecretService {
+  return SecretService.withCodecs({
+    codecs: new Map<string, SecretCodec>([
+      ["v1", new StaticKeySecretCodec(KEY)],
+      ["v2", v2],
+    ]),
+    writeVersion,
+  });
+}
+
+describe("write-version resolution (fail-fast, the Java @PostConstruct contract)", () => {
+  it("refuses a write version with no registered codec, naming the registered set", () => {
+    expect(() =>
+      SecretService.withCodecs({
+        codecs: new Map([["v1", new StaticKeySecretCodec(KEY)]]),
+        writeVersion: "v2",
+      }),
+    ).toThrow(
+      "STIGMER_ENCRYPTION_WRITE_VERSION is 'v2' but this deployment has no codec for it (registered: v1)",
+    );
+  });
+
+  it("refuses an undispatchable version token and a key/version mismatch", () => {
+    expect(() =>
+      SecretService.withCodecs({
+        codecs: new Map([["vault", new StaticKeySecretCodec(KEY)]]),
+        writeVersion: "vault",
+      }),
+    ).toThrow("version tokens must match v<digits>");
+    expect(() =>
+      SecretService.withCodecs({
+        codecs: new Map([["v2", new StaticKeySecretCodec(KEY)]]),
+        writeVersion: "v2",
+      }),
+    ).toThrow("the registry key must equal the codec's own version");
+  });
+});
+
+describe("read dispatch on the value's own version token", () => {
+  it("routes each stored value to its own codec, whatever the write version", async () => {
+    const v2 = fakeV2();
+    const svc = facadeWith(v2, "v2");
+    const v1Value = await SecretService.create(KEY).encrypt("one", SCOPE);
+    const v2Value = await v2.encrypt("two", SCOPE);
+    expect(await svc.decrypt(v1Value)).toBe("one");
+    expect(await svc.decrypt(v2Value)).toBe("two");
+  });
+
+  it("writes with exactly the configured codec", async () => {
+    const v2 = fakeV2();
+    const svc = facadeWith(v2, "v2");
+    const sealed = await svc.encrypt("fresh", SCOPE);
+    expect(sealed.startsWith("enc:v2:")).toBe(true);
+    // No silent upgrades: a stored v1 value carried through encrypt stays v1.
+    const v1Value = await SecretService.create(KEY).encrypt("stay", SCOPE);
+    expect(await svc.encrypt(v1Value, SCOPE)).toBe(v1Value);
+  });
+
+  it("classifies versions through versionOf (the sweep's parse)", () => {
+    const svc = SecretService.create(KEY);
+    expect(svc.versionOf("enc:v1:abc")).toBe(1);
+    expect(svc.versionOf("enc:v12:abc")).toBe(12);
+    expect(svc.versionOf("plaintext")).toBeUndefined();
+    expect(svc.versionOf("")).toBeUndefined();
+    expect(svc.versionOf(REDACTED_MARKER)).toBeUndefined();
+  });
+});
+
+describe("batch verbs", () => {
+  it("encryptAll passes already-encrypted values through and batches the rest natively", async () => {
+    const v2 = fakeV2();
+    const svc = facadeWith(v2, "v2");
+    const preSealed = await SecretService.create(KEY).encrypt("old", SCOPE);
+    const input = new Map([
+      ["A", "alpha"],
+      ["B", preSealed],
+      ["C", "gamma"],
+    ]);
+    const out = await svc.encryptAll(input, SCOPE);
+    expect([...out.keys()]).toEqual(["A", "B", "C"]); // input order preserved
+    expect(out.get("B")).toBe(preSealed); // no silent upgrade inside a batch
+    expect(out.get("A")?.startsWith("enc:v2:")).toBe(true);
+    expect(out.get("C")?.startsWith("enc:v2:")).toBe(true);
+    expect(v2.batchEncryptCalls).toBe(1); // ONE native batch, not per-value
+    expect(v2.encryptCalls).toBe(0);
+  });
+
+  it("encryptAll falls back to looping the singular verb for codecs without a native batch (v1)", async () => {
+    const svc = SecretService.create(KEY);
+    const out = await svc.encryptAll(
+      new Map([
+        ["A", "alpha"],
+        ["B", "beta"],
+      ]),
+      SCOPE,
+    );
+    expect(await svc.decrypt(out.get("A") ?? "")).toBe("alpha");
+    expect(await svc.decrypt(out.get("B") ?? "")).toBe("beta");
+  });
+
+  it("decryptAll groups by version, batching where the codec can and passing plaintext through", async () => {
+    const v2 = fakeV2();
+    const svc = facadeWith(v2, "v2");
+    const v1Value = await SecretService.create(KEY).encrypt("one", SCOPE);
+    const v2Value = await v2.encrypt("two", SCOPE);
+    const out = await svc.decryptAll(
+      new Map([
+        ["A", v1Value],
+        ["B", v2Value],
+        ["C", "plain"],
+      ]),
+    );
+    expect([...out.entries()]).toEqual([
+      ["A", "one"],
+      ["B", "two"],
+      ["C", "plain"],
+    ]);
+    expect(v2.batchDecryptCalls).toBe(1);
+  });
+
+  it("decryptAll refuses a version with no codec as the unavailable arm (whole-batch failure)", async () => {
+    const svc = SecretService.create(KEY);
+    await expect(
+      svc.decryptAll(new Map([["A", "enc:v2:AAAA"]])),
+    ).rejects.toThrow(EncryptionUnavailableError);
+  });
+});
+
+describe("encryptAllAtMostV2 (the executioncontext pin, vault project DD-005)", () => {
+  it("uses the write codec at write-version v1 (the OSS default)", async () => {
+    const svc = SecretService.create(KEY);
+    const out = await svc.encryptAllAtMostV2(new Map([["A", "alpha"]]), SCOPE);
+    expect(out.get("A")?.startsWith(ENCRYPTED_PREFIX)).toBe(true);
+  });
+
+  it("uses the write codec at write-version v2 (equals the Java pin)", async () => {
+    const v2 = fakeV2();
+    const svc = facadeWith(v2, "v2");
+    const out = await svc.encryptAllAtMostV2(new Map([["A", "alpha"]]), SCOPE);
+    expect(out.get("A")?.startsWith("enc:v2:")).toBe(true);
+  });
+
+  it("caps at v2 when the write version is above it (the future v3 flip)", async () => {
+    const v2 = fakeV2();
+    const v3 = { ...fakeV2(), version: "v3" };
+    const svc = SecretService.withCodecs({
+      codecs: new Map<string, SecretCodec>([
+        ["v1", new StaticKeySecretCodec(KEY)],
+        ["v2", v2],
+        ["v3", v3],
+      ]),
+      writeVersion: "v3",
+    });
+    const out = await svc.encryptAllAtMostV2(new Map([["A", "alpha"]]), SCOPE);
+    expect(out.get("A")?.startsWith("enc:v2:")).toBe(true);
+  });
+
+  it("refuses when the cap is needed but no v2 codec is registered", async () => {
+    const v3 = { ...fakeV2(), version: "v3" };
+    const svc = SecretService.withCodecs({
+      codecs: new Map<string, SecretCodec>([
+        ["v1", new StaticKeySecretCodec(KEY)],
+        ["v3", v3],
+      ]),
+      writeVersion: "v3",
+    });
+    await expect(
+      svc.encryptAllAtMostV2(new Map([["A", "alpha"]]), SCOPE),
+    ).rejects.toThrow(EncryptionUnavailableError);
+  });
+});
+
+describe("reencrypt (the sweep's one upgrade door)", () => {
+  it("upgrades a lower-version value to the write version, round-trip intact", async () => {
+    const v2 = fakeV2();
+    const svc = facadeWith(v2, "v2");
+    const v1Value = await SecretService.create(KEY).encrypt("secret", SCOPE);
+    const upgraded = await svc.reencrypt(v1Value, SCOPE);
+    expect(upgraded.startsWith("enc:v2:")).toBe(true);
+    expect(await svc.decrypt(upgraded)).toBe("secret");
+  });
+
+  it("is UPWARD-ONLY: a value at or above the write version returns unchanged", async () => {
+    const v2 = fakeV2();
+    // Write version v1, stored value v2 — a rolled-back write-version
+    // lever must never mass-downgrade (in a v3 world: mass KV destruction).
+    const svc = facadeWith(v2, "v1");
+    const v2Value = await v2.encrypt("hold", SCOPE);
+    expect(await svc.reencrypt(v2Value, SCOPE)).toBe(v2Value);
+    // Same version is also unchanged (idempotent for converged rows).
+    const v1Svc = SecretService.create(KEY);
+    const v1Value = await v1Svc.encrypt("hold", SCOPE);
+    expect(await v1Svc.reencrypt(v1Value, SCOPE)).toBe(v1Value);
+  });
+
+  it("seals bare plaintext (the fail-open-era damage, cloud #226)", async () => {
+    const svc = SecretService.create(KEY);
+    const sealed = await svc.reencrypt("stored plaintext", SCOPE);
+    expect(sealed.startsWith(ENCRYPTED_PREFIX)).toBe(true);
+    expect(await svc.decrypt(sealed)).toBe("stored plaintext");
+  });
+
+  it("refuses the literal redaction marker as value-scoped corruption", async () => {
+    const svc = SecretService.create(KEY);
+    await expect(svc.reencrypt(REDACTED_MARKER, SCOPE)).rejects.toThrow(
+      InvalidCiphertextError,
+    );
+  });
+
+  it("passes empty values through unchanged", async () => {
+    expect(await SecretService.create(KEY).reencrypt("", SCOPE)).toBe("");
+  });
+
+  it("round-trip-verifies BEFORE returning: a lying codec is caught, nothing persisted", async () => {
+    const lying: SecretCodec = {
+      version: "v2",
+      encrypt: () => Promise.resolve("enc:v2:bm90LXRoZS1zZWNyZXQ="), // "not-the-secret"
+      decrypt: () => Promise.resolve("not-the-secret"),
+    };
+    const svc = facadeWith(lying, "v2");
+    await expect(svc.reencrypt("the-secret", SCOPE)).rejects.toThrow(
+      "re-encryption round-trip verification failed",
+    );
+  });
+});
+
+describe("EncryptionScope (the Java record's validation invariants)", () => {
+  it("derives org-<slug> tenancy and the platform tenant", () => {
+    const org = EncryptionScope.forOrganization("acme-corp");
+    expect(org.tenantSegment).toBe("org-acme-corp");
+    expect(org.kekKeyName()).toBe("org-acme-corp");
+    expect(org.isLocated()).toBe(false);
+
+    const platform = EncryptionScope.forPlatformResource(
+      "cursoraccount",
+      "acc_1",
+    );
+    expect(platform.tenantSegment).toBe("platform");
+    expect(platform.isLocated()).toBe(true);
+  });
+
+  it("rejects invalid org slugs (the metadata.proto contract, verbatim)", () => {
+    for (const bad of ["", "A", "a", "-x", "x-", "org platform", "Ürg"]) {
+      expect(() => EncryptionScope.forOrganization(bad)).toThrow(
+        "encryption scope requires a valid org slug",
+      );
+    }
+  });
+
+  it("rejects malformed locations and keyNames without a location", () => {
+    expect(() =>
+      EncryptionScope.forOrganizationResource("acme", "Channel_App", "slug"),
+    ).toThrow("encryption scope kind must be a lowercase server-side constant");
+    expect(() =>
+      EncryptionScope.forOrganizationResource("acme", "channelapp", "  "),
+    ).toThrow("encryption scope id must not be blank");
+    expect(() =>
+      EncryptionScope.forOrganization("acme").withKeyName("client_secret"),
+    ).toThrow("keyName requires a located scope");
+    expect(() =>
+      EncryptionScope.forOrganizationResource(
+        "acme",
+        "channelapp",
+        "s",
+      ).withKeyName(""),
+    ).toThrow("keyName must not be empty");
+  });
+
+  it("attaches keyNames to located scopes for singular encrypts", () => {
+    const located = EncryptionScope.forOrganizationResource(
+      "acme",
+      "environment",
+      "prod-env",
+    ).withKeyName("API_KEY");
+    expect(located.keyName).toBe("API_KEY");
+    expect(located.kind).toBe("environment");
+    expect(located.id).toBe("prod-env");
+  });
+});

--- a/backend/services/stigmer-server/src/encryption/__tests__/encryption.test.ts
+++ b/backend/services/stigmer-server/src/encryption/__tests__/encryption.test.ts
@@ -3,9 +3,16 @@
  * (proven against the Go-generated fixture, DD-001), the keyless
  * pass-through/fail-loud asymmetry, encrypt idempotence (the marker
  * round-trip's foundation), the error taxonomy (invalid ciphertext vs
- * decryption failed vs disabled), and the fail-closed handling of
- * future-version prefixes. Ports pkg/encryption/encryption_test.go and
- * adds the adversarial arms the T01 plan lists.
+ * decryption failed vs disabled — now the two-armed family of errors.ts),
+ * and the fail-closed handling of future-version prefixes. Ports
+ * pkg/encryption/encryption_test.go and adds the adversarial arms the T01
+ * plan lists. One deliberate contract change with the codec seam
+ * (20260830.04 Stage 1): an unregistered version now refuses as
+ * EncryptionUnavailableError (the machinery is missing, the value may be
+ * fine) instead of the accidental invalid-base64 arm — still fail-closed,
+ * now the honest arm. The seam itself (registry dispatch, write-version
+ * resolution, batch verbs, reencrypt, scope) is pinned by
+ * codec-seam.test.ts.
  */
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -16,6 +23,8 @@ import {
   DecryptionFailedError,
   ENCRYPTED_PREFIX,
   EncryptionDisabledError,
+  EncryptionScope,
+  EncryptionUnavailableError,
   GCM_NONCE_SIZE,
   GCM_TAG_SIZE,
   InvalidCiphertextError,
@@ -25,6 +34,7 @@ import {
 
 const KEY = Buffer.alloc(32, 7);
 const OTHER_KEY = Buffer.alloc(32, 8);
+const SCOPE = EncryptionScope.forOrganization("test-org");
 
 function enabled(): SecretService {
   return SecretService.create(KEY);
@@ -35,7 +45,7 @@ function disabled(): SecretService {
 }
 
 describe("SecretService round-trip", () => {
-  it("encrypts and decrypts back to the plaintext", () => {
+  it("encrypts and decrypts back to the plaintext", async () => {
     const svc = enabled();
     const plaintexts = [
       "hello world",
@@ -46,45 +56,51 @@ describe("SecretService round-trip", () => {
       "a".repeat(10_000),
     ];
     for (const pt of plaintexts) {
-      const ct = svc.encrypt(pt);
+      const ct = await svc.encrypt(pt, SCOPE);
       expect(ct.startsWith(ENCRYPTED_PREFIX)).toBe(true);
-      expect(svc.decrypt(ct)).toBe(pt);
+      expect(await svc.decrypt(ct)).toBe(pt);
     }
   });
 
-  it("produces a unique nonce per encryption (same plaintext, different ciphertext)", () => {
+  it("produces a unique nonce per encryption (same plaintext, different ciphertext)", async () => {
     const svc = enabled();
-    expect(svc.encrypt("same input")).not.toBe(svc.encrypt("same input"));
+    expect(await svc.encrypt("same input", SCOPE)).not.toBe(
+      await svc.encrypt("same input", SCOPE),
+    );
   });
 
-  it("emits the exact sealed layout: base64(nonce || ct || tag)", () => {
+  it("emits the exact sealed layout: base64(nonce || ct || tag)", async () => {
     const svc = enabled();
-    const ct = svc.encrypt("abc");
+    const ct = await svc.encrypt("abc", SCOPE);
     const sealed = Buffer.from(ct.slice(ENCRYPTED_PREFIX.length), "base64");
     expect(sealed.length).toBe(GCM_NONCE_SIZE + 3 + GCM_TAG_SIZE);
   });
 
-  it("is idempotent on already-prefixed input (the marker-restore round-trip)", () => {
+  it("is idempotent on already-prefixed input (the marker-restore round-trip)", async () => {
     const svc = enabled();
-    const ct = svc.encrypt("stored secret");
-    expect(svc.encrypt(ct)).toBe(ct);
+    const ct = await svc.encrypt("stored secret", SCOPE);
+    expect(await svc.encrypt(ct, SCOPE)).toBe(ct);
   });
 });
 
 describe("SecretService disabled (keyless) semantics", () => {
-  it("reports disabled and passes plaintext through encrypt unchanged", () => {
+  it("reports disabled and passes plaintext through encrypt unchanged", async () => {
     const svc = disabled();
     expect(svc.isEnabled()).toBe(false);
-    expect(svc.encrypt("plain")).toBe("plain");
+    expect(await svc.encrypt("plain", SCOPE)).toBe("plain");
   });
 
-  it("passes unprefixed values through decrypt (legacy plaintext rows)", () => {
-    expect(disabled().decrypt("legacy plaintext")).toBe("legacy plaintext");
+  it("passes unprefixed values through decrypt (legacy plaintext rows)", async () => {
+    expect(await disabled().decrypt("legacy plaintext")).toBe(
+      "legacy plaintext",
+    );
   });
 
-  it("fails LOUD decrypting a prefixed value — never returns ciphertext as-is", () => {
-    const ct = enabled().encrypt("secret");
-    expect(() => disabled().decrypt(ct)).toThrow(EncryptionDisabledError);
+  it("fails LOUD decrypting a prefixed value — never returns ciphertext as-is", async () => {
+    const ct = await enabled().encrypt("secret", SCOPE);
+    await expect(disabled().decrypt(ct)).rejects.toThrow(
+      EncryptionDisabledError,
+    );
   });
 
   it("treats an empty key buffer as disabled, like Go's len(key) == 0", () => {
@@ -99,42 +115,68 @@ describe("SecretService error taxonomy", () => {
     );
   });
 
-  it("fails with DecryptionFailedError on a tampered ciphertext byte", () => {
+  it("fails with DecryptionFailedError on a tampered ciphertext byte", async () => {
     const svc = enabled();
-    const ct = svc.encrypt("tamper me");
+    const ct = await svc.encrypt("tamper me", SCOPE);
     const sealed = Buffer.from(ct.slice(ENCRYPTED_PREFIX.length), "base64");
     sealed[GCM_NONCE_SIZE] ^= 0xff; // flip one ciphertext bit
     const tampered = ENCRYPTED_PREFIX + sealed.toString("base64");
-    expect(() => svc.decrypt(tampered)).toThrow(DecryptionFailedError);
+    await expect(svc.decrypt(tampered)).rejects.toThrow(DecryptionFailedError);
   });
 
-  it("fails with DecryptionFailedError under the wrong key", () => {
-    const ct = enabled().encrypt("keyed secret");
-    expect(() => SecretService.create(OTHER_KEY).decrypt(ct)).toThrow(
+  it("fails with DecryptionFailedError under the wrong key", async () => {
+    const ct = await enabled().encrypt("keyed secret", SCOPE);
+    await expect(SecretService.create(OTHER_KEY).decrypt(ct)).rejects.toThrow(
       DecryptionFailedError,
     );
   });
 
-  it("fails with InvalidCiphertextError on corrupted base64", () => {
-    expect(() => enabled().decrypt("enc:v1:!!!not-base64!!!")).toThrow(
+  it("fails with InvalidCiphertextError on corrupted base64", async () => {
+    await expect(enabled().decrypt("enc:v1:!!!not-base64!!!")).rejects.toThrow(
       InvalidCiphertextError,
     );
   });
 
-  it("fails with InvalidCiphertextError on truncated sealed bytes", () => {
+  it("fails with InvalidCiphertextError on truncated sealed bytes", async () => {
     const short = Buffer.alloc(GCM_NONCE_SIZE + GCM_TAG_SIZE - 1, 1);
-    expect(() =>
+    await expect(
       enabled().decrypt(ENCRYPTED_PREFIX + short.toString("base64")),
-    ).toThrow(InvalidCiphertextError);
+    ).rejects.toThrow(InvalidCiphertextError);
   });
 
-  it("fails CLOSED on future-version prefixes instead of decrypting them as v1", () => {
+  it("fails CLOSED on unregistered-version prefixes as the unavailable arm", async () => {
     // enc:v2: is isEncrypted-matched (fail-open-as-plaintext would be the
-    // bug) but not decryptable by this build — Go's TrimPrefix leaves the
-    // prefix in place and the strict base64 check rejects it.
-    const v1 = enabled().encrypt("future");
+    // bug) but has no codec in a v1-only facade. Before the codec seam
+    // this refused as accidental invalid-base64; it now refuses as
+    // EncryptionUnavailableError — the value may be perfectly valid, the
+    // machinery is missing (the Java taxonomy's recorded rationale).
+    const v1 = await enabled().encrypt("future", SCOPE);
     const v2 = v1.replace("enc:v1:", "enc:v2:");
-    expect(() => enabled().decrypt(v2)).toThrow(InvalidCiphertextError);
+    await expect(enabled().decrypt(v2)).rejects.toThrow(
+      EncryptionUnavailableError,
+    );
+    await expect(enabled().decrypt(v2)).rejects.toThrow(
+      "unsupported encrypted-value version 'v2'",
+    );
+  });
+
+  it("keeps the taxonomy arms distinguishable by inheritance", () => {
+    // The two-armed classification (errors.ts): value-scoped failures are
+    // InvalidCiphertextError (incl. DecryptionFailedError); infrastructure
+    // failures are EncryptionUnavailableError (incl. the keyless case).
+    // The resolution lanes' skip/propagate split branches on exactly this.
+    expect(new DecryptionFailedError(new Error("x"))).toBeInstanceOf(
+      InvalidCiphertextError,
+    );
+    expect(new EncryptionDisabledError()).toBeInstanceOf(
+      EncryptionUnavailableError,
+    );
+    expect(new EncryptionDisabledError().message).toBe(
+      "encryption is not enabled - no key configured",
+    );
+    expect(new DecryptionFailedError(new Error("x")).message).toBe(
+      "decryption failed - wrong key or tampered data",
+    );
   });
 });
 
@@ -183,13 +225,13 @@ describe("cross-edition compatibility (Go-generated fixture, DD-001)", () => {
   );
   const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as Fixture;
 
-  it("decrypts every ciphertext the Go implementation produced", () => {
-    const svc = SecretService.create(
-      Buffer.from(fixture.keyBase64, "base64"),
-    );
+  it("decrypts every ciphertext the Go implementation produced", async () => {
+    const svc = SecretService.create(Buffer.from(fixture.keyBase64, "base64"));
     expect(fixture.entries.length).toBeGreaterThanOrEqual(7);
     for (const entry of fixture.entries) {
-      expect(svc.decrypt(entry.ciphertext), entry.name).toBe(entry.plaintext);
+      expect(await svc.decrypt(entry.ciphertext), entry.name).toBe(
+        entry.plaintext,
+      );
     }
   });
 });

--- a/backend/services/stigmer-server/src/encryption/codec.ts
+++ b/backend/services/stigmer-server/src/encryption/codec.ts
@@ -1,0 +1,113 @@
+/**
+ * One version of the secret-value wire format (enc:v<N>:...) — ports the
+ * cloud edition's ai.stigmer.infra.encryption.SecretCodec: the whole
+ * mapping between the stored string and the plaintext, including where
+ * the bytes live, but NO policy.
+ *
+ * SecretService is the only caller: it owns every policy decision —
+ * idempotency short-circuits, unprefixed pass-through, which codec new
+ * writes use, unknown-version refusal — so a codec never sees a value
+ * that is already encrypted and never decides what "disabled" means.
+ * Registration flows through exactly one door: the built-in v1 codec is
+ * installed at the boot/compose.ts consumption site, extension codecs
+ * through the `secretCodecs` ExtensionDrivers field (never a module-level
+ * side registry — the DD-006 one-registry doctrine).
+ *
+ * In the Java original a codec was pure crypto over the stored string
+ * alone until v3; the v3 codec stores the secret's value in the vault KV
+ * store and keeps only an authenticated pointer in the string, so
+ * encrypt/decrypt there include store I/O (the vault project's DD-005
+ * widening). That is why every verb here is async even though the
+ * built-in v1 codec never awaits anything.
+ *
+ * TS shape note: Java's interface carries default methods; here the
+ * batch/lifecycle verbs are OPTIONAL and the facade owns the fallbacks
+ * (loop the singular verbs; delete is a no-op) — a codec implements them
+ * only when it can do better (the v2 envelope codec batches all data-key
+ * wraps into one Transit round trip).
+ */
+import type { EncryptionScope } from "./scope.js";
+
+export interface SecretCodec {
+  /**
+   * The version token this codec serves — the literal text between
+   * `enc:` and the second colon (e.g. "v1"). Dispatch compares tokens
+   * literally: "v01" is not "v1" and resolves to no codec, by design.
+   */
+  readonly version: string;
+
+  /**
+   * Encrypts a plaintext value, producing `enc:<version>:...`.
+   *
+   * @param plaintext never already encrypted (the facade short-circuits)
+   * @param scope the tenancy scope whose key seals this value; the v1
+   *   codec ignores it, vault-backed codecs key (and, when located,
+   *   place) the value by it
+   * @throws EncryptionUnavailableError when the codec's key provider
+   *   cannot be reached
+   */
+  encrypt(plaintext: string, scope: EncryptionScope): Promise<string>;
+
+  /**
+   * Decrypts a value carrying this codec's prefix. No scope parameter:
+   * the sealed value self-describes (the envelope carries its tenant and,
+   * for v3, its KV pointer).
+   *
+   * @throws InvalidCiphertextError when the value itself is bad
+   *   (tampered, truncated, malformed, wrong key)
+   * @throws EncryptionUnavailableError when the machinery to decrypt an
+   *   otherwise-plausible value is missing
+   */
+  decrypt(encrypted: string): Promise<string>;
+
+  /**
+   * Encrypts many values under one scope, key names from the map keys.
+   * OPTIONAL — absent, the facade loops encrypt(), which is correct for
+   * any codec; the v2 envelope codec implements it to wrap all data keys
+   * in ONE KEK round trip. Fails as a whole: callers of the batched
+   * paths fail the whole request on any encryption error, so per-entry
+   * partial results would go unused. Result keyed as the input,
+   * iteration order preserved.
+   */
+  encryptAll?(
+    plaintexts: ReadonlyMap<string, string>,
+    scope: EncryptionScope,
+  ): Promise<Map<string, string>>;
+
+  /**
+   * Decrypts many values carrying this codec's prefix. OPTIONAL — same
+   * fallback and whole-batch failure contract as encryptAll; the v2
+   * envelope codec implements it to unwrap all data keys in one KEK
+   * round trip per key id.
+   */
+  decryptAll?(
+    encrypted: ReadonlyMap<string, string>,
+  ): Promise<Map<string, string>>;
+
+  /**
+   * Destroys any external state backing a stored value — the lifecycle
+   * hook v3 introduced (a resource deletion or secret-key removal must
+   * remove the value from the KV store, or it leaks there forever).
+   * OPTIONAL — absent means no-op, which is CORRECT for v1/v2: their
+   * stored string IS the (encrypted) value, so deleting the resource row
+   * deletes everything. Idempotent by contract. Call sites are delete
+   * paths whose database write already succeeded, so the facade's
+   * callers treat failures as best-effort (Stage 3 wires them).
+   *
+   * @throws InvalidCiphertextError when the value is bad (nothing
+   *   derivable to clean up)
+   * @throws EncryptionUnavailableError when the external state is
+   *   unreachable
+   */
+  delete?(encrypted: string): Promise<void>;
+
+  /**
+   * Whether this codec can actually seal new values. OPTIONAL — absent
+   * means enabled (the Java posture: a codec bean exists exactly when its
+   * key machinery does, so registration IS the ability to encrypt). Only
+   * the OSS v1 codec implements it: its keyless WARN-degrade state
+   * (oss#394) is a deliberate, modeled condition the write steps branch
+   * on.
+   */
+  isEnabled?(): boolean;
+}

--- a/backend/services/stigmer-server/src/encryption/encryption.ts
+++ b/backend/services/stigmer-server/src/encryption/encryption.ts
@@ -1,38 +1,67 @@
 /**
- * Secret encryption service — ports pkg/encryption/encryption.go, the Go
- * twin of the cloud edition's Java EnvironmentSecretService. Cross-edition
- * wire contract: ciphertext produced by any edition decrypts in the others
- * (proven by the Go-generated fixture, sub-project DD-001).
+ * Secret encryption facade — the single entry point for sealing and
+ * unsealing secret values, a versioned-codec registry behind the
+ * SecretService identity every domain already holds.
  *
- * Format: enc:v1:<base64(nonce || ciphertext || tag)>
- *   - AES-256-GCM, 12-byte crypto-random nonce (unique per encryption),
- *     16-byte GCM tag, standard padded Base64.
+ * Provenance: began as a port of pkg/encryption/encryption.go (the
+ * retired Go server, single static-key format); reshaped by the pre-X1
+ * sealing slice (20260830.04 Stage 1, rulings Q1/Q2) into the port of the
+ * cloud edition's SecretEncryptionService + SecretCodecRegistry so the
+ * cloud composition can register the vault-backed enc:v2/v3 codecs
+ * through the `secretCodecs` extension driver point. The v1 crypto lives
+ * in v1-codec.ts; the taxonomy in errors.ts; the scope in scope.ts.
  *
- * Keyless ("disabled") semantics are load-bearing and asymmetric:
- *   - encrypt() passes plaintext through (the WARN-degrade posture — the
- *     write steps own the per-request warning, oss#394);
- *   - decrypt() of a PREFIXED value fails loud (EncryptionDisabledError):
- *     stored ciphertext with no key must never be returned as-is;
- *   - decrypt() of an unprefixed value passes through (legacy plaintext
- *     rows, pre-oss#405).
+ * Architecture (the Java facade's, verbatim): every stored secret is a
+ * versioned string (enc:v<N>:...). READS dispatch on the value's own
+ * version token, so any mix of versions in the store stays readable; a
+ * version with no codec here is refused loudly as
+ * EncryptionUnavailableError — the value may be perfectly valid, the
+ * machinery is missing (never fail open, never mislabel it as a bad
+ * value). WRITES use exactly one codec, chosen by
+ * STIGMER_ENCRYPTION_WRITE_VERSION (name byte-pinned across editions; OSS
+ * default v1) and resolved FAIL-FAST at construction: naming a version
+ * with no registered codec refuses to boot rather than silently writing
+ * something else.
  *
- * NOT ported: pkg/encryption/payloadcodec — that is the Temporal payload
- * lane, already extracted to backend/libs/ts/temporal-codecs (D4 #1); the
- * server's decode side arrives with the worker sub-projects.
+ * No silent version upgrades: encrypt returns an already-prefixed value
+ * unchanged, whatever its version (the ***REDACTED*** round-trip copies
+ * stored values back into new state before encryption re-runs, and they
+ * must survive that second pass byte-identically). The ONE deliberate
+ * exception is reencrypt — the explicit, auditable door the
+ * secret-convergence sweep walks through: upward-only and
+ * round-trip-verified.
+ *
+ * Policy lives HERE, never in a codec: a codec never sees an
+ * already-encrypted value, never sees an unprefixed one, and never
+ * decides what "disabled" means (codec.ts records the contract).
  */
-import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
-
-import { KEY_SIZE, getOrCreateNamedKey } from "./key-manager.js";
+import { StaticKeySecretCodec, V1_VERSION } from "./v1-codec.js";
+import type { SecretCodec } from "./codec.js";
+import type { EncryptionScope } from "./scope.js";
+import {
+  EncryptionUnavailableError,
+  InvalidCiphertextError,
+} from "./errors.js";
+import { getOrCreateNamedKey } from "./key-manager.js";
 import type { KeyLoaderOptions } from "./key-manager.js";
 
-/** Nonce size for AES-GCM (12 bytes = 96 bits, NIST) — Go GCMNonceSize. */
-export const GCM_NONCE_SIZE = 12;
-
-/** GCM authentication tag size (128 bits) — Go's gcm.Overhead(). */
-export const GCM_TAG_SIZE = 16;
-
-/** Version prefix for encrypted values — Go EncryptedPrefix. */
-export const ENCRYPTED_PREFIX = "enc:v1:";
+// The taxonomy, the v1 wire constants and the scope re-export here so the
+// module keeps its historical import surface (every domain imports from
+// encryption/encryption.js) — one module to import, five to maintain.
+export {
+  DecryptionFailedError,
+  EncryptionDisabledError,
+  EncryptionUnavailableError,
+  InvalidCiphertextError,
+} from "./errors.js";
+export {
+  ENCRYPTED_PREFIX,
+  GCM_NONCE_SIZE,
+  GCM_TAG_SIZE,
+  StaticKeySecretCodec,
+} from "./v1-codec.js";
+export { EncryptionScope, PLATFORM_TENANT } from "./scope.js";
+export type { SecretCodec } from "./codec.js";
 
 /** Env var configuring the secrets key (Base64 32B) — Go EnvKeyName. */
 export const ENCRYPTION_KEY_ENV_VAR = "STIGMER_ENCRYPTION_KEY";
@@ -41,38 +70,42 @@ export const ENCRYPTION_KEY_ENV_VAR = "STIGMER_ENCRYPTION_KEY";
 export const ENCRYPTION_KEY_FILE_NAME = "encryption.key";
 
 /**
+ * Env var selecting the write codec — byte-pinned across editions (the
+ * cloud's stigmer.encryption.write-version binds the same name). OSS
+ * default: v1. A blank value normalizes to the default: this is a
+ * rollback lever, and rollback levers must be robust to sloppy unsetting
+ * (the Java EncryptionConfig note).
+ */
+export const ENCRYPTION_WRITE_VERSION_ENV_VAR =
+  "STIGMER_ENCRYPTION_WRITE_VERSION";
+
+/** The OSS default write version — the built-in static-key codec. */
+export const DEFAULT_WRITE_VERSION = V1_VERSION;
+
+/**
+ * The sentinel replacing every non-empty secret value at every
+ * resource-returning boundary — Go steps.RedactedMarker, pinned by the
+ * conformance suite and byte-identical in the cloud edition. Lives with
+ * the facade (the Java shape) because reencrypt must refuse it;
+ * domain/environment/constants.ts re-exports it for its historical
+ * importers. A client sending it BACK on a write means "keep the existing
+ * secret" (the round-trip contract; see preserveRedactedSecrets).
+ */
+export const REDACTED_MARKER = "***REDACTED***";
+
+/**
  * Matches ciphertext in ANY supported-or-future version of the enc:v<N>:
- * family. Matching all versions (not just v1) is load-bearing: an
+ * family, capturing the version digits. Anchored so a value merely
+ * CONTAINING the prefix is not mistaken for ciphertext. Matching all
+ * versions (not just the ones registered here) is load-bearing: an
  * unmatched version would be treated as plaintext at every dispatch site
  * and fail open (returned or re-encrypted as if it were a real value).
  * Mirrors the cloud edition's SecretEncryptionService.VERSIONED_PREFIX.
  */
-const VERSIONED_PREFIX = /^enc:v\d+:/;
+const VERSIONED_PREFIX = /^enc:v(\d+):/;
 
-/** Go ErrInvalidCiphertext — malformed input (bad base64, too short). */
-export class InvalidCiphertextError extends Error {
-  constructor(detail: string) {
-    super(`invalid ciphertext format: ${detail}`);
-    this.name = "InvalidCiphertextError";
-  }
-}
-
-/** Go ErrDecryptionFailed — wrong key or tampered data. */
-export class DecryptionFailedError extends Error {
-  constructor(cause: unknown) {
-    super("decryption failed - wrong key or tampered data");
-    this.name = "DecryptionFailedError";
-    this.cause = cause;
-  }
-}
-
-/** Go ErrEncryptionDisabled — decrypting a prefixed value with no key. */
-export class EncryptionDisabledError extends Error {
-  constructor() {
-    super("encryption is not enabled - no key configured");
-    this.name = "EncryptionDisabledError";
-  }
-}
+/** Registered version tokens are v<digits> — the dispatchable shape. */
+const VERSION_TOKEN = /^v(\d+)$/;
 
 /**
  * Go IsCiphertextShaped: whether a value merely has the SHAPE of
@@ -91,37 +124,51 @@ export function isCiphertextShaped(value: string): boolean {
   return VERSIONED_PREFIX.test(value);
 }
 
+/** The version token a stored value carries ("v2"), or undefined. */
+function versionTokenOf(value: string): string | undefined {
+  const match = VERSIONED_PREFIX.exec(value);
+  return match === null ? undefined : `v${match[1]}`;
+}
+
 /**
  * Encryption/decryption for environment (and other domain) secrets. Safe
  * for concurrent use; construct via one of the factories below.
  */
 export class SecretService {
-  private readonly key: Buffer | undefined;
+  private readonly codecs: ReadonlyMap<string, SecretCodec>;
+  private readonly writeCodec: SecretCodec;
+  /** Numeric form of the write version, for reencrypt's upward-only rule. */
+  private readonly writeVersionNumber: number;
 
-  private constructor(key: Buffer | undefined) {
-    this.key = key;
+  private constructor(
+    codecs: ReadonlyMap<string, SecretCodec>,
+    writeCodec: SecretCodec,
+    writeVersionNumber: number,
+  ) {
+    this.codecs = codecs;
+    this.writeCodec = writeCodec;
+    this.writeVersionNumber = writeVersionNumber;
   }
 
   /**
-   * Go NewSecretService: nil/empty key → disabled (pass-through) service;
-   * a present key must be exactly 32 bytes.
+   * Go NewSecretService, kept signature-stable across the codec seam: a
+   * v1-only facade writing v1 — the shape of every OSS deployment with no
+   * extension composed, and of every test that constructs the service
+   * directly. nil/empty key → disabled (pass-through) v1; a present key
+   * must be exactly 32 bytes.
    */
   static create(key: Buffer | undefined): SecretService {
-    if (key === undefined || key.length === 0) {
-      return new SecretService(undefined);
-    }
-    if (key.length !== KEY_SIZE) {
-      throw new Error(
-        `encryption key must be exactly 32 bytes (256 bits): got ${key.length} bytes`,
-      );
-    }
-    return new SecretService(key);
+    return SecretService.withCodecs({
+      codecs: new Map([[V1_VERSION, new StaticKeySecretCodec(key)]]),
+      writeVersion: V1_VERSION,
+    });
   }
 
   /**
-   * Go NewSecretServiceFromEnv: key via the shared ladder (env var → key
-   * file → auto-generate). Throws only on unusable explicit configuration;
-   * the composition root maps that to the WARN-degrade posture.
+   * Go NewSecretServiceFromEnv: a v1-only facade with the key from the
+   * shared ladder (env var → key file → auto-generate). Throws only on
+   * unusable explicit configuration; the composition root maps that to
+   * the WARN-degrade posture.
    */
   static fromEnv(options: KeyLoaderOptions = {}): SecretService {
     const key = getOrCreateNamedKey(
@@ -132,9 +179,57 @@ export class SecretService {
     return SecretService.create(key);
   }
 
-  /** Go IsEnabled: whether a key is configured. */
+  /**
+   * The parameterized construction path — the composition root's door
+   * (boot/compose.ts assembles built-in v1 + extension codecs and the
+   * resolved write version). Fail-fast on a write version with no codec:
+   * refusing to start beats silently writing a different version (the
+   * Java @PostConstruct contract). Every map key must be a dispatchable
+   * v<digits> token matching its codec's own version — a registration
+   * dispatch could never reach must fail loudly, not sit dark.
+   */
+  static withCodecs(options: {
+    readonly codecs: ReadonlyMap<string, SecretCodec>;
+    readonly writeVersion: string;
+  }): SecretService {
+    for (const [token, codec] of options.codecs) {
+      if (!VERSION_TOKEN.test(token)) {
+        throw new Error(
+          `secret codec registered under '${token}' — version tokens must match v<digits> (the enc:v<N>: dispatch shape)`,
+        );
+      }
+      if (codec.version !== token) {
+        throw new Error(
+          `secret codec registered under '${token}' declares version '${codec.version}' — the registry key must equal the codec's own version`,
+        );
+      }
+    }
+    const writeCodec = options.codecs.get(options.writeVersion);
+    if (writeCodec === undefined) {
+      const registered = [...options.codecs.keys()].sort().join(", ");
+      throw new Error(
+        `${ENCRYPTION_WRITE_VERSION_ENV_VAR} is '${options.writeVersion}' but this deployment has no codec for it (registered: ${registered}). Refusing to start rather than silently writing a different version.`,
+      );
+    }
+    // The token shape was validated above, so the capture always matches.
+    const writeVersionNumber = Number(
+      VERSION_TOKEN.exec(options.writeVersion)?.[1],
+    );
+    return new SecretService(
+      new Map(options.codecs),
+      writeCodec,
+      writeVersionNumber,
+    );
+  }
+
+  /**
+   * Whether new values can actually be sealed — delegated to the write
+   * codec (absent isEnabled means enabled: registration IS the ability,
+   * the Java posture; only the OSS v1 codec models a keyless state). The
+   * write steps branch on this for the WARN-degrade posture (oss#394).
+   */
   isEnabled(): boolean {
-    return this.key !== undefined;
+    return this.writeCodec.isEnabled?.() ?? true;
   }
 
   /**
@@ -147,86 +242,284 @@ export class SecretService {
   }
 
   /**
-   * Go Encrypt: enc:v1:<base64(nonce || ct || tag)>; disabled → plaintext
-   * unchanged; already-prefixed input → unchanged.
-   *
-   * The idempotent pass-through TRUSTS its callers: it exists for
-   * store-restored ciphertext (the ***REDACTED*** round-trip copies stored
-   * values back into the new state before this runs), which must survive a
-   * second pass unchanged. It is NOT a safe place to validate provenance —
-   * only the request pipeline knows whether a prefixed value came from the
-   * store or from a client. Client-supplied enc:v<N>: input is rejected at
-   * every write boundary via isCiphertextShaped (oss#395); do not "fix"
-   * smuggling here, it would break the marker round-trip.
+   * The version number a stored value carries (enc:v<N>: → N), or
+   * undefined for anything else (plaintext, markers, empty strings). The
+   * public face of the dispatch parse, for callers that classify stored
+   * values — the convergence sweep's upward-only rule and the
+   * encryption-state gauges key on it.
    */
-  encrypt(plaintext: string): string {
-    if (this.key === undefined) {
-      return plaintext;
-    }
-    if (this.isEncrypted(plaintext)) {
-      return plaintext;
-    }
-    const nonce = randomBytes(GCM_NONCE_SIZE);
-    const cipher = createCipheriv("aes-256-gcm", this.key, nonce);
-    const ciphertext = Buffer.concat([
-      cipher.update(plaintext, "utf8"),
-      cipher.final(),
-    ]);
-    const tag = cipher.getAuthTag();
-    // Layout matches Go's gcm.Seal(nonce, nonce, plaintext, nil):
-    // nonce || ciphertext || tag, then standard Base64.
-    const sealed = Buffer.concat([nonce, ciphertext, tag]);
-    return ENCRYPTED_PREFIX + sealed.toString("base64");
+  versionOf(value: string): number | undefined {
+    const match = VERSIONED_PREFIX.exec(value);
+    return match === null ? undefined : Number(match[1]);
   }
 
   /**
-   * Go Decrypt: unprefixed values pass through (legacy plaintext
-   * compatibility); prefixed values decrypt or fail with the taxonomy the
-   * callers branch on (invalid-ciphertext / decryption-failed /
-   * encryption-disabled).
+   * Encrypts a plaintext secret under the given scope, using the
+   * configured write version.
+   *
+   * Idempotent for already-prefixed input of ANY version — returned
+   * unchanged (no silent upgrades; see the module header). The
+   * pass-through TRUSTS its callers: it exists for store-restored
+   * ciphertext (the ***REDACTED*** round-trip), and it is NOT a safe
+   * place to validate provenance — only the request pipeline knows
+   * whether a prefixed value came from the store or from a client.
+   * Client-supplied enc:v<N>: input is rejected at every write boundary
+   * via isCiphertextShaped (oss#395); do not "fix" smuggling here.
    */
-  decrypt(encrypted: string): string {
-    if (!this.isEncrypted(encrypted)) {
+  async encrypt(plaintext: string, scope: EncryptionScope): Promise<string> {
+    if (this.isEncrypted(plaintext)) {
+      return plaintext;
+    }
+    return this.writeCodec.encrypt(plaintext, scope);
+  }
+
+  /**
+   * Encrypts many values under one scope in as few key-provider round
+   * trips as the write codec allows (one, for the v2 envelope codec).
+   * Per-entry semantics are identical to encrypt(): already-encrypted
+   * values of any version pass through unchanged. Result keyed as the
+   * input, iteration order preserved; fails as a whole (the batched
+   * write paths fail the whole request on any encryption error).
+   */
+  async encryptAll(
+    plaintexts: ReadonlyMap<string, string>,
+    scope: EncryptionScope,
+  ): Promise<Map<string, string>> {
+    return this.encryptAllWith(this.writeCodec, plaintexts, scope);
+  }
+
+  /**
+   * Encrypts a batch capped at the v2 envelope format: the write codec
+   * when the write version is v1 or v2, the v2 codec when the write
+   * version is above it. The generalization of the Java facade's
+   * encryptAllV2 pin (vault project DD-005) for a family that includes
+   * v1-only OSS deployments — see the executioncontext rationale:
+   * ephemeral values on a latency-budgeted read path, sealed where v2
+   * costs one batched Transit round trip and v3 (no KV batch endpoint,
+   * located-scope requirement) cannot follow. At write=v1 this is the
+   * write codec (OSS today); at write=v2 it equals Java's pin; at a
+   * future write=v3 flip it keeps these lanes on v2 instead of breaking
+   * them.
+   */
+  async encryptAllAtMostV2(
+    plaintexts: ReadonlyMap<string, string>,
+    scope: EncryptionScope,
+  ): Promise<Map<string, string>> {
+    const codec =
+      this.writeVersionNumber <= 2 ? this.writeCodec : this.codecFor("v2");
+    return this.encryptAllWith(codec, plaintexts, scope);
+  }
+
+  /**
+   * Decrypts an encrypted secret value, dispatching on the value's own
+   * version token. Unprefixed values pass through unchanged (legacy
+   * plaintext compatibility, pre-oss#405 rows); prefixed values decrypt
+   * or fail with the two-armed taxonomy (errors.ts). A version with no
+   * codec here is EncryptionUnavailableError — before the codec seam
+   * this build failed such values CLOSED as invalid base64 (the literal
+   * v1 prefix never stripped); the refusal stays closed, now with the
+   * honest arm and copy (a deliberate, recorded change — no wire test
+   * observes it).
+   */
+  async decrypt(encrypted: string): Promise<string> {
+    const token = versionTokenOf(encrypted);
+    if (token === undefined) {
       return encrypted;
     }
-    if (this.key === undefined) {
-      throw new EncryptionDisabledError();
-    }
-
-    // Go TrimPrefix semantics: only the LITERAL enc:v1: prefix is
-    // stripped. A future-version value (enc:v2:…) is matched by
-    // isEncrypted but keeps its prefix here, fails the strict Base64
-    // check below, and surfaces as invalid ciphertext — exactly Go's
-    // fail-closed handling of versions this build cannot decrypt.
-    const base64Data = encrypted.startsWith(ENCRYPTED_PREFIX)
-      ? encrypted.slice(ENCRYPTED_PREFIX.length)
-      : encrypted;
-    const sealed = Buffer.from(base64Data, "base64");
-    // Node's lenient decoder never throws; the round-trip check restores
-    // Go's strict-decode error for corrupted Base64.
-    if (sealed.toString("base64") !== base64Data) {
-      throw new InvalidCiphertextError("invalid base64 encoding");
-    }
-    if (sealed.length < GCM_NONCE_SIZE + GCM_TAG_SIZE) {
-      throw new InvalidCiphertextError("ciphertext too short");
-    }
-
-    const nonce = sealed.subarray(0, GCM_NONCE_SIZE);
-    const ciphertext = sealed.subarray(
-      GCM_NONCE_SIZE,
-      sealed.length - GCM_TAG_SIZE,
-    );
-    const tag = sealed.subarray(sealed.length - GCM_TAG_SIZE);
-
-    const decipher = createDecipheriv("aes-256-gcm", this.key, nonce);
-    decipher.setAuthTag(tag);
-    try {
-      return Buffer.concat([
-        decipher.update(ciphertext),
-        decipher.final(),
-      ]).toString("utf8");
-    } catch (error) {
-      throw new DecryptionFailedError(error);
-    }
+    return this.codecFor(token).decrypt(encrypted);
   }
+
+  /**
+   * Decrypts many values in as few key-provider round trips as their
+   * codecs allow, grouping by each value's own version token. Per-entry
+   * semantics are identical to decrypt(): non-encrypted values pass
+   * through. Fails as a whole — callers needing per-key skip semantics
+   * (the resolution lanes) loop decrypt() instead.
+   */
+  async decryptAll(
+    encrypted: ReadonlyMap<string, string>,
+  ): Promise<Map<string, string>> {
+    const byVersion = new Map<string, Map<string, string>>();
+    for (const [key, value] of encrypted) {
+      const token = versionTokenOf(value);
+      if (token === undefined) {
+        continue;
+      }
+      let group = byVersion.get(token);
+      if (group === undefined) {
+        group = new Map<string, string>();
+        byVersion.set(token, group);
+      }
+      group.set(key, value);
+    }
+
+    const decrypted = new Map<string, string>();
+    for (const [token, group] of byVersion) {
+      const codec = this.codecFor(token);
+      const groupResult =
+        codec.decryptAll !== undefined
+          ? await codec.decryptAll(group)
+          : await loopDecryptAll(codec, group);
+      for (const [key, value] of groupResult) {
+        decrypted.set(key, value);
+      }
+    }
+
+    const result = new Map<string, string>();
+    for (const [key, value] of encrypted) {
+      result.set(key, decrypted.get(key) ?? value);
+    }
+    return result;
+  }
+
+  /**
+   * Destroys any external state backing a stored value, dispatching on
+   * the value's own version token — the lifecycle counterpart of
+   * decrypt(). Plaintext and marker values are no-ops by construction;
+   * v1/v2 values are no-ops by codec contract (their stored string IS
+   * the value). Call sites are resource-delete and key-removal paths
+   * whose database write already succeeded, so callers treat failures as
+   * best-effort (the Stage 3 wiring owns that posture).
+   */
+  async delete(storedValue: string): Promise<void> {
+    const token = versionTokenOf(storedValue);
+    if (token === undefined) {
+      return;
+    }
+    await this.codecFor(token).delete?.(storedValue);
+  }
+
+  /**
+   * Re-encrypts a stored value to the current write version — the ONE
+   * deliberate exception to the no-silent-upgrades doctrine, built for
+   * the secret-convergence sweep and the future v3 migration pass. Three
+   * rules, each load-bearing (the Java facade's, verbatim):
+   *
+   *   - UPWARD-ONLY: a value already at (or above) the write version is
+   *     returned unchanged. Rolling the write-version lever down must
+   *     never trigger a mass downgrade — in a v3 world that would mean
+   *     mass KV destruction on a config change.
+   *   - ROUND-TRIP-VERIFIED: the new ciphertext is decrypted and compared
+   *     to the plaintext before being returned, so a codec bug can never
+   *     hand the caller an unreadable value to persist.
+   *   - NO EXTERNAL-STATE DESTRUCTION: an old value's backing state (v3
+   *     KV entries) is NOT destroyed here — the caller persists the new
+   *     value first and only then cleans up, or a failed persist would
+   *     leave the stored pointer dangling.
+   *
+   * A non-encrypted, non-marker value is treated as plaintext and sealed
+   * — stored plaintext secrets are damage from the fail-open era (the
+   * cloud's #226 lesson; OSS keyless windows leave the same rows) and
+   * sealing them is strictly an improvement. The literal redaction
+   * marker is refused as InvalidCiphertextError: a stored marker is
+   * corruption from a marker-persist bug, and sealing it would hide the
+   * corruption behind valid ciphertext.
+   *
+   * @throws InvalidCiphertextError value-scoped (callers may skip)
+   * @throws EncryptionUnavailableError infrastructure (callers must abort)
+   */
+  async reencrypt(
+    storedValue: string,
+    scope: EncryptionScope,
+  ): Promise<string> {
+    if (storedValue === "") {
+      return storedValue;
+    }
+    if (storedValue === REDACTED_MARKER) {
+      throw new InvalidCiphertextError(
+        "stored value is the literal redaction marker — corruption from a marker-persist bug, not a secret; refusing to seal it",
+      );
+    }
+
+    const version = this.versionOf(storedValue);
+    let plaintext: string;
+    if (version !== undefined) {
+      if (version >= this.writeVersionNumber) {
+        return storedValue;
+      }
+      plaintext = await this.decrypt(storedValue);
+    } else {
+      plaintext = storedValue;
+    }
+
+    const reencrypted = await this.writeCodec.encrypt(plaintext, scope);
+    // Round-trip proof BEFORE the caller can persist anything: decrypt
+    // the new value through the normal read path, require an exact match.
+    const verification = await this.decrypt(reencrypted);
+    if (verification !== plaintext) {
+      throw new InvalidCiphertextError(
+        `re-encryption round-trip verification failed for a ${
+          version !== undefined ? `v${version}` : "plaintext"
+        } value: the freshly written ${this.writeCodec.version} ciphertext did not decrypt back to the original plaintext — nothing was persisted; this is a codec bug, stop the migration`,
+      );
+    }
+    return reencrypted;
+  }
+
+  /** The batch-encrypt mechanics shared by encryptAll and the v2 cap. */
+  private async encryptAllWith(
+    codec: SecretCodec,
+    plaintexts: ReadonlyMap<string, string>,
+    scope: EncryptionScope,
+  ): Promise<Map<string, string>> {
+    const toEncrypt = new Map<string, string>();
+    for (const [key, value] of plaintexts) {
+      if (!this.isEncrypted(value)) {
+        toEncrypt.set(key, value);
+      }
+    }
+
+    const encrypted =
+      toEncrypt.size === 0
+        ? new Map<string, string>()
+        : codec.encryptAll !== undefined
+          ? await codec.encryptAll(toEncrypt, scope)
+          : await loopEncryptAll(codec, toEncrypt, scope);
+
+    const result = new Map<string, string>();
+    for (const [key, value] of plaintexts) {
+      result.set(key, encrypted.get(key) ?? value);
+    }
+    return result;
+  }
+
+  /**
+   * The codec for a stored value's version token, or the loud unavailable
+   * refusal — the Java registry's "no codec for this version" contract.
+   */
+  private codecFor(token: string): SecretCodec {
+    const codec = this.codecs.get(token);
+    if (codec === undefined) {
+      const registered = [...this.codecs.keys()].sort().join(", ");
+      throw new EncryptionUnavailableError(
+        `unsupported encrypted-value version '${token}' - this deployment decrypts only [${registered}]. The value was written by a format this deployment has no codec for; fix the deployment before reading it.`,
+      );
+    }
+    return codec;
+  }
+}
+
+/** The facade-owned fallback for codecs without a native batch encrypt. */
+async function loopEncryptAll(
+  codec: SecretCodec,
+  plaintexts: ReadonlyMap<string, string>,
+  scope: EncryptionScope,
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  for (const [key, value] of plaintexts) {
+    result.set(key, await codec.encrypt(value, scope));
+  }
+  return result;
+}
+
+/** The facade-owned fallback for codecs without a native batch decrypt. */
+async function loopDecryptAll(
+  codec: SecretCodec,
+  encrypted: ReadonlyMap<string, string>,
+): Promise<Map<string, string>> {
+  const result = new Map<string, string>();
+  for (const [key, value] of encrypted) {
+    result.set(key, await codec.decrypt(value));
+  }
+  return result;
 }

--- a/backend/services/stigmer-server/src/encryption/errors.ts
+++ b/backend/services/stigmer-server/src/encryption/errors.ts
@@ -1,0 +1,86 @@
+/**
+ * The secret-encryption error taxonomy — two arms, mirroring the cloud
+ * edition's SecretEncryptionService exception pair (EncryptionException →
+ * InvalidCiphertext / EncryptionUnavailable), because "skip this one
+ * value" is safe for exactly one of them:
+ *
+ *   - InvalidCiphertextError (and its wrong-key/tampered specialization
+ *     DecryptionFailedError): the VALUE is bad — tampered, truncated,
+ *     malformed Base64, or sealed under a different key. Retrying cannot
+ *     help and the failure is scoped to that one value, so per-key skip
+ *     policies (the environment/executioncontext resolution lanes) may
+ *     drop it and continue.
+ *
+ *   - EncryptionUnavailableError (and its keyless specialization
+ *     EncryptionDisabledError): the MACHINERY is missing — the value's
+ *     version has no codec in this deployment, no key is configured, or a
+ *     codec's external key provider is unreachable. The stored value may
+ *     be perfectly valid, so skipping would silently drop a credential on
+ *     a transient infrastructure failure; callers must let this arm
+ *     propagate (the resolution lanes fail the request on it).
+ *
+ * The four concrete classes predate the arms (they are blessed exports the
+ * commit-pin consumer catches); the arms were introduced by re-parenting
+ * (20260830.04 Stage 1) so every existing `instanceof` keeps its meaning
+ * and every `.name` and message byte stays exactly as shipped.
+ */
+
+/**
+ * Go ErrInvalidCiphertext — the value itself is bad (bad base64, too
+ * short, or — via the DecryptionFailedError subclass — wrong key or
+ * tampered bytes). The value-scoped arm: per-key skip policies may skip
+ * it and continue.
+ */
+export class InvalidCiphertextError extends Error {
+  constructor(detail: string) {
+    super(`invalid ciphertext format: ${detail}`);
+    this.name = "InvalidCiphertextError";
+  }
+}
+
+/**
+ * Go ErrDecryptionFailed — wrong key or tampered data. A specialization
+ * of InvalidCiphertextError (the cloud edition folds this case into
+ * InvalidCiphertext outright): the failure is still scoped to the one
+ * value, so it rides the value-scoped arm.
+ */
+export class DecryptionFailedError extends InvalidCiphertextError {
+  constructor(cause: unknown) {
+    super("wrong key or tampered data");
+    // This class shipped before the taxonomy fold, so its copy does not
+    // carry the parent's "invalid ciphertext format:" prefix — preserved
+    // byte-for-byte (the message reaches logs at the resolution lanes).
+    this.message = "decryption failed - wrong key or tampered data";
+    this.name = "DecryptionFailedError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * The machinery needed to process an otherwise-plausible value is
+ * unavailable: the value carries a format version this deployment has no
+ * codec for, or a codec's key machinery cannot be reached. The stored
+ * value may be perfectly valid — treating this like InvalidCiphertextError
+ * and skipping would silently drop a credential, so callers must let it
+ * propagate. Ports the cloud edition's EncryptionUnavailableException.
+ */
+export class EncryptionUnavailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "EncryptionUnavailableError";
+  }
+}
+
+/**
+ * Go ErrEncryptionDisabled — decrypting a prefixed value with no key
+ * configured. A specialization of EncryptionUnavailableError: keyless is
+ * one instance of "machinery missing" (the stored ciphertext may be
+ * perfectly valid — e.g. the key file was lost), so it rides the
+ * infrastructure arm the resolution lanes propagate.
+ */
+export class EncryptionDisabledError extends EncryptionUnavailableError {
+  constructor() {
+    super("encryption is not enabled - no key configured");
+    this.name = "EncryptionDisabledError";
+  }
+}

--- a/backend/services/stigmer-server/src/encryption/scope.ts
+++ b/backend/services/stigmer-server/src/encryption/scope.ts
@@ -1,0 +1,152 @@
+/**
+ * The scope under which a secret is encrypted — ports the cloud edition's
+ * ai.stigmer.infra.encryption.EncryptionScope record: its tenancy (which
+ * key-encryption key wraps it) and — when the write version needs one —
+ * the location of the secret in the resource model (which vault KV path
+ * stores its value).
+ *
+ * Exists as a type (rather than bare strings threaded through encrypt) so
+ * a call site cannot pass unvalidated or empty values, and so the
+ * tenant-name derivation lives in exactly one place.
+ *
+ * The tenant segment — one discriminator for keys and paths:
+ * `tenantSegment` is `org-<slug>` for organization-scoped resources and
+ * the literal `platform` for platform-scoped ones. The same string is the
+ * Transit key name (kekKeyName) and the KV path root, deliberately: the
+ * `org-` prefix makes an organization literally named "platform"
+ * collision-free in both namespaces at once.
+ *
+ * Located scopes (v3 writes): the vault-backed enc:v3: codec derives a KV
+ * path `{tenant}/{kind}/{id}/{key}` (enc-v3-wire-format.md in the vault
+ * migration project docs), so v3 writes need a scope carrying kind and id
+ * — built with forOrganizationResource / forPlatformResource. The v1/v2
+ * codecs ignore location entirely, so their call sites use
+ * forOrganization unchanged (the pre-v3 posture, kept deliberately —
+ * write paths adopt located scopes only when a v3 write flip demands
+ * them). keyName names the secret for SINGULAR encrypts (withKeyName);
+ * batch encrypts take key names from their map keys instead.
+ *
+ * Validation: org slugs must match the org-slug contract from
+ * ai.stigmer.commons.apiresource metadata.proto
+ * (^[a-z][a-z0-9-]*[a-z0-9]$, min 2 chars). That charset is safe as a
+ * Transit key name and as a KV path segment, so passing validation here
+ * guarantees the derived names need no escaping. The check matters even
+ * though callers read the org from server state, not client input: a
+ * malformed slug reaching a crypto key name would otherwise fail deep
+ * inside the vault with a routing error naming nothing.
+ */
+
+/** The reserved tenant segment for platform-scoped resources. */
+export const PLATFORM_TENANT = "platform";
+
+/** Prefix of organization tenant segments; what makes PLATFORM_TENANT unclaimable. */
+const ORG_TENANT_PREFIX = "org-";
+
+/**
+ * The org-slug contract from metadata.proto, verbatim. Kept in lockstep
+ * with the proto: a value that passes resource validation always passes
+ * here.
+ */
+const ORG_SLUG = /^[a-z][a-z0-9-]*[a-z0-9]$/;
+
+/** Resource kinds are server-side constants: lowercase, no separators. */
+const KIND = /^[a-z][a-z0-9]*$/;
+
+export class EncryptionScope {
+  private constructor(
+    /** `org-<slug>` or `platform` — the Transit key name and KV path root. */
+    readonly tenantSegment: string,
+    /** The resource kind, lowercase (undefined when not located). */
+    readonly kind: string | undefined,
+    /** The resource's immutable identity (undefined exactly when kind is). */
+    readonly id: string | undefined,
+    /** The secret's key name for singular encrypts (undefined for batch calls). */
+    readonly keyName: string | undefined,
+  ) {}
+
+  /**
+   * A tenancy-only scope — all a v1/v2 write needs. The long-standing
+   * factory; every pre-v3 call site uses exactly this.
+   */
+  static forOrganization(orgSlug: string): EncryptionScope {
+    return new EncryptionScope(
+      orgSegment(orgSlug),
+      undefined,
+      undefined,
+      undefined,
+    );
+  }
+
+  /**
+   * A located org-scoped scope, as v3 batch writes need: the KV path root
+   * is `org-<slug>/<kind>/<id>`, key names come from the batch map keys.
+   */
+  static forOrganizationResource(
+    orgSlug: string,
+    kind: string,
+    id: string,
+  ): EncryptionScope {
+    validateLocation(kind, id);
+    return new EncryptionScope(orgSegment(orgSlug), kind, id, undefined);
+  }
+
+  /**
+   * A located platform-scoped scope (e.g. CursorAccount in the cloud
+   * composition): the KV path root is `platform/<kind>/<id>` and the KEK
+   * is the reserved PLATFORM_TENANT Transit key.
+   */
+  static forPlatformResource(kind: string, id: string): EncryptionScope {
+    validateLocation(kind, id);
+    return new EncryptionScope(PLATFORM_TENANT, kind, id, undefined);
+  }
+
+  /**
+   * This scope with the secret's key name attached — for SINGULAR
+   * encrypts, where no batch map key can name the secret. Requires a
+   * located scope.
+   */
+  withKeyName(keyName: string): EncryptionScope {
+    if (this.kind === undefined) {
+      throw new Error(
+        `encryption scope keyName requires a located scope (kind + id) - keyName '${keyName}' names a secret inside a resource`,
+      );
+    }
+    if (keyName === "") {
+      throw new Error("encryption scope keyName must not be empty");
+    }
+    return new EncryptionScope(this.tenantSegment, this.kind, this.id, keyName);
+  }
+
+  /** Whether this scope names a resource location (required for v3 writes). */
+  isLocated(): boolean {
+    return this.kind !== undefined;
+  }
+
+  /**
+   * The Transit key name that wraps data keys for this scope — identical
+   * to tenantSegment by design (see the module header).
+   */
+  kekKeyName(): string {
+    return this.tenantSegment;
+  }
+}
+
+function orgSegment(orgSlug: string): string {
+  if (!ORG_SLUG.test(orgSlug)) {
+    throw new Error(
+      `encryption scope requires a valid org slug (pattern ${ORG_SLUG.source}), got: '${orgSlug}'`,
+    );
+  }
+  return ORG_TENANT_PREFIX + orgSlug;
+}
+
+function validateLocation(kind: string, id: string): void {
+  if (!KIND.test(kind)) {
+    throw new Error(
+      `encryption scope kind must be a lowercase server-side constant (pattern ${KIND.source}), got: '${kind}'`,
+    );
+  }
+  if (id.trim() === "") {
+    throw new Error("encryption scope id must not be blank");
+  }
+}

--- a/backend/services/stigmer-server/src/encryption/v1-codec.ts
+++ b/backend/services/stigmer-server/src/encryption/v1-codec.ts
@@ -1,0 +1,143 @@
+/**
+ * The built-in enc:v1 static-key codec — the crypto that lived directly
+ * on SecretService before the versioned-codec seam (20260830.04 Stage 1),
+ * extracted byte-for-byte. Provenance: ports pkg/encryption/encryption.go
+ * (the retired Go server), the Go twin of the cloud edition's RETIRED v1
+ * codec (deleted 2026-08, PR-3 of the vault migration). Cross-edition
+ * wire contract: same wire format, but a DIFFERENT key per deployment —
+ * the OSS enc:v1 is a same-wire-format SIBLING of the cloud's retired v1,
+ * never interchangeable ciphertext.
+ *
+ * Format: enc:v1:<base64(nonce || ciphertext || tag)>
+ *   - AES-256-GCM, 12-byte crypto-random nonce (unique per encryption),
+ *     16-byte GCM tag, standard padded Base64.
+ *
+ * Keyless ("disabled") semantics are load-bearing and asymmetric:
+ *   - encrypt() passes plaintext through (the WARN-degrade posture — the
+ *     write steps own the per-request warning, oss#394);
+ *   - decrypt() fails loud (EncryptionDisabledError): stored ciphertext
+ *     with no key must never be returned as-is.
+ * The unprefixed-plaintext pass-through (pre-oss#405 rows) is FACADE
+ * policy, not codec behavior — this codec only ever sees enc:v1: values.
+ *
+ * The scope parameter is deliberately ignored: v1 has one deployment-wide
+ * key, no per-tenant KEK and no location. It is threaded anyway so every
+ * call site already carries the tenancy a vault-backed codec needs — the
+ * whole point of the seam.
+ */
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+import type { SecretCodec } from "./codec.js";
+import {
+  DecryptionFailedError,
+  EncryptionDisabledError,
+  InvalidCiphertextError,
+} from "./errors.js";
+import { KEY_SIZE } from "./key-manager.js";
+import type { EncryptionScope } from "./scope.js";
+
+/** Nonce size for AES-GCM (12 bytes = 96 bits, NIST) — Go GCMNonceSize. */
+export const GCM_NONCE_SIZE = 12;
+
+/** GCM authentication tag size (128 bits) — Go's gcm.Overhead(). */
+export const GCM_TAG_SIZE = 16;
+
+/** Version prefix for v1-encrypted values — Go EncryptedPrefix. */
+export const ENCRYPTED_PREFIX = "enc:v1:";
+
+/** The version token the static-key codec serves. */
+export const V1_VERSION = "v1";
+
+export class StaticKeySecretCodec implements SecretCodec {
+  readonly version = V1_VERSION;
+
+  private readonly key: Buffer | undefined;
+
+  /**
+   * Go NewSecretService's key contract, now the codec's: nil/empty key →
+   * disabled (keyless) codec; a present key must be exactly 32 bytes.
+   */
+  constructor(key: Buffer | undefined) {
+    if (key === undefined || key.length === 0) {
+      this.key = undefined;
+      return;
+    }
+    if (key.length !== KEY_SIZE) {
+      throw new Error(
+        `encryption key must be exactly 32 bytes (256 bits): got ${key.length} bytes`,
+      );
+    }
+    this.key = key;
+  }
+
+  /** Go IsEnabled: whether a key is configured. */
+  isEnabled(): boolean {
+    return this.key !== undefined;
+  }
+
+  /**
+   * Go Encrypt's crypto arm: enc:v1:<base64(nonce || ct || tag)>;
+   * disabled → plaintext unchanged (the WARN-degrade posture). The
+   * already-prefixed idempotent pass-through is facade policy and never
+   * reaches here.
+   */
+  // async without await: the interface is async for vault-backed codecs
+  // (Transit/KV round trips); v1 is pure local crypto.
+  async encrypt(plaintext: string, _scope: EncryptionScope): Promise<string> {
+    if (this.key === undefined) {
+      return plaintext;
+    }
+    const nonce = randomBytes(GCM_NONCE_SIZE);
+    const cipher = createCipheriv("aes-256-gcm", this.key, nonce);
+    const ciphertext = Buffer.concat([
+      cipher.update(plaintext, "utf8"),
+      cipher.final(),
+    ]);
+    const tag = cipher.getAuthTag();
+    // Layout matches Go's gcm.Seal(nonce, nonce, plaintext, nil):
+    // nonce || ciphertext || tag, then standard Base64.
+    const sealed = Buffer.concat([nonce, ciphertext, tag]);
+    return ENCRYPTED_PREFIX + sealed.toString("base64");
+  }
+
+  /**
+   * Go Decrypt's crypto arm: the value carries this codec's prefix (the
+   * facade dispatched it here) and decrypts or fails with the taxonomy
+   * the callers branch on (invalid-ciphertext / decryption-failed /
+   * encryption-disabled).
+   */
+  async decrypt(encrypted: string): Promise<string> {
+    if (this.key === undefined) {
+      throw new EncryptionDisabledError();
+    }
+
+    const base64Data = encrypted.slice(ENCRYPTED_PREFIX.length);
+    const sealed = Buffer.from(base64Data, "base64");
+    // Node's lenient decoder never throws; the round-trip check restores
+    // Go's strict-decode error for corrupted Base64.
+    if (sealed.toString("base64") !== base64Data) {
+      throw new InvalidCiphertextError("invalid base64 encoding");
+    }
+    if (sealed.length < GCM_NONCE_SIZE + GCM_TAG_SIZE) {
+      throw new InvalidCiphertextError("ciphertext too short");
+    }
+
+    const nonce = sealed.subarray(0, GCM_NONCE_SIZE);
+    const ciphertext = sealed.subarray(
+      GCM_NONCE_SIZE,
+      sealed.length - GCM_TAG_SIZE,
+    );
+    const tag = sealed.subarray(sealed.length - GCM_TAG_SIZE);
+
+    const decipher = createDecipheriv("aes-256-gcm", this.key, nonce);
+    decipher.setAuthTag(tag);
+    try {
+      return Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+      ]).toString("utf8");
+    } catch (error) {
+      throw new DecryptionFailedError(error);
+    }
+  }
+}

--- a/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
@@ -17,6 +17,7 @@ import type { DescMessage } from "@bufbuild/protobuf";
 
 import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
 import type { ChannelRuntime } from "../../domain/agentchannel/channel-runtime.js";
+import type { SecretCodec } from "../../encryption/codec.js";
 import type { ModelCatalogProvider } from "../../domain/workflow/registry/model-catalog-provider.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
@@ -84,6 +85,14 @@ const fakeSandboxDriver: SandboxProvisionerFactory = () => {
   throw new Error("unit-test sandbox driver factory — never constructed");
 };
 
+// Never invoked — the merge tests assert identity and the §2b throws.
+function fakeCodec(version: string): SecretCodec {
+  const never = (): never => {
+    throw new Error("unit-test secret codec — never invoked");
+  };
+  return { version, encrypt: never, decrypt: never };
+}
+
 function fakeChannelRuntime(): ChannelRuntime {
   const never = (): never => {
     throw new Error("unit-test channel runtime — never invoked");
@@ -126,6 +135,7 @@ describe("resolveExtensions — defaults", () => {
     expect(resolved.drivers.artifactStorageDrivers.size).toBe(0);
     expect(resolved.drivers.sandboxProvisionerDrivers.size).toBe(0);
     expect(resolved.drivers.channelRuntime).toBeUndefined();
+    expect(resolved.drivers.secretCodecs.size).toBe(0);
     expect(resolved.services).toEqual([]);
     expect(resolved.workers).toEqual([]);
   });
@@ -250,6 +260,24 @@ describe("resolveExtensions — merge semantics", () => {
     expect(resolved.drivers.listReadScope).toBe(scope);
     // The empty state resolves explicitly, never a missing key.
     expect(resolveExtensions([]).drivers.listReadScope).toBeUndefined();
+  });
+
+  it("merges secret codecs as a version-keyed map across units (20260830.04)", () => {
+    const v2 = fakeCodec("v2");
+    const v3 = fakeCodec("v3");
+    const resolved = resolveExtensions([
+      {
+        name: "vault-envelope",
+        drivers: { secretCodecs: new Map([["v2", v2]]) },
+      },
+      { name: "vault-kv", drivers: { secretCodecs: new Map([["v3", v3]]) } },
+    ]);
+    expect([...resolved.drivers.secretCodecs.keys()].sort()).toEqual([
+      "v2",
+      "v3",
+    ]);
+    expect(resolved.drivers.secretCodecs.get("v2")).toBe(v2);
+    expect(resolved.drivers.secretCodecs.get("v3")).toBe(v3);
   });
 });
 
@@ -518,5 +546,58 @@ describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
         ),
       );
     }
+  });
+
+  it("throws on a secret codec registered as v1, shadowing the built-in", () => {
+    expect(() =>
+      resolveExtensions([
+        {
+          name: "shadowing",
+          drivers: { secretCodecs: new Map([["v1", fakeCodec("v1")]]) },
+        },
+      ]),
+    ).toThrow(
+      "extension 'shadowing' registers secret codec 'v1', which shadows the built-in static-key codec — the v1 token is reserved",
+    );
+  });
+
+  it("throws on a duplicated secret-codec version across units, naming both", () => {
+    expect(() =>
+      resolveExtensions([
+        {
+          name: "first-vault",
+          drivers: { secretCodecs: new Map([["v2", fakeCodec("v2")]]) },
+        },
+        {
+          name: "second-vault",
+          drivers: { secretCodecs: new Map([["v2", fakeCodec("v2")]]) },
+        },
+      ]),
+    ).toThrowError(
+      /extension 'second-vault' registers secret codec 'v2', but 'first-vault' already did/,
+    );
+  });
+
+  it("throws on an undispatchable secret-codec token or a key/version mismatch", () => {
+    // A token read dispatch could never route to (not v<digits>).
+    expect(() =>
+      resolveExtensions([
+        {
+          name: "bad-token",
+          drivers: { secretCodecs: new Map([["vault", fakeCodec("vault")]]) },
+        },
+      ]),
+    ).toThrowError(/version tokens must match v<digits>/);
+    // A key that does not equal the codec's own declared version.
+    expect(() =>
+      resolveExtensions([
+        {
+          name: "mismatched",
+          drivers: { secretCodecs: new Map([["v2", fakeCodec("v3")]]) },
+        },
+      ]),
+    ).toThrowError(
+      /extension 'mismatched' registers secret codec 'v2' \(codec declares 'v3'\)/,
+    );
   });
 });

--- a/backend/services/stigmer-server/src/extensions/drivers.ts
+++ b/backend/services/stigmer-server/src/extensions/drivers.ts
@@ -18,6 +18,8 @@
  *     ExecutionReadScope (absorbed, gate ruling Q2)
  *   - visitor error policy (the transport-boundary sanitizer's
  *     edition semantics) — landed with 20260830.03, gate ruling Q1
+ *   - secret codecs (the versioned secret-value wire formats) — landed
+ *     with 20260830.04 Stage 1, gate ruling Q2
  *
  * Merge rules (enforced by resolveExtensions, DD-006 §2b): the two
  * provider kinds are single-instance points — a second declaring unit is
@@ -31,6 +33,7 @@
  */
 import type { ArtifactStorageDriverFactory } from "../artifactstorage/artifact-storage.js";
 import type { ChannelRuntime } from "../domain/agentchannel/channel-runtime.js";
+import type { SecretCodec } from "../encryption/codec.js";
 import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
 import type { VisitorErrorPolicy } from "../pipeline/interceptors/error-boundary.js";
 import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
@@ -114,4 +117,17 @@ export interface ExtensionDrivers {
    * raw-error conversion — OSS wire behavior otherwise byte-identical.
    */
   readonly visitorErrorPolicy?: VisitorErrorPolicy;
+  /**
+   * Secret codecs registrable by wire-format version token (20260830.04
+   * Stage 1, gate ruling Q2) — one entry per enc:v<N>: format the
+   * composition can read and (when selected by
+   * STIGMER_ENCRYPTION_WRITE_VERSION) write. Instances, not factories:
+   * the Java posture is "registration IS the ability to encrypt" — a
+   * codec exists exactly when its key machinery does. The built-in "v1"
+   * token is reserved (the OSS static-key codec installs at the
+   * compose.ts consumption site); registering it, or duplicating a
+   * version across units, is a boot throw. When absent, the facade is
+   * v1-only — OSS behavior byte-identical.
+   */
+  readonly secretCodecs?: ReadonlyMap<string, SecretCodec>;
 }

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -38,6 +38,8 @@ import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_inf
 import type { ArtifactStorageDriverFactory } from "../artifactstorage/artifact-storage.js";
 import { BUILT_IN_STORAGE_TYPES } from "../artifactstorage/artifact-storage.js";
 import type { ChannelRuntime } from "../domain/agentchannel/channel-runtime.js";
+import type { SecretCodec } from "../encryption/codec.js";
+import { V1_VERSION } from "../encryption/v1-codec.js";
 import type { ListReadScope } from "./list-read-scope.js";
 import type { ModelCatalogProvider } from "../domain/workflow/registry/model-catalog-provider.js";
 import type { VisitorErrorPolicy } from "../pipeline/interceptors/error-boundary.js";
@@ -175,6 +177,13 @@ export interface ResolvedExtensionDrivers {
    * boundary runs only its structural raw-error conversion.
    */
   readonly visitorErrorPolicy: VisitorErrorPolicy | undefined;
+  /**
+   * Registered version token → codec (20260830.04 Stage 1), validated
+   * against the built-in v1. Empty = the facade is v1-only, OSS behavior
+   * byte-identical. The compose.ts keys stage merges the built-in v1
+   * codec in and resolves the write version fail-fast.
+   */
+  readonly secretCodecs: ReadonlyMap<string, SecretCodec>;
 }
 
 /**
@@ -224,6 +233,8 @@ export function resolveExtensions(
     SandboxProvisionerFactory
   >();
   const sandboxDriverDeclaredBy = new Map<string, string>();
+  const secretCodecs = new Map<string, SecretCodec>();
+  const secretCodecDeclaredBy = new Map<string, string>();
 
   for (const unit of units) {
     if (unit.name === "") {
@@ -374,6 +385,33 @@ export function resolveExtensions(
       }
     }
 
+    if (unit.drivers?.secretCodecs !== undefined) {
+      for (const [version, codec] of unit.drivers.secretCodecs) {
+        if (version === V1_VERSION) {
+          throw new Error(
+            `extension '${unit.name}' registers secret codec '${version}', which shadows the built-in static-key codec — the v1 token is reserved`,
+          );
+        }
+        if (!/^v\d+$/.test(version) || codec.version !== version) {
+          // A registration read-dispatch could never route to must fail
+          // loudly, not sit dark (the gateSteps rule): tokens are the
+          // enc:v<N>: capture, and the key must equal the codec's own
+          // version.
+          throw new Error(
+            `extension '${unit.name}' registers secret codec '${version}' (codec declares '${codec.version}') — version tokens must match v<digits> and key their own codec`,
+          );
+        }
+        const declaredBy = secretCodecDeclaredBy.get(version);
+        if (declaredBy !== undefined) {
+          throw new Error(
+            `extension '${unit.name}' registers secret codec '${version}', but '${declaredBy}' already did — codec versions must be unique across the composed set`,
+          );
+        }
+        secretCodecs.set(version, codec);
+        secretCodecDeclaredBy.set(version, unit.name);
+      }
+    }
+
     if (unit.gateSteps !== undefined) {
       for (const [slot, steps] of unit.gateSteps) {
         if (!DECLARED_GATE_SLOTS.has(slot)) {
@@ -419,6 +457,7 @@ export function resolveExtensions(
       channelRuntime,
       listReadScope,
       visitorErrorPolicy,
+      secretCodecs,
     },
     services,
     workers,

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -166,6 +166,11 @@ export {
   AuditNotFoundError,
   ResourceNotFoundError,
 } from "./store/interface.js";
+// The maintenance-surface row shape (20260830.04 Stage 1, ruling Q3):
+// what findResourcesRawOrderedAfter pages and what
+// replaceResourceDataIfUnchanged guards on — the secret-convergence
+// sweep's storage contract.
+export type { RawResourceDocument } from "./store/interface.js";
 export type {
   ArtifactStorage,
   ArtifactStorageDriverFactory,
@@ -207,18 +212,27 @@ export {
   TOKEN_TYPE_EXECUTION_SCOPED,
 } from "./runnerauth/runnerauth.js";
 
-// The cross-edition secret envelope (enc:v1 — AES-256-GCM, the format the
-// Java SecretEncryptionService shares): compositions building extension
-// domains with secret-bearing columns seal under the SAME envelope the
-// OSS store uses (C4 gate ruling Q4's interim posture; C2/C3 inherit the
-// seam). The service, not the primitives — the format stays defined
-// exactly once.
+// The secret-sealing seam (20260830.04 Stage 1, gate rulings Q2/Q3 —
+// widening the C4-era enc:v1 block): the SecretService facade over the
+// versioned-codec registry (async, scoped, batched, with reencrypt as the
+// sweep's one upgrade door), the SecretCodec contract an extension's
+// vault-backed formats implement (drivers.secretCodecs), the
+// EncryptionScope tenancy/location record every seal site threads, and
+// the TWO-ARMED error taxonomy the skip/propagate policies branch on
+// (value-scoped InvalidCiphertextError family vs infrastructure
+// EncryptionUnavailableError family). The service and its contract types,
+// not the crypto primitives — each wire format stays defined exactly
+// once. The maintenance-surface store verbs this seam blessed ride the
+// Store interface above; RawResourceDocument is their row shape.
 export {
   DecryptionFailedError,
   EncryptionDisabledError,
+  EncryptionScope,
+  EncryptionUnavailableError,
   InvalidCiphertextError,
   SecretService,
 } from "./encryption/encryption.js";
+export type { SecretCodec } from "./encryption/codec.js";
 
 // The O6 driver seam (§6d): the sandbox-provisioner contract an extension
 // implements to register its own isolation driver (selected through the

--- a/backend/services/stigmer-server/src/store/__tests__/store-contract.ts
+++ b/backend/services/stigmer-server/src/store/__tests__/store-contract.ts
@@ -23,6 +23,7 @@
  * Driver-physical behavior (column layouts, FTS5/tsvector internals,
  * migration chains) stays in each driver's own tests.
  */
+import { fromBinary, toBinary } from "@bufbuild/protobuf";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
@@ -404,6 +405,143 @@ export function describeStoreContract(
         OrganizationSchema,
       );
       expect(matches).toHaveLength(1);
+    });
+  });
+
+  // The maintenance surface (20260830.04 Stage 1, ruling Q3) — ports the
+  // Java contract shapes (PostgresAgentRepositoryContractTest): keyset
+  // paging from "", stale-expectation loses, deleted-row loses.
+  describe("maintenance surface: raw ordered scan + bytes-level CAS", () => {
+    it('findResourcesRawOrderedAfter pages the whole kind in id order from ""', async () => {
+      for (const id of ["raw-b", "raw-a", "raw-c"]) {
+        await fx.store.saveResource(
+          KIND,
+          id,
+          OrganizationSchema,
+          makeOrganization({ id }),
+        );
+      }
+
+      const firstPage = await fx.store.findResourcesRawOrderedAfter(
+        KIND,
+        "",
+        2,
+      );
+      expect(firstPage.map((row) => row.id)).toEqual(["raw-a", "raw-b"]);
+      // The bytes are the EXACT stored marshaling — they parse back to the
+      // row (the CAS guards on these same bytes).
+      const parsed = fromBinary(OrganizationSchema, firstPage[0]!.data);
+      expect(parsed.metadata?.id).toBe("raw-a");
+
+      const lastId = firstPage[firstPage.length - 1]!.id;
+      const secondPage = await fx.store.findResourcesRawOrderedAfter(
+        KIND,
+        lastId,
+        2,
+      );
+      expect(secondPage.map((row) => row.id)).toEqual(["raw-c"]);
+
+      await expect(
+        fx.store.findResourcesRawOrderedAfter(KIND, "", 0),
+      ).rejects.toThrow("limit must be positive");
+    });
+
+    it("replaceResourceDataIfUnchanged applies against the read bytes and loses to any interleaved write", async () => {
+      await fx.store.saveResource(
+        KIND,
+        "cas",
+        OrganizationSchema,
+        makeOrganization({ id: "cas" }),
+      );
+      const read = (
+        await fx.store.findResourcesRawOrderedAfter(KIND, "", 1)
+      )[0]!;
+      const transformed = makeOrganization({
+        id: "cas",
+        description: "transformed",
+      });
+
+      expect(
+        await fx.store.replaceResourceDataIfUnchanged(
+          KIND,
+          "cas",
+          read.data,
+          toBinary(OrganizationSchema, transformed),
+        ),
+      ).toBe(true);
+      const loaded = await fx.store.getResource(
+        KIND,
+        "cas",
+        OrganizationSchema,
+      );
+      expect(loaded.spec?.description).toBe("transformed");
+
+      // The same expectation is now stale — the document changed under it,
+      // so a second swap against the old bytes must lose, row untouched.
+      const clobber = makeOrganization({
+        id: "cas",
+        description: "would-clobber",
+      });
+      expect(
+        await fx.store.replaceResourceDataIfUnchanged(
+          KIND,
+          "cas",
+          read.data,
+          toBinary(OrganizationSchema, clobber),
+        ),
+      ).toBe(false);
+      const untouched = await fx.store.getResource(
+        KIND,
+        "cas",
+        OrganizationSchema,
+      );
+      expect(untouched.spec?.description).toBe("transformed");
+
+      // A deleted row is a lost swap, never an upsert.
+      await fx.store.deleteResource(KIND, "cas");
+      expect(
+        await fx.store.replaceResourceDataIfUnchanged(
+          KIND,
+          "cas",
+          read.data,
+          toBinary(OrganizationSchema, clobber),
+        ),
+      ).toBe(false);
+      expect(await fx.store.listResources(KIND)).toHaveLength(0);
+    });
+
+    it("concurrent request-path writers win: a save between read and swap defeats the CAS", async () => {
+      await fx.store.saveResource(
+        KIND,
+        "race",
+        OrganizationSchema,
+        makeOrganization({ id: "race" }),
+      );
+      const read = (
+        await fx.store.findResourcesRawOrderedAfter(KIND, "", 1)
+      )[0]!;
+
+      // The interleaved writer (a normal request-path upsert).
+      await fx.store.saveResource(
+        KIND,
+        "race",
+        OrganizationSchema,
+        makeOrganization({ id: "race", description: "writer wins" }),
+      );
+
+      expect(
+        await fx.store.replaceResourceDataIfUnchanged(
+          KIND,
+          "race",
+          read.data,
+          toBinary(
+            OrganizationSchema,
+            makeOrganization({ id: "race", description: "sweep loses" }),
+          ),
+        ),
+      ).toBe(false);
+      const kept = await fx.store.getResource(KIND, "race", OrganizationSchema);
+      expect(kept.spec?.description).toBe("writer wins");
     });
   });
 
@@ -908,9 +1046,10 @@ export function describeStoreContract(
         offset: 0,
       });
       expect(narrowed.countsByKind).toEqual({ agent: 1, workflow: 1 });
-      expect(
-        narrowed.hits.map((hit) => hit.resourceId).sort(),
-      ).toEqual(["agt-mine", "wfl-any"]);
+      expect(narrowed.hits.map((hit) => hit.resourceId).sort()).toEqual([
+        "agt-mine",
+        "wfl-any",
+      ]);
 
       // An EMPTY set for a kind matches nothing for that kind.
       const emptyKind = await fx.store.querySearchIndex({

--- a/backend/services/stigmer-server/src/store/interface.ts
+++ b/backend/services/stigmer-server/src/store/interface.ts
@@ -422,6 +422,17 @@ export interface PendingOAuthStateStore {
   cleanupExpired(): Promise<number>;
 }
 
+/**
+ * One live row as stored — the id plus the EXACT marshaled bytes, for the
+ * maintenance surface (the Java RawDocument shape): a sweep reads pages of
+ * these, transforms, and swaps back with replaceResourceDataIfUnchanged
+ * guarding on the same bytes.
+ */
+export interface RawResourceDocument {
+  readonly id: string;
+  readonly data: Uint8Array;
+}
+
 // =============================================================================
 // The store contract
 // =============================================================================
@@ -525,6 +536,51 @@ export interface Store {
     labelValue: string,
     schema: Desc,
   ): Promise<Uint8Array[]>;
+
+  // ---------------------------------------------------------------------------
+  // The maintenance surface (20260830.04 Stage 1, ruling Q3) — the
+  // secret-convergence sweep's storage contract, mirroring the cloud
+  // repository primitives (AbstractPostgresApiResourceRepository.
+  // findRawOrderedAfter / replaceDataIfUnchanged). Blessed exports:
+  // maintenance flows visit every row and persist only when nothing
+  // interleaved — never through the RPC surfaces (update handlers
+  // re-trigger side effects, and the ***REDACTED*** round-trip copies
+  // stored ciphertext back, making upgrades impossible through that
+  // door) and never through extension SQL against this schema.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * One keyset page of a kind as raw documents — id plus the exact stored
+   * bytes, which is what replaceResourceDataIfUnchanged guards on. Keyset
+   * pagination on the id is stable under concurrent writes, where
+   * LIMIT/OFFSET paging is not (the Java findRawOrderedAfter rationale).
+   * Pass "" to start from the first row (ids are non-empty text, so every
+   * id sorts above it), then the last id of each page. Throws on a
+   * non-positive limit.
+   */
+  findResourcesRawOrderedAfter(
+    kind: ApiResourceKind,
+    afterIdExclusive: string,
+    limit: number,
+  ): Promise<RawResourceDocument[]>;
+
+  /**
+   * Whole-document compare-and-swap: replaces the stored bytes ONLY when
+   * they still equal `expectedData` — the exact bytes the row was read
+   * with (the TS analogue of Java's bound-JSON-text replaceDataIfUnchanged;
+   * BYTEA equality is exact by construction, no canonicalization games).
+   *
+   * @returns true when the swap applied; false when the row changed OR
+   *   was deleted since the read (a lost swap, never an upsert) — the
+   *   caller retries from a fresh read or lets the next scheduled pass
+   *   pick the row up. Concurrent request-path writers always win.
+   */
+  replaceResourceDataIfUnchanged(
+    kind: ApiResourceKind,
+    id: string,
+    expectedData: Uint8Array,
+    newData: Uint8Array,
+  ): Promise<boolean>;
 
   /** Removes all resources of a kind; returns the count deleted. */
   deleteResourcesByKind(kind: ApiResourceKind): Promise<number>;

--- a/backend/services/stigmer-server/src/store/postgres/store.ts
+++ b/backend/services/stigmer-server/src/store/postgres/store.ts
@@ -54,6 +54,7 @@ import type {
   OAuthGrantStore,
   PendingOAuthState,
   PendingOAuthStateStore,
+  RawResourceDocument,
   ScheduleRunRecord,
   SearchIndexEntry,
   SearchIndexHit,
@@ -263,6 +264,44 @@ export class PostgresStore implements Store {
   ): Promise<Uint8Array[]> {
     const rows = await this.listResources(kind);
     return filterRowsByLabel(rows, schema, labelKey, labelValue);
+  }
+
+  async findResourcesRawOrderedAfter(
+    kind: ApiResourceKind,
+    afterIdExclusive: string,
+    limit: number,
+  ): Promise<RawResourceDocument[]> {
+    if (limit <= 0) {
+      throw new Error(`limit must be positive, got ${limit}`);
+    }
+    // Keyset pagination over the (kind, id) primary key — stable under
+    // concurrent writes (the interface's maintenance-surface contract).
+    const result = await this.open().query(
+      `SELECT id, data FROM resources WHERE kind = $1 AND id > $2 ORDER BY id LIMIT $3`,
+      [apiResourceKindName(kind), afterIdExclusive, limit],
+    );
+    return result.rows as Array<{ id: string; data: Uint8Array }>;
+  }
+
+  async replaceResourceDataIfUnchanged(
+    kind: ApiResourceKind,
+    id: string,
+    expectedData: Uint8Array,
+    newData: Uint8Array,
+  ): Promise<boolean> {
+    // BYTEA equality in the WHERE clause makes the compare-and-swap one
+    // atomic statement: zero rows changed means the row moved on (or was
+    // deleted) since the read — a lost swap, never an upsert.
+    const result = await this.open().query(
+      `UPDATE resources SET data = $1, updated_at = now() WHERE kind = $2 AND id = $3 AND data = $4`,
+      [
+        Buffer.from(newData),
+        apiResourceKindName(kind),
+        id,
+        Buffer.from(expectedData),
+      ],
+    );
+    return result.rowCount === 1;
   }
 
   async deleteResourcesByKind(kind: ApiResourceKind): Promise<number> {
@@ -808,7 +847,9 @@ export class PostgresStore implements Store {
         }
       }
       scopeClauses.push(
-        kindClauses.length === 0 ? `AND FALSE` : `AND (${kindClauses.join(" OR ")})`,
+        kindClauses.length === 0
+          ? `AND FALSE`
+          : `AND (${kindClauses.join(" OR ")})`,
       );
     }
     const scopeSql = scopeClauses.join("\n        ");

--- a/backend/services/stigmer-server/src/store/sqlite/store.ts
+++ b/backend/services/stigmer-server/src/store/sqlite/store.ts
@@ -49,6 +49,7 @@ import type {
   OAuthGrantStore,
   PendingOAuthState,
   PendingOAuthStateStore,
+  RawResourceDocument,
   ScheduleRunRecord,
   SearchIndexEntry,
   SearchIndexHit,
@@ -282,6 +283,45 @@ export class SqliteStore implements Store {
       labelKey,
       labelValue,
     );
+  }
+
+  async findResourcesRawOrderedAfter(
+    kind: ApiResourceKind,
+    afterIdExclusive: string,
+    limit: number,
+  ): Promise<RawResourceDocument[]> {
+    if (limit <= 0) {
+      throw new Error(`limit must be positive, got ${limit}`);
+    }
+    const db = this.open();
+    // Keyset pagination over the (kind, id) primary key — stable under
+    // concurrent writes (the interface's maintenance-surface contract).
+    return db
+      .prepare(
+        `SELECT id, data FROM resources WHERE kind = ? AND id > ? ORDER BY id LIMIT ?`,
+      )
+      .all(apiResourceKindName(kind), afterIdExclusive, limit) as Array<{
+      id: string;
+      data: Uint8Array;
+    }>;
+  }
+
+  async replaceResourceDataIfUnchanged(
+    kind: ApiResourceKind,
+    id: string,
+    expectedData: Uint8Array,
+    newData: Uint8Array,
+  ): Promise<boolean> {
+    const db = this.open();
+    // BLOB equality in the WHERE clause makes the compare-and-swap one
+    // atomic statement: zero rows changed means the row moved on (or was
+    // deleted) since the read — a lost swap, never an upsert.
+    const result = db
+      .prepare(
+        `UPDATE resources SET data = ?, updated_at = datetime('now') WHERE kind = ? AND id = ? AND data = ?`,
+      )
+      .run(newData, apiResourceKindName(kind), id, expectedData);
+    return Number(result.changes) === 1;
   }
 
   async deleteResourcesByKind(kind: ApiResourceKind): Promise<number> {
@@ -813,7 +853,9 @@ export class SqliteStore implements Store {
         }
       }
       scopeClauses.push(
-        kindClauses.length === 0 ? `AND 1 = 0` : `AND (${kindClauses.join(" OR ")})`,
+        kindClauses.length === 0
+          ? `AND 1 = 0`
+          : `AND (${kindClauses.join(" OR ")})`,
       );
     }
     const scopeSql = scopeClauses.join("\n        ");

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -37,6 +37,7 @@ import {
   SendChannelMessageOutputSchema,
 } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/message_io_pb";
 import { BillingAccountSchema } from "@stigmer/protos/ai/stigmer/billing/v1/billing_account_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { BillingQueryController } from "@stigmer/protos/ai/stigmer/billing/v1/query_pb";
 import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
 
@@ -46,6 +47,8 @@ import {
   callerIdentityOf,
   composeServer,
   createLogger,
+  EncryptionScope,
+  EncryptionUnavailableError,
   InvalidTokenError,
   loadConfig,
   LOADED_EXECUTION_KEY,
@@ -81,6 +84,7 @@ import type {
   OrganizationDirectory,
   PipelineStep,
   PresignedUpload,
+  RawResourceDocument,
   ResourceAuthorizationLifecycle,
   ResourceCreatedEvent,
   ResourceDeletedEvent,
@@ -91,6 +95,8 @@ import type {
   SandboxCredentialRequest,
   SandboxProvisioner,
   SandboxProvisionerFactory,
+  SecretCodec,
+  SecretService,
   ServerExtension,
   Store,
   VisibilityChangedEvent,
@@ -376,6 +382,67 @@ const channelRuntime: ChannelRuntime = {
 };
 
 /**
+ * A consumer-shaped vault-backed secret codec (the 20260830.04 Stage 1
+ * seam, ruling Q2) — one enc:v<N>: wire format registered by version
+ * token through drivers.secretCodecs. The scope carries the tenancy a
+ * per-org KEK keys by; the taxonomy split is contract: a bad VALUE is
+ * InvalidCiphertextError (skippable per key), missing MACHINERY is
+ * EncryptionUnavailableError (must abort — this fake's every arm, it has
+ * no real vault). The batch verbs and delete are optional: absent here,
+ * the facade loops the singular verbs and treats delete as a no-op.
+ */
+const consumerVaultCodec: SecretCodec = {
+  version: "v2",
+  encrypt: (plaintext: string, scope: EncryptionScope) => {
+    void plaintext;
+    void scope.kekKeyName();
+    return Promise.reject(
+      new EncryptionUnavailableError("compile-proof codec — never invoked"),
+    );
+  },
+  decrypt: (encrypted: string) => {
+    void encrypted;
+    return Promise.reject(
+      new EncryptionUnavailableError("compile-proof codec — never invoked"),
+    );
+  },
+};
+
+/**
+ * The secret-convergence sweep's exact shape (Stage 3 consumes it): page
+ * raw documents through the blessed maintenance verbs, reseal through the
+ * facade's one upgrade door, and persist only when nothing interleaved —
+ * the bytes-guarded compare-and-swap. Never executed; it pins that the
+ * Store surface and the facade verbs stay sufficient for the sweep.
+ */
+export async function consumerSweepPage(
+  store: Store,
+  secrets: SecretService,
+  afterId: string,
+): Promise<string | undefined> {
+  const scope = EncryptionScope.forOrganizationResource(
+    "consumer-org",
+    "environment",
+    "env-slug",
+  );
+  const page: RawResourceDocument[] = await store.findResourcesRawOrderedAfter(
+    ApiResourceKind.environment,
+    afterId,
+    100,
+  );
+  for (const row of page) {
+    void (await secrets.reencrypt("enc:v1:fake", scope.withKeyName("KEY")));
+    void (await store.replaceResourceDataIfUnchanged(
+      ApiResourceKind.environment,
+      row.id,
+      row.data,
+      row.data,
+    ));
+  }
+  return page.length > 0 ? page[page.length - 1]?.id : undefined;
+}
+
+/**
  * An extension-registered service handler built the OSS controller idiom
  * (C4 Stage 4): the verified caller read once via callerIdentityOf, then
  * a chain fronted by the exported Authorize (descriptor-driven from the
@@ -488,6 +555,9 @@ export const fakeExtension: ServerExtension = {
     // The C3 serving seam: a composed runtime flips the agentchannel
     // install/messaging/conversation arms from refusal to serving.
     channelRuntime,
+    // The 20260830.04 sealing seam: vault-backed wire formats registered
+    // by version token ("v1" is the reserved built-in).
+    secretCodecs: new Map([["v2", consumerVaultCodec]]),
   },
   services: [registerBillingService],
   workers: [workerFactory],


### PR DESCRIPTION
## Summary
Stage 1 of the pre-X1 sealing slice (stigmer-cloud project `20260830.04.sp.secret-sealing-and-vault-codecs`): `SecretService` becomes a facade over a versioned codec registry, so the cloud composition can register vault-backed `enc:v2`/`enc:v3` wire formats through the extension registry while the empty-extension OSS build stays byte-identical. Also lands the secret-convergence sweep's blessed storage contract (raw ordered scan + bytes-level CAS) in both store drivers.

## Context
Production (cloud) seals secrets as `enc:v2` envelopes under per-org OpenBAO Transit KEKs; the TS composition must read every production ciphertext and write at production parity before the Java service can retire (gate rulings Q1/Q2/Q3/Q7 of the sub-project's plan gate). This PR is the OSS seam that makes those codecs registrable; the codecs themselves, the sweep worker, and the ciphertext movers follow in the cloud repo (Stages 2–4).

## Changes
- **`src/encryption/`**: `SecretCodec` contract (`codec.ts`), `EncryptionScope` — the Java record ported with its validation invariants (`scope.ts`), the extracted v1 static-key codec (`v1-codec.ts`, crypto byte-identical), the two-armed error taxonomy by re-parenting (`errors.ts`), and the reworked facade: read dispatch on the value's own `enc:v<N>:` token, ONE write version resolved fail-fast (`STIGMER_ENCRYPTION_WRITE_VERSION`, OSS default `v1`), async scoped `encrypt`/`decrypt`, batch verbs, `encryptAllAtMostV2` (the Java `encryptAllV2` executioncontext pin, generalized as a cap), upward-only round-trip-verified `reencrypt`, `versionOf`, and the `delete` lifecycle verb (no-op for v1/v2; delete-site wiring is Stage 3).
- **`src/extensions/`**: the `secretCodecs` driver point — version-keyed map merge; registering `v1` (the reserved built-in), a duplicate version, or an undispatchable token is a boot throw naming the offending unit(s).
- **`boot/compose.ts`**: codec-map assembly at the consumption site (built-in v1 + extension codecs), fail-fast write-version resolution outside the WARN-degrade catch; the keyless WARN-degrade posture (oss#394) preserved byte-for-byte.
- **Call sites**: every sealing site (environment, executioncontext, oauthapp, channelapp, mcpserver ×3) converts to `await` + tenancy scope (`EncryptionScope.forOrganization`, the pre-v3 posture); EC sealing becomes one batch through the v2 cap; the two resolution lanes' per-key skip policies now propagate the whole infrastructure arm (`EncryptionUnavailableError`) so a future vault outage can never silently drop a credential.
- **Store**: `findResourcesRawOrderedAfter` (keyset scan by id) + `replaceResourceDataIfUnchanged` (bytes-level CAS; lost swap, never an upsert) in the interface and BOTH drivers, with shared contract tests porting the Java shapes.
- **Surface**: exports-map seam block (`SecretCodec`, `EncryptionScope`, `EncryptionUnavailableError`, `RawResourceDocument`); the extension-consumer compile proof registers a fake v2 codec and exercises the sweep shape.
- `REDACTED_MARKER` relocated to the encryption facade (reencrypt refuses it; domain→encryption is the dependency direction), re-exported from `domain/environment/constants.ts` — byte unchanged.

## Implementation notes
- The exact-v2 Java pin cannot port (the same call site must run in v1-only OSS), so `encryptAllAtMostV2` seals with the LOWER of the write version and v2 — identical to today at write=v1, identical to Java at write=v2, and preserves Java's protection at a future v3 flip.
- Taxonomy by re-parenting keeps all four existing error classes, names, and message bytes; the two arms emerge by inheritance (`DecryptionFailedError extends InvalidCiphertextError`; `EncryptionDisabledError extends EncryptionUnavailableError`).
- Deliberate recorded changes, both conformance-invisible: an unregistered-version decrypt now refuses as `EncryptionUnavailableError` with the Java copy shape (previously died accidentally as `invalid base64 encoding`; still fail-closed, now the honest arm); the EC seal-failure Internal copy is batch-level (the per-key copy was unreachable for local AES-GCM).

## Breaking changes
- None on the wire. The blessed library surface changes shape (async `encrypt`/`decrypt`, required `EncryptionScope`): the one commit-pin consumer (the cloud composition) updates when it bumps the pin in Stage 2.

## Test plan
- `npm run typecheck && npm test` (stigmer-server): 159 files, 2116 passed.
- New suites: `encryption/__tests__/codec-seam.test.ts` (dispatch, write-version fail-fast, batches, the v2 cap, reencrypt rules, scope invariants), registry merge throws, shared store-contract block (keyset paging, stale-expectation loses, deleted-row loses, concurrent-writer race) green on BOTH drivers (sqlite + Postgres 16).
- `make test-extension-consumer`: compile proof green.
- **All four conformance rosters byte-identical (the empty-extension proof)**: `local` 499 passed, `local-execution` 160 passed, `local-postgres` 499 passed, `local-postgres-execution` 160 passed — zero roster edits.

## Risks
- The async conversion touches every sealing path; the conformance rosters and the full unit suite are the containment proof. Rollback is a single revert — no schema or wire-format changes ship here.

## Checklist
- [x] Tests added/updated
- [x] Backward compatible on the wire (library surface change disclosed above)
- [ ] Docs: none needed (internal seam; module intent headers carry the contract)

Made with [Cursor](https://cursor.com)