### PR TITLE
test(conformance): pin ApiKey update key-material immutability cross-edition

### DIFF
--- a/backend/services/stigmer-server/src/domain/apikey/steps.ts
+++ b/backend/services/stigmer-server/src/domain/apikey/steps.ts
@@ -12,15 +12,17 @@
  *     is the ONLY time the plaintext ever leaves the server; the store
  *     and audit rows hold the hash. The INTERNAL copy is byte-pinned to
  *     the Java step's.
- *   - PreserveKeyMaterial (O3 gate ruling Q9 — SECURITY): update keeps
- *     spec.key_hash and spec.fingerprint from the STORED resource, so
- *     only the expiry fields are client-mutable. The Java update handler
- *     documents this contract but runs the full-spec-replacement pipeline
- *     without enforcing it — a caller with edit permission could rewrite
- *     the hash to one whose plaintext they know and mint a credential
- *     that authenticates as the key's owner. Deliberate divergence from
- *     the Java BEHAVIOR, convergence with its documented contract; the
- *     cloud-side fix is dispositioned separately (T01_1_review.md Q9).
+ *   - PreserveKeyMaterial (O3 gate ruling Q9): update keeps spec.key_hash
+ *     and spec.fingerprint from the STORED resource, so only the expiry
+ *     fields are client-mutable. Ruling Q9's original impersonation
+ *     rationale was corrected by stigmer-cloud#544's execution: the Java
+ *     pipeline's computed-field clearing already strips both fields from
+ *     every update request (forgery never persisted) — but nothing
+ *     restored them, so every Java update persisted EMPTY key material
+ *     and bricked the key. Both editions now strip-and-restore: this
+ *     step here, ApiKeyUpdateHandler.PreserveKeyMaterial there. The
+ *     shared contract is pinned by the apikey conformance suite's
+ *     update-immutability arm.
  */
 import { Code, ConnectError } from "@connectrpc/connect";
 

--- a/test/conformance/src/suites/apikey.conformance.test.ts
+++ b/test/conformance/src/suites/apikey.conformance.test.ts
@@ -13,18 +13,19 @@
 //     itself cross-edition);
 //   - the fingerprint is the plaintext's last 6 characters;
 //   - update round-trips the expiry fields; delete returns the resource and
-//     the key stops resolving.
+//     the key stops resolving;
+//   - update NEVER changes key material (ruling Q9, closed by
+//     stigmer-cloud#544): altered spec.key_hash/fingerprint in an update
+//     are ignored and the stored values survive, proven on a post-update
+//     read. Both editions strip-and-restore (TS PreserveKeyMaterial;
+//     Java ApiKeyUpdateHandler.PreserveKeyMaterial) — this arm is red
+//     against a cloud target older than the #544 fix by design.
 //
 // Deliberately OUT of this suite (edition authorization postures, not
 // contract divergences — O3 gate ruling Q5):
 //   - getByKeyHash: the cloud gates it behind a platform-admin FGA check;
 //     OSS's permissive single-team default serves it openly. The lookup
 //     path is pinned by the server's own unit suites on both sides.
-//   - update immutability of key_hash/fingerprint: enforced by the TS
-//     server (ruling Q9 — a SECURITY divergence from the cloud's
-//     unenforced pipeline, converging with its documented contract). It
-//     becomes a conformance assertion when the cloud side's disposition
-//     lands; until then this suite never sends altered key material.
 import { createHash } from "node:crypto";
 
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
@@ -163,6 +164,49 @@ describe("ApiKey conformance", () => {
     );
     expect(updated.spec?.neverExpires).toBe(true);
     expect(updated.status?.audit?.specAudit?.event).toBe("updated");
+  });
+
+  it("update ignores altered key material — the stored hash and fingerprint survive (ruling Q9 / stigmer-cloud#544)", async () => {
+    const { org } = await target.provisionTenancy();
+    const created = await createKey(org);
+    const plaintext = created.spec?.keyHash ?? "";
+    const storedHash = storageHash(plaintext);
+
+    const updated = await clients.apiKeyCommand.update({
+      apiVersion: API_VERSION,
+      kind: KIND,
+      metadata: {
+        id: created.metadata?.id ?? "",
+        name: created.metadata?.name ?? "",
+        org: created.metadata?.org ?? "",
+      },
+      spec: {
+        // Forged key material a caller with edit permission might send —
+        // both editions must ignore it (strip-and-restore), never persist
+        // it, and never wipe the stored values.
+        keyHash: storageHash("stk_attacker-known-plaintext"),
+        fingerprint: "forged",
+        neverExpires: true,
+      },
+    });
+
+    expect(
+      updated.spec?.keyHash,
+      "the update response carries the stored hash, not the forged one",
+    ).toBe(storedHash);
+    expect(updated.spec?.fingerprint).toBe(created.spec?.fingerprint);
+
+    const fetched = await clients.apiKeyQuery.get({
+      value: created.metadata!.id,
+    });
+    expect(
+      fetched.spec?.keyHash,
+      "the stored hash survives the update — neither forged nor wiped",
+    ).toBe(storedHash);
+    expect(fetched.spec?.fingerprint).toBe(created.spec?.fingerprint);
+    expect(fetched.spec?.neverExpires, "the expiry change still lands").toBe(
+      true,
+    );
   });
 
   it("delete returns the resource; the id stops resolving", async () => {


### PR DESCRIPTION
## Summary
Adds the apikey conformance assertion this suite's header scheduled for "when the cloud side's disposition lands": an update carrying altered `key_hash`/`fingerprint` is ignored — the stored values survive, proven on a post-update read. Also corrects the stale impersonation rationale in `domain/apikey/steps.ts` (comment only, zero behavior change).

## Context
Pairs with stigmer/stigmer-cloud#575 (**merge that one FIRST** — this arm is red against a cloud target older than that fix by design). The #544 execution corrected the original O3 ruling-Q9 rationale: the Java pipeline's computed-field clearing always defeated hash forgery, but nothing restored the cleared fields, so every Java apikey update persisted EMPTY key material and bricked the key. Both editions now strip-and-restore; this arm pins the shared contract so neither can regress. Full corrected diagnosis: https://github.com/stigmer/stigmer-cloud/issues/544#issuecomment-5493638726

## Changes
- `test/conformance/src/suites/apikey.conformance.test.ts`: the update-immutability arm (forged key material in the update → response and post-update read both carry the stored hash/fingerprint; the expiry change still lands); header caveat replaced with the live contract statement.
- `backend/services/stigmer-server/src/domain/apikey/steps.ts`: `PreserveKeyMaterial` intent comment corrected to the clearing-based diagnosis (the TS behavior was always correct; only the justification text was stale).

## Breaking changes
- None (test + comment only).

## Test plan
- Local target: 31 files, 500 passed / 13 skipped (the baseline 499 + this arm) — the TS server proves the contract.
- Hermetic cloud target against the FIXED fat JAR built from stigmer-cloud#575's branch (Testcontainers + real OpenFGA): apikey suite 7/7 green.
- Red-proof against an UNFIXED (main) fat JAR recorded on the PR after CI-independent verification.
- `tsc --noEmit`: server clean; conformance package's 19 pre-existing errors in untouched packages (mcp-server, sdk/typescript) unchanged (19 before and after).

## Risks
- Nightly `ci.conformance-cloud` goes red on this arm only if it runs against a cloud pin older than stigmer-cloud#575 — the merge order (cloud first) prevents this.

Made with [Cursor](https://cursor.com)