### PR TITLE
feat(server): runner-credential capability seams for the composition parity gaps

### DIFF
--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -691,8 +691,11 @@ export async function composeServer(
         requireInProcess().executionEnvironmentReader.getSecretValue(input),
       updateVariables: (request) =>
         requireInProcess().executionEnvironmentReader.updateVariables(request),
-      create: (environment) =>
-        requireInProcess().executionEnvironmentReader.create(environment),
+      create: (environment, caller) =>
+        requireInProcess().executionEnvironmentReader.create(
+          environment,
+          caller,
+        ),
       delete: (input) =>
         requireInProcess().executionEnvironmentReader.delete(input),
     },
@@ -870,6 +873,7 @@ export async function composeServer(
       authorizer,
       authorizationLifecycle,
       listReadScope: extensions.drivers.listReadScope,
+      runnerCredentialProvider: runnerCredentials,
     });
     registerAgentExecutionServices(router, {
       store,
@@ -877,6 +881,7 @@ export async function composeServer(
       authorizer,
       authorizationLifecycle,
       listReadScope: extensions.drivers.listReadScope,
+      runnerCredentialProvider: runnerCredentials,
       broker: agentExecutionStreamBroker,
       engineState: executionEngineState,
       modelRegistry: modelCatalog,

--- a/backend/services/stigmer-server/src/boot/inprocess.ts
+++ b/backend/services/stigmer-server/src/boot/inprocess.ts
@@ -290,7 +290,15 @@ export function createInProcessClients(
       list: (request) => environmentQuery.list(request),
       getSecretValue: (input) => environmentQuery.getSecretValue(input),
       updateVariables: (request) => environmentCommand.updateVariables(request),
-      create: (environment) => environmentCommand.create(environment),
+      // The managed-env create propagates the connecting user when the
+      // lane has one (ruling R5 — the Java createAsCaller posture; parity
+      // entry 20260830.05): ownership tuples land on the user, not the
+      // unattributable internal class.
+      create: (environment, caller) =>
+        environmentCommand.create(
+          environment,
+          caller === undefined ? undefined : asCaller(caller),
+        ),
       delete: (input) => environmentCommand.delete(input),
     },
     executionContextCreator: {

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/record-runner-lineage-labels.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/record-runner-lineage-labels.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Pins the lineage-label vouching step (parity entry 20260830.05, the
+ * Java RecordRunnerLineageLabelsStep port): no lineage labels means no
+ * capability consult; the capability's true vouches exactly the present
+ * lineage keys (the guard then passes them while a smuggled sibling still
+ * refuses); false vouches nothing; a binding-violation throw propagates;
+ * and with no capability composed the step is a no-op — nothing vouched,
+ * today's OSS behavior.
+ */
+import { describe, expect, it } from "vitest";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { CallerIdentity } from "../../../extensions/identity.js";
+import type { RunnerCredentialProvider } from "../../../runnerauth/runner-credential-provider.js";
+import { RequestContext } from "../../../pipeline/request-context.js";
+import { serverStampedReservedLabels } from "../../../pipeline/steps/server-stamped-reserved-labels.js";
+import {
+  newRecordRunnerLineageLabelsStep,
+  WORKFLOW_EXECUTION_ID_LABEL,
+  WORKFLOW_TASK_LABEL,
+} from "../record-runner-lineage-labels.js";
+
+/** A cloud-shaped runner caller (class = the token_type claim). */
+const RUNNER: CallerIdentity = {
+  identityId: "ida_runner",
+  callerClass: "workflow_sandbox",
+  issuer: "stigmer",
+  rawToken: "opaque-to-oss",
+};
+
+function executionCtx(
+  labels: Record<string, string>,
+): RequestContext<typeof AgentExecutionSchema> {
+  return new RequestContext(
+    AgentExecutionSchema,
+    create(AgentExecutionSchema, { metadata: { name: "e", labels } }),
+    RUNNER,
+    ApiResourceKind.agent_execution,
+  );
+}
+
+function providerWith(
+  vouch?: (caller: CallerIdentity, workflowExecutionId: string) => boolean,
+): RunnerCredentialProvider {
+  return {
+    isEnabled: () => false,
+    mint: () => {
+      throw new Error("not under test");
+    },
+    verify: () => {
+      throw new Error("not under test");
+    },
+    ...(vouch === undefined ? {} : { vouchRunnerLineageLabels: vouch }),
+  };
+}
+
+describe("RecordRunnerLineageLabels", () => {
+  it("consults nothing when the request carries no lineage labels", () => {
+    const step = newRecordRunnerLineageLabelsStep(
+      providerWith(() => {
+        throw new Error("must not be consulted");
+      }),
+    );
+    const ctx = executionCtx({ ordinary: "fine" });
+    step.execute(ctx);
+    expect(serverStampedReservedLabels(ctx).size).toBe(0);
+  });
+
+  it("vouches exactly the present lineage keys on true", () => {
+    const observed: string[] = [];
+    const step = newRecordRunnerLineageLabelsStep(
+      providerWith((_caller, workflowExecutionId) => {
+        observed.push(workflowExecutionId);
+        return true;
+      }),
+    );
+    const ctx = executionCtx({
+      [WORKFLOW_EXECUTION_ID_LABEL]: "wfe_1",
+      [WORKFLOW_TASK_LABEL]: "notify",
+      "stigmer.ai/default-agent": "true", // never vouched by this step
+    });
+    step.execute(ctx);
+    expect(observed).toEqual(["wfe_1"]);
+    const stamped = serverStampedReservedLabels(ctx);
+    expect(stamped.has(WORKFLOW_EXECUTION_ID_LABEL)).toBe(true);
+    expect(stamped.has(WORKFLOW_TASK_LABEL)).toBe(true);
+    expect(stamped.has("stigmer.ai/default-agent")).toBe(false);
+    expect(stamped.size).toBe(2);
+  });
+
+  it("vouches only the task key when the execution-id label is absent", () => {
+    const step = newRecordRunnerLineageLabelsStep(providerWith(() => true));
+    const ctx = executionCtx({ [WORKFLOW_TASK_LABEL]: "notify" });
+    step.execute(ctx);
+    const stamped = serverStampedReservedLabels(ctx);
+    expect(stamped.has(WORKFLOW_TASK_LABEL)).toBe(true);
+    expect(stamped.size).toBe(1);
+  });
+
+  it("vouches nothing for a non-runner credential (false)", () => {
+    const step = newRecordRunnerLineageLabelsStep(providerWith(() => false));
+    const ctx = executionCtx({ [WORKFLOW_EXECUTION_ID_LABEL]: "wfe_1" });
+    step.execute(ctx);
+    expect(serverStampedReservedLabels(ctx).size).toBe(0);
+  });
+
+  it("a binding-violation refusal propagates untouched", () => {
+    const refusal = new ConnectError(
+      "workflow lineage label names a workflow execution this runner credential is not bound to",
+      Code.InvalidArgument,
+    );
+    const step = newRecordRunnerLineageLabelsStep(
+      providerWith(() => {
+        throw refusal;
+      }),
+    );
+    let error: unknown;
+    try {
+      step.execute(executionCtx({ [WORKFLOW_EXECUTION_ID_LABEL]: "wfe_other" }));
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBe(refusal);
+  });
+
+  it("is a no-op with no capability composed — today's OSS behavior", () => {
+    const step = newRecordRunnerLineageLabelsStep(providerWith());
+    const ctx = executionCtx({ [WORKFLOW_EXECUTION_ID_LABEL]: "wfe_1" });
+    step.execute(ctx);
+    expect(serverStampedReservedLabels(ctx).size).toBe(0);
+  });
+});

--- a/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
@@ -45,6 +45,8 @@ import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
 import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
+import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
+import { newRecordRunnerLineageLabelsStep } from "./record-runner-lineage-labels.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import {
   newDeleteResourceStep,
@@ -169,6 +171,13 @@ export interface AgentExecutionControllerDeps {
   readonly modelRegistry: ModelCatalogProvider;
   /** The shared artifact blob store (attachments + artifact reads). */
   readonly artifactStorage: ArtifactStorage;
+  /**
+   * The composed runner-credential provider — RecordRunnerLineageLabels
+   * consults its vouchRunnerLineageLabels capability at create (parity
+   * entry 20260830.05). The OSS default defines no capabilities, so the
+   * step is a no-op with it.
+   */
+  readonly runnerCredentialProvider: RunnerCredentialProvider;
   /**
    * The in-process edges the create pipeline consumes (lazy providers —
    * the routes↔clients cycle resolves at request time, DD-002).
@@ -307,6 +316,10 @@ async function createExecution(
     .addStep(newEnsureSessionOrAgentResolvedStep(deps.logger))
     .addStep(newResolveSlugStep())
     .addStep(newBuildNewStateStep())
+    // Vouches the runner-stamped workflow lineage labels (or refuses a
+    // wrong-binding stamp) BEFORE the guard diffs them — the Java
+    // RecordRunnerLineageLabelsStep position (parity entry 20260830.05).
+    .addStep(newRecordRunnerLineageLabelsStep(deps.runnerCredentialProvider))
     .addStep(newGuardReservedLabelsStep(deps.authorizer))
     .addStep(newNormalizeReferencesStep())
     .addStep(newEnsureEngineAvailableStep(deps.engineState));

--- a/backend/services/stigmer-server/src/domain/agentexecution/record-runner-lineage-labels.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/record-runner-lineage-labels.ts
@@ -1,0 +1,76 @@
+/**
+ * RecordRunnerLineageLabels — the agent-execution create chain's
+ * lineage-label vouching step (the Java
+ * AgentExecutionCreateHandler.RecordRunnerLineageLabelsStep port,
+ * cloud#386; parity entry 20260830.05, C5 readout finding F3).
+ *
+ * The workflow runner's CallAgent activity
+ * (backend/services/runner/src/activities/call-agent.ts) stamps
+ * `stigmer.ai/workflow-execution-id` and `stigmer.ai/workflow-task` on
+ * every child execution it creates — the lineage the agent_call
+ * environment resolution keys on. GuardReservedLabels would reject that
+ * create outright (the guard predates the runner sender and never got
+ * the matching exemption — in OSS the permissive default Authorizer
+ * masks this; a composition with a real Authorizer refuses).
+ *
+ * The step records EXACTLY the two lineage keys through
+ * server-stamped-reserved-labels.ts, and only when the composed
+ * RunnerCredentialProvider's vouchRunnerLineageLabels capability vouches
+ * for the caller — the capability owns both caller classification (its
+ * own token-type vocabulary; no caller class expresses "runner" and OSS
+ * must not learn another edition's lane names) and the binding rule (a
+ * workflow-bound credential may only stamp its own workflow execution;
+ * the capability REFUSES a mismatch by throwing). With no capability
+ * composed nothing is vouched, which is byte-identical OSS behavior.
+ *
+ * Placement: after BuildNewState (the labels inspected are the ones the
+ * guard will diff), immediately before GuardReservedLabels. Non-runner
+ * callers vouch nothing and stay fully subject to the guard — a client
+ * sending these same keys itself is still rejected.
+ */
+import type { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+
+import type { PipelineStep } from "../../pipeline/pipeline.js";
+import type { RequestContext } from "../../pipeline/request-context.js";
+import { recordServerStampedReservedLabels } from "../../pipeline/steps/server-stamped-reserved-labels.js";
+import { metadataOf } from "../../pipeline/steps/shapes.js";
+import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
+
+/**
+ * The lineage label keys, byte-pinned on three sides: the runner's
+ * CallAgent stamp, the Java ExecutionEnvironmentComposer's resolution
+ * read, and this vouching step.
+ */
+export const WORKFLOW_EXECUTION_ID_LABEL = "stigmer.ai/workflow-execution-id";
+export const WORKFLOW_TASK_LABEL = "stigmer.ai/workflow-task";
+
+export function newRecordRunnerLineageLabelsStep(
+  provider: RunnerCredentialProvider,
+): PipelineStep<typeof AgentExecutionSchema> {
+  return {
+    name: "RecordRunnerLineageLabels",
+    execute(ctx: RequestContext<typeof AgentExecutionSchema>): void {
+      const vouch = provider.vouchRunnerLineageLabels;
+      if (vouch === undefined) {
+        return;
+      }
+      const labels = metadataOf(ctx.newState)?.labels ?? {};
+      const workflowExecutionId = labels[WORKFLOW_EXECUTION_ID_LABEL] ?? "";
+      const taskName = labels[WORKFLOW_TASK_LABEL] ?? "";
+      if (workflowExecutionId === "" && taskName === "") {
+        return;
+      }
+      // The capability throws its own byte-pinned refusal on a binding
+      // violation; false means "not a runner credential" — vouch nothing.
+      if (!vouch.call(provider, ctx.callerIdentity, workflowExecutionId)) {
+        return;
+      }
+      if (workflowExecutionId !== "") {
+        recordServerStampedReservedLabels(ctx, WORKFLOW_EXECUTION_ID_LABEL);
+      }
+      if (taskName !== "") {
+        recordServerStampedReservedLabels(ctx, WORKFLOW_TASK_LABEL);
+      }
+    },
+  };
+}

--- a/backend/services/stigmer-server/src/domain/mcpserver/complete-oauth-connect.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/complete-oauth-connect.ts
@@ -156,13 +156,17 @@ export async function completeOAuthConnect(
   }
 
   // Resolve the managed environment: reuse from an existing grant or
-  // create new.
+  // create new — the create AS THE COMPLETING CALLER (ruling R5, parity
+  // entry 20260830.05): ownership tuples land on the connecting user
+  // under a composed tuple-lifecycle driver, so the environment stays
+  // visible in their scoped lists (the Java createAsCaller posture).
   const managedEnvId = await resolveOrCreateManagedEnvironment(
     deps,
     pendingState.identityAccountId,
     mcpServerId,
     org,
     mcpServer.metadata?.name ?? "",
+    identity,
   );
 
   // Build token variables (plaintext — the environment pipeline encrypts).
@@ -292,6 +296,7 @@ async function resolveOrCreateManagedEnvironment(
   mcpServerId: string,
   org: string,
   mcpServerName: string,
+  caller: CallerIdentity,
 ): Promise<string> {
   let existingGrant;
   try {
@@ -323,7 +328,7 @@ async function resolveOrCreateManagedEnvironment(
 
   const envName = `OAuth: ${mcpServerName}`;
   try {
-    return await deps.managedEnv.createManagedEnvironment(envName, org);
+    return await deps.managedEnv.createManagedEnvironment(envName, org, caller);
   } catch (error) {
     throw internalError(
       error,

--- a/backend/services/stigmer-server/src/domain/mcpserver/oauth/managed-env.ts
+++ b/backend/services/stigmer-server/src/domain/mcpserver/oauth/managed-env.ts
@@ -21,6 +21,7 @@ import { ApiResourceDeleteInputSchema } from "@stigmer/protos/ai/stigmer/commons
 import type { MessageInitShape } from "@bufbuild/protobuf";
 
 import type { Logger } from "../../../boot/logger.js";
+import type { CallerIdentity } from "../../../extensions/identity.js";
 
 /** The label marking system-managed OAuth-token environments. */
 export const MANAGED_ENV_LABEL = "stigmer.ai/managed";
@@ -37,8 +38,17 @@ export interface ManagedEnvironmentClient {
   updateVariables(
     request: MessageInitShape<typeof UpdateEnvironmentVariablesRequestSchema>,
   ): Promise<Environment>;
+  /**
+   * `caller` propagates the ORIGINAL caller through the in-process hop
+   * (ruling R5; Java createAsCaller — parity entry 20260830.05): the
+   * created environment's owner attribution lands on the connecting
+   * user, so it stays visible and manageable under an enforcing
+   * Authorizer. Absent = the minted internal class (the pre-R5 shape,
+   * kept for hops with no request caller).
+   */
   create(
     environment: MessageInitShape<typeof EnvironmentSchema>,
+    caller?: CallerIdentity,
   ): Promise<Environment>;
   delete(
     input: MessageInitShape<typeof ApiResourceDeleteInputSchema>,
@@ -56,9 +66,18 @@ export class ManagedEnvironmentService {
    * stigmer.ai/managed=true label and returns its resource id (Go
    * CreateManagedEnvironment). The environment goes through the standard
    * create pipeline, which handles id generation, slug resolution,
-   * timestamps, and search indexing.
+   * timestamps, and search indexing. `caller` propagates the connecting
+   * user through the hop (ruling R5, parity entry 20260830.05) so a
+   * composed tuple-lifecycle driver attributes ownership to them — the
+   * Java createAsCaller posture ("org link + owner = caller"); the
+   * reserved-label guard keys its trust arm on the in-process ORIGIN,
+   * so the managed label still passes with a propagated caller.
    */
-  async createManagedEnvironment(name: string, org: string): Promise<string> {
+  async createManagedEnvironment(
+    name: string,
+    org: string,
+    caller?: CallerIdentity,
+  ): Promise<string> {
     let created: Environment;
     try {
       created = await this.client.create(
@@ -71,6 +90,7 @@ export class ManagedEnvironmentService {
             labels: { [MANAGED_ENV_LABEL]: "true" },
           },
         }),
+        caller,
       );
     } catch (error) {
       throw new Error(

--- a/backend/services/stigmer-server/src/domain/memory/__tests__/capture-credential.test.ts
+++ b/backend/services/stigmer-server/src/domain/memory/__tests__/capture-credential.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Pins the gate→defaults capture-credential handoff (parity entry
+ * 20260830.05, the Java MemoryCreateHandler sandbox semantics): when
+ * GuardMemoryCapture admitted a session-scoped capture credential,
+ * ResolveMemoryDefaults writes the token's proved subject ("the sub IS
+ * the human subject the session belongs to") and overrides
+ * provenance.session_id with the proved session (server-proved beats
+ * runner-reported), creating provenance when the request supplied none;
+ * without the handoff the OSS arms stand (empty-string sentinel subject,
+ * provenance stored as supplied).
+ */
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import { MemorySchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { CallerIdentity } from "../../../extensions/identity.js";
+import { RequestContext } from "../../../pipeline/request-context.js";
+import { MEMORY_CAPTURE_CREDENTIAL_KEY } from "../../../pipeline/steps/guard-memory-capture.js";
+import { newResolveMemoryDefaultsStep } from "../steps.js";
+
+const CALLER: CallerIdentity = {
+  identityId: "ida_human",
+  callerClass: "sandbox",
+  issuer: "stigmer",
+  rawToken: "opaque",
+};
+
+function memoryCtx(spec: {
+  provenance?: { sessionId?: string; agentId?: string; toolCallId?: string };
+}): RequestContext<typeof MemorySchema> {
+  return new RequestContext(
+    MemorySchema,
+    create(MemorySchema, {
+      metadata: { name: "m", org: "org_acme" },
+      spec: { content: "fact", ...spec },
+    }),
+    CALLER,
+    ApiResourceKind.memory,
+  );
+}
+
+describe("ResolveMemoryDefaults with an admitted capture credential", () => {
+  it("writes the proved subject and overrides provenance.session_id", () => {
+    const ctx = memoryCtx({
+      provenance: {
+        sessionId: "ses_runner_reported",
+        agentId: "agt_1",
+        toolCallId: "forged",
+      },
+    });
+    ctx.set(MEMORY_CAPTURE_CREDENTIAL_KEY, {
+      subjectIdentityAccountId: "ida_human",
+      provedSessionId: "ses_proved",
+    });
+    newResolveMemoryDefaultsStep().execute(ctx);
+    expect(ctx.newState.spec?.subjectIdentityAccountId).toBe("ida_human");
+    expect(ctx.newState.spec?.provenance?.sessionId).toBe("ses_proved");
+    // The threaded agent id survives; the forged tool_call_id never does.
+    expect(ctx.newState.spec?.provenance?.agentId).toBe("agt_1");
+    expect(ctx.newState.spec?.provenance?.toolCallId).toBe("");
+  });
+
+  it("creates provenance when the request supplied none", () => {
+    const ctx = memoryCtx({});
+    ctx.set(MEMORY_CAPTURE_CREDENTIAL_KEY, {
+      subjectIdentityAccountId: "ida_human",
+      provedSessionId: "ses_proved",
+    });
+    newResolveMemoryDefaultsStep().execute(ctx);
+    expect(ctx.newState.spec?.provenance?.sessionId).toBe("ses_proved");
+  });
+
+  it("without the handoff the OSS arms stand", () => {
+    const ctx = memoryCtx({
+      provenance: { sessionId: "ses_supplied", toolCallId: "forged" },
+    });
+    newResolveMemoryDefaultsStep().execute(ctx);
+    expect(ctx.newState.spec?.subjectIdentityAccountId).toBe("");
+    expect(ctx.newState.spec?.provenance?.sessionId).toBe("ses_supplied");
+    expect(ctx.newState.spec?.provenance?.toolCallId).toBe("");
+  });
+});

--- a/backend/services/stigmer-server/src/domain/memory/controller.ts
+++ b/backend/services/stigmer-server/src/domain/memory/controller.ts
@@ -68,6 +68,7 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 
 import type { Logger } from "../../boot/logger.js";
 import type { Authorizer } from "../../extensions/authorizer.js";
+import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
 import type { ListReadScope } from "../../extensions/list-read-scope.js";
 import type { ResourceAuthorizationLifecycle } from "../../extensions/resource-authorization.js";
 import { apiResourceKindKey } from "../../pipeline/interceptors/apiresource.js";
@@ -128,6 +129,13 @@ export interface MemoryControllerDeps {
   readonly authorizationLifecycle: ResourceAuthorizationLifecycle | undefined;
   /** The composed list read scope — list narrows through it; undefined = the OSS full scan (20260830.01). */
   readonly listReadScope: ListReadScope | undefined;
+  /**
+   * The composed runner-credential provider — GuardMemoryCapture consults
+   * its authorizeMemoryCapture capability for the runner-credential
+   * eligibility arm (parity entry 20260830.05). The OSS default defines
+   * no capabilities, so the gate's behavior is unchanged with it.
+   */
+  readonly runnerCredentialProvider: RunnerCredentialProvider;
 }
 
 /** Registers both memory services on the router (routes stage). */
@@ -183,7 +191,7 @@ async function createMemory(
       newAuthorizeStep(MemoryCommandController.method.create, deps.authorizer),
     )
     .addStep(newValidateProtoStep())
-    .addStep(newGuardMemoryCaptureStep())
+    .addStep(newGuardMemoryCaptureStep(deps.runnerCredentialProvider))
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveMemoryDefaultsStep())
     .addStep(newCheckMemoryEnablementStep(deps.store))

--- a/backend/services/stigmer-server/src/domain/memory/steps.ts
+++ b/backend/services/stigmer-server/src/domain/memory/steps.ts
@@ -46,6 +46,7 @@ import {
   generateId,
   setAuditFieldsForUpdate,
 } from "../../pipeline/steps/defaults.js";
+import { memoryCaptureCredentialOf } from "../../pipeline/steps/guard-memory-capture.js";
 import { compareCreatedAtDesc } from "../../pipeline/steps/helpers.js";
 import { EXISTING_RESOURCE_KEY } from "../../pipeline/steps/load-existing.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
@@ -90,6 +91,15 @@ export const LIST_RESULT_KEY = "listResult";
  *     session/org with the token's own claims. Post-create the field is
  *     immutable either way (ValidateMemoryUpdate): attribution that can
  *     be edited is not attribution.
+ *  5. When GuardMemoryCapture admitted a session-scoped capture
+ *     credential (the composed provider's authorizeMemoryCapture
+ *     capability — parity entry 20260830.05), the token's PROVED claims
+ *     replace both edition defaults: the subject is the credential's
+ *     human ("the sub IS the human subject the session belongs to",
+ *     Java MemoryCreateHandler) and provenance.session_id is overridden
+ *     with the token's own session claim (server-proved beats
+ *     runner-reported). Absent the handoff, the OSS arms above apply
+ *     unchanged.
  */
 export function newResolveMemoryDefaultsStep(): PipelineStep<
   typeof MemorySchema
@@ -125,15 +135,25 @@ export function newResolveMemoryDefaultsStep(): PipelineStep<
         );
       }
 
-      // The subject stays server-owned (DD-005 D2): the OSS sentinel; the
-      // cloud edition derives it from the calling credential.
-      spec.subjectIdentityAccountId = "";
+      // The subject stays server-owned (DD-005 D2): the OSS sentinel, or
+      // the admitted capture credential's proved human (step doc point 5).
+      const captureCredential = memoryCaptureCredentialOf(ctx);
+      spec.subjectIdentityAccountId =
+        captureCredential?.subjectIdentityAccountId ?? "";
 
       // Provenance is capture-path-supplied (see the step doc, point 4);
       // only tool_call_id is force-cleared — unreachable via MCP in v1, so
       // a supplied value could only be an invention.
       if (spec.provenance !== undefined) {
         spec.provenance.toolCallId = "";
+      }
+      // An admitted capture credential's session claim overrides the
+      // threaded value (step doc point 5) — server-proved attribution.
+      if (captureCredential !== undefined) {
+        if (spec.provenance === undefined) {
+          spec.provenance = create(MemoryProvenanceSchema, {});
+        }
+        spec.provenance.sessionId = captureCredential.provedSessionId;
       }
     },
   };

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -204,6 +204,11 @@ export type {
   RunnerScopedTokenExchange,
   RunnerScopedTokenRequest,
   SandboxCredentialRequest,
+  // The parity-entry-20260830.05 capability shape: the memory
+  // capture-eligibility verdict (admit carries the token's proved
+  // subject + session claims for the defaults step's Java-parity
+  // derivation).
+  MemoryCaptureDecision,
 } from "./runnerauth/runner-credential-provider.js";
 export type { MintedToken } from "./runnerauth/runnerauth.js";
 export {

--- a/backend/services/stigmer-server/src/pipeline/steps/__tests__/guard-memory-capture.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/__tests__/guard-memory-capture.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Pins the memory capture-eligibility gate (parity entry 20260830.05,
+ * stigmer-cloud#564): the authorizeMemoryCapture capability's three
+ * verdicts (admit stashes the proved claims, refuse answers the
+ * byte-pinned PERMISSION_DENIED copy, no-opinion falls through to the
+ * gate's own machine/platform_client_id logic), the capture org handed to
+ * the capability, the org-mismatch throw propagating untouched, and the
+ * absent-capability posture staying byte-identical to the pre-seam gate
+ * (trusted-local and OIDC callers admit; machine and
+ * platform_client_id-carrying callers refuse).
+ */
+import { describe, expect, it } from "vitest";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import { MemorySchema } from "@stigmer/protos/ai/stigmer/agentic/memory/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { CallerIdentity } from "../../../extensions/identity.js";
+import type {
+  MemoryCaptureDecision,
+  RunnerCredentialProvider,
+} from "../../../runnerauth/runner-credential-provider.js";
+import { RequestContext } from "../../request-context.js";
+import {
+  MEMORY_CAPTURE_CALLER_MESSAGE,
+  memoryCaptureCredentialOf,
+  newGuardMemoryCaptureStep,
+} from "../guard-memory-capture.js";
+
+const LOCAL_USER: CallerIdentity = {
+  identityId: "local",
+  callerClass: "user",
+  issuer: "",
+  rawToken: "",
+};
+
+/** A cloud-shaped caller whose class is its token_type (sandbox lane). */
+const SANDBOX_CALLER: CallerIdentity = {
+  identityId: "ida_human",
+  callerClass: "sandbox",
+  issuer: "stigmer",
+  rawToken: "opaque-to-oss",
+};
+
+function memoryCtx(
+  caller: CallerIdentity,
+  org = "org_acme",
+): RequestContext<typeof MemorySchema> {
+  return new RequestContext(
+    MemorySchema,
+    create(MemorySchema, {
+      metadata: { name: "m", org },
+      spec: { content: "fact" },
+    }),
+    caller,
+    ApiResourceKind.memory,
+  );
+}
+
+/** A provider whose only relevant surface is the capture capability. */
+function providerWith(
+  decide?: (caller: CallerIdentity, org: string) => MemoryCaptureDecision,
+): RunnerCredentialProvider {
+  return {
+    isEnabled: () => false,
+    mint: () => {
+      throw new Error("not under test");
+    },
+    verify: () => {
+      throw new Error("not under test");
+    },
+    ...(decide === undefined ? {} : { authorizeMemoryCapture: decide }),
+  };
+}
+
+function jwtWith(payload: Record<string, unknown>): string {
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `header.${body}.signature`;
+}
+
+describe("GuardMemoryCapture with the capability composed", () => {
+  it("admit stashes the proved claims for ResolveMemoryDefaults", () => {
+    const step = newGuardMemoryCaptureStep<typeof MemorySchema>(
+      providerWith(() => ({
+        verdict: "admit",
+        subjectIdentityAccountId: "ida_human",
+        provedSessionId: "ses_proved",
+      })),
+    );
+    const ctx = memoryCtx(SANDBOX_CALLER);
+    step.execute(ctx);
+    expect(memoryCaptureCredentialOf(ctx)).toEqual({
+      subjectIdentityAccountId: "ida_human",
+      provedSessionId: "ses_proved",
+    });
+  });
+
+  it("refuse answers the byte-pinned PERMISSION_DENIED copy", () => {
+    const step = newGuardMemoryCaptureStep<typeof MemorySchema>(
+      providerWith(() => ({ verdict: "refuse" })),
+    );
+    let error: unknown;
+    try {
+      step.execute(memoryCtx(SANDBOX_CALLER));
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.PermissionDenied);
+    expect((error as ConnectError).rawMessage).toBe(
+      MEMORY_CAPTURE_CALLER_MESSAGE,
+    );
+  });
+
+  it("hands the capability the caller and the capture org", () => {
+    const observed: Array<{ caller: CallerIdentity; org: string }> = [];
+    const step = newGuardMemoryCaptureStep<typeof MemorySchema>(
+      providerWith((caller, org) => {
+        observed.push({ caller, org });
+        return { verdict: "no-opinion" };
+      }),
+    );
+    step.execute(memoryCtx(SANDBOX_CALLER, "org_zeta"));
+    expect(observed).toEqual([{ caller: SANDBOX_CALLER, org: "org_zeta" }]);
+  });
+
+  it("an org-mismatch throw from the capability propagates untouched", () => {
+    const mismatch = new ConnectError(
+      "memory capture is scoped to the session's organization",
+      Code.PermissionDenied,
+    );
+    const step = newGuardMemoryCaptureStep<typeof MemorySchema>(
+      providerWith(() => {
+        throw mismatch;
+      }),
+    );
+    let error: unknown;
+    try {
+      step.execute(memoryCtx(SANDBOX_CALLER, "org_other"));
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBe(mismatch);
+  });
+
+  it("no-opinion falls through: platform_client_id carriers still refuse", () => {
+    const step = newGuardMemoryCaptureStep<typeof MemorySchema>(
+      providerWith(() => ({ verdict: "no-opinion" })),
+    );
+    const minted: CallerIdentity = {
+      identityId: "ida_guest",
+      callerClass: "guest",
+      issuer: "stigmer",
+      rawToken: jwtWith({ platform_client_id: "pc_1" }),
+    };
+    expect(() => step.execute(memoryCtx(minted))).toThrowError(
+      MEMORY_CAPTURE_CALLER_MESSAGE,
+    );
+  });
+
+  it("internal and in-process callers never consult the capability", () => {
+    const step = newGuardMemoryCaptureStep<typeof MemorySchema>(
+      providerWith(() => {
+        throw new Error("must not be consulted");
+      }),
+    );
+    step.execute(
+      memoryCtx({
+        identityId: "internal",
+        callerClass: "internal",
+        issuer: "",
+        rawToken: "",
+      }),
+    );
+    step.execute(memoryCtx({ ...LOCAL_USER, origin: "in-process" }));
+  });
+});
+
+describe("GuardMemoryCapture without the capability (the pre-seam gate)", () => {
+  it("admits trusted-local and OIDC callers", () => {
+    const step = newGuardMemoryCaptureStep<typeof MemorySchema>(
+      providerWith(),
+    );
+    step.execute(memoryCtx(LOCAL_USER));
+    step.execute(
+      memoryCtx({
+        identityId: "ida_oidc",
+        callerClass: "user",
+        issuer: "https://issuer.example",
+        rawToken: jwtWith({ sub: "ida_oidc" }),
+      }),
+    );
+  });
+
+  it("refuses machine callers and platform_client_id carriers", () => {
+    const step = newGuardMemoryCaptureStep<typeof MemorySchema>(
+      providerWith(),
+    );
+    expect(() =>
+      step.execute(memoryCtx({ ...LOCAL_USER, callerClass: "machine" })),
+    ).toThrowError(MEMORY_CAPTURE_CALLER_MESSAGE);
+    expect(() =>
+      step.execute(
+        memoryCtx({
+          ...LOCAL_USER,
+          rawToken: jwtWith({ platform_client_id: "pc_1" }),
+        }),
+      ),
+    ).toThrowError(MEMORY_CAPTURE_CALLER_MESSAGE);
+  });
+
+  it("admits a runner-shaped caller — the recorded pre-fix posture", () => {
+    // With no capability composed the gate cannot classify runner
+    // credentials — the single-user OSS posture admits them (the #564
+    // narrowing is CLOUD policy, shipped in the cloud capability).
+    const step = newGuardMemoryCaptureStep<typeof MemorySchema>(
+      providerWith(),
+    );
+    step.execute(memoryCtx(SANDBOX_CALLER));
+  });
+});

--- a/backend/services/stigmer-server/src/pipeline/steps/__tests__/guard-reserved-labels.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/__tests__/guard-reserved-labels.test.ts
@@ -25,6 +25,7 @@ import {
 } from "../guard-reserved-labels.js";
 import { EXISTING_RESOURCE_KEY } from "../load-existing.js";
 import { newPermissiveSingleTeamAuthorizer } from "../authorize.js";
+import { recordServerStampedReservedLabels } from "../server-stamped-reserved-labels.js";
 
 const USER: CallerIdentity = {
   identityId: "ida_alice",
@@ -153,5 +154,37 @@ describe("GuardReservedLabels", () => {
       { identityId: "internal", callerClass: "internal", issuer: "", rawToken: "" },
     );
     await expect(Promise.resolve(step.execute(ctx))).resolves.toBeUndefined();
+  });
+
+  it("server-stamped keys pass while an unstamped sibling still refuses", async () => {
+    // The parity-entry-20260830.05 arm (Java ServerStampedReservedLabels):
+    // a step's per-request record exempts exactly the recorded keys — a
+    // smuggled sibling in the same request is still rejected.
+    const step = newGuardReservedLabelsStep<typeof AgentSchema>(denying());
+    const vouched = agentCtx({ "stigmer.ai/workflow-execution-id": "wfe_1" });
+    recordServerStampedReservedLabels(
+      vouched,
+      "stigmer.ai/workflow-execution-id",
+    );
+    await expect(Promise.resolve(step.execute(vouched))).resolves.toBeUndefined();
+
+    const smuggled = agentCtx({
+      "stigmer.ai/workflow-execution-id": "wfe_1",
+      "stigmer.ai/default-agent": "true",
+    });
+    recordServerStampedReservedLabels(
+      smuggled,
+      "stigmer.ai/workflow-execution-id",
+    );
+    const error = await step
+      .execute(smuggled)
+      ?.catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).rawMessage).toContain(
+      "stigmer.ai/default-agent",
+    );
+    expect((error as ConnectError).rawMessage).not.toContain(
+      "stigmer.ai/workflow-execution-id",
+    );
   });
 });

--- a/backend/services/stigmer-server/src/pipeline/steps/__tests__/server-stamped-reserved-labels.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/__tests__/server-stamped-reserved-labels.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Pins the per-request server-stamped reserved-label record (parity entry
+ * 20260830.05, the Java ServerStampedReservedLabels port): recording
+ * accumulates across calls, reads never invent, and the record is
+ * request-scoped — a second context sees nothing.
+ */
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+
+import type { CallerIdentity } from "../../../extensions/identity.js";
+import { RequestContext } from "../../request-context.js";
+import {
+  recordServerStampedReservedLabels,
+  serverStampedReservedLabels,
+} from "../server-stamped-reserved-labels.js";
+
+const USER: CallerIdentity = {
+  identityId: "ida_alice",
+  callerClass: "user",
+  issuer: "stigmer",
+  rawToken: "tok",
+};
+
+function ctx(): RequestContext<typeof AgentSchema> {
+  return new RequestContext(
+    AgentSchema,
+    create(AgentSchema, { metadata: { name: "a" } }),
+    USER,
+    ApiResourceKind.agent,
+  );
+}
+
+describe("serverStampedReservedLabels", () => {
+  it("answers empty when nothing was recorded", () => {
+    expect(serverStampedReservedLabels(ctx()).size).toBe(0);
+  });
+
+  it("accumulates recorded keys across calls", () => {
+    const c = ctx();
+    recordServerStampedReservedLabels(c, "stigmer.ai/workflow-execution-id");
+    recordServerStampedReservedLabels(c, "stigmer.ai/workflow-task");
+    const stamped = serverStampedReservedLabels(c);
+    expect(stamped.has("stigmer.ai/workflow-execution-id")).toBe(true);
+    expect(stamped.has("stigmer.ai/workflow-task")).toBe(true);
+    expect(stamped.size).toBe(2);
+  });
+
+  it("is request-scoped — a second context sees nothing", () => {
+    const first = ctx();
+    recordServerStampedReservedLabels(first, "stigmer.ai/x");
+    expect(serverStampedReservedLabels(ctx()).size).toBe(0);
+  });
+});

--- a/backend/services/stigmer-server/src/pipeline/steps/guard-memory-capture.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/guard-memory-capture.ts
@@ -1,10 +1,13 @@
 /**
  * GuardMemoryCapture — the memory create chain's capture-eligibility gate
  * (C2 Stage 3D; the Java MemoryCreateHandler's first gate, DD-002 D4 as
- * amended): memory may only be captured for a FIRST-PARTY HUMAN OPERATOR.
- * Machine accounts and every minted-credential lane — PlatformClient user
- * tokens, guest embeds, channel senders, schedule runs — stay refused;
- * "the label is not authorization; the server refuses."
+ * amended): memory may only be captured for a FIRST-PARTY HUMAN OPERATOR
+ * — or the remember tool's SESSION-SCOPED sandbox credential acting as
+ * its human subject (the Stage 3 decision, restored for compositions by
+ * parity entry 20260830.05 / stigmer-cloud#564). Machine accounts and
+ * every minted-credential lane — PlatformClient user tokens, guest
+ * embeds, channel senders, schedule runs — stay refused; "the label is
+ * not authorization; the server refuses."
  *
  * The credential class is read from the VERIFIED token's own claims
  * (position 1 verified it; decoding here is a read of trusted state):
@@ -13,29 +16,47 @@
  * channel, and schedule tokens alike), so its presence IS the exclusion
  * the Java RequestCallerIdentity.isFirstPartyHumanOperator computes.
  *
- * OSS byte-identity: trusted-local callers carry no token and OIDC
- * console logins carry no platform_client_id claim — the step admits
- * both, so the single-user posture is unchanged (proven by the rosters).
- *
- * Known refinement, recorded: Java additionally admits the remember
- * tool's SESSION-SCOPED sandbox credential. Runner credentials verify
- * through their own lane and carry no platform_client_id, so they pass
- * this gate; the session-bound-only narrowing rides the sandbox
- * credential work (C4's lane) where the session binding is expressible.
+ * RUNNER credentials carry neither the machine class nor that claim —
+ * their eligibility is EDITION POLICY, so the gate consults the composed
+ * RunnerCredentialProvider's authorizeMemoryCapture capability (the
+ * token-type vocabulary that classifies a runner credential is the
+ * provider's own; no caller class expresses it and OSS never learns
+ * another edition's lane names). The capability's three verdicts:
+ * `admit` (the session-scoped capture lane — the token's proved subject
+ * and session id are stashed under MEMORY_CAPTURE_CREDENTIAL_KEY for
+ * ResolveMemoryDefaults' Java-parity field derivation), `refuse` (a
+ * runner credential outside the capture lane — the byte-pinned copy
+ * below), `no-opinion` (not a credential the implementation classifies —
+ * this gate's own logic applies). The capability throws its own
+ * byte-pinned refusal for the org-mismatch arm. With no capability
+ * composed the gate's logic is byte-identical to before the seam: OSS
+ * trusted-local callers carry no token and OIDC console logins carry no
+ * platform_client_id claim — the step admits both, so the single-user
+ * posture is unchanged (proven by the rosters).
  */
 import type { DescMessage } from "@bufbuild/protobuf";
 import { Code, ConnectError } from "@connectrpc/connect";
 
 import type { PipelineStep } from "../pipeline.js";
 import type { RequestContext } from "../request-context.js";
+import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
+import { metadataOf } from "./shapes.js";
 
 /** The Java MemoryPolicy.MEMORY_CAPTURE_CALLER_MESSAGE, byte-pinned. */
 export const MEMORY_CAPTURE_CALLER_MESSAGE =
   "memory can only be captured for a first-party human operator";
 
-export function newGuardMemoryCaptureStep<
-  Desc extends DescMessage,
->(): PipelineStep<Desc> {
+/**
+ * Context key carrying an admitted capture credential's proved claims
+ * (subjectIdentityAccountId + provedSessionId) from this gate to
+ * ResolveMemoryDefaults — present exactly when the capability answered
+ * `admit`, so the defaults step needs no second consult.
+ */
+export const MEMORY_CAPTURE_CREDENTIAL_KEY = "memoryCaptureCredential";
+
+export function newGuardMemoryCaptureStep<Desc extends DescMessage>(
+  provider?: RunnerCredentialProvider,
+): PipelineStep<Desc> {
   return {
     name: "GuardMemoryCapture",
     execute(ctx: RequestContext<Desc>): void {
@@ -44,6 +65,37 @@ export function newGuardMemoryCaptureStep<
         // Server-composed traversals are not capture requests from a
         // credential; the entry-point request already passed the gate.
         return;
+      }
+      const decide = provider?.authorizeMemoryCapture;
+      if (decide !== undefined) {
+        // The org the capture addresses — the capability's org-mismatch
+        // arm checks it against the token's own claim (and throws its
+        // byte-pinned refusal itself). Empty when the request carries
+        // none; Java requires metadata.org before its org-match arm, so
+        // an empty value can only ever narrow.
+        const org = metadataOf(ctx.newState)?.org ?? "";
+        const decision = decide.call(provider, caller, org);
+        switch (decision.verdict) {
+          case "admit":
+            ctx.set(MEMORY_CAPTURE_CREDENTIAL_KEY, {
+              subjectIdentityAccountId: decision.subjectIdentityAccountId,
+              provedSessionId: decision.provedSessionId,
+            });
+            return;
+          case "refuse":
+            throw new ConnectError(
+              MEMORY_CAPTURE_CALLER_MESSAGE,
+              Code.PermissionDenied,
+            );
+          case "no-opinion":
+            break;
+          default: {
+            const exhaustive: never = decision;
+            throw new Error(
+              `unknown memory capture decision ${JSON.stringify(exhaustive)}`,
+            );
+          }
+        }
       }
       if (
         caller.callerClass === "machine" ||
@@ -56,6 +108,31 @@ export function newGuardMemoryCaptureStep<
       }
     },
   };
+}
+
+/** An admitted capture credential's proved claims (the context payload). */
+export interface MemoryCaptureCredential {
+  readonly subjectIdentityAccountId: string;
+  readonly provedSessionId: string;
+}
+
+/**
+ * Reads the admitted capture credential stashed by this gate, if any —
+ * ResolveMemoryDefaults' half of the handoff.
+ */
+export function memoryCaptureCredentialOf<Desc extends DescMessage>(
+  ctx: RequestContext<Desc>,
+): MemoryCaptureCredential | undefined {
+  const payload = ctx.get(MEMORY_CAPTURE_CREDENTIAL_KEY);
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "subjectIdentityAccountId" in payload &&
+    "provedSessionId" in payload
+  ) {
+    return payload as MemoryCaptureCredential;
+  }
+  return undefined;
 }
 
 function carriesPlatformClientClaim(rawToken: string): boolean {

--- a/backend/services/stigmer-server/src/pipeline/steps/guard-reserved-labels.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/guard-reserved-labels.ts
@@ -29,6 +29,12 @@
  *     Environment, which the console legitimately sends on create — the
  *     one allowlist entry, kept here with the doctrine so widening it is
  *     one reviewable diff.
+ *   - SERVER-STAMPED KEYS pass (server-stamped-reserved-labels.ts, the
+ *     Java ServerStampedReservedLabels arm, cloud#386): a step that made
+ *     the trust decision for specific keys on THIS request records
+ *     exactly those keys, and the guard exempts exactly them (the
+ *     agentexecution create chain's RecordRunnerLineageLabels is the
+ *     first recorder — parity entry 20260830.05).
  *   - LABELS only, deliberately not annotations (annotations carry no
  *     resolution or authorization semantics).
  *
@@ -49,6 +55,7 @@ import { internalError } from "../errors.js";
 import type { PipelineStep } from "../pipeline.js";
 import type { RequestContext } from "../request-context.js";
 import { EXISTING_RESOURCE_KEY } from "./load-existing.js";
+import { serverStampedReservedLabels } from "./server-stamped-reserved-labels.js";
 import { metadataOf } from "./shapes.js";
 
 /** The platform-reserved label key namespace (SystemManagedLabels). */
@@ -110,8 +117,9 @@ export function newGuardReservedLabelsStep<Desc extends DescMessage>(
 
       const allowlist =
         CLIENT_CONTRACT_ALLOWLIST.get(ctx.apiResourceKind) ?? new Set();
+      const stamped = serverStampedReservedLabels(ctx);
       const mutations = reservedLabelMutations(stored, requested).filter(
-        (key) => !allowlist.has(key),
+        (key) => !allowlist.has(key) && !stamped.has(key),
       );
       if (mutations.length === 0) {
         return;

--- a/backend/services/stigmer-server/src/pipeline/steps/server-stamped-reserved-labels.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/server-stamped-reserved-labels.ts
@@ -1,0 +1,56 @@
+/**
+ * ServerStampedReservedLabels — the per-request record of reserved
+ * `stigmer.ai/*` label keys that pipeline steps vouched for server-side
+ * (the Java ServerStampedReservedLabels port, cloud#386; parity entry
+ * 20260830.05).
+ *
+ * Some lanes legitimately carry reserved labels the client "sent": the
+ * workflow runner's CallAgent activity stamps the lineage pair
+ * (`stigmer.ai/workflow-execution-id`, `stigmer.ai/workflow-task`) on
+ * every child execution it creates. To GuardReservedLabels, which diffs
+ * the built state against the stored one, those stamps are
+ * indistinguishable from client mutations. A step that has made the
+ * trust decision for specific keys records EXACTLY those keys here, and
+ * the guard exempts exactly them — everything else in the namespace
+ * stays operator-only, so a client smuggling a different reserved key
+ * into the same request is still rejected.
+ *
+ * The record lives in the request context's metadata map: only server
+ * code can reach it, and it never survives the request (the same
+ * request-scoped posture as Java's gRPC Context key).
+ */
+import type { DescMessage } from "@bufbuild/protobuf";
+
+import type { RequestContext } from "../request-context.js";
+
+/** The context-metadata key carrying the vouched key set. */
+const STAMPED_KEYS_CONTEXT_KEY = "serverStampedReservedLabels";
+
+/**
+ * Records reserved label keys the calling step vouched for on this
+ * request. Call immediately next to the decision that vouches them, so
+ * the record and the decision cannot drift apart.
+ */
+export function recordServerStampedReservedLabels<Desc extends DescMessage>(
+  ctx: RequestContext<Desc>,
+  ...keys: ReadonlyArray<string>
+): void {
+  const existing = ctx.get(STAMPED_KEYS_CONTEXT_KEY);
+  const stamped = existing instanceof Set ? (existing as Set<string>) : new Set<string>();
+  for (const key of keys) {
+    stamped.add(key);
+  }
+  ctx.set(STAMPED_KEYS_CONTEXT_KEY, stamped);
+}
+
+/**
+ * The reserved label keys server-side steps vouched for on this request
+ * so far — GuardReservedLabels' exemption set. Empty when nothing was
+ * recorded (an empty answer only narrows what passes).
+ */
+export function serverStampedReservedLabels<Desc extends DescMessage>(
+  ctx: RequestContext<Desc>,
+): ReadonlySet<string> {
+  const stamped = ctx.get(STAMPED_KEYS_CONTEXT_KEY);
+  return stamped instanceof Set ? (stamped as Set<string>) : new Set<string>();
+}

--- a/backend/services/stigmer-server/src/runnerauth/runner-credential-provider.ts
+++ b/backend/services/stigmer-server/src/runnerauth/runner-credential-provider.ts
@@ -129,6 +129,32 @@ export interface SandboxCredentialRequest {
 }
 
 /**
+ * The memory-capture eligibility answer for one caller (the sixth
+ * capability, parity entry 20260830.05 — the Java
+ * MemoryCreateHandler.ResolveMemoryDefaults runner arm):
+ *
+ *   - `no-opinion`: the caller's credential is not one this
+ *     implementation classifies — the gate's own eligibility logic
+ *     applies unchanged.
+ *   - `refuse`: a runner-class credential outside the capture lane —
+ *     the gate answers its byte-pinned PERMISSION_DENIED copy.
+ *   - `admit`: the session-scoped capture lane. The implementation
+ *     hands over the token's own proved claims: the subject the record
+ *     belongs to (Java: "the sub IS the human subject the session
+ *     belongs to") and the session id provenance is overridden with
+ *     (server-proved beats runner-reported). Both are the
+ *     implementation's claim vocabulary — OSS never decodes them.
+ */
+export type MemoryCaptureDecision =
+  | { readonly verdict: "no-opinion" }
+  | { readonly verdict: "refuse" }
+  | {
+      readonly verdict: "admit";
+      readonly subjectIdentityAccountId: string;
+      readonly provedSessionId: string;
+    };
+
+/**
  * Mints and verifies runner credentials per lane. Implementations must be
  * stateless-safe for concurrent use (they gate every ExecutionContext
  * decrypt and every execution dispatch).
@@ -217,6 +243,57 @@ export interface RunnerCredentialProvider {
    * method → today's exact behavior (static env keys only).
    */
   resolvePayloadKey?(keyId: string): Promise<Buffer | undefined>;
+
+  /**
+   * The workflow-lineage vouching decision for an agent-execution create
+   * that carries the runner-stamped lineage labels (parity entry
+   * 20260830.05; the Java RecordRunnerLineageLabelsStep, cloud#386,
+   * consumed by the agentexecution chain's RecordRunnerLineageLabels
+   * step). The implementation owns
+   * BOTH halves of the decision: whether the caller's credential is a
+   * runner credential at all (its own token-type vocabulary — no caller
+   * class expresses this, and OSS must not learn another edition's
+   * lane names), and whether a workflow-bound credential may stamp the
+   * given workflow execution id ("a workflow sandbox cannot stamp
+   * another workflow's lineage" — Java verifies the label against the
+   * token's own binding).
+   *
+   * Returns true to vouch the lineage keys (the guard then exempts
+   * exactly them), false for a non-runner credential (nothing vouched —
+   * the caller stays fully subject to the guard). REFUSES by throwing a
+   * ConnectError with the implementation's byte-pinned copy when the
+   * binding check fails. `stampedWorkflowExecutionId` is empty when the
+   * request stamped only the task label — no binding to check.
+   *
+   * Absent method → nothing is vouched (today's exact OSS behavior: the
+   * permissive default Authorizer is what admits the local runner's
+   * lineage write, and a strict composition without the capability keeps
+   * refusing).
+   */
+  vouchRunnerLineageLabels?(
+    caller: CallerIdentity,
+    stampedWorkflowExecutionId: string,
+  ): boolean;
+
+  /**
+   * The memory capture-eligibility decision for one caller (parity entry
+   * 20260830.05, stigmer-cloud#564; the Java MemoryCreateHandler runner
+   * arm: admit `isSessionSandbox()`, refuse every other runner
+   * credential). Consulted by GuardMemoryCapture
+   * BEFORE its own eligibility logic; `no-opinion` falls through to
+   * that logic unchanged. REFUSES the org-mismatch arm by throwing a
+   * ConnectError with the implementation's byte-pinned copy (Java:
+   * "a mismatch is a forged address, not a routing choice" —
+   * `captureOrg` is the request's metadata.org, checked against the
+   * token's own org claim).
+   *
+   * Absent method → the gate's existing logic exactly (today's OSS
+   * behavior: the trusted-local single-user posture admits, honestly).
+   */
+  authorizeMemoryCapture?(
+    caller: CallerIdentity,
+    captureOrg: string,
+  ): MemoryCaptureDecision;
 }
 
 /**

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -88,6 +88,7 @@ import type {
   ResourceAuthorizationLifecycle,
   ResourceCreatedEvent,
   ResourceDeletedEvent,
+  MemoryCaptureDecision,
   RunnerBootstrapCredentials,
   RunnerCredentialProvider,
   RunnerScopedTokenExchange,
@@ -262,6 +263,26 @@ const credentialProvider: RunnerCredentialProvider = {
   // server-managed rpk_ payload keys the bootstrap arm above hands out.
   resolvePayloadKey: async (keyId: string): Promise<Buffer | undefined> =>
     keyId === "rpk_fake" ? Buffer.from("a2V5", "base64") : undefined,
+  // The two parity-entry-20260830.05 capabilities: the workflow-lineage
+  // vouching decision (agentexecution create) and the memory
+  // capture-eligibility decision (GuardMemoryCapture). Both classify the
+  // caller by the implementation's OWN token vocabulary — the shapes
+  // compile against the exports map alone.
+  vouchRunnerLineageLabels: (
+    _caller: CallerIdentity,
+    stampedWorkflowExecutionId: string,
+  ): boolean => stampedWorkflowExecutionId !== "wfe_unbound",
+  authorizeMemoryCapture: (
+    _caller: CallerIdentity,
+    captureOrg: string,
+  ): MemoryCaptureDecision =>
+    captureOrg === ""
+      ? { verdict: "refuse" }
+      : {
+          verdict: "admit",
+          subjectIdentityAccountId: "ida_fake",
+          provedSessionId: "ses_fake",
+        },
 };
 
 /**


### PR DESCRIPTION
## Summary

The OSS half of parity entry 20260830.05 (the pre-X1 home for C5 readout findings F3/F4 + stigmer-cloud#564) — three composition-vs-Java authorization-gate parity divergences closed through the established capability-seam pattern, with zero behavior change for OSS compositions:

- **The server-stamped reserved-labels record** (`src/pipeline/steps/server-stamped-reserved-labels.ts`, the Java `ServerStampedReservedLabels` port, cloud#386): a per-request vouched-keys record consumed by `GuardReservedLabels` — a step that made the trust decision for specific keys exempts exactly those keys; a smuggled sibling in the same request still refuses.
- **`RecordRunnerLineageLabels`** in the agentexecution create chain (Java's position: after BuildNewState, before the guard): vouches the runner's `stigmer.ai/workflow-execution-id`/`workflow-task` lineage stamps through the NEW optional `vouchRunnerLineageLabels` provider capability — the implementation owns both caller classification (its own token-type vocabulary; no caller class expresses "runner" and OSS deliberately does not know another edition's lane names) and the workflow-sandbox binding rule ("a workflow sandbox cannot stamp another workflow's lineage"). Fixes the composition's refusal of the runner's `call-agent` child create (C5 F3) — the recorded "blanket runner-caller-class arm" shape was deliberately rejected as MORE permissive than Java.
- **`GuardMemoryCapture`** consults the NEW optional `authorizeMemoryCapture` capability for the runner arm (stigmer-cloud#564): `admit` hands the token's proved subject/session to `ResolveMemoryDefaults` (Java's sub-is-the-human + server-proved session semantics), `refuse` answers the byte-pinned copy, `no-opinion` falls through to the unchanged machine/`platform_client_id` logic.
- **The connect lane's managed-environment create propagates the completing caller** (ruling R5, the Java `createAsCaller` posture) through the existing in-process `asCaller` options — a composed tuple-lifecycle driver then attributes ownership, making `OAuth: <name>` environments owner-visible (C5 F4). Zero driver changes needed.

Absent capabilities, every arm keeps today's exact OSS behavior by construction.

## Test plan

- [x] 29 new/extended unit arms: the record (accumulation/isolation), the guard's stamped + smuggled-sibling arms, the gate's capability matrix (admit/refuse/no-opinion/org handoff/internal skip + the absent-capability posture), the lineage step's six arms, the defaults handoff
- [x] All four local conformance rosters byte-identical: local 499/13, local-postgres 499/13, local-execution 160/3, local-postgres-execution 160/3
- [x] Full unit suite 2138 green; typecheck clean; extension-consumer compile proof extended with both capabilities and green
- [x] Measured cloud readout on the C5-shape substrate (spike composition + hermetic Java join-mode): the 3 target EC-1 reds GREEN (child-approval forwarding; both managed-env visibility arms); EC-1 156/5/2 and Class A 476/1/35 with every residual classified (C5-disclosed F5/F6 + the disclosed F7 artifact + one A/B-proven pre-existing main regression filed as stigmer-cloud#572) — full record in the entry's `readout.md`

The cloud half (the two capability implementations, failing-first) is the paired stigmer-cloud PR; merge this one first (the submodule re-pin precedent).

Made with [Cursor](https://cursor.com)