### PR TITLE
fix(runner): settle unresolved tool calls honestly and stop phantom approval promises

### DIFF
--- a/backend/services/runner/src/activities/execute-cursor/__tests__/cursor-generate-image-live.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/cursor-generate-image-live.test.ts
@@ -83,36 +83,42 @@ describeWithCursorKey("generateImage live ground truth (issue #965)", () => {
 
     // Mirror the runner's arrangement (session-lifecycle.ts createAgent):
     // local cwd + the "project" setting source that loads .cursor/hooks.json.
+    // The model is pinned to the incident's (aex_01m1a6ww billed composer-2.5).
     const agent = await Agent.create({
       apiKey: CURSOR_API_KEY,
+      model: { id: "composer-2.5" },
       local: { cwd: workspaceRoot, settingSources: ["project"] },
       platform: { workspaceRef: `genimage-spike-${Date.now()}`, stateRoot },
     });
 
-    const updates: Array<Record<string, unknown>> = [];
-    const result = await agent.send(
+    // The runner's exact consumption shape (index.ts / turn-stream.ts):
+    // send() registers the run; run.stream() is the event source; run.wait()
+    // is the terminal result.
+    const run = await agent.send(
       "Use your generateImage tool to generate a simple image of a solid red " +
         "circle on a white background and save it to red-circle.png in the " +
         "workspace. Do not ask questions; invoke the tool directly. If the " +
         "tool fails, state the exact error text you received and stop.",
-      {
-        onDelta: ({ update }) => {
-          const u = update as unknown as Record<string, unknown>;
-          if (u && typeof u === "object" && "type" in u) {
-            updates.push(u);
-          }
-        },
-      },
     );
+
+    const events: Array<Record<string, unknown>> = [];
+    for await (const event of run.stream()) {
+      const e = event as unknown as Record<string, unknown>;
+      if (e && typeof e === "object" && "type" in e) events.push(e);
+    }
+    const result = await run.wait();
 
     // ---- Findings dump (the deliverable of this instrument) ----
     console.log(`[genimage-spike] run status: ${result.status} (durationMs=${result.durationMs})`);
 
-    const toolEvents = updates.filter((u) =>
-      u.type === "tool-call-started" || u.type === "tool-call-completed",
-    );
-    for (const ev of toolEvents) {
-      console.log(`[genimage-spike] tool event: ${JSON.stringify(ev).slice(0, 600)}`);
+    for (const ev of events) {
+      if (ev.type === "tool_call" || ev.type === "status") {
+        console.log(`[genimage-spike] event: ${JSON.stringify(ev).slice(0, 800)}`);
+      }
+    }
+    const finalAssistant = events.filter((e) => e.type === "assistant").at(-1);
+    if (finalAssistant) {
+      console.log(`[genimage-spike] final assistant: ${JSON.stringify(finalAssistant).slice(0, 800)}`);
     }
 
     const hookInvocations: Array<Record<string, unknown>> = [];

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/cursor-generate-image-live.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/cursor-generate-image-live.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Live ground-truth capture for Cursor's native `generateImage` tool (issue
+ * #965) — the Phase-0 discipline from cursor_hitl_test.go applied to the
+ * interaction-channel tool family.
+ *
+ * WHY THIS EXISTS. Production incident aex_01m1a6ww3nmp4952ar5v0g4g85: an
+ * agent invoked `generateImage`, the call hung twice and settled
+ * TOOL_CALL_INTERRUPTED, and the model told the user a write approval was
+ * pending — an approval the platform never held (the run had
+ * auto_approve_all ON, so nothing was ever denied). The block happened
+ * inside the Cursor agent runtime, in a layer no Stigmer seam touches:
+ * `generateImage` rides the SDK's interaction-query channel
+ * (generateImageRequestQuery), not the ordinary tool path, and the SDK
+ * exposes no public interaction-listener seam the runner could answer it
+ * from. This test is the standing instrument that answers, against the REAL
+ * SDK the runner ships:
+ *
+ *  1. Does `generateImage` complete AT ALL in the runner's headless local
+ *     arrangement (Agent.create({ local }), project setting sources)?
+ *  2. Does the `preToolUse` hook fire for it — i.e. CAN the Stigmer HITL
+ *     gate see it — and under which `tool_name`?
+ *  3. What exact error/result does the model see when it fails?
+ *
+ * The answers decide the #965 fix shape: hook visible + capability works →
+ * classify + gate behind the standard write approval; otherwise → the
+ * honest-unavailability posture (there is no seam to gate or deny it).
+ *
+ * Skipped without CURSOR_API_KEY (the cursor-sdk-auth-smoke.test.ts
+ * convention) — it spends real credits for one short turn. Findings are
+ * PRINTED, not asserted: like the Phase-0 capture, this documents upstream
+ * behavior we do not own; the only hard assertion is that the run itself
+ * reaches a terminal outcome (no infinite hang at the SDK boundary).
+ *
+ * Run with: CURSOR_API_KEY=<key> npx vitest run cursor-generate-image-live
+ */
+
+import { describe, it, expect } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, chmodSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const CURSOR_API_KEY = process.env.CURSOR_API_KEY ?? "";
+const describeWithCursorKey = CURSOR_API_KEY ? describe : describe.skip;
+
+/**
+ * A minimal observation-only preToolUse/beforeMCPExecution hook: appends every
+ * invocation's stdin JSON to a log file and ALLOWS everything. Proves whether
+ * the hook layer sees `generateImage` at all (question 2) without gating the
+ * run — the capability question (1) needs the tool to actually attempt.
+ */
+function installObservationHook(workspaceRoot: string, logPath: string): void {
+  const hooksDir = join(workspaceRoot, ".cursor");
+  mkdirSync(hooksDir, { recursive: true });
+  const scriptPath = join(hooksDir, "observe-hook.sh");
+  writeFileSync(
+    scriptPath,
+    `#!/bin/bash\nINPUT=$(cat)\nprintf '%s\\n' "$INPUT" >> "${logPath}" 2>/dev/null || true\necho '{"permission":"allow"}'\n`,
+    "utf-8",
+  );
+  chmodSync(scriptPath, 0o755);
+  writeFileSync(
+    join(hooksDir, "hooks.json"),
+    JSON.stringify({
+      version: 1,
+      hooks: {
+        preToolUse: [{ command: scriptPath }],
+        beforeMCPExecution: [{ command: scriptPath }],
+      },
+    }),
+    "utf-8",
+  );
+}
+
+describeWithCursorKey("generateImage live ground truth (issue #965)", () => {
+  it("captures whether generateImage completes headless and whether preToolUse sees it", async () => {
+    const { Agent } = await import("@cursor/sdk");
+
+    const workspaceRoot = mkdtempSync(join(tmpdir(), "stigmer-genimage-spike-"));
+    const stateRoot = join(workspaceRoot, ".sdk-state");
+    mkdirSync(stateRoot, { recursive: true });
+    const hookLog = join(workspaceRoot, "hook-invocations.jsonl");
+    installObservationHook(workspaceRoot, hookLog);
+
+    // Mirror the runner's arrangement (session-lifecycle.ts createAgent):
+    // local cwd + the "project" setting source that loads .cursor/hooks.json.
+    const agent = await Agent.create({
+      apiKey: CURSOR_API_KEY,
+      local: { cwd: workspaceRoot, settingSources: ["project"] },
+      platform: { workspaceRef: `genimage-spike-${Date.now()}`, stateRoot },
+    });
+
+    const updates: Array<Record<string, unknown>> = [];
+    const result = await agent.send(
+      "Use your generateImage tool to generate a simple image of a solid red " +
+        "circle on a white background and save it to red-circle.png in the " +
+        "workspace. Do not ask questions; invoke the tool directly. If the " +
+        "tool fails, state the exact error text you received and stop.",
+      {
+        onDelta: ({ update }) => {
+          const u = update as unknown as Record<string, unknown>;
+          if (u && typeof u === "object" && "type" in u) {
+            updates.push(u);
+          }
+        },
+      },
+    );
+
+    // ---- Findings dump (the deliverable of this instrument) ----
+    console.log(`[genimage-spike] run status: ${result.status} (durationMs=${result.durationMs})`);
+
+    const toolEvents = updates.filter((u) =>
+      u.type === "tool-call-started" || u.type === "tool-call-completed",
+    );
+    for (const ev of toolEvents) {
+      console.log(`[genimage-spike] tool event: ${JSON.stringify(ev).slice(0, 600)}`);
+    }
+
+    const hookInvocations: Array<Record<string, unknown>> = [];
+    if (existsSync(hookLog)) {
+      for (const line of readFileSync(hookLog, "utf-8").split("\n")) {
+        if (!line.trim()) continue;
+        try { hookInvocations.push(JSON.parse(line)); } catch { /* partial line */ }
+      }
+    }
+    console.log(
+      `[genimage-spike] hook invocations: ${hookInvocations.length} — tool_names=` +
+        JSON.stringify(hookInvocations.map((h) => `${h.hook_event_name}:${h.tool_name}`)),
+    );
+    const hookSawGenerateImage = hookInvocations.some(
+      (h) => typeof h.tool_name === "string" && /generate.?image/i.test(h.tool_name),
+    );
+    console.log(`[genimage-spike] preToolUse saw generateImage: ${hookSawGenerateImage}`);
+
+    const imageOnDisk = readdirSync(workspaceRoot).filter((f) => f.endsWith(".png"));
+    console.log(`[genimage-spike] png files in workspace: ${JSON.stringify(imageOnDisk)}`);
+
+    // The one hard assertion: the SDK boundary itself must not hang — a
+    // terminal run outcome is required for the findings above to be trustable.
+    expect(["finished", "error", "cancelled"]).toContain(result.status);
+  }, 300_000);
+});

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/turn-boundary.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/turn-boundary.test.ts
@@ -32,7 +32,7 @@ import {
 } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { captureBaselineToLedger } from "../capture-flow.js";
 import { denialLedgerPath } from "../approval-state.js";
-import { toolCallIdentityToken } from "../message-translator.js";
+import { toolCallIdentityToken, UNRESOLVED_TOOL_CALL_ERROR } from "../message-translator.js";
 import { runTurnBoundary, type TurnBoundaryOptions } from "../turn-boundary.js";
 
 const execFileAsync = promisify(execFile);
@@ -403,5 +403,157 @@ describe("runTurnBoundary", () => {
 
     expect(result.deniedToolCallCount).toBe(1);
     expect(shellCall.status).toBe(ToolCallStatus.TOOL_CALL_WAITING_APPROVAL);
+  });
+});
+
+// The issue #965 invariant: an unresolved tool must never silently complete.
+// The production fixture is aex_01m1a6ww3nmp4952ar5v0g4g85 — Cursor's native
+// `generateImage` (an interaction-channel tool no Stigmer seam touches) hung
+// with no result event and no ledger entry, the turn completed, and the model's
+// last words promised a write approval the platform never held. The boundary
+// must settle such rows to an honest INTERRUPTED and put the platform's own
+// disclosure on the transcript so the model's claim is never the last word.
+describe("runTurnBoundary — unresolved tool calls on a completing turn (issue #965)", () => {
+  /** The incident's exact row shape: a streamed call that never resolved. */
+  function hangingGenerateImage(id: string): AgentMessage {
+    return create(AgentMessageSchema, {
+      type: MessageType.MESSAGE_AI,
+      toolCalls: [
+        create(ToolCallSchema, {
+          id,
+          name: "generateImage",
+          status: ToolCallStatus.TOOL_CALL_RUNNING,
+          args: { description: "a red circle", filePath: "red-circle.png" },
+        }),
+      ],
+    });
+  }
+
+  it("settles the incident shape to INTERRUPTED and discloses it (regression: aex_01m1a6ww)", async () => {
+    const status = newStatus();
+    const baseline = await captureBaselineToLedger({
+      status,
+      gitRoot: repo,
+      executionId: EXEC_ID,
+      changeSetId: CHANGE_SET_ID,
+    });
+    status.messages.push(hangingGenerateImage("tc-genimage-1"));
+
+    const result = await runTurnBoundary(boundaryOpts(status, baseline));
+
+    // The turn completes (no pause) — but not silently.
+    expect(result.waiting).toBe(false);
+    expect(result.settledUnresolvedCount).toBe(1);
+
+    const row = status.messages[0].toolCalls[0];
+    // INTERRUPTED, never FAILED: the one settled status a recovery replay may
+    // supersede (the #207 contract) — a FAILED stamp would freeze the row.
+    expect(row.status).toBe(ToolCallStatus.TOOL_CALL_INTERRUPTED);
+    expect(row.error).toBe(UNRESOLVED_TOOL_CALL_ERROR);
+    expect(row.isStreaming).toBe(false);
+    expect(row.completedAt).not.toBe("");
+
+    // The platform's disclosure is the transcript's last word — it names the
+    // tool and explicitly denies the phantom approval.
+    const last = status.messages[status.messages.length - 1];
+    expect(last.type).toBe(MessageType.MESSAGE_SYSTEM);
+    expect(last.content).toContain("generateImage");
+    expect(last.content).toContain("No approval is pending");
+  });
+
+  it("leaves non-terminal rows to the pause machinery on a PAUSING turn", async () => {
+    const status = newStatus();
+    const baseline = await captureBaselineToLedger({
+      status,
+      gitRoot: repo,
+      executionId: EXEC_ID,
+      changeSetId: CHANGE_SET_ID,
+    });
+    // A captured file change makes the turn pause…
+    await write("notes.md", "original notes\npaused-turn edit\n");
+    status.messages.push(
+      streamedEdit("tc-edit-1", "notes.md", "original notes\npaused-turn edit\n"),
+    );
+    // …while a hanging row rides the same turn.
+    status.messages.push(hangingGenerateImage("tc-genimage-2"));
+
+    const result = await runTurnBoundary(boundaryOpts(status, baseline));
+
+    expect(result.waiting).toBe(true);
+    expect(result.settledUnresolvedCount).toBe(0);
+    // Untouched by THIS sweep (a pausing turn's rows belong to the reconcile /
+    // collapse machinery, which has its own treatment for orphaned attempts).
+    expect(status.messages[1].toolCalls[0].status).toBe(ToolCallStatus.TOOL_CALL_RUNNING);
+  });
+
+  it("never settles a ledger-attributed row — that is the kinded machinery's call", async () => {
+    const status = newStatus();
+    const baseline = await captureBaselineToLedger({
+      status,
+      gitRoot: repo,
+      executionId: EXEC_ID,
+      changeSetId: CHANGE_SET_ID,
+    });
+    const secretWrite = create(ToolCallSchema, {
+      id: "tc-secret-1",
+      name: "edit",
+      status: ToolCallStatus.TOOL_CALL_PENDING,
+      args: { path: ".env", content: "API_KEY=x" },
+    });
+    status.messages.push(
+      create(AgentMessageSchema, { type: MessageType.MESSAGE_AI, toolCalls: [secretWrite] }),
+    );
+    // A secret-kind hard-block entry: attributable (kind non-approval), so the
+    // row is accounted for and must NOT be swept as "unresolved".
+    await writeFile(
+      denialLedgerPath(hitlDir),
+      JSON.stringify({
+        toolName: "Write",
+        token: toolCallIdentityToken(secretWrite),
+        kind: "secret",
+      }) + "\n",
+      "utf-8",
+    );
+
+    const result = await runTurnBoundary(boundaryOpts(status, baseline));
+
+    expect(result.settledUnresolvedCount).toBe(0);
+    expect(secretWrite.status).toBe(ToolCallStatus.TOOL_CALL_PENDING);
+  });
+
+  it("scopes to THIS turn: seeded prior-turn rows and terminal rows are untouched", async () => {
+    const status = newStatus();
+    const baseline = await captureBaselineToLedger({
+      status,
+      gitRoot: repo,
+      executionId: EXEC_ID,
+      changeSetId: CHANGE_SET_ID,
+    });
+    // Message 0 is seeded prior-turn context (already adjudicated elsewhere).
+    status.messages.push(hangingGenerateImage("tc-prior-turn"));
+    // Message 1 opens this turn: one real terminal row.
+    status.messages.push(
+      create(AgentMessageSchema, {
+        type: MessageType.MESSAGE_AI,
+        toolCalls: [
+          create(ToolCallSchema, {
+            id: "tc-done",
+            name: "Read",
+            status: ToolCallStatus.TOOL_CALL_COMPLETED,
+            result: "file contents",
+          }),
+        ],
+      }),
+    );
+
+    const result = await runTurnBoundary(
+      boundaryOpts(status, baseline, { turnStartMessageIndex: 1 }),
+    );
+
+    expect(result.settledUnresolvedCount).toBe(0);
+    expect(status.messages[0].toolCalls[0].status).toBe(ToolCallStatus.TOOL_CALL_RUNNING);
+    expect(status.messages[1].toolCalls[0].status).toBe(ToolCallStatus.TOOL_CALL_COMPLETED);
+    // No disclosure was appended.
+    expect(status.messages.at(-1)?.type).toBe(MessageType.MESSAGE_AI);
   });
 });

--- a/backend/services/runner/src/activities/execute-cursor/message-translator.ts
+++ b/backend/services/runner/src/activities/execute-cursor/message-translator.ts
@@ -1924,6 +1924,121 @@ export function detectUnattributedHookBlocks(
 }
 
 /**
+ * The honest terminal error stamped on a tool call that never resolved (issue
+ * #965). Deliberately states all three negatives — not executed, not approved,
+ * not denied — because the incident's harm was the model claiming an approval
+ * was pending: this text is what the transcript shows INSTEAD of a spinner or
+ * a silent after-the-fact interruption, and it must leave no room for an
+ * approval-is-coming reading.
+ */
+export const UNRESOLVED_TOOL_CALL_ERROR =
+  "The tool did not return a result before the turn ended. It was never " +
+  "executed, approved, or denied — no approval is pending for it.";
+
+/** One never-resolved tool call the turn boundary settled (issue #965). */
+export interface UnresolvedToolCall {
+  toolCallId: string;
+  toolName: string;
+}
+
+/**
+ * Settle this-turn tool calls that are still NON-TERMINAL when a turn
+ * completes without pausing — the issue #965 invariant, the sibling of
+ * {@link detectUnattributedHookBlocks}' #205 invariant ("a blocked tool must
+ * never silently complete" → "an unresolved tool must never silently
+ * complete").
+ *
+ * THE SHAPE THIS CATCHES. A tool that hangs INSIDE the Cursor agent runtime —
+ * the production case is `generateImage`, which rides the SDK's
+ * interaction-query channel rather than the ordinary tool path — streams a
+ * tool_call start, never streams a result, and is invisible to every Stigmer
+ * seam: the hook never denied it (no ledger entry), so the reconcile never
+ * gated it, and the turn completes with the row still PENDING/RUNNING. Before
+ * this sweep, the server's terminal settle (issue #207) stamped such rows
+ * TOOL_CALL_INTERRUPTED silently AFTER the runner reported completion — the
+ * transcript's last word stayed whatever the model claimed, which in
+ * aex_01m1a6ww3nmp4952ar5v0g4g85 was a promise that an approval was pending
+ * when none existed.
+ *
+ * Settling here instead makes the runner the author of the honest record: the
+ * row gets TOOL_CALL_INTERRUPTED with {@link UNRESOLVED_TOOL_CALL_ERROR}, and
+ * the caller (turn-boundary.ts) appends a system disclosure naming what never
+ * ran.
+ *
+ * WHY INTERRUPTED AND NEVER FAILED. TOOL_CALL_INTERRUPTED is deliberately the
+ * one settled status the monotonic merge guard lets live execution evidence
+ * supersede (see the guard's note in this file, ~line 331): if this FAILED
+ * execution is later RECOVERED, the harness checkpoint may re-execute the call
+ * under its original id, and the replayed events must be able to advance the
+ * row to its true outcome. A boundary-stamped FAILED would freeze it forever.
+ *
+ * WHY IT NEVER FAILS THE RUN (unlike #205). A foreign hook block is provably
+ * adversarial — approval semantics are permanently broken, so completing would
+ * always be a lie. An unresolved row can also be benign stream event-loss
+ * where the tool actually ran; failing the run would convert those into
+ * regressions. Disclosure restores honesty at zero regression risk.
+ *
+ * Scope and exclusions, in order:
+ *  - THIS turn's parent-transcript rows only (from `turnStartMessageIndex`):
+ *    seeded prior-turn rows were adjudicated by their own execution's settle,
+ *    and sub-agent inner rows are the server settle's concern — the parent row
+ *    (e.g. the Task call) is what the user sees. Mirrors #205's scoping.
+ *  - Only PENDING/RUNNING rows: every terminal row was adjudicated, and
+ *    WAITING_APPROVAL rows belong to the pause machinery (the caller only runs
+ *    this sweep on a NON-pausing turn, so none should exist here anyway).
+ *  - Only rows with NO denial-ledger entry of ANY kind (exact token, then the
+ *    normalized-path fallback — the same two identities every sweep in this
+ *    file uses): a ledger-attributed row is the unattended/secret/fail-closed
+ *    machinery's to settle, not ours.
+ *
+ * Returns the settled calls so the boundary can disclose and log them.
+ */
+export function settleUnresolvedToolCalls(
+  messages: readonly AgentMessage[],
+  turnStartMessageIndex: number,
+  ledger: readonly DeniedLedgerEntry[],
+  workspaceRoot?: string,
+): UnresolvedToolCall[] {
+  const ledgerTokens = new Set(ledger.map((e) => e.token));
+  const ledgerNormalizedSalients = new Set<string>();
+  if (workspaceRoot) {
+    for (const entry of ledger) {
+      const decoded = decodeIdentityToken(entry.token);
+      if (!decoded) continue;
+      const normalized = normalizedFileSalient(decoded.key, decoded.salient, workspaceRoot);
+      if (normalized) ledgerNormalizedSalients.add(normalized);
+    }
+  }
+
+  const matchesLedger = (tc: ToolCall): boolean => {
+    if (ledgerTokens.has(toolCallIdentityToken(tc))) return true;
+    if (!workspaceRoot) return false;
+    const id = toolIdentity(tc.name, tc.mcpServerSlug, toolCallArgs(tc));
+    const normalized = normalizedFileSalient(id.key, id.salient, workspaceRoot);
+    return !!normalized && ledgerNormalizedSalients.has(normalized);
+  };
+
+  const settled: UnresolvedToolCall[] = [];
+  for (const msg of messages.slice(Math.max(0, turnStartMessageIndex))) {
+    for (const tc of msg.toolCalls) {
+      if (
+        tc.status !== ToolCallStatus.TOOL_CALL_PENDING &&
+        tc.status !== ToolCallStatus.TOOL_CALL_RUNNING
+      ) {
+        continue;
+      }
+      if (matchesLedger(tc)) continue;
+      tc.status = ToolCallStatus.TOOL_CALL_INTERRUPTED;
+      tc.error = UNRESOLVED_TOOL_CALL_ERROR;
+      tc.isStreaming = false;
+      if (!tc.completedAt) tc.completedAt = utcTimestamp();
+      settled.push({ toolCallId: tc.id, toolName: tc.name });
+    }
+  }
+  return settled;
+}
+
+/**
  * Stamp the tool calls the hook denied under UNATTENDED approval mode
  * (DD-014) as terminal TOOL_CALL_SKIPPED rows with UNATTENDED_SKIP
  * provenance — the Cursor twin of the native harness's

--- a/backend/services/runner/src/activities/execute-cursor/prompt-builder.ts
+++ b/backend/services/runner/src/activities/execute-cursor/prompt-builder.ts
@@ -751,12 +751,24 @@ const TOOL_APPROVAL_PROTOCOL_INTRO =
  * well-behaved model otherwise concludes the environment is broken and tells the
  * user to "enable hooks in your Cursor settings", contradicting the approval
  * card. This rule reframes that signal as the gate working as designed.
+ *
+ * The fifth rule is the fourth's honesty boundary (issue #965): the gate
+ * recognition must be scoped to the PLATFORM'S OWN message texts ("blocked by
+ * a hook"; "submitted to the user for approval"), because a failure inside the
+ * harness itself can ALSO speak in permission vocabulary — the production case
+ * was Cursor's native generateImage hanging with a write-permission-flavored
+ * error, which the old any-"requires approval"-text reading turned into the
+ * model promising the user an approval card the platform never held. A failure
+ * without the platform's notice is an ordinary tool failure and must be
+ * reported as one; the platform's approval surface is never narrated into
+ * existence.
  */
 const TOOL_APPROVAL_PROTOCOL_RULES: readonly string[] = [
   "Carry out every action by calling the appropriate tool directly. Never describe an action you intend to take and then stop, and never ask the user for permission in prose.",
   "When an action needs approval, the platform pauses it, asks the user, and resumes you automatically after they decide. You do not request approval yourself — invoking the tool is how you request it.",
   "Even if a tool or MCP server instructs you to confirm with the user before acting (for example before sending, deleting, or purchasing), do NOT ask in prose. Invoke the tool and let the platform's approval step handle it.",
-  "A tool result that says the action was blocked, denied, requires approval, or was \"blocked by a hook\" is the platform's approval gate doing its job — it is NOT an error and NOT a Cursor misconfiguration. Never tell the user to change Cursor settings, enable hooks, or fix their configuration; the gate is intentional and the platform will resume you automatically once the user decides.",
+  "A tool result that says it was \"blocked by a hook\" or that the action was \"submitted to the user for approval\" is the platform's approval gate doing its job — it is NOT an error and NOT a Cursor misconfiguration. Never tell the user to change Cursor settings, enable hooks, or fix their configuration; the gate is intentional, and for THESE results the platform will resume you automatically once the user decides.",
+  "Any other tool failure — including one that mentions permissions or approval but does not carry the platform's approval notice above — is an ordinary failure, not the approval gate. Report it to the user honestly as something that did not run. NEVER tell the user an approval is pending or that you will be resumed automatically unless the tool result carried the platform's approval notice; the platform shows its own approval prompts, and you must not invent one.",
   "If an action is declined, do not retry it or attempt a workaround for it; continue with the rest of the task.",
 ];
 

--- a/backend/services/runner/src/activities/execute-cursor/turn-boundary.ts
+++ b/backend/services/runner/src/activities/execute-cursor/turn-boundary.ts
@@ -12,7 +12,12 @@
  *     and redact the model's provisional post-denial narration;
  *  5. detect UNATTRIBUTED hook blocks (issue #205) — a tool blocked by a hook
  *     with no ledger entry of any kind was denied by a FOREIGN hook the merge
- *     preserved, and the caller fails the run rather than completing silently.
+ *     preserved, and the caller fails the run rather than completing silently;
+ *  6. settle UNRESOLVED tool calls (issue #965) — a this-turn row still
+ *     non-terminal on a completing turn with no ledger attribution hung inside
+ *     the harness and can never complete; it is settled to an honest
+ *     TOOL_CALL_INTERRUPTED and disclosed on the transcript instead of being
+ *     silently stamped by the server's terminal settle after the fact.
  *
  * Extracted from the activity entry point (index.ts Phase 12) so it is directly
  * unit-testable AND re-enterable: the poisoned-handle / transport-timeout
@@ -51,9 +56,14 @@ import {
   clearProvisionalPostDenialNarration,
   detectUnattributedHookBlocks,
   reconcileDeniedToolCalls,
+  settleUnresolvedToolCalls,
   stampUnattendedSkippedToolCalls,
+  utcTimestamp,
   type UnattributedHookBlock,
 } from "./message-translator.js";
+import { create } from "@bufbuild/protobuf";
+import { AgentMessageSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+import { MessageType } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 
 // How long the boundary waits for the first-denial-stop's run.cancel() to
 // settle before reading the final denial ledger and capturing the turn's tree.
@@ -140,6 +150,16 @@ export interface TurnBoundaryResult {
    * undone (a pausing turn is not silent — the caller logs and pauses as usual).
    */
   readonly unattributedHookBlocks: readonly UnattributedHookBlock[];
+  /**
+   * This-turn tool calls settled to TOOL_CALL_INTERRUPTED because they were
+   * still non-terminal on a completing turn with no ledger attribution (issue
+   * #965) — the harness returned no result for them and the platform holds no
+   * approval for them. Informational: the boundary already settled the rows
+   * and appended the transcript disclosure; the run is NOT failed for these
+   * (unlike #205's unattributed blocks, an unresolved row can be benign
+   * stream event-loss, so failing would over-punish).
+   */
+  readonly settledUnresolvedCount: number;
 }
 
 /**
@@ -338,6 +358,49 @@ export async function runTurnBoundary(opts: TurnBoundaryOptions): Promise<TurnBo
     primaryWorkspaceDir,
   );
   const waiting = deniedToolCalls.length > 0 || capturedChangeCount > 0;
+
+  // Issue #965 invariant: an unresolved tool must never silently complete.
+  // On a COMPLETING (non-pausing) turn, any this-turn row still PENDING /
+  // RUNNING with no ledger attribution hung inside the harness (the production
+  // case: `generateImage`, which rides the SDK's interaction-query channel and
+  // is invisible to the hook). Settle it to an honest TOOL_CALL_INTERRUPTED —
+  // never FAILED, so a recovery replay can still supersede it (#207) — and
+  // disclose it on the transcript, so the model's own narration (which may
+  // have promised an approval the platform does not hold) is never the last
+  // word. A PAUSING turn is skipped: its non-terminal rows belong to the
+  // reconcile/collapse machinery above. Runs AFTER the unattended stamp so a
+  // ledger-attributed row is already SKIPPED and cannot double-settle, and
+  // AFTER the #205 detection so a hook-block FAILED row keeps its distinct,
+  // run-failing treatment. Deliberately does NOT fail the run (unlike #205):
+  // an unresolved row can also be benign stream event-loss where the tool
+  // actually ran, and converting those into failures would be a regression.
+  let settledUnresolved: readonly { toolCallId: string; toolName: string }[] = [];
+  if (!waiting) {
+    settledUnresolved = settleUnresolvedToolCalls(
+      status.messages,
+      turnStartMessageIndex,
+      deniedLedger,
+      primaryWorkspaceDir,
+    );
+    if (settledUnresolved.length > 0) {
+      const names = [...new Set(settledUnresolved.map((s) => s.toolName))].join(", ");
+      status.messages.push(create(AgentMessageSchema, {
+        type: MessageType.MESSAGE_SYSTEM,
+        content:
+          `Note: the following tool call(s) never completed and were not executed: ${names}. ` +
+          `No approval is pending for them — if the agent said otherwise, disregard that. ` +
+          `You can ask the agent to try again.`,
+        timestamp: utcTimestamp(),
+      }));
+      console.warn(
+        `ExecuteCursor turn boundary: settled ${settledUnresolved.length} unresolved ` +
+        `tool call(s) to INTERRUPTED with disclosure [${names}] — the harness returned ` +
+        `no result for them and no ledger entry accounts for them (issue #965; ` +
+        `execution=${executionId})`,
+      );
+    }
+  }
+
   if (unattributedHookBlocks.length > 0) {
     const culprits = (foreignGatingHooks?.length ?? 0) > 0
       ? ` — likely foreign workspace hook(s): ${foreignGatingHooks!.join(", ")}`
@@ -366,5 +429,6 @@ export async function runTurnBoundary(opts: TurnBoundaryOptions): Promise<TurnBo
     capturedChangeCount,
     deniedToolCallCount: deniedToolCalls.length,
     unattributedHookBlocks,
+    settledUnresolvedCount: settledUnresolved.length,
   };
 }


### PR DESCRIPTION
## Summary

A tool call that hangs inside the Cursor harness can never again end a turn silently or let the model promise the user an approval the platform does not hold. The turn boundary now settles unresolved tool calls to an honest `TOOL_CALL_INTERRUPTED` with a visible transcript disclosure, and the approval-protocol prompt scopes its auto-resume promise to the platform's own gate messages.

## Context

Production incident (session `ses_01m1a6ta70p7dw9vpw8dvcvk90`, execution `aex_01m1a6ww3nmp4952ar5v0g4g85`): Cursor's native `generateImage` — an interaction-channel tool no Stigmer seam touches — hung twice, settled `TOOL_CALL_INTERRUPTED` only via the server's silent after-the-fact stamp, and the model's final words told the user to "approve the pending action". No approval existed: the run had `auto_approve_all` ON, so nothing was ever denied. Full record and spike findings on the issue.

The live spike (committed as the standing instrument) proved the capability itself works headless and that the hook layer never receives the `generateImage` name — so the fix is honesty at the boundary, not a new gate. The cloud-sandbox availability half is stigmer/stigmer-cloud#580; first-class `GENERATE_IMAGE` taxonomy/rendering is #966.

## Changes

- **`message-translator.ts`**: new `settleUnresolvedToolCalls` — this-turn rows still PENDING/RUNNING at a completing (non-pausing) turn with no denial-ledger attribution (exact token + normalized-path fallback, the file's standard two identities) are settled to `TOOL_CALL_INTERRUPTED` with an honest error (`UNRESOLVED_TOOL_CALL_ERROR`). INTERRUPTED — never FAILED — preserves the #207 recovery-supersede contract.
- **`turn-boundary.ts`**: runs the sweep on non-pausing turns (after the unattended stamp and #205 detection), appends a `MESSAGE_SYSTEM` disclosure naming what never ran, and reports `settledUnresolvedCount`. Deliberately does NOT fail the run — unlike #205's foreign-hook blocks, an unresolved row can be benign stream event-loss.
- **`prompt-builder.ts`**: rule 4's "the platform will resume you automatically" is now scoped to the platform's own gate texts ("blocked by a hook" / "submitted to the user for approval"); a new rule 5 requires any other failure — even permission-flavored — to be reported honestly, never narrated into a pending approval. The no-"fix your Cursor settings" guidance is unchanged.
- **`cursor-generate-image-live.test.ts`** (new, key-gated): the standing ground-truth instrument for `generateImage` — completes headless? does `preToolUse` see it? — following the auth-smoke skip-without-key convention.

## Test plan

- 4 new turn-boundary regression tests, including the incident's exact shape (hanging `generateImage` on a completing turn → INTERRUPTED + disclosure), the pausing-turn exclusion, ledger-attribution exclusion, and this-turn scoping. Affected suites green: turn-boundary 14/14, message-translator, hitl-ledger, hook-script — 209 tests.
- Full runner suite: 4,736 passed (5 initial failures were parallel-load timeouts on heavy git/bash tests; all pass serially, unrelated files).
- `tsc --noEmit` clean.
- Live instrument run against `@cursor/sdk@1.0.13` + `composer-2.5` (findings recorded on the issue).

## Risks

Low. The sweep only touches rows that today would be silently stamped INTERRUPTED by the server anyway — it moves the stamp earlier, adds the honest error text, and adds a disclosure message. The prompt change narrows (never widens) when the model may claim an approval exists.

Closes #965
