### PR TITLE
feat(backend/stigmer-server): post-authentication caller-guard extension point

### DIFF
--- a/.cursor/rules/backend/ts-server-guidelines.mdc
+++ b/.cursor/rules/backend/ts-server-guidelines.mdc
@@ -113,6 +113,21 @@ eventually violate creatively.
   transition; decorators contribute only fields the shared reply schema
   carries, clone-committed per decorator. Workflowexecution deliberately
   has NO hooks (unmetered in cloud; nothing built ahead of need).
+- **Caller guards run post-stamp on the serving chain ONLY** (entry
+  20260902.02 ruling Q1; `src/extensions/caller-guards.ts`). A guard
+  enforces the MINTING CLIENT's contract (the platform-client controls:
+  deletion-revocation liveness, Origin vs allowed_origins) — a different
+  concern from token verification, never folded into an IdentityVerifier.
+  Registration is `ServerExtension.callerGuards` (list point, unit
+  order); the serving chassis runs guards over the FINAL stamped
+  identity, first throw wins. The in-process chain takes no guards — the
+  exemption is structural, never a runtime skip a guard re-implements.
+  Fault doctrine is the verifier chain's: a guard's ConnectError is its
+  own wire mapping; any other throw is INTERNAL, never softened into a
+  denial. Skip logic (claim-less tokens, the token_type exemption,
+  health/reflection services) is the composition's business, decoded
+  from `CallerIdentity.rawToken` — OSS runs every guard on every serving
+  request and stays policy-free.
 - **The composition root is staged plain functions** (config → storage →
   temporal → controllers → routes → listen). No DI framework. A missing
   dependency is a compile error or a loud boot throw, never a silent no-op.

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -1098,15 +1098,23 @@ export async function composeServer(
     routes,
     // The serving chain's position-1 identity source is the verifier
     // chassis over the composed verifiers (O2; zero verifiers = the
-    // trusted-local posture, byte-identical wire behavior). The in-process
-    // transport above carries its own position-1 source — the internal
-    // caller class only it can mint (ruling Q4). Position 0 is the error
-    // boundary (20260830.03): the raw-error conversion net plus the
-    // composed visitor sanitizer — SERVING chain only, so in-process
-    // hops keep full diagnostics by construction.
+    // trusted-local posture, byte-identical wire behavior) followed by
+    // the composed caller guards (20260902.02; zero guards = today's
+    // behavior). The in-process transport above carries its own
+    // position-1 source — the internal caller class only it can mint
+    // (ruling Q4), and NO guards: the in-process exemption is structural
+    // (caller-guards.ts). Position 0 is the error boundary (20260830.03):
+    // the raw-error conversion net plus the composed visitor sanitizer —
+    // SERVING chain only, so in-process hops keep full diagnostics by
+    // construction.
     interceptors: buildInterceptorChain(
       logger,
-      createVerifierChainInterceptor(identityVerifiers, logger, authEnabled),
+      createVerifierChainInterceptor(
+        identityVerifiers,
+        extensions.callerGuards,
+        logger,
+        authEnabled,
+      ),
       createErrorBoundaryInterceptor(
         logger,
         extensions.drivers.visitorErrorPolicy,

--- a/backend/services/stigmer-server/src/domain/artifact/__tests__/artifact.test.ts
+++ b/backend/services/stigmer-server/src/domain/artifact/__tests__/artifact.test.ts
@@ -244,7 +244,9 @@ describe("artifact domain — create & content addressing", () => {
         },
         {
           router: {
-            interceptors: [createVerifierChainInterceptor([], silentLogger)],
+            interceptors: [
+              createVerifierChainInterceptor([], [], silentLogger),
+            ],
           },
         },
       );

--- a/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
@@ -169,6 +169,89 @@ describe("extension composition (composed server)", () => {
 });
 
 /**
+ * The caller-guard arm (entry 20260902.02 ruling Q1): a composed guard
+ * is enforced on the SERVING chain and structurally absent from the
+ * in-process chain. This is the wiring proof the unit arms cannot give —
+ * it pins that compose.ts threads resolved guards into the serving
+ * chassis AND that boot/inprocess.ts has no guard path at all (the TS
+ * rendering of the Java InProcessCallContextHolder exemption, proven by
+ * execution rather than by signature).
+ */
+describe("extension composition (caller guards)", () => {
+  let server: ComposedServer;
+  let dir: string;
+  let portTransport: Transport;
+  const guardedProcedures: string[] = [];
+
+  const GUARD_REFUSAL_MESSAGE = "refused by the composed test guard";
+
+  const guardExtension: ServerExtension = {
+    name: "fake-guard",
+    callerGuards: [
+      {
+        name: "refuse-all",
+        guard: (_caller, method) => {
+          guardedProcedures.push(`${method.parent.typeName}/${method.name}`);
+          return Promise.reject(
+            new ConnectError(GUARD_REFUSAL_MESSAGE, Code.PermissionDenied),
+          );
+        },
+      },
+    ],
+  };
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "caller-guard-test-"));
+    server = await composeServer({
+      config: loadConfig({
+        STIGMER_MODEL_REGISTRY_REFRESH: "off",
+        DB_PATH: path.join(dir, "stigmer.db"),
+        ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      }),
+      logger: createLogger({ level: "error", pretty: false, write: () => {} }),
+      extensions: [guardExtension],
+      portOverride: 0,
+      host: "127.0.0.1",
+    });
+    const port = await server.start();
+    portTransport = createGrpcTransport({
+      baseUrl: `http://127.0.0.1:${port}`,
+    });
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("enforces the composed guard on the bound port with the guard's own wire mapping", async () => {
+    const client = createClient(PlatformQueryController, portTransport);
+    const failure = await client
+      .getServerInfo({})
+      .then(() => null)
+      .catch((error: unknown) => ConnectError.from(error));
+    expect(failure?.code).toBe(Code.PermissionDenied);
+    expect(failure?.rawMessage).toBe(GUARD_REFUSAL_MESSAGE);
+    expect(guardedProcedures).toContain(
+      "ai.stigmer.platform.v1.PlatformQueryController/getServerInfo",
+    );
+  });
+
+  it("never runs the guard on the in-process transport — the structural skip", async () => {
+    const before = guardedProcedures.length;
+    const client = createClient(
+      PlatformQueryController,
+      server.inProcessTransport,
+    );
+    // The SAME procedure the port lane just saw refused (a guard-only
+    // unit declares no edition, so the answer is the OSS default).
+    const info = await client.getServerInfo({});
+    expect(info.edition).toBe(ServerEdition.oss);
+    expect(guardedProcedures.length).toBe(before);
+  });
+});
+
+/**
  * The O5 driver-substitution arm: every consumption site routes through
  * the composed drivers — the registry lane serves the substituted
  * catalog's document, the platform exchange mints through the substituted

--- a/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
@@ -24,6 +24,7 @@ import type { RunnerCredentialProvider } from "../../runnerauth/runner-credentia
 import type { SandboxProvisionerFactory } from "../../sandbox/provisioner.js";
 import type { WorkerFactory } from "../../temporal/manager.js";
 import type { Authorizer } from "../authorizer.js";
+import type { CallerGuard } from "../caller-guards.js";
 import { DECLARED_GATE_SLOTS, GATE_SLOT_NAMES } from "../gate-slots.js";
 import type { GateSlotName } from "../gate-slots.js";
 import type { IdentityVerifier } from "../identity.js";
@@ -40,6 +41,11 @@ const denyAll: Authorizer = {
 
 function verifier(name: string): IdentityVerifier {
   return { name, verify: () => Promise.resolve(null) };
+}
+
+// Never invoked — the guard's identity is what the merge tests assert.
+function callerGuard(name: string): CallerGuard {
+  return { name, guard: () => Promise.resolve() };
 }
 
 // Never invoked — the factory's identity is what the merge tests assert.
@@ -127,6 +133,7 @@ describe("resolveExtensions — defaults", () => {
     expect(resolved.edition).toBe(ServerEdition.oss);
     expect(resolved.authorizer).toBeUndefined();
     expect(resolved.identityVerifiers).toEqual([]);
+    expect(resolved.callerGuards).toEqual([]);
     expect(resolved.gateSteps.size).toBe(0);
     expect(resolved.statusObservers).toEqual([]);
     expect(resolved.responseDecorators).toEqual([]);
@@ -155,6 +162,7 @@ describe("resolveExtensions — merge semantics", () => {
       {
         name: "alpha",
         identityVerifiers: [verifier("a1"), verifier("a2")],
+        callerGuards: [callerGuard("g1")],
         services: [registerA],
         statusTransitionHooks: { observers: [observerA] },
       },
@@ -163,6 +171,7 @@ describe("resolveExtensions — merge semantics", () => {
         edition: ServerEdition.cloud,
         authorizer: allowAll,
         identityVerifiers: [verifier("b1")],
+        callerGuards: [callerGuard("g2"), callerGuard("g3")],
         services: [registerB],
         workers: [workerFactory],
         statusTransitionHooks: { responseDecorators: [decoratorB] },
@@ -175,6 +184,11 @@ describe("resolveExtensions — merge semantics", () => {
       "a1",
       "a2",
       "b1",
+    ]);
+    expect(resolved.callerGuards.map((g) => g.name)).toEqual([
+      "g1",
+      "g2",
+      "g3",
     ]);
     expect(resolved.services).toEqual([registerA, registerB]);
     expect(resolved.workers).toEqual([workerFactory]);

--- a/backend/services/stigmer-server/src/extensions/caller-guards.ts
+++ b/backend/services/stigmer-server/src/extensions/caller-guards.ts
@@ -1,0 +1,61 @@
+/**
+ * The post-authentication caller-guard seam (convergence entry
+ * 20260902.02, gate ruling Q1) — enforcement of the MINTING CLIENT's
+ * contract, run by the serving chassis after the position-1 identity
+ * stamp. The TS rendering of the cloud Java
+ * PlatformClientEnforcementInterceptor's home: verification says who the
+ * caller IS (the IdentityVerifier chain, deliberately token-only); a
+ * guard says whether the client that minted the credential may still be
+ * served (deletion-revocation liveness, cloud#342; Origin vs
+ * allowed_origins, oss#375). Java separates the two classes the same way.
+ *
+ * List point — guards concatenate in unit order and run in composed
+ * order; the first throw wins. OSS composes zero guards, so with none
+ * registered the serving chain behaves byte-identically to before the
+ * point existed (the conformance rosters pin that).
+ *
+ * The in-process exemption is STRUCTURAL, not policed: guards are a
+ * parameter of the serving chain's identity source only
+ * (createVerifierChainInterceptor); the in-process interceptor has no
+ * guard parameter to forget — the TS rendering of the Java
+ * InProcessCallContextHolder skip.
+ *
+ * Skip logic is the guard's own business. OSS runs every composed guard
+ * on every serving request with the FINAL stamped identity (claimed or
+ * trusted-local): which tokens a guard exempts (claim-less tokens, the
+ * load-bearing token_type skip, health/reflection services) is edition
+ * policy, decoded by the guard from CallerIdentity.rawToken — never OSS
+ * type widening (the O5 Q4 vocabulary doctrine).
+ *
+ * Fault doctrine (the verifier-chain doctrine applied to admission): a
+ * guard that REFUSES throws a ConnectError — its own wire mapping, and
+ * deliberate-refusal codes pass the position-0 error boundary untouched,
+ * so byte-pinned refusal copy survives to the wire. Any other throw is
+ * an infrastructure fault — INTERNAL, never softened into a denial (a
+ * store outage during a liveness read must not read as "client
+ * deleted"). The chassis logs both arms with the guard's name: position
+ * 1 sits outside the logging interceptor, so a guard's refusal would
+ * otherwise leave no operator record.
+ */
+import type { DescMethod } from "@bufbuild/protobuf";
+
+import type { CallerIdentity } from "./identity.js";
+
+export interface CallerGuard {
+  /** Names the guard in refusal and fault logs (e.g. 'platform-client'). */
+  readonly name: string;
+  /**
+   * Admits by returning; refuses by throwing a ConnectError (the guard's
+   * own wire mapping). Runs on unary AND stream calls, once per call at
+   * admission, before the handler and before validation. `method` carries
+   * its parent service descriptor (service-level skips need no extra
+   * parameter); `headers` is the request's wire metadata (the Origin
+   * check reads the plain lowercase `origin` key, the verified
+   * guest-mint-lane idiom).
+   */
+  guard(
+    caller: CallerIdentity,
+    method: DescMethod,
+    headers: Headers,
+  ): Promise<void>;
+}

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -50,6 +50,7 @@ import type { ScheduleFireCallerMint } from "./schedule-fire-caller.js";
 import { BUILT_IN_SANDBOX_PROVISIONER_TYPES } from "../sandbox/provisioner.js";
 import type { WorkerFactory } from "../temporal/manager.js";
 import type { Authorizer } from "./authorizer.js";
+import type { CallerGuard } from "./caller-guards.js";
 import type { ExtensionDrivers } from "./drivers.js";
 import { DECLARED_GATE_SLOTS } from "./gate-slots.js";
 import type { GateSlotName, ResolvedGateSteps } from "./gate-slots.js";
@@ -94,6 +95,12 @@ export interface ServerExtension {
   /** Ordered verifier-chain entries, appended in unit order (consumed by O2). */
   readonly identityVerifiers?: ReadonlyArray<IdentityVerifier>;
   /**
+   * Post-authentication caller guards, appended in unit order (entry
+   * 20260902.02 ruling Q1) — run by the serving chain's identity source
+   * after the stamp, never by the in-process chain (caller-guards.ts).
+   */
+  readonly callerGuards?: ReadonlyArray<CallerGuard>;
+  /**
    * Gate-step registrations per declared slot (consumed by O4). Every key
    * must name a declared slot — an unknown slot is a boot throw, the §2b
    * contract that keeps a composition and its pinned server honest.
@@ -130,6 +137,7 @@ export interface ResolvedExtensions {
    */
   readonly authorizer: Authorizer | undefined;
   readonly identityVerifiers: ReadonlyArray<IdentityVerifier>;
+  readonly callerGuards: ReadonlyArray<CallerGuard>;
   /** Slot name → steps, validated against DECLARED_GATE_SLOTS. */
   readonly gateSteps: ResolvedGateSteps;
   readonly statusObservers: ReadonlyArray<AgentExecutionStatusObserver>;
@@ -204,6 +212,7 @@ export function resolveExtensions(
 ): ResolvedExtensions {
   const unitNames: string[] = [];
   const identityVerifiers: IdentityVerifier[] = [];
+  const callerGuards: CallerGuard[] = [];
   const gateSteps = new Map<string, ReadonlyArray<PipelineStep<DescMessage>>>();
   const statusObservers: AgentExecutionStatusObserver[] = [];
   const responseDecorators: AgentExecutionResponseDecorator[] = [];
@@ -450,6 +459,7 @@ export function resolveExtensions(
     }
 
     identityVerifiers.push(...(unit.identityVerifiers ?? []));
+    callerGuards.push(...(unit.callerGuards ?? []));
     statusObservers.push(...(unit.statusTransitionHooks?.observers ?? []));
     responseDecorators.push(
       ...(unit.statusTransitionHooks?.responseDecorators ?? []),
@@ -463,6 +473,7 @@ export function resolveExtensions(
     edition: edition ?? ServerEdition.oss,
     authorizer,
     identityVerifiers,
+    callerGuards,
     gateSteps,
     statusObservers,
     responseDecorators,

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -57,6 +57,15 @@ export type {
   CallerIdentity,
   IdentityVerifier,
 } from "./extensions/identity.js";
+// The 20260902.02 seam: post-authentication caller guards
+// (ServerExtension.callerGuards) — enforcement of the MINTING CLIENT's
+// contract, run by the serving chassis after the position-1 identity
+// stamp and never by the in-process chain (the structural exemption).
+// The composition owns WHO is exempt and WHAT refuses (skip sets,
+// byte-pinned copy, liveness reads); OSS owns the walk, the fault
+// mapping (ConnectError = the guard's wire shape; any other throw =
+// INTERNAL), and the ordering.
+export type { CallerGuard } from "./extensions/caller-guards.js";
 // The caller-identity read idiom for extension-registered services (C2
 // Stage 3, 20260827.10): extension RPC handlers traverse the same
 // interceptor chain as OSS controllers, so the identity stamped at chain
@@ -158,6 +167,12 @@ export {
   callerIdentityKey,
   callerIdentityOf,
 } from "./pipeline/interceptors/auth.js";
+// The serving chassis factory (20260902.02, the error-boundary
+// precedent): a composition's OWN tests must drive its caller guards
+// through the REAL stamp→guard mechanism — the walk order, the fault
+// mapping, the refusal pass-through — never a re-derivation. Production
+// wiring stays compose.ts's job.
+export { createVerifierChainInterceptor } from "./pipeline/interceptors/auth.js";
 export { newPipeline } from "./pipeline/pipeline.js";
 export { newAuthorizeStep } from "./pipeline/steps/authorize.js";
 export { newValidateProtoStep } from "./pipeline/steps/validation.js";

--- a/backend/services/stigmer-server/src/pipeline/__tests__/chain.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/__tests__/chain.test.ts
@@ -82,7 +82,7 @@ function testHarness(handlers: {
       router: {
         interceptors: buildInterceptorChain(
           logger,
-          createVerifierChainInterceptor([], logger),
+          createVerifierChainInterceptor([], [], logger),
         ),
       },
     },

--- a/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/auth.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/auth.test.ts
@@ -6,8 +6,11 @@
  * Q1+Q2 — tokenless is UNAUTHENTICATED with the Java byte-pinned copy,
  * except is_public methods), the trusted-local modeled state in both
  * operator postures, the internal caller class's structural minting
- * invariant (ruling Q4 — a wire request can never carry it), and the
- * shared bearer parser's shape.
+ * invariant (ruling Q4 — a wire request can never carry it), the
+ * caller-guard walk (20260902.02 ruling Q1 — guards run over the FINAL
+ * stamped identity, first throw wins, ConnectError is the guard's own
+ * wire mapping, any other throw is INTERNAL), and the shared bearer
+ * parser's shape.
  */
 import { describe, expect, it, afterEach } from "vitest";
 import { Code, ConnectError, createContextValues } from "@connectrpc/connect";
@@ -17,6 +20,7 @@ import type { DescMethod } from "@bufbuild/protobuf";
 import { ApiKeyQueryController } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/query_pb";
 import { PlatformQueryController } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
 
+import type { CallerGuard } from "../../../extensions/caller-guards.js";
 import type {
   CallerIdentity,
   IdentityVerifier,
@@ -71,6 +75,9 @@ async function runInterceptor(
     header,
     contextValues,
     method,
+    // The parent service descriptor rides every real request; the guard
+    // fault log reads its typeName.
+    service: method.parent,
     stream: false,
   } as never);
   return stamped;
@@ -102,6 +109,7 @@ describe("verifier chain walk", () => {
             return Promise.resolve(null);
           }),
         ],
+        [],
         silentLogger,
       ),
       "Bearer tok",
@@ -124,6 +132,7 @@ describe("verifier chain walk", () => {
             return Promise.resolve(CLAIMED);
           }),
         ],
+        [],
         silentLogger,
       ),
       "Bearer tok",
@@ -138,6 +147,7 @@ describe("verifier chain walk", () => {
       runInterceptor(
         createVerifierChainInterceptor(
           [verifier("oidc", () => Promise.reject(reject))],
+          [],
           silentLogger,
         ),
         "Bearer tok",
@@ -149,6 +159,7 @@ describe("verifier chain walk", () => {
     const error = await runInterceptor(
       createVerifierChainInterceptor(
         [verifier("oidc", () => Promise.reject(new Error("JWKS unreachable")))],
+        [],
         silentLogger,
       ),
       "Bearer tok",
@@ -162,7 +173,7 @@ describe("verifier chain walk", () => {
 describe("conditional strictness (ruling Q6 — both postures)", () => {
   it("zero verifiers: a presented-but-unclaimed token falls through SILENTLY to trusted-local", async () => {
     const identity = await runInterceptor(
-      createVerifierChainInterceptor([], silentLogger),
+      createVerifierChainInterceptor([], [], silentLogger),
       "Bearer garbage-token",
     );
     expect(identity).toEqual(trustedLocalIdentity());
@@ -172,6 +183,7 @@ describe("conditional strictness (ruling Q6 — both postures)", () => {
     const error = await runInterceptor(
       createVerifierChainInterceptor(
         [verifier("oidc", () => Promise.resolve(null))],
+        [],
         silentLogger,
       ),
       "Bearer garbage-token",
@@ -185,12 +197,15 @@ describe("conditional strictness (ruling Q6 — both postures)", () => {
 
   it("an absent token falls to trusted-local in both verifier postures when authentication is not required", async () => {
     expect(
-      await runInterceptor(createVerifierChainInterceptor([], silentLogger)),
+      await runInterceptor(
+        createVerifierChainInterceptor([], [], silentLogger),
+      ),
     ).toEqual(trustedLocalIdentity());
     expect(
       await runInterceptor(
         createVerifierChainInterceptor(
           [verifier("oidc", () => Promise.resolve(null))],
+          [],
           silentLogger,
         ),
       ),
@@ -205,6 +220,7 @@ describe("require-authentication posture (O3 rulings Q1+Q2)", () => {
         Promise.resolve(token === "tok" ? CLAIMED : null),
       ),
     ],
+    [],
     silentLogger,
     true,
   );
@@ -279,10 +295,214 @@ describe("internal caller class (ruling Q4 — structurally unmintable from the 
     // ("user"), never "internal" — the serving chain has no code path
     // that produces the class.
     const identity = await runInterceptor(
-      createVerifierChainInterceptor([], silentLogger),
+      createVerifierChainInterceptor([], [], silentLogger),
       "Bearer forged.internal.token",
     );
     expect(identity?.callerClass).toBe("user");
+  });
+});
+
+describe("caller-guard walk (20260902.02 ruling Q1)", () => {
+  function guard(
+    name: string,
+    body: (caller: CallerIdentity) => Promise<void>,
+  ): CallerGuard {
+    return { name, guard: (caller) => body(caller) };
+  }
+
+  it("guards run over the FINAL stamped identity — the claimed arm", async () => {
+    const seen: CallerIdentity[] = [];
+    await runInterceptor(
+      createVerifierChainInterceptor(
+        [verifier("oidc", () => Promise.resolve(CLAIMED))],
+        [
+          guard("recorder", (caller) => {
+            seen.push(caller);
+            return Promise.resolve();
+          }),
+        ],
+        silentLogger,
+      ),
+      "Bearer tok",
+    );
+    expect(seen).toEqual([CLAIMED]);
+  });
+
+  it("guards run over the FINAL stamped identity — the trusted-local arm", async () => {
+    const seen: CallerIdentity[] = [];
+    await runInterceptor(
+      createVerifierChainInterceptor(
+        [],
+        [
+          guard("recorder", (caller) => {
+            seen.push(caller);
+            return Promise.resolve();
+          }),
+        ],
+        silentLogger,
+      ),
+    );
+    expect(seen).toEqual([trustedLocalIdentity()]);
+  });
+
+  it("a guard receives the request's method descriptor and headers", async () => {
+    let seenMethod: DescMethod | undefined;
+    let seenOrigin: string | null = null;
+    const inspecting: CallerGuard = {
+      name: "inspector",
+      guard: (_caller, method, headers) => {
+        seenMethod = method;
+        seenOrigin = headers.get("origin");
+        return Promise.resolve();
+      },
+    };
+    const header = new Headers();
+    header.set("origin", "https://app.example.test");
+    const contextValues = createContextValues();
+    await createVerifierChainInterceptor(
+      [],
+      [inspecting],
+      silentLogger,
+    )(((request: { contextValues: typeof contextValues }) => {
+      void request;
+      return Promise.resolve({} as never);
+    }) as never)({
+      header,
+      contextValues,
+      method: ApiKeyQueryController.method.get,
+      service: ApiKeyQueryController,
+      stream: false,
+    } as never);
+    expect(seenMethod).toBe(ApiKeyQueryController.method.get);
+    expect(seenOrigin).toBe("https://app.example.test");
+  });
+
+  it("a guard's ConnectError is its own wire mapping (propagated untouched)", async () => {
+    const refusal = new ConnectError(
+      "platform client was deleted",
+      Code.Unauthenticated,
+    );
+    await expect(
+      runInterceptor(
+        createVerifierChainInterceptor(
+          [],
+          [guard("platform-client", () => Promise.reject(refusal))],
+          silentLogger,
+        ),
+      ),
+    ).rejects.toBe(refusal);
+  });
+
+  it("a guard's plain throw is an infrastructure fault → INTERNAL, never a denial", async () => {
+    const error = await runInterceptor(
+      createVerifierChainInterceptor(
+        [],
+        [
+          guard("platform-client", () =>
+            Promise.reject(new Error("postgres unreachable")),
+          ),
+        ],
+        silentLogger,
+      ),
+    ).catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(ConnectError);
+    expect((error as ConnectError).code).toBe(Code.Internal);
+    expect((error as ConnectError).rawMessage).toBe("internal server error");
+  });
+
+  it("guards run in composed order; the first throw wins and later guards never run", async () => {
+    const ran: string[] = [];
+    const refusal = new ConnectError("refused", Code.PermissionDenied);
+    const error = await runInterceptor(
+      createVerifierChainInterceptor(
+        [],
+        [
+          guard("first", () => {
+            ran.push("first");
+            return Promise.resolve();
+          }),
+          guard("second", () => {
+            ran.push("second");
+            return Promise.reject(refusal);
+          }),
+          guard("third", () => {
+            ran.push("third");
+            return Promise.resolve();
+          }),
+        ],
+        silentLogger,
+      ),
+    ).catch((e: unknown) => e);
+    expect(error).toBe(refusal);
+    expect(ran).toEqual(["first", "second"]);
+  });
+
+  it("a refused request never reaches the handler", async () => {
+    let handlerRan = false;
+    const interceptor = createVerifierChainInterceptor(
+      [],
+      [
+        guard("refuser", () =>
+          Promise.reject(new ConnectError("no", Code.PermissionDenied)),
+        ),
+      ],
+      silentLogger,
+    );
+    await interceptor((() => {
+      handlerRan = true;
+      return Promise.resolve({} as never);
+    }) as never)({
+      header: new Headers(),
+      contextValues: createContextValues(),
+      method: ApiKeyQueryController.method.get,
+      service: ApiKeyQueryController,
+      stream: false,
+    } as never).catch(() => undefined);
+    expect(handlerRan).toBe(false);
+  });
+
+  it("guards never run when the verifier chain already refused the request", async () => {
+    let guardRan = false;
+    await runInterceptor(
+      createVerifierChainInterceptor(
+        [verifier("oidc", () => Promise.resolve(null))],
+        [
+          guard("recorder", () => {
+            guardRan = true;
+            return Promise.resolve();
+          }),
+        ],
+        silentLogger,
+      ),
+      "Bearer unclaimed-token",
+    ).catch(() => undefined);
+    expect(guardRan).toBe(false);
+  });
+
+  it("the chassis records a refusal with the guard's name (position 1 is outside the logging interceptor)", async () => {
+    const warned: Array<Record<string, unknown>> = [];
+    const capturingLogger = {
+      ...silentLogger,
+      warn: (_message: string, fields?: Record<string, unknown>) => {
+        warned.push(fields ?? {});
+      },
+    };
+    await runInterceptor(
+      createVerifierChainInterceptor(
+        [],
+        [
+          guard("platform-client", () =>
+            Promise.reject(new ConnectError("no", Code.PermissionDenied)),
+          ),
+        ],
+        capturingLogger,
+      ),
+    ).catch(() => undefined);
+    expect(warned).toHaveLength(1);
+    expect(warned[0]).toMatchObject({
+      guard: "platform-client",
+      code: "PermissionDenied",
+    });
   });
 });
 

--- a/backend/services/stigmer-server/src/pipeline/interceptors/auth.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/auth.ts
@@ -7,10 +7,15 @@
  *
  *   - createVerifierChainInterceptor — the serving chain's source: an
  *     ordered claim-or-pass walk over the composed IdentityVerifiers (the
- *     TS rendering of the Java ProviderManager chain).
+ *     TS rendering of the Java ProviderManager chain), followed by the
+ *     composed CallerGuards over the stamped identity (entry 20260902.02
+ *     ruling Q1 — see extensions/caller-guards.ts for the contract and
+ *     its doctrine).
  *   - createInProcessCallerInterceptor — the in-process router
  *     transport's source: stamps the `internal` caller class (ruling Q4,
- *     the TS rendering of the Java in-process authorization skip).
+ *     the TS rendering of the Java in-process authorization skip). It
+ *     takes NO guards — the in-process exemption is structural
+ *     (caller-guards.ts), not a runtime skip.
  *
  * The internal class is mintable ONLY here, only by the in-process
  * interceptor: the serving chain always overwrites the position-1 value
@@ -60,12 +65,18 @@
  * to the verification side).
  */
 import { Code, ConnectError, createContextKey } from "@connectrpc/connect";
-import type { HandlerContext, Interceptor } from "@connectrpc/connect";
+import type {
+  HandlerContext,
+  Interceptor,
+  StreamRequest,
+  UnaryRequest,
+} from "@connectrpc/connect";
 import { getOption } from "@bufbuild/protobuf";
 
 import { is_public } from "@stigmer/protos/ai/stigmer/commons/rpc/method_options_pb";
 
 import type { Logger } from "../../boot/logger.js";
+import type { CallerGuard } from "../../extensions/caller-guards.js";
 import type {
   CallerIdentity,
   IdentityVerifier,
@@ -139,12 +150,21 @@ export function trustedLocalIdentity(): CallerIdentity {
  * The serving chain's position-1 identity source: walks the composed
  * verifiers in order (OSS entries first, extension entries after, in
  * extension-unit order — registry contract), stamps the claimed identity
- * or the trusted-local fallback per the strictness contract above.
- * Covers unary AND streams — identity is per-request state, not a
- * unary-pipeline concern like the apiresource kind.
+ * or the trusted-local fallback per the strictness contract above, then
+ * runs the composed caller guards over the stamped identity (entry
+ * 20260902.02 ruling Q1). Covers unary AND streams — identity is
+ * per-request state, not a unary-pipeline concern like the apiresource
+ * kind.
+ *
+ * `guards` is REQUIRED, like the identity source on buildInterceptorChain:
+ * a serving transport that forgets its guards must be a compile error,
+ * never a silently unenforced edge — the exact failure class this seam
+ * exists to close (the cloud's platform-client controls went unported
+ * through five green readouts because nothing forced them).
  */
 export function createVerifierChainInterceptor(
   verifiers: ReadonlyArray<IdentityVerifier>,
+  guards: ReadonlyArray<CallerGuard>,
   logger: Logger,
   requireAuthentication = false,
 ): Interceptor {
@@ -178,12 +198,50 @@ export function createVerifierChainInterceptor(
         Code.Unauthenticated,
       );
     }
-    request.contextValues.set(
-      callerIdentityKey,
-      identity ?? trustedLocalIdentity(),
-    );
+    const stamped = identity ?? trustedLocalIdentity();
+    request.contextValues.set(callerIdentityKey, stamped);
+    await runCallerGuards(guards, stamped, request, logger);
     return next(request);
   };
+}
+
+/**
+ * The composed-order guard walk (caller-guards.ts contract): every guard
+ * runs against the FINAL stamped identity; the first throw wins. A
+ * ConnectError is the guard's own wire mapping; any other throw is an
+ * infrastructure fault (INTERNAL — a store outage during a liveness read
+ * must never read as an admission refusal). Both arms are recorded here:
+ * position 1 sits outside the logging interceptor, so this is a guard
+ * outcome's only operator record (the verifier-rejection precedent
+ * above).
+ */
+async function runCallerGuards(
+  guards: ReadonlyArray<CallerGuard>,
+  caller: CallerIdentity,
+  request: UnaryRequest | StreamRequest,
+  logger: Logger,
+): Promise<void> {
+  for (const guard of guards) {
+    try {
+      await guard.guard(caller, request.method, request.header);
+    } catch (error) {
+      const procedure = `/${request.service.typeName}/${request.method.name}`;
+      if (error instanceof ConnectError) {
+        logger.warn("caller guard refused the request", {
+          guard: guard.name,
+          procedure,
+          code: Code[error.code],
+        });
+        throw error;
+      }
+      logger.error("caller guard failed", {
+        guard: guard.name,
+        procedure,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throw internalError(error, "internal server error");
+    }
+  }
 }
 
 /**

--- a/backend/services/stigmer-server/src/query/search/__tests__/controller.test.ts
+++ b/backend/services/stigmer-server/src/query/search/__tests__/controller.test.ts
@@ -49,7 +49,7 @@ function searchClientOver(store: SearchQueryStore) {
     },
     {
       router: {
-        interceptors: [createVerifierChainInterceptor([], silentLogger)],
+        interceptors: [createVerifierChainInterceptor([], [], silentLogger)],
       },
     },
   );
@@ -125,7 +125,9 @@ describe("activity error mapping", () => {
         },
         {
           router: {
-            interceptors: [createVerifierChainInterceptor([], silentLogger)],
+            interceptors: [
+              createVerifierChainInterceptor([], [], silentLogger),
+            ],
           },
         },
       );

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -20,7 +20,8 @@
  * infrastructure for no additional proof.
  */
 import { create } from "@bufbuild/protobuf";
-import type { DescMessage } from "@bufbuild/protobuf";
+import type { DescMessage, DescMethod } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
 import type { ConnectRouter } from "@connectrpc/connect";
 
 import { AgentChannelSchema } from "@stigmer/protos/ai/stigmer/agentic/agentchannel/v1/api_pb";
@@ -74,6 +75,7 @@ import type {
   ArtifactStorage,
   ArtifactStorageDriverFactory,
   Authorizer,
+  CallerGuard,
   CallerIdentity,
   ChannelRuntime,
   ComposedServer,
@@ -114,6 +116,26 @@ const authorizer: Authorizer = {
         ? { kind: "allow" as const }
         : { kind: "deny" as const, reason: "machine callers are refused here" },
     ),
+};
+
+/**
+ * A consumer-shaped caller guard (the 20260902.02 seam) — the
+ * platform-client enforcement shape: skip logic lives entirely in the
+ * guard (claim-less tokens, the load-bearing token_type exemption),
+ * refusal is the guard's own ConnectError with byte-pinned copy, and the
+ * Origin header rides the request headers the chassis passes through.
+ */
+const callerGuard: CallerGuard = {
+  name: "consumer-platform-client",
+  guard: (caller: CallerIdentity, method: DescMethod, headers: Headers) => {
+    void method.parent.typeName;
+    if (caller.rawToken === "" || headers.get("origin") === null) {
+      return Promise.resolve();
+    }
+    return Promise.reject(
+      new ConnectError("platform client was deleted", Code.Unauthenticated),
+    );
+  },
 };
 
 /** A claim-or-pass verifier (the O2 chain-entry shape). */
@@ -561,6 +583,9 @@ export const fakeExtension: ServerExtension = {
   edition: ServerEdition.cloud,
   authorizer,
   identityVerifiers: [verifier],
+  // The 20260902.02 seam: post-authentication caller guards, serving
+  // chain only.
+  callerGuards: [callerGuard],
   // The O4 slot vocabulary is typed: registering into a slot name outside
   // GateSlotName fails this compile (the §2b contract's compile-time layer).
   gateSteps: new Map<GateSlotName, ReadonlyArray<PipelineStep<DescMessage>>>([


### PR DESCRIPTION
## Summary

Stage 1 of convergence entry `20260902.02.sp.platform-client-enforcement-and-facade-remint` (the parent's F1 ruling, 2026-09-02): the OSS **caller-guard extension point** — `ServerExtension.callerGuards`, run by the serving chassis immediately after the position-1 identity stamp. Empty by default: every OSS composition behaves byte-identically to before this point existed.

## Context

The cloud composition never ported Java's `PlatformClientEnforcementInterceptor` (deletion-revocation liveness cloud#342, Origin vs `allowed_origins` oss#375) — post-cutover that is a silent security regression on every composition-served lane. The `IdentityVerifier` contract is deliberately token-only (verification says who you are; the minting client's contract is a different concern), so enforcement needs its own seam. Stage 2 (stigmer-cloud) registers the actual guard and the billing-facade re-mint; Stage 3 adds the cross-edition conformance arms.

## Changes

- `src/extensions/caller-guards.ts` — the `CallerGuard` contract: flat `(caller, method, headers)` signature (the `VisitorErrorPolicy` shape), refusal by throwing `ConnectError`, all skip logic composition-owned (OSS stays policy-free).
- `src/extensions/registry.ts` — `callerGuards` as a list point, concatenated in unit order beside `identityVerifiers`.
- `src/pipeline/interceptors/auth.ts` — `createVerifierChainInterceptor` gains guards as a **required** second parameter and walks them over the FINAL stamped identity (first throw wins). Fault doctrine mirrors the verifier chain: a guard's `ConnectError` is its own wire mapping; any other throw is INTERNAL, never softened into a denial. Refusals and faults are chassis-logged (position 1 sits outside the logging interceptor). The in-process interceptor takes no guards — the Java `InProcessCallContextHolder` exemption rendered structurally.
- `src/index.ts` — exports the `CallerGuard` type and `createVerifierChainInterceptor` (the error-boundary precedent: a composition's own tests drive guards through the REAL stamp→guard mechanism, never a re-derivation).
- `test/extension-consumer` — a consumer-shaped guard in the compile proof.
- `.cursor/rules/backend/ts-server-guidelines.mdc` — the registration note (ruling Q1's rider).

## Implementation notes

- Guards as a **required** parameter is deliberate: this entry exists because an enforcement control went silently missing through five green readouts; a future serving transport that forgets guards must be a compile error, the same doctrine that makes the identity source required on `buildInterceptorChain`.
- Guard errors pass through the position-0 error boundary untouched by construction: PERMISSION_DENIED and UNAUTHENTICATED are outside `SANITIZED_CODES`, so Stage 2's byte-pinned Java refusal copy survives to the wire.

## Breaking changes

None on the wire. `createVerifierChainInterceptor`'s signature widens (build-time only; all call sites updated).

## Test plan

- 9 new unit arms (stamped-identity claimed/trusted-local, ConnectError propagation, plain-throw→INTERNAL, chassis refusal log, ordering, refused-never-reaches-handler, verifier-refusal-precedes-guards, method+headers pass-through) + registry merge arms.
- The composed end-to-end pair in `extension-composition.test.ts`: a fake refuse-all guard is enforced on the bound port and never runs on the in-process transport for the SAME procedure — the structural skip proven through the real composed server.
- Full suite: 2170 passed / 62 skipped. Typecheck clean. `make test-extension-consumer` green.
- **All four local conformance rosters byte-identical**: 500/13 (sqlite CRUD), 160/3 (sqlite execution), 500/13 (postgres CRUD), 160/3 (postgres execution).

## Risks

- Zero composed guards is the shipped OSS state; the rosters pin byte-identity. The guard walk only executes when a composition registers guards (Stage 2).

## Checklist

- [x] Docs updated (guidelines registration note; module intent headers)
- [x] Tests added/updated
- [x] Backward compatible on the wire

Made with [Cursor](https://cursor.com)