### PR TITLE
feat(backend/stigmer-server): scheduleFireCaller driver point — who a schedule fire acts as

### DIFF
--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -464,14 +464,20 @@ export async function composeServer(
   );
   // Every fire enters the FULL execution create pipeline through the
   // in-process agentexecution client (Go server.go 581: the RunStarter's
-  // ExecutionCreator edge).
+  // ExecutionCreator edge). The composed scheduleFireCaller driver
+  // (stigmer-cloud#572), when present, gives each fire its edition
+  // identity — propagated by the creator's asCaller lane.
   const scheduleRunStarter = new RunStarter({
     store,
     config: scheduleTemporalConfig,
     executions: {
-      create: (execution) =>
-        requireInProcess().scheduleExecutionCreator.create(execution),
+      create: (execution, fireCaller) =>
+        requireInProcess().scheduleExecutionCreator.create(
+          execution,
+          fireCaller,
+        ),
     },
+    fireCallerMint: extensions.drivers.scheduleFireCaller,
     logger,
   });
   const scheduleReconciler = new ScheduleReconciler(

--- a/backend/services/stigmer-server/src/boot/inprocess.ts
+++ b/backend/services/stigmer-server/src/boot/inprocess.ts
@@ -337,9 +337,17 @@ export function createInProcessClients(
     // The schedule clock's fire edge — the plain Create RPC (Go's
     // ExecutionCreator). Since O2 every call through this transport
     // carries the internal caller class stamped at position 1; its audit
-    // derivation equals the old process-global operator identity.
+    // derivation equals the old process-global operator identity. A
+    // composed fire caller (the scheduleFireCaller driver point,
+    // stigmer-cloud#572) propagates instead — the RunStarter mints it per
+    // fire, so the created execution and its auto-created session carry
+    // the edition's schedule identity (ruling R5's asCaller lane).
     scheduleExecutionCreator: {
-      create: (execution) => agentExecutionCommand.create(execution),
+      create: (execution, fireCaller) =>
+        agentExecutionCommand.create(
+          execution,
+          fireCaller === undefined ? undefined : asCaller(fireCaller),
+        ),
     },
     // The project reconciler's delete routing — Go's
     // ResourceDeleterAdapter.Delete switch (execution_engine.go:75-92).

--- a/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
@@ -262,6 +262,44 @@ describe("resolveExtensions — merge semantics", () => {
     expect(resolveExtensions([]).drivers.listReadScope).toBeUndefined();
   });
 
+  it("keeps the declared ScheduleFireCallerMint as the resolved singleton (stigmer-cloud#572)", () => {
+    const mint = {
+      mintFireCaller: () =>
+        Promise.resolve({
+          identityId: "ida_sched",
+          callerClass: "schedule",
+          issuer: "stigmer",
+          rawToken: "jwt",
+        }),
+    };
+    const resolved = resolveExtensions([
+      { name: "iam", drivers: { scheduleFireCaller: mint } },
+    ]);
+    expect(resolved.drivers.scheduleFireCaller).toBe(mint);
+    // The empty state resolves explicitly, never a missing key.
+    expect(resolveExtensions([]).drivers.scheduleFireCaller).toBeUndefined();
+  });
+
+  it("throws on a second ScheduleFireCallerMint, naming both units", () => {
+    const mint = {
+      mintFireCaller: () =>
+        Promise.resolve({
+          identityId: "ida_sched",
+          callerClass: "schedule",
+          issuer: "stigmer",
+          rawToken: "jwt",
+        }),
+    };
+    expect(() =>
+      resolveExtensions([
+        { name: "mint-a", drivers: { scheduleFireCaller: mint } },
+        { name: "mint-b", drivers: { scheduleFireCaller: mint } },
+      ]),
+    ).toThrowError(
+      /extension 'mint-b' registers a ScheduleFireCallerMint, but 'mint-a' already did/,
+    );
+  });
+
   it("merges secret codecs as a version-keyed map across units (20260830.04)", () => {
     const v2 = fakeCodec("v2");
     const v3 = fakeCodec("v3");

--- a/backend/services/stigmer-server/src/extensions/drivers.ts
+++ b/backend/services/stigmer-server/src/extensions/drivers.ts
@@ -20,6 +20,9 @@
  *     edition semantics) — landed with 20260830.03, gate ruling Q1
  *   - secret codecs (the versioned secret-value wire formats) — landed
  *     with 20260830.04 Stage 1, gate ruling Q2
+ *   - schedule-fire caller (who a schedule fire acts as) — landed with
+ *     the stigmer-cloud#572 fix (the Java schedule-token mechanism's
+ *     seam; ruled 2026-09-01)
  *
  * Merge rules (enforced by resolveExtensions, DD-006 §2b): the two
  * provider kinds are single-instance points — a second declaring unit is
@@ -41,6 +44,7 @@ import type { SandboxProvisionerFactory } from "../sandbox/provisioner.js";
 import type { ListReadScope } from "./list-read-scope.js";
 import type { OrganizationDirectory } from "./organization-directory.js";
 import type { ResourceAuthorizationLifecycle } from "./resource-authorization.js";
+import type { ScheduleFireCallerMint } from "./schedule-fire-caller.js";
 
 /** The driver contributions of one extension unit. */
 export interface ExtensionDrivers {
@@ -130,4 +134,13 @@ export interface ExtensionDrivers {
    * v1-only — OSS behavior byte-identical.
    */
   readonly secretCodecs?: ReadonlyMap<string, SecretCodec>;
+  /**
+   * The schedule-fire caller mint (stigmer-cloud#572; single-instance
+   * point) — the identity a schedule fire acts as when it re-enters the
+   * execution create pipeline. When composed, the RunStarter propagates
+   * the minted caller through the R5 in-process header on every fire
+   * (cron tick and manual trigger alike); when absent, fires enter as
+   * the `internal` class — OSS behavior byte-identical.
+   */
+  readonly scheduleFireCaller?: ScheduleFireCallerMint;
 }

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -46,6 +46,7 @@ import type { VisitorErrorPolicy } from "../pipeline/interceptors/error-boundary
 import type { PipelineStep } from "../pipeline/pipeline.js";
 import type { RunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
 import type { SandboxProvisionerFactory } from "../sandbox/provisioner.js";
+import type { ScheduleFireCallerMint } from "./schedule-fire-caller.js";
 import { BUILT_IN_SANDBOX_PROVISIONER_TYPES } from "../sandbox/provisioner.js";
 import type { WorkerFactory } from "../temporal/manager.js";
 import type { Authorizer } from "./authorizer.js";
@@ -178,6 +179,12 @@ export interface ResolvedExtensionDrivers {
    */
   readonly visitorErrorPolicy: VisitorErrorPolicy | undefined;
   /**
+   * The stigmer-cloud#572 schedule-fire caller mint — undefined =
+   * schedule fires enter the create pipeline as the `internal` class,
+   * OSS behavior byte-identical.
+   */
+  readonly scheduleFireCaller: ScheduleFireCallerMint | undefined;
+  /**
    * Registered version token → codec (20260830.04 Stage 1), validated
    * against the built-in v1. Empty = the facade is v1-only, OSS behavior
    * byte-identical. The compose.ts keys stage merges the built-in v1
@@ -223,6 +230,8 @@ export function resolveExtensions(
   let listReadScopeDeclaredBy: string | undefined;
   let visitorErrorPolicy: VisitorErrorPolicy | undefined;
   let visitorErrorPolicyDeclaredBy: string | undefined;
+  let scheduleFireCaller: ScheduleFireCallerMint | undefined;
+  let scheduleFireCallerDeclaredBy: string | undefined;
   const artifactStorageDrivers = new Map<
     string,
     ArtifactStorageDriverFactory
@@ -345,6 +354,16 @@ export function resolveExtensions(
       visitorErrorPolicyDeclaredBy = unit.name;
     }
 
+    if (unit.drivers?.scheduleFireCaller !== undefined) {
+      if (scheduleFireCallerDeclaredBy !== undefined) {
+        throw new Error(
+          `extension '${unit.name}' registers a ScheduleFireCallerMint, but '${scheduleFireCallerDeclaredBy}' already did — exactly one may be composed`,
+        );
+      }
+      scheduleFireCaller = unit.drivers.scheduleFireCaller;
+      scheduleFireCallerDeclaredBy = unit.name;
+    }
+
     if (unit.drivers?.artifactStorageDrivers !== undefined) {
       for (const [name, factory] of unit.drivers.artifactStorageDrivers) {
         if ((BUILT_IN_STORAGE_TYPES as ReadonlyArray<string>).includes(name)) {
@@ -458,6 +477,7 @@ export function resolveExtensions(
       listReadScope,
       visitorErrorPolicy,
       secretCodecs,
+      scheduleFireCaller,
     },
     services,
     workers,

--- a/backend/services/stigmer-server/src/extensions/schedule-fire-caller.ts
+++ b/backend/services/stigmer-server/src/extensions/schedule-fire-caller.ts
@@ -1,0 +1,33 @@
+/**
+ * The schedule-fire caller seam (stigmer-cloud#572) — WHO a schedule fire
+ * acts as when the RunStarter re-enters the execution create pipeline.
+ *
+ * OSS deliberately has no caller identity on this lane (DD-015 D-G: the
+ * single-user edition has no tokens to carry one), so with no driver
+ * composed every fire enters as the in-process `internal` class — today's
+ * behavior, byte-identical. The cloud edition's Java baseline instead
+ * mints a schedule JWT per fire (sub = the org's system-schedule account,
+ * claim = the firing Schedule id) so the created session and execution
+ * carry real attribution and the schedule's viewer set reaches the run
+ * (the FGA model's session#schedule link — "without it a scheduled run is
+ * invisible to every human, including the schedule's owner"). This seam
+ * lets a composition supply that identity; the fire then propagates it
+ * through the R5 caller-propagation header exactly like the other
+ * request-origin in-process creates.
+ *
+ * Single-instance point. The mint is per fire — the schedule id is a
+ * claim of the minted credential, never a cached field — and a mint
+ * failure is an infrastructure fault: the RunStarter lets it propagate,
+ * so the tick activity retries (the deterministic execution name absorbs
+ * the retry) and a manual trigger surfaces the failure to its caller.
+ */
+import type { CallerIdentity } from "./identity.js";
+
+export interface ScheduleFireCallerMint {
+  /**
+   * Mints the caller identity one fire acts as. `rawToken` must carry the
+   * edition's verifiable credential for the identity (compositions read
+   * fire-scoped claims — e.g. the schedule id — from it downstream).
+   */
+  mintFireCaller(org: string, scheduleId: string): Promise<CallerIdentity>;
+}

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -95,6 +95,10 @@ export type {
   ListReadScope,
   ListEntryMeta,
 } from "./extensions/list-read-scope.js";
+// The stigmer-cloud#572 seam: the identity a schedule fire acts as
+// (drivers.scheduleFireCaller) — the composition mints it per fire; the
+// RunStarter propagates it through the R5 in-process header.
+export type { ScheduleFireCallerMint } from "./extensions/schedule-fire-caller.js";
 // The 20260830.03 seam: the visitor-sanitization policy the serving
 // chain's error boundary consumes (drivers.visitorErrorPolicy) — the
 // composition supplies WHO is on the anonymous surface and WHAT copy

--- a/backend/services/stigmer-server/src/temporal/schedule/__tests__/run-starter.test.ts
+++ b/backend/services/stigmer-server/src/temporal/schedule/__tests__/run-starter.test.ts
@@ -251,6 +251,131 @@ describe("RunStarter.startRun — against a real store", () => {
     await store.deleteResource(ApiResourceKind.agent_execution, "aex_01prior");
   });
 
+  // The scheduleFireCaller seam (stigmer-cloud#572): composed → every
+  // create carries the per-fire minted caller; absent → the create
+  // carries none (the internal lane, byte-identical); mint failure → an
+  // infrastructure throw the tick retries; the idempotent path never
+  // mints (a found winner needs no credential).
+  describe("fire-caller mint (stigmer-cloud#572)", () => {
+    const mintedCaller = {
+      identityId: "ida_schedule_acct",
+      callerClass: "schedule",
+      issuer: "stigmer",
+      rawToken: "minted.jwt",
+    };
+
+    it("propagates the minted caller to the create, minting per (org, scheduleId)", async () => {
+      const mintCalls: Array<{ org: string; scheduleId: string }> = [];
+      let seenCaller: unknown = "unset";
+      const runStarter = new RunStarter({
+        store,
+        config,
+        executions: {
+          create: async (_execution, fireCaller) => {
+            seenCaller = fireCaller;
+            return create(AgentExecutionSchema, {
+              metadata: { id: "aex_01minted", org: "acme" },
+            });
+          },
+        },
+        fireCallerMint: {
+          mintFireCaller: async (org, scheduleId) => {
+            mintCalls.push({ org, scheduleId });
+            return mintedCaller;
+          },
+        },
+        logger: silentLogger,
+      });
+
+      const outcome = await runStarter.startRun(scheduleWith(), NOMINAL);
+      expect(outcome).toEqual({
+        kind: "started",
+        executionId: "aex_01minted",
+        alreadyExisted: false,
+      });
+      expect(mintCalls).toEqual([{ org: "acme", scheduleId: "sch_01test" }]);
+      expect(seenCaller).toBe(mintedCaller);
+    });
+
+    it("passes no caller when no mint is composed (the OSS internal lane)", async () => {
+      let seenCaller: unknown = "unset";
+      const runStarter = new RunStarter({
+        store,
+        config,
+        executions: {
+          create: async (_execution, fireCaller) => {
+            seenCaller = fireCaller;
+            return create(AgentExecutionSchema, {
+              metadata: { id: "aex_01plain", org: "acme" },
+            });
+          },
+        },
+        logger: silentLogger,
+      });
+      const outcome = await runStarter.startRun(scheduleWith(), NOMINAL);
+      expect(outcome.kind).toBe("started");
+      expect(seenCaller).toBeUndefined();
+    });
+
+    it("throws (retryable) when the mint fails — never a silent internal fallback", async () => {
+      const runStarter = new RunStarter({
+        store,
+        config,
+        executions: {
+          create: async () => {
+            throw new Error("create must not run when the mint failed");
+          },
+        },
+        fireCallerMint: {
+          mintFireCaller: async () => {
+            throw new Error("account provisioning unavailable");
+          },
+        },
+        logger: silentLogger,
+      });
+      await expect(runStarter.startRun(scheduleWith(), NOMINAL)).rejects.toThrow(
+        /mint schedule fire caller for sch_01test: account provisioning unavailable/,
+      );
+    });
+
+    it("never mints on the idempotent path (the winner needs no credential)", async () => {
+      await store.saveResource(
+        ApiResourceKind.agent_execution,
+        "aex_01winner",
+        AgentExecutionSchema,
+        create(AgentExecutionSchema, {
+          metadata: {
+            id: "aex_01winner",
+            org: "acme",
+            slug: scheduledExecutionName("sch_01test", NOMINAL),
+          },
+        }),
+      );
+      const runStarter = new RunStarter({
+        store,
+        config,
+        executions: {
+          create: async () => {
+            throw new Error("create must not run on the idempotent path");
+          },
+        },
+        fireCallerMint: {
+          mintFireCaller: async () => {
+            throw new Error("mint must not run on the idempotent path");
+          },
+        },
+        logger: silentLogger,
+      });
+      const outcome = await runStarter.startRun(scheduleWith(), NOMINAL);
+      expect(outcome).toEqual({
+        kind: "started",
+        executionId: "aex_01winner",
+        alreadyExisted: true,
+      });
+      await store.deleteResource(ApiResourceKind.agent_execution, "aex_01winner");
+    });
+  });
+
   it("answers targetMissing with the byte-pinned copy when the agent is gone", async () => {
     const runStarter = starter(async () => {
       throw new Error("unreachable");

--- a/backend/services/stigmer-server/src/temporal/schedule/run-starter.ts
+++ b/backend/services/stigmer-server/src/temporal/schedule/run-starter.ts
@@ -5,7 +5,11 @@
  * context, persist, workflow start). Where the cloud starter mints a
  * schedule token and re-enters the pipeline behind FGA gates, OSS has no
  * caller identity by design (DD-015 D-G): the org is stamped from the
- * schedule's own metadata.
+ * schedule's own metadata. A composition restores the Java posture through
+ * the scheduleFireCaller driver point (stigmer-cloud#572): when composed,
+ * every fire mints its caller and the create propagates it via the R5
+ * in-process header; a mint failure propagates like any infrastructure
+ * fault (the tick activity retries, the trigger surfaces it).
  *
  * Idempotency is the CLOCK's job here (DD-015 D-F): the OSS create
  * pipeline deliberately has no duplicate check (it would tax every
@@ -42,6 +46,8 @@ import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/
 import { ApiResourceMetadataSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { CallerIdentity } from "../../extensions/identity.js";
+import type { ScheduleFireCallerMint } from "../../extensions/schedule-fire-caller.js";
 import { findResourceBySlug } from "../../pipeline/steps/helpers.js";
 import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
@@ -81,10 +87,16 @@ export type RunOutcomeResult =
 /**
  * The narrow slice of the in-process agent-execution client the run
  * starter needs (Go ExecutionCreator; satisfied through
- * src/boot/inprocess.ts).
+ * src/boot/inprocess.ts). `fireCaller`, when present, is the composed
+ * edition identity the fire acts as — the implementation propagates it
+ * through the R5 in-process header; absent, the create enters as the
+ * `internal` class (the OSS default, byte-identical).
  */
 export interface ScheduleExecutionCreator {
-  create(execution: AgentExecution): Promise<AgentExecution>;
+  create(
+    execution: AgentExecution,
+    fireCaller?: CallerIdentity,
+  ): Promise<AgentExecution>;
 }
 
 /**
@@ -197,6 +209,8 @@ export interface RunStarterDeps {
   readonly store: Store;
   readonly config: ScheduleTemporalConfig;
   readonly executions: ScheduleExecutionCreator;
+  /** The composed fire-caller mint, or undefined (the OSS internal lane). */
+  readonly fireCallerMint?: ScheduleFireCallerMint;
   readonly logger: Logger;
 }
 
@@ -274,10 +288,31 @@ export class RunStarter {
       return { kind: "started", executionId, alreadyExisted: true };
     }
 
+    // The composed fire-caller mint (stigmer-cloud#572): minted per fire,
+    // after the idempotency lookup (a found winner needs no credential)
+    // and before the create it authenticates. Failure is an
+    // infrastructure fault — thrown, so the tick activity retries under
+    // the deterministic name and a manual trigger surfaces it.
+    let fireCaller: CallerIdentity | undefined;
+    if (this.deps.fireCallerMint !== undefined) {
+      try {
+        fireCaller = await this.deps.fireCallerMint.mintFireCaller(
+          org,
+          scheduleId,
+        );
+      } catch (error) {
+        throw new Error(
+          `mint schedule fire caller for ${scheduleId}: ${error instanceof Error ? error.message : String(error)}`,
+          { cause: error },
+        );
+      }
+    }
+
     let created: AgentExecution;
     try {
       created = await this.deps.executions.create(
         this.buildExecutionRequest(schedule, resolved.agent, executionName, nominalFireTime),
+        fireCaller,
       );
     } catch (error) {
       if (!(error instanceof ConnectError)) {

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -96,6 +96,7 @@ import type {
   SandboxCredentialRequest,
   SandboxProvisioner,
   SandboxProvisionerFactory,
+  ScheduleFireCallerMint,
   SecretCodec,
   SecretService,
   ServerExtension,
@@ -430,6 +431,25 @@ const consumerVaultCodec: SecretCodec = {
 };
 
 /**
+ * A consumer-shaped schedule-fire caller mint (the stigmer-cloud#572
+ * seam) — the identity a schedule fire acts as, minted per fire. The
+ * cloud edition's real driver mints a schedule JWT (sub = the org's
+ * system-schedule account, claim = the firing Schedule id); this fake
+ * proves the contract compiles from consumer code.
+ */
+const consumerScheduleFireCaller: ScheduleFireCallerMint = {
+  mintFireCaller: (org: string, scheduleId: string) => {
+    void scheduleId;
+    return Promise.resolve({
+      identityId: `ida_schedule_${org}`,
+      callerClass: "schedule",
+      issuer: "stigmer",
+      rawToken: "compile-proof.jwt",
+    });
+  },
+};
+
+/**
  * The secret-convergence sweep's exact shape (Stage 3 consumes it): page
  * raw documents through the blessed maintenance verbs, reseal through the
  * facade's one upgrade door, and persist only when nothing interleaved —
@@ -579,6 +599,8 @@ export const fakeExtension: ServerExtension = {
     // The 20260830.04 sealing seam: vault-backed wire formats registered
     // by version token ("v1" is the reserved built-in).
     secretCodecs: new Map([["v2", consumerVaultCodec]]),
+    // The stigmer-cloud#572 seam: who a schedule fire acts as.
+    scheduleFireCaller: consumerScheduleFireCaller,
   },
   services: [registerBillingService],
   workers: [workerFactory],


### PR DESCRIPTION
## Summary

The OSS half of the [stigmer-cloud#572](https://github.com/stigmer/stigmer-cloud/issues/572) fix: on the cloud composition, schedule-fired sessions and executions were created by the anonymous `internal` caller — no owner attribution, no `session#schedule` link — so a scheduled run was invisible to **everyone**, including the schedule's owner (the FGA model's own documented consequence). Java's baseline mints a schedule JWT per fire; this PR gives compositions the seam to do the same.

- **New single-instance driver point `scheduleFireCaller`** (`ScheduleFireCallerMint`: `mintFireCaller(org, scheduleId) → CallerIdentity`) — registered like the nine existing points, loud-fail on duplicates, exported on the DD-005 map, extension-consumer compile proof extended.
- **The RunStarter mints per fire** (after the idempotency lookup, before the create) and the schedule-execution creator propagates the minted caller through the existing R5 in-process header — both fire paths (cron tick and manual trigger) ride the one code path.
- **Absent driver = today's `internal` lane, byte-identical**: all four local conformance rosters unchanged (500/13, 500/13-postgres, 160/3, 160/3-postgres-execution); OSS units 2159 green.
- **Mint failure is a thrown infrastructure fault** — the tick activity retries under the deterministic execution name; a manual trigger surfaces it. Never a silent fall-through to the anonymous lane.

The cloud driver (system-schedule account + schedule JWT + the `session#schedule` link tuple) lands in the paired stigmer-cloud PR, which closes the issue.

## Test plan

- [x] `npm run typecheck` + full unit suite (2159 passed) in `backend/services/stigmer-server`
- [x] New unit arms: registry singleton + duplicate throw; RunStarter mint propagation, absent-mint byte-identity, mint-failure throw, idempotent-path no-mint
- [x] All four local conformance rosters byte-identical to main
- [x] Live-proven end-to-end with the cloud driver on the spike composition (see the paired PR's `spike/schedule-fire-proof.ts`)

Part of stigmer-cloud#572 (the cloud PR carries the close).

Made with [Cursor](https://cursor.com)