### PR TITLE
feat(backend/stigmer-server): wire secret backing-state cleanup at delete sites and expose the composed facade

### DIFF
--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -157,6 +157,17 @@ export interface ComposedServer {
   /** The persistence layer (exposed for tests; domain code gets it injected). */
   store: Store;
   /**
+   * The composed secret-encryption facade — the SAME instance every
+   * domain seals and opens with (one facade per composition, the Go
+   * one-pointer posture). Exposed for compositions whose extensions run
+   * maintenance lanes over stored ciphertext — the secret-convergence
+   * sweep's reencrypt door and the encryption-state census (convergence
+   * 20260830.04 Stage 3, gate ruling G2): a twin facade built from the
+   * same codec map would duplicate KEK caches and silently drift from
+   * the boot-resolved write version.
+   */
+  secrets: SecretService;
+  /**
    * The Temporal lifecycle manager (exposed for composed tests asserting
    * engine-state behavior). Health semantics are unchanged by it: a down
    * engine never flips gRPC health — that is the engine-unavailable
@@ -1099,6 +1110,7 @@ export async function composeServer(
   return {
     healthState,
     store,
+    secrets: secretService,
     temporalManager,
     runnerAuthService,
     agentExecutionStreamBroker,

--- a/backend/services/stigmer-server/src/domain/channelapp/controller.ts
+++ b/backend/services/stigmer-server/src/domain/channelapp/controller.ts
@@ -80,6 +80,7 @@ import {
   newCreateAuthorizationTuplesStep,
 } from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newDestroySecretBackingStateStep } from "../../pipeline/steps/secret-cleanup.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
@@ -90,6 +91,7 @@ import {
   newEncryptChannelAppSecretsForUpdateStep,
   newValidateProviderImmutableStep,
   redactChannelApp,
+  secretValuesOfChannelApp,
 } from "./steps.js";
 
 export interface ChannelAppControllerDeps {
@@ -294,6 +296,12 @@ async function deleteChannelApp(
     .addStep(newDeleteResourceStep(deps.store))
     .addStep(
       newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
+    .addStep(
+      newDestroySecretBackingStateStep<
+        typeof ChannelAppCommandController.method.delete.input,
+        typeof ChannelAppSchema
+      >(deps.secretService, deps.logger, secretValuesOfChannelApp),
     )
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/domain/channelapp/steps.ts
+++ b/backend/services/stigmer-server/src/domain/channelapp/steps.ts
@@ -101,6 +101,33 @@ function redactWhatsApp(whatsapp: WhatsAppChannelAppConfig): void {
 }
 
 /**
+ * The sealed values a ChannelApp carries — the delete chain's extractor
+ * for DestroySecretBackingState. The provider arm is immutable, so
+ * exactly one arm holds values; the field lists mirror the redact
+ * functions above (the provider-arm tripwire covers both — an arm added
+ * without coverage here fails the same exhaustiveness check).
+ */
+export function secretValuesOfChannelApp(app: ChannelApp): string[] {
+  const provider = app.spec?.providerConfig;
+  switch (provider?.case) {
+    case "slack":
+      return [provider.value.clientSecret, provider.value.signingSecret];
+    case "whatsapp":
+      return [
+        provider.value.appSecret,
+        provider.value.accessToken,
+        provider.value.verifyToken,
+      ];
+    case undefined:
+      return [];
+    default: {
+      const exhaustive: never = provider;
+      throw new Error(`unhandled provider arm: ${String(exhaustive)}`);
+    }
+  }
+}
+
+/**
  * EncryptChannelAppSecrets — Go encryptChannelAppSecretsStep: the oauthapp
  * encryptClientSecretStep generalized to a provider oneof carrying
  * multiple secrets (Slack: client_secret and signing_secret; WhatsApp:

--- a/backend/services/stigmer-server/src/domain/environment/controller.ts
+++ b/backend/services/stigmer-server/src/domain/environment/controller.ts
@@ -101,6 +101,7 @@ import {
   newUpdateVisibilityTuplesStep,
 } from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newDestroySecretBackingStateStep } from "../../pipeline/steps/secret-cleanup.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import {
@@ -114,6 +115,7 @@ import { environmentSearchExtractor } from "./search-extractor.js";
 import {
   SECRET_VALUE_KEY,
   UPDATED_ENVIRONMENT_KEY,
+  newDestroyDroppedEnvironmentSecretsStep,
   newEncryptSecretValuesStep,
   newEnforcePersonalUniquenessStep,
   newExtractAndDecryptSingleKeyStep,
@@ -121,6 +123,7 @@ import {
   newMergeVariablesAndPersistStep,
   newPreserveRedactedSecretsStep,
   newRemoveVariableKeysAndPersistStep,
+  secretValuesOfEnvironment,
 } from "./steps.js";
 
 export interface EnvironmentControllerDeps {
@@ -239,6 +242,9 @@ async function update(
     .addStep(newNormalizeReferencesStep())
     .addStep(newPersistStep(deps.store))
     .addStep(
+      newDestroyDroppedEnvironmentSecretsStep(deps.secretService, deps.logger),
+    )
+    .addStep(
       newIndexSearchStep(deps.store, environmentSearchExtractor, deps.logger),
     )
     .build()
@@ -323,6 +329,12 @@ async function deleteEnvironment(
     .addStep(newDeleteResourceStep(deps.store))
     .addStep(
       newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
+    .addStep(
+      newDestroySecretBackingStateStep<
+        typeof EnvironmentCommandController.method.delete.input,
+        typeof EnvironmentSchema
+      >(deps.secretService, deps.logger, secretValuesOfEnvironment),
     )
     .addStep(newDeleteSearchIndexStep(deps.store, deps.logger))
     .build()
@@ -604,7 +616,13 @@ async function removeVariables(
     )
     .addStep(newValidateProtoStep())
     .addStep(newLoadEnvironmentByIdStep(deps.store))
-    .addStep(newRemoveVariableKeysAndPersistStep(deps.store))
+    .addStep(
+      newRemoveVariableKeysAndPersistStep(
+        deps.store,
+        deps.secretService,
+        deps.logger,
+      ),
+    )
     .build()
     .execute(reqCtx);
 

--- a/backend/services/stigmer-server/src/domain/environment/steps.ts
+++ b/backend/services/stigmer-server/src/domain/environment/steps.ts
@@ -50,6 +50,7 @@ import { setAuditFieldsForUpdate } from "../../pipeline/steps/defaults.js";
 import { findResourceByLabelAndOrg } from "../../pipeline/steps/helpers.js";
 import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
 import { TARGET_RESOURCE_KEY } from "../../pipeline/steps/load-target.js";
+import { destroySecretBackingState } from "../../pipeline/steps/secret-cleanup.js";
 import type { Store } from "../../store/interface.js";
 import {
   PERSONAL_LABEL_KEY,
@@ -480,9 +481,18 @@ export function newMergeVariablesAndPersistStep(
  * and persists. Requires LoadEnvironmentByID first; stores the modified
  * environment under UPDATED_ENVIRONMENT_KEY; stamps SpecAudit. No search
  * re-index, as in Go.
+ *
+ * The removed keys' sealed values have their external backing state
+ * destroyed AFTER the persist (the Java RemoveAndPersist site, wired by
+ * convergence 20260830.04 Stage 3): the old values must be captured
+ * BEFORE the deletion mutates the loaded resource, and destruction is
+ * best-effort — a failure never fails the remove (secret-cleanup.ts
+ * carries the full contract). A no-op under the OSS v1-only codec set.
  */
 export function newRemoveVariableKeysAndPersistStep(
   store: Store,
+  secretService: SecretService,
+  logger: Logger,
 ): PipelineStep<typeof RemoveEnvironmentVariablesRequestSchema> {
   return {
     name: "RemoveVariableKeysAndPersist",
@@ -498,8 +508,13 @@ export function newRemoveVariableKeysAndPersistStep(
       }
 
       const keys = ctx.input.keys;
+      const removedSecretValues: string[] = [];
       if (env.spec?.data !== undefined) {
         for (const key of keys) {
+          const removed = env.spec.data[key];
+          if (removed !== undefined && removed.isSecret) {
+            removedSecretValues.push(removed.value);
+          }
           delete env.spec.data[key];
         }
       }
@@ -529,7 +544,78 @@ export function newRemoveVariableKeysAndPersistStep(
         );
       }
 
+      await destroySecretBackingState(
+        secretService,
+        logger,
+        {
+          kind: "environment",
+          resourceId: env.metadata?.id ?? "",
+          operation: "removeVariables",
+        },
+        removedSecretValues,
+      );
+
       ctx.set(UPDATED_ENVIRONMENT_KEY, env);
     },
   };
+}
+
+/**
+ * DestroyDroppedEnvironmentSecrets — the Java
+ * DestroyDroppedEnvironmentSecrets step (wired by convergence
+ * 20260830.04 Stage 3): post-persist in the full-resource update chain,
+ * destroys the external backing state of secret keys the update DROPPED.
+ * Strictly dropped keys only — a key that survives with a rotated value
+ * keeps its KV path (superseded versions age out via the store's
+ * max_versions retention), and marker-preserved keys carry their stored
+ * ciphertext forward unchanged. Best-effort by the secret-cleanup
+ * contract; a no-op under the OSS v1-only codec set.
+ *
+ * Requires LoadExisting (the pre-update state) and runs after Persist —
+ * destroying before the row is written would dangle stored pointers on
+ * a persist failure.
+ */
+export function newDestroyDroppedEnvironmentSecretsStep(
+  secretService: SecretService,
+  logger: Logger,
+): PipelineStep<typeof EnvironmentSchema> {
+  return {
+    name: "DestroyDroppedEnvironmentSecrets",
+    async execute(
+      ctx: RequestContext<typeof EnvironmentSchema>,
+    ): Promise<void> {
+      const existing = ctx.get(EXISTING_RESOURCE_KEY) as
+        | Environment
+        | undefined;
+      const oldData = existing?.spec?.data;
+      if (oldData === undefined) {
+        return;
+      }
+      const newData = ctx.newState.spec?.data ?? {};
+      const droppedSecretValues = Object.entries(oldData)
+        .filter(([key, value]) => value.isSecret && newData[key] === undefined)
+        .map(([, value]) => value.value);
+      await destroySecretBackingState(
+        secretService,
+        logger,
+        {
+          kind: "environment",
+          resourceId: existing?.metadata?.id ?? "",
+          operation: "update",
+        },
+        droppedSecretValues,
+      );
+    },
+  };
+}
+
+/**
+ * The sealed values an environment carries — the delete chain's
+ * extractor for DestroySecretBackingState (every is_secret entry;
+ * blank values are skipped by the destroyer).
+ */
+export function secretValuesOfEnvironment(env: Environment): string[] {
+  return Object.values(env.spec?.data ?? {})
+    .filter((value) => value.isSecret)
+    .map((value) => value.value);
 }

--- a/backend/services/stigmer-server/src/domain/oauthapp/controller.ts
+++ b/backend/services/stigmer-server/src/domain/oauthapp/controller.ts
@@ -81,6 +81,7 @@ import {
   newCreateAuthorizationTuplesStep,
 } from "../../pipeline/steps/authorization-tuples.js";
 import { newPersistStep } from "../../pipeline/steps/persist.js";
+import { newDestroySecretBackingStateStep } from "../../pipeline/steps/secret-cleanup.js";
 import { newResolveSlugStep } from "../../pipeline/steps/slug.js";
 import { newValidateProtoStep } from "../../pipeline/steps/validation.js";
 import { newValidateVisibilityStep } from "../../pipeline/steps/validate-visibility.js";
@@ -287,6 +288,14 @@ async function deleteOAuthApp(
     .addStep(newDeleteResourceStep(deps.store))
     .addStep(
       newCleanupIamPoliciesStep(deps.authorizationLifecycle, deps.logger),
+    )
+    .addStep(
+      newDestroySecretBackingStateStep<
+        typeof OAuthAppCommandController.method.delete.input,
+        typeof OAuthAppSchema
+      >(deps.secretService, deps.logger, (app) =>
+        app.spec === undefined ? [] : [app.spec.clientSecret],
+      ),
     )
     .build()
     .execute(reqCtx);

--- a/backend/services/stigmer-server/src/extensions/__tests__/secret-cleanup-composed.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/secret-cleanup-composed.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Pins the Q7 secret-cleanup wiring END TO END (convergence 20260830.04
+ * Stage 3): a composed server with an extension-registered fake "v9"
+ * codec (write version v9, so every sealed value has recordable backing
+ * state) proves, through real gRPC calls, that:
+ *
+ *   - the three delete chains (environment, oauthapp, channelapp)
+ *     destroy exactly the doomed resource's sealed values;
+ *   - the environment update chain destroys ONLY dropped keys — a
+ *     rotated key keeps its backing state (superseded versions age out
+ *     via the store's retention, the Java posture), and marker-preserved
+ *     keys are untouched;
+ *   - removeVariables destroys the removed keys and ignores unknowns;
+ *     the updateVariables merge lane destroys nothing;
+ *   - a destroy failure NEVER fails the request (best-effort after the
+ *     store write);
+ *   - the composed facade rides ComposedServer.secrets (gate ruling G2)
+ *     — the same instance the domains sealed with.
+ *
+ * The v1-only default arm (cleanup as a silent no-op) is pinned by the
+ * conformance rosters; the unit-level contract lives in
+ * pipeline/steps/__tests__/secret-cleanup.test.ts.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createClient } from "@connectrpc/connect";
+import type { Client, Transport } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { ChannelAppSchema } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/api_pb";
+import { ChannelAppCommandController } from "@stigmer/protos/ai/stigmer/agentic/channelapp/v1/command_pb";
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { EnvironmentCommandController } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/command_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { OAuthAppSchema } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/api_pb";
+import { OAuthAppCommandController } from "@stigmer/protos/ai/stigmer/iam/oauthapp/v1/command_pb";
+
+import { loadConfig } from "../../boot/config.js";
+import { composeServer } from "../../boot/compose.js";
+import type { ComposedServer } from "../../boot/compose.js";
+import { createLogger } from "../../boot/logger.js";
+import type { SecretCodec } from "../../encryption/codec.js";
+import type { EncryptionScope } from "../../encryption/encryption.js";
+import { REDACTED_MARKER } from "../../encryption/encryption.js";
+import { ResourceNotFoundError } from "../../store/interface.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const TEST_KEY_B64 = Buffer.alloc(32, 9).toString("base64");
+const ORG = "acme";
+
+/** The recordable backing state: delete() logs calls; failNext arms throws. */
+class RecordingCodec implements SecretCodec {
+  readonly version = "v9";
+  readonly deleted: string[] = [];
+  readonly failNext: Error[] = [];
+
+  async encrypt(plaintext: string, _scope: EncryptionScope): Promise<string> {
+    return `enc:v9:${Buffer.from(plaintext, "utf8").toString("base64")}`;
+  }
+
+  async decrypt(encrypted: string): Promise<string> {
+    return Buffer.from(encrypted.slice("enc:v9:".length), "base64").toString(
+      "utf8",
+    );
+  }
+
+  async delete(storedValue: string): Promise<void> {
+    const failure = this.failNext.shift();
+    if (failure !== undefined) {
+      throw failure;
+    }
+    this.deleted.push(storedValue);
+  }
+}
+
+const codec = new RecordingCodec();
+
+let server: ComposedServer;
+let dir: string;
+let envCommand: Client<typeof EnvironmentCommandController>;
+let oauthCommand: Client<typeof OAuthAppCommandController>;
+let channelCommand: Client<typeof ChannelAppCommandController>;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "secret-cleanup-composed-"));
+  vi.stubEnv("STIGMER_ENCRYPTION_KEY", TEST_KEY_B64);
+  // The composition posture under test: extension codec v9 IS the write
+  // version, so freshly sealed values carry recordable backing state.
+  vi.stubEnv("STIGMER_ENCRYPTION_WRITE_VERSION", "v9");
+  server = await composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      TEMPORAL_HOST_PORT: "127.0.0.1:1",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      STORAGE_PATH: path.join(dir, "storage"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    extensions: [
+      {
+        name: "fake-secret-codecs",
+        drivers: {
+          secretCodecs: new Map<string, SecretCodec>([["v9", codec]]),
+        },
+      },
+    ],
+    portOverride: 0,
+    host: "127.0.0.1",
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  envCommand = createClient(EnvironmentCommandController, transport);
+  oauthCommand = createClient(OAuthAppCommandController, transport);
+  channelCommand = createClient(ChannelAppCommandController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+beforeEach(() => {
+  codec.deleted.length = 0;
+  codec.failNext.length = 0;
+});
+
+let counter = 0;
+function envInput(
+  data: Record<string, { value: string; isSecret: boolean }>,
+  name?: string,
+) {
+  counter += 1;
+  return {
+    apiVersion: "agentic.stigmer.ai/v1",
+    kind: "Environment",
+    metadata: { name: name ?? `Cleanup Env ${counter}`, org: ORG },
+    spec: { description: "secret-cleanup composed pin", data },
+  };
+}
+
+async function storedEnvData(id: string): Promise<Record<string, string>> {
+  const env = await server.store.getResource(
+    ApiResourceKind.environment,
+    id,
+    EnvironmentSchema,
+  );
+  return Object.fromEntries(
+    Object.entries(env.spec?.data ?? {}).map(([k, v]) => [k, v.value]),
+  );
+}
+
+describe("the composed facade exposure (gate ruling G2)", () => {
+  it("ComposedServer.secrets is the instance the domains sealed with", async () => {
+    const created = await envCommand.create(
+      envInput({ TOKEN: { value: "open-sesame", isSecret: true } }),
+    );
+    const stored = await storedEnvData(created.metadata!.id);
+    expect(stored["TOKEN"]).toMatch(/^enc:v9:/);
+    expect(await server.secrets.decrypt(stored["TOKEN"]!)).toBe("open-sesame");
+  });
+});
+
+describe("delete chains destroy sealed backing state", () => {
+  it("environment delete destroys every sealed value, never the plain ones", async () => {
+    const created = await envCommand.create(
+      envInput({
+        FIRST: { value: "secret-one", isSecret: true },
+        SECOND: { value: "secret-two", isSecret: true },
+        PLAIN: { value: "visible", isSecret: false },
+      }),
+    );
+    const stored = await storedEnvData(created.metadata!.id);
+
+    await envCommand.delete({ resourceId: created.metadata!.id });
+
+    expect([...codec.deleted].sort()).toEqual(
+      [stored["FIRST"]!, stored["SECOND"]!].sort(),
+    );
+  });
+
+  it("oauthapp delete destroys the sealed client secret", async () => {
+    counter += 1;
+    const created = await oauthCommand.create({
+      apiVersion: "iam.stigmer.ai/v1",
+      kind: "OAuthApp",
+      metadata: { name: `Cleanup Vendor ${counter}`, org: ORG },
+      spec: {
+        provider: "TestVendor",
+        clientId: "client-id",
+        clientSecret: "vendor-client-secret",
+        authorizationUrl: "https://vendor.example.com/oauth/authorize",
+        tokenUrl: "https://vendor.example.com/oauth/token",
+        scopes: ["read"],
+      },
+    });
+    const storedApp = await server.store.getResource(
+      ApiResourceKind.oauth_app,
+      created.metadata!.id,
+      OAuthAppSchema,
+    );
+    const sealed = storedApp.spec!.clientSecret;
+    expect(sealed).toMatch(/^enc:v9:/);
+
+    await oauthCommand.delete({ resourceId: created.metadata!.id });
+
+    expect(codec.deleted).toEqual([sealed]);
+  });
+
+  it("channelapp delete destroys the provider arm's sealed fields", async () => {
+    counter += 1;
+    const created = await channelCommand.create({
+      apiVersion: "agentic.stigmer.ai/v1",
+      kind: "ChannelApp",
+      metadata: { name: `Cleanup Slack ${counter}`, org: ORG },
+      spec: {
+        providerConfig: {
+          case: "slack" as const,
+          value: {
+            clientId: "1234.5678",
+            clientSecret: "shh-client-secret",
+            signingSecret: "shh-signing-secret",
+          },
+        },
+      },
+    });
+    const storedApp = await server.store.getResource(
+      ApiResourceKind.channel_app,
+      created.metadata!.id,
+      ChannelAppSchema,
+    );
+    const slack =
+      storedApp.spec?.providerConfig.case === "slack"
+        ? storedApp.spec.providerConfig.value
+        : undefined;
+    expect(slack).toBeDefined();
+
+    await channelCommand.delete({ resourceId: created.metadata!.id });
+
+    expect([...codec.deleted].sort()).toEqual(
+      [slack!.clientSecret, slack!.signingSecret].sort(),
+    );
+  });
+
+  it("a destroy failure never fails the delete (best-effort after the row is gone)", async () => {
+    const created = await envCommand.create(
+      envInput({ DOOMED: { value: "secret", isSecret: true } }),
+    );
+    codec.failNext.push(new Error("vault is down"));
+
+    await expect(
+      envCommand.delete({ resourceId: created.metadata!.id }),
+    ).resolves.toBeDefined();
+
+    await expect(
+      server.store.getResource(
+        ApiResourceKind.environment,
+        created.metadata!.id,
+        EnvironmentSchema,
+      ),
+    ).rejects.toBeInstanceOf(ResourceNotFoundError);
+    expect(codec.deleted).toEqual([]);
+  });
+});
+
+describe("environment update and variable lanes", () => {
+  it("update destroys ONLY dropped keys; marker-preserved keys are untouched", async () => {
+    const name = `Cleanup Env Drop ${++counter}`;
+    const created = await envCommand.create(
+      envInput(
+        {
+          DROPPED: { value: "goes-away", isSecret: true },
+          KEPT: { value: "stays", isSecret: true },
+        },
+        name,
+      ),
+    );
+    const before = await storedEnvData(created.metadata!.id);
+
+    await envCommand.update(
+      envInput({ KEPT: { value: REDACTED_MARKER, isSecret: true } }, name),
+    );
+
+    expect(codec.deleted).toEqual([before["DROPPED"]!]);
+    const after = await storedEnvData(created.metadata!.id);
+    expect(after["KEPT"]).toBe(before["KEPT"]);
+    expect(after["DROPPED"]).toBeUndefined();
+  });
+
+  it("a rotated key is NOT a drop — its old backing state survives", async () => {
+    const name = `Cleanup Env Rotate ${++counter}`;
+    const created = await envCommand.create(
+      envInput({ KEY: { value: "old-secret", isSecret: true } }, name),
+    );
+
+    await envCommand.update(
+      envInput({ KEY: { value: "new-secret", isSecret: true } }, name),
+    );
+
+    expect(codec.deleted).toEqual([]);
+    const after = await storedEnvData(created.metadata!.id);
+    expect(await server.secrets.decrypt(after["KEY"]!)).toBe("new-secret");
+  });
+
+  it("removeVariables destroys the removed keys, ignoring unknown keys", async () => {
+    const created = await envCommand.create(
+      envInput({
+        REMOVED: { value: "goes-away", isSecret: true },
+        SURVIVOR: { value: "stays", isSecret: true },
+      }),
+    );
+    const before = await storedEnvData(created.metadata!.id);
+
+    await envCommand.removeVariables({
+      environmentId: created.metadata!.id,
+      keys: ["REMOVED", "GHOST"],
+    });
+
+    expect(codec.deleted).toEqual([before["REMOVED"]!]);
+    const after = await storedEnvData(created.metadata!.id);
+    expect(after["SURVIVOR"]).toBe(before["SURVIVOR"]);
+  });
+
+  it("the updateVariables merge lane destroys nothing (an overwrite keeps its path)", async () => {
+    const created = await envCommand.create(
+      envInput({ KEY: { value: "old-secret", isSecret: true } }),
+    );
+
+    await envCommand.updateVariables({
+      environmentId: created.metadata!.id,
+      variables: { KEY: { value: "rotated", isSecret: true } },
+    });
+
+    expect(codec.deleted).toEqual([]);
+    const after = await storedEnvData(created.metadata!.id);
+    expect(await server.secrets.decrypt(after["KEY"]!)).toBe("rotated");
+  });
+});

--- a/backend/services/stigmer-server/src/pipeline/steps/__tests__/secret-cleanup.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/__tests__/secret-cleanup.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Pins the secret backing-state cleanup contract (convergence 20260830.04
+ * Stage 3, gate ruling Q7) at the unit level: the destroyer walks every
+ * sealed value best-effort — one failure logs ERROR and never interrupts
+ * the rest or the request — while plaintext, markers, and blanks are
+ * silent no-ops by the facade's own dispatch (the property that keeps the
+ * OSS default codec set conformance-invisible). The step arm reads the
+ * doomed resource from EXISTING_RESOURCE_KEY and no-ops when it is
+ * absent. The end-to-end wiring through the delete/update/removeVariables
+ * chains is pinned in extensions/__tests__/secret-cleanup-composed.test.ts.
+ */
+import { create } from "@bufbuild/protobuf";
+import { describe, expect, it } from "vitest";
+
+import { EnvironmentSchema } from "@stigmer/protos/ai/stigmer/agentic/environment/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import type { SecretCodec } from "../../../encryption/codec.js";
+import {
+  EncryptionScope,
+  REDACTED_MARKER,
+  SecretService,
+} from "../../../encryption/encryption.js";
+import type { CallerIdentity } from "../../../extensions/identity.js";
+import { RequestContext } from "../../request-context.js";
+import { EXISTING_RESOURCE_KEY } from "../load-existing.js";
+import {
+  destroySecretBackingState,
+  newDestroySecretBackingStateStep,
+} from "../secret-cleanup.js";
+
+const caller: CallerIdentity = {
+  identityId: "ida_test",
+  callerClass: "user",
+  issuer: "",
+  rawToken: "",
+};
+
+/**
+ * A codec whose delete records calls; failNext holds errors thrown one
+ * per call (queue order), so a test can fail the first destroy and prove
+ * the walk continues to the second.
+ */
+class RecordingCodec implements SecretCodec {
+  readonly version = "v9";
+  readonly deleted: string[] = [];
+  readonly failNext: Error[] = [];
+
+  async encrypt(plaintext: string, _scope: EncryptionScope): Promise<string> {
+    return `enc:v9:${Buffer.from(plaintext, "utf8").toString("base64")}`;
+  }
+
+  async decrypt(encrypted: string): Promise<string> {
+    return Buffer.from(encrypted.slice("enc:v9:".length), "base64").toString(
+      "utf8",
+    );
+  }
+
+  async delete(storedValue: string): Promise<void> {
+    const failure = this.failNext.shift();
+    if (failure !== undefined) {
+      throw failure;
+    }
+    this.deleted.push(storedValue);
+  }
+}
+
+function newFixture(): {
+  codec: RecordingCodec;
+  secrets: SecretService;
+  errorLines: string[];
+} {
+  const codec = new RecordingCodec();
+  const secrets = SecretService.withCodecs({
+    codecs: new Map<string, SecretCodec>([["v9", codec]]),
+    writeVersion: "v9",
+  });
+  const errorLines: string[] = [];
+  return { codec, secrets, errorLines };
+}
+
+function captureLogger(errorLines: string[]) {
+  return createLogger({
+    level: "error",
+    pretty: false,
+    write: (line: string) => {
+      errorLines.push(line);
+    },
+  });
+}
+
+describe("destroySecretBackingState (the SecretValueCleanup port)", () => {
+  it("destroys each sealed value in order, skipping blanks", async () => {
+    const { codec, secrets, errorLines } = newFixture();
+    const a = await codec.encrypt(
+      "alpha",
+      EncryptionScope.forOrganization("acme"),
+    );
+    const b = await codec.encrypt(
+      "beta",
+      EncryptionScope.forOrganization("acme"),
+    );
+
+    await destroySecretBackingState(
+      secrets,
+      captureLogger(errorLines),
+      { kind: "environment", resourceId: "env_1" },
+      [a, "", b],
+    );
+
+    expect(codec.deleted).toEqual([a, b]);
+    expect(errorLines).toEqual([]);
+  });
+
+  it("plaintext and the marker are silent no-ops (the conformance-invisibility property)", async () => {
+    const { codec, secrets, errorLines } = newFixture();
+
+    await destroySecretBackingState(
+      secrets,
+      captureLogger(errorLines),
+      { kind: "environment", resourceId: "env_2" },
+      ["just-plaintext", REDACTED_MARKER],
+    );
+
+    expect(codec.deleted).toEqual([]);
+    expect(errorLines).toEqual([]);
+  });
+
+  it("a destroy failure logs ERROR and never interrupts the rest or throws", async () => {
+    const { codec, secrets, errorLines } = newFixture();
+    const a = await codec.encrypt(
+      "alpha",
+      EncryptionScope.forOrganization("acme"),
+    );
+    const b = await codec.encrypt(
+      "beta",
+      EncryptionScope.forOrganization("acme"),
+    );
+
+    codec.failNext.push(new Error("vault is down"));
+
+    await expect(
+      destroySecretBackingState(
+        secrets,
+        captureLogger(errorLines),
+        { kind: "environment", resourceId: "env_3" },
+        [a, b],
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(codec.deleted).toEqual([b]);
+    expect(errorLines).toHaveLength(1);
+    expect(errorLines[0]).toContain(
+      "secret backing-state destruction failed after persist",
+    );
+    expect(errorLines[0]).toContain("env_3");
+  });
+
+  it("an unregistered version refuses on the unavailable arm and is contained", async () => {
+    const { codec, secrets, errorLines } = newFixture();
+
+    await expect(
+      destroySecretBackingState(
+        secrets,
+        captureLogger(errorLines),
+        { kind: "environment", resourceId: "env_4" },
+        ["enc:v1:AAAA"],
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(codec.deleted).toEqual([]);
+    expect(errorLines).toHaveLength(1);
+  });
+});
+
+describe("DestroySecretBackingState (the delete-chain step)", () => {
+  it("extracts the doomed resource's sealed values from context", async () => {
+    const { codec, secrets, errorLines } = newFixture();
+    const sealed = await codec.encrypt(
+      "alpha",
+      EncryptionScope.forOrganization("acme"),
+    );
+    const env = create(EnvironmentSchema, {
+      metadata: { id: "env_5", org: "acme" },
+      spec: {
+        data: {
+          SEALED: { value: sealed, isSecret: true },
+          PLAIN: { value: "visible", isSecret: false },
+        },
+      },
+    });
+
+    const ctx = new RequestContext(
+      EnvironmentSchema,
+      create(EnvironmentSchema, {}),
+      caller,
+      ApiResourceKind.environment,
+    );
+    ctx.set(EXISTING_RESOURCE_KEY, env);
+
+    const step = newDestroySecretBackingStateStep<
+      typeof EnvironmentSchema,
+      typeof EnvironmentSchema
+    >(secrets, captureLogger(errorLines), (resource) =>
+      Object.values(resource.spec?.data ?? {})
+        .filter((value) => value.isSecret)
+        .map((value) => value.value),
+    );
+    expect(step.name).toBe("DestroySecretBackingState");
+    await step.execute(ctx);
+
+    expect(codec.deleted).toEqual([sealed]);
+    expect(errorLines).toEqual([]);
+  });
+
+  it("no-ops when the doomed resource is absent from context", async () => {
+    const { codec, secrets, errorLines } = newFixture();
+    const ctx = new RequestContext(
+      EnvironmentSchema,
+      create(EnvironmentSchema, {}),
+      caller,
+      ApiResourceKind.environment,
+    );
+
+    const step = newDestroySecretBackingStateStep<
+      typeof EnvironmentSchema,
+      typeof EnvironmentSchema
+    >(secrets, captureLogger(errorLines), () => {
+      throw new Error("extractor must not run without a resource");
+    });
+    await step.execute(ctx);
+
+    expect(codec.deleted).toEqual([]);
+    expect(errorLines).toEqual([]);
+  });
+});

--- a/backend/services/stigmer-server/src/pipeline/steps/secret-cleanup.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/secret-cleanup.ts
@@ -1,0 +1,109 @@
+/**
+ * Secret backing-state cleanup — the OSS half of the Java
+ * SecretValueCleanup contract (secrets-vault migration; wired here by
+ * convergence 20260830.04 Stage 3, gate ruling Q7). When a resource
+ * carrying sealed secrets is deleted — or a secret-bearing key is
+ * dropped by an update — the stored ciphertext's EXTERNAL backing state
+ * must be destroyed: for enc:v3 values that is a KV entry in the vault;
+ * for enc:v1/v2 values (the ciphertext IS the stored value), plaintext,
+ * and the ***REDACTED*** marker, SecretService.delete is a no-op by
+ * construction. Under the OSS default codec set (v1 only) this module
+ * therefore never changes observable behavior — the conformance rosters
+ * pin that.
+ *
+ * Failure semantics (Java parity; the CleanupIamPolicies discipline):
+ * best-effort, AFTER the store write. The row is already gone or
+ * updated, so a destroy failure must never fail the request — each
+ * failure logs ERROR with the resource identity and the pass continues.
+ * The cloud edition additionally counts sweep-side destroy failures
+ * (stigmer.encryption.cleanup.failures); the OSS delete sites log only
+ * (Stage-3 gate ruling G4 — an accepted, disclosed divergence that is
+ * moot until a composition writes enc:v3).
+ */
+import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
+
+import type { Logger } from "../../boot/logger.js";
+import type { SecretService } from "../../encryption/encryption.js";
+import { getKindName } from "../apiresource-meta.js";
+import type { PipelineStep } from "../pipeline.js";
+import type { RequestContext } from "../request-context.js";
+import { EXISTING_RESOURCE_KEY } from "./load-existing.js";
+import type { HasMetadataShape } from "./shapes.js";
+
+/**
+ * Destroys the external backing state of each stored secret value,
+ * best-effort: one failure logs ERROR (with the caller's identifying
+ * fields) and never interrupts the rest. Blank values are skipped — the
+ * facade would no-op them anyway, and skipping keeps the logs honest.
+ *
+ * Exported for the write-boundary steps that must capture their old
+ * values before mutating (environment removeVariables) and for the
+ * domain steps that destroy on a key diff rather than a delete.
+ */
+export async function destroySecretBackingState(
+  secretService: SecretService,
+  logger: Logger,
+  fields: Record<string, unknown>,
+  storedValues: readonly string[],
+): Promise<void> {
+  for (const storedValue of storedValues) {
+    if (storedValue === "") {
+      continue;
+    }
+    try {
+      await secretService.delete(storedValue);
+    } catch (error) {
+      // The DB write already succeeded — an orphaned external entry is
+      // the recoverable outcome (the vault retains it; the convergence
+      // sweep's census keeps it visible). Never the request's failure.
+      logger.error(
+        "secret backing-state destruction failed after persist — external state may be orphaned",
+        {
+          ...fields,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
+    }
+  }
+}
+
+/**
+ * DestroySecretBackingState — after the store delete in every delete
+ * chain whose kind carries sealed secrets (environment, oauthapp,
+ * channelapp; the OAuth-managed environment lane rides the environment
+ * chain through the in-process client). Reads the doomed resource from
+ * EXISTING_RESOURCE_KEY (seeded by LoadExistingForDelete); the
+ * per-domain extractor names which spec fields hold sealed values.
+ */
+export function newDestroySecretBackingStateStep<
+  InputDesc extends DescMessage,
+  ResourceDesc extends DescMessage,
+>(
+  secretService: SecretService,
+  logger: Logger,
+  extractSecretValues: (
+    resource: MessageShape<ResourceDesc>,
+  ) => readonly string[],
+): PipelineStep<InputDesc> {
+  return {
+    name: "DestroySecretBackingState",
+    async execute(ctx: RequestContext<InputDesc>): Promise<void> {
+      const deleted = ctx.get(EXISTING_RESOURCE_KEY) as
+        | MessageShape<ResourceDesc>
+        | undefined;
+      if (deleted === undefined) {
+        return;
+      }
+      const metadata = (deleted as unknown as HasMetadataShape).metadata;
+      await destroySecretBackingState(
+        secretService,
+        logger,
+        {
+          kind: getKindName(ctx.apiResourceKind),
+          resourceId: metadata?.id ?? "",
+        },
+        extractSecretValues(deleted),
+      );
+    },
+  };
+}

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -573,6 +573,19 @@ export async function composeFakeCloud(): Promise<ComposedServer> {
 }
 
 /**
+ * The Stage-3 sweep's runtime wiring shape (20260830.04 gate ruling G2):
+ * a composition's maintenance lane reaches the LIVE composed facade and
+ * store off the compose return — never a twin facade built from the same
+ * codec map, which would duplicate KEK caches and drift from the
+ * boot-resolved write version.
+ */
+export async function consumerSweepOverComposedServer(
+  server: ComposedServer,
+): Promise<void> {
+  await consumerSweepPage(server.store, server.secrets, "");
+}
+
+/**
  * The exported driver interfaces are consumable in extension signatures —
  * the O5 registrations above populate them; this bundle keeps the plain
  * type positions covered too.


### PR DESCRIPTION
## Summary

The Stage-3 OSS half of the pre-X1 sealing slice (convergence 20260830.04, gate rulings Q7 + G2): every OSS chain that deletes or drops a sealed secret now destroys the value's external backing state through the `SecretService` facade, and the composed facade instance is exposed on `ComposedServer` for composition maintenance lanes (the secret-convergence sweep and the encryption-state census land in the cloud composition next, consuming this seam).

## Context

The Java service destroys a sealed value's external state (an enc:v3 KV entry) whenever the owning row is deleted or the key is dropped — best-effort, after the DB write, never failing the request. Stage 1 gave the OSS facade the `delete` verb, but no OSS chain called it. This PR wires the Java site inventory onto the OSS chains so the v3 codec family (registered dormant by the cloud extension since stigmer-cloud#570) has its cleanup hooks in place before any composition ever writes v3.

## Changes

- **`src/pipeline/steps/secret-cleanup.ts`** (new): `destroySecretBackingState` (the Java `SecretValueCleanup` port — per-value best-effort, ERROR-logged, never throws) and the shared `DestroySecretBackingState` step (reads the doomed resource from `EXISTING_RESOURCE_KEY`, per-domain extractor).
- **Delete chains**: the step slots after `CleanupIamPolicies` in `environment-delete`, `oauthapp-delete`, and `channelapp-delete` (the OAuth-managed environment lane rides the environment chain through the in-process client). Extractors: every `is_secret` entry (environment), `spec.clientSecret` (oauthapp), the provider arm's sealed fields with the `never`-closed oneof switch (channelapp).
- **Environment update chain**: new `DestroyDroppedEnvironmentSecrets` step, post-`Persist` — strictly DROPPED keys only; a rotated key keeps its backing state (superseded KV versions age out via `max_versions`), marker-preserved keys are untouched.
- **`removeVariables`**: `RemoveVariableKeysAndPersist` captures the removed keys' values before mutating and destroys them after the persist. The `updateVariables` merge lane deliberately destroys nothing (Java parity).
- **`ComposedServer.secrets`** (gate ruling G2): the live composed facade, mirroring the existing `store` exposure; the extension-consumer proof gains the sweep's runtime wiring shape (`consumerSweepOverComposedServer`).

## Implementation notes

- Under the OSS default codec set (v1 only) every destroy is a no-op by the facade's own dispatch (v1 has no external state; plaintext/markers return before dispatch) — the wiring is conformance-invisible by construction.
- Disclosed divergence (gate ruling G4): Java counted cleanup failures on one metric covering all sites; in the TS split the OSS delete sites log ERROR only (OSS has no metrics registry) while the cloud sweep lane counts on its meter. Moot until the v3 write flip (plantonhq/planton#475); revisit then.

## Breaking changes

- None (the `ComposedServer` field is additive; step additions are wire-invisible under the default codec set).

## Test plan

- `npm run typecheck` clean; 2131 unit tests green (161 files), 15 new:
  - `pipeline/steps/__tests__/secret-cleanup.test.ts` — the best-effort contract at unit level (blank/plaintext/marker no-ops, failure containment, unregistered-version refusal contained, step context handling).
  - `extensions/__tests__/secret-cleanup-composed.test.ts` — END TO END through a composed server with a fake extension-registered v9 write codec: all three delete chains destroy exactly the sealed values; dropped-vs-rotated-vs-marker-preserved update semantics; removeVariables/updateVariables split; a destroy failure never fails the delete; `ComposedServer.secrets` decrypts what the domains sealed.
- All four conformance rosters byte-identical: local 499, local-postgres 499, local-execution 160, local-postgres-execution 160 (zero roster edits).
- Extension-consumer compile proof green.

## Risks

- Low: every new code path is best-effort-after-persist and a no-op under the shipped codec set. Rollback is a revert; no data shape changes.

Made with [Cursor](https://cursor.com)