### PR TITLE
test(conformance): cross-edition platform-client enforcement arms

### DIFF
--- a/test/conformance/src/harness/clients.ts
+++ b/test/conformance/src/harness/clients.ts
@@ -122,6 +122,13 @@ export interface TransportOptions {
   // cloud target, whose service authenticates callers; local targets run
   // without auth and omit it.
   bearerToken?: string;
+  // Stamped as the plain lowercase `origin` metadata key on every RPC — the
+  // header browsers attach to cross-origin fetches and page script cannot
+  // forge. Suites set it to simulate a browser context (the platform-client
+  // allowed_origins enforcement arms replay a leaked token from a foreign
+  // site this way); leaving it unset mirrors non-browser callers (curl,
+  // backend services), whose absence of Origin never refuses.
+  origin?: string;
 }
 
 export function createTransport(
@@ -136,6 +143,13 @@ export function createTransport(
     const authorization = `Bearer ${options.bearerToken}`;
     interceptors.push((next) => (req) => {
       req.header.set("authorization", authorization);
+      return next(req);
+    });
+  }
+  if (options.origin !== undefined) {
+    const origin = options.origin;
+    interceptors.push((next) => (req) => {
+      req.header.set("origin", origin);
       return next(req);
     });
   }

--- a/test/conformance/src/suites/platformclient-enforcement.conformance.test.ts
+++ b/test/conformance/src/suites/platformclient-enforcement.conformance.test.ts
@@ -1,0 +1,171 @@
+// Platform-client enforcement conformance (entry 20260902.02 Stage 3).
+//
+// Pins the minting PlatformClient's contract on every serving-edge request
+// bearing a PlatformClient-minted USER token — the two controls the Java
+// PlatformClientEnforcementInterceptor has always enforced and the
+// composition's platform-client caller guard ported (the F1 ruling's
+// permanent posture):
+//
+//   - deletion-revocation (stigmer-cloud#342): deleting a platform client
+//     revokes its outstanding user tokens on the NEXT request — refused
+//     UNAUTHENTICATED, fail closed. Liveness runs unconditionally BEFORE
+//     the origin skip, so revocation can never be sidestepped by omitting
+//     an attacker-omittable header;
+//   - Origin vs allowed_origins (stigmer/stigmer#375): a browser request
+//     from an origin outside the client's allowlist is refused
+//     PERMISSION_DENIED — the per-client compensating control for a
+//     gateway whose CORS policy deliberately reflects all origins. Absence
+//     never refuses on this arm: non-browser callers send no Origin and
+//     liveness above is their control.
+//
+// Refusal copy is byte-pinned across editions (the arms assert exact
+// rawMessage bytes) — integrators see identical refusals from the Java
+// service and the TS composition. Coverage of both controls was ZERO before
+// this suite; that gap is how the enforcement went silently missing from
+// the composition through five green readouts (the entry's origin story).
+//
+// Cloud editions only (the platformClientTokens capability): the local OSS
+// targets route no PlatformClient controllers and compose zero caller
+// guards — there is no minting lane and no contract to pin, so every arm
+// skips (the scheduleFiring posture).
+import { Code } from "@connectrpc/connect";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import { createTransport, makeClients } from "../harness/clients";
+import { mintCloudUserToken } from "../harness/cloud-env";
+import { FixtureTracker } from "../harness/fixtures";
+import { expectGrpcCode } from "../contract/errors";
+import { createTarget, type TargetProfile } from "../targets";
+import { uniqueName } from "../support/naming";
+import {
+  cloudGrpcBaseUrl,
+  createEnforcementPlatformClient,
+  deletePlatformClientById,
+} from "../support/platformclients";
+
+// The Java interceptor's UNAUTHENTICATED copy, byte-pinned on both editions
+// (PlatformClientEnforcementInterceptor.java and the composition's
+// platform-client guard assemble this exact string).
+const DELETED_CLIENT_MESSAGE =
+  "The platform client that minted this token has been deleted, " +
+  "so the token is no longer accepted. Mint a new user token " +
+  "from an active platform client.";
+
+// The Java interceptor's PERMISSION_DENIED copy, byte-pinned likewise; the
+// refused origin is interpolated raw (origins are public identifiers).
+function originRefusalMessage(origin: string): string {
+  return (
+    `Request origin '${origin}' is not in this platform client's ` +
+    "allowed_origins. Add it to the PlatformClient's allowed_origins to " +
+    "permit browser requests from this origin."
+  );
+}
+
+let target: TargetProfile;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+function enforcementCapable(): boolean {
+  return target.capabilities.platformClientTokens;
+}
+
+// Provisions an org (owned by the primary user), a PlatformClient inside it,
+// and a fresh user token minted by that client — the complete lane every arm
+// starts from. The org and (unless an arm deletes it itself) the client are
+// cleaned up in reverse order.
+async function provisionMintingLane(options: {
+  allowedOrigins?: readonly string[];
+  deferClientCleanup: boolean;
+}): Promise<{ clientId: string; token: string }> {
+  const context = await target.provisionTenancy();
+  fixtures.defer(() => target.cleanupTenancy(context));
+  const client = await createEnforcementPlatformClient({
+    org: context.org,
+    name: uniqueName("enforcement-pc"),
+    allowedOrigins: options.allowedOrigins,
+  });
+  if (options.deferClientCleanup) {
+    fixtures.defer(() => deletePlatformClientById(client.id));
+  }
+  const token = await mintCloudUserToken(
+    cloudGrpcBaseUrl(),
+    client.credentials,
+    uniqueName("enforcement-user"),
+  );
+  return { clientId: client.id, token };
+}
+
+describe("platform-client enforcement — the minting client's contract (cloud editions only)", () => {
+  it("deleting the platform client revokes its outstanding user tokens on the next request", async (ctx) => {
+    if (!enforcementCapable()) return ctx.skip();
+    const lane = await provisionMintingLane({ deferClientCleanup: false });
+    const minted = makeClients(
+      createTransport(cloudGrpcBaseUrl(), { bearerToken: lane.token }),
+    );
+
+    // The token is live before the delete — the probe RPC succeeds for any
+    // authenticated caller (findMyOrganizations skips authorization, so a
+    // pass/refuse flip here isolates the enforcement, not grants).
+    await minted.organizationQuery.findMyOrganizations({});
+
+    await deletePlatformClientById(lane.clientId);
+
+    const denied = await expectGrpcCode(
+      () => minted.organizationQuery.findMyOrganizations({}),
+      Code.Unauthenticated,
+      "request with a deleted platform client's user token",
+    );
+    expect(denied.rawMessage).toBe(DELETED_CLIENT_MESSAGE);
+  });
+
+  it("a browser request from an origin outside allowed_origins is refused", async (ctx) => {
+    if (!enforcementCapable()) return ctx.skip();
+    const lane = await provisionMintingLane({
+      allowedOrigins: ["https://allowed.example"],
+      deferClientCleanup: true,
+    });
+    const foreignBrowser = makeClients(
+      createTransport(cloudGrpcBaseUrl(), {
+        bearerToken: lane.token,
+        origin: "https://evil.example",
+      }),
+    );
+
+    const denied = await expectGrpcCode(
+      () => foreignBrowser.organizationQuery.findMyOrganizations({}),
+      Code.PermissionDenied,
+      "leaked-token replay from a foreign browser origin",
+    );
+    expect(denied.rawMessage).toBe(
+      originRefusalMessage("https://evil.example"),
+    );
+  });
+
+  it("a request without an Origin header passes an allowlisted client (absence never refuses)", async (ctx) => {
+    if (!enforcementCapable()) return ctx.skip();
+    const lane = await provisionMintingLane({
+      allowedOrigins: ["https://allowed.example"],
+      deferClientCleanup: true,
+    });
+    const nonBrowser = makeClients(
+      createTransport(cloudGrpcBaseUrl(), { bearerToken: lane.token }),
+    );
+
+    // Same client, same token, no browser context: liveness ran (the client
+    // exists) and the origin arm does not apply — the call must succeed even
+    // though allowed_origins is non-empty.
+    await nonBrowser.organizationQuery.findMyOrganizations({});
+  });
+});

--- a/test/conformance/src/support/platformclients.ts
+++ b/test/conformance/src/support/platformclients.ts
@@ -1,0 +1,98 @@
+// Platform-client provisioning for the enforcement arms.
+// Domain: conformance support.
+//
+// The PlatformClient surface is cloud IAM vocabulary — the local OSS targets
+// route none of its controllers — so these helpers deliberately live OUTSIDE
+// ConformanceClients (which stays the shared-contract surface every suite
+// sees) and build their own clients over the CLOUD_ENV contract, the same
+// direct-createClient posture the identity bootstrap uses (harness/cloud-env).
+// Only suites gated on the platformClientTokens capability may call them;
+// everywhere else the CLOUD_ENV variables are absent by design and the
+// loud requireCloudEnv failure is a suite-gating bug, not an environment one.
+//
+// The primary conformance user creates and deletes the arms' clients: it owns
+// every org provisionTenancy creates, and org owners hold the PlatformClient
+// lifecycle grants (the readout-bootstrap real-lane precedent).
+import { createClient } from "@connectrpc/connect";
+import { PlatformClientCommandController } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/command_pb";
+
+import {
+  CLOUD_ENV,
+  type PlatformClientCredentials,
+} from "../harness/cloud-env";
+import { createTransport } from "../harness/clients";
+
+export interface ProvisionedPlatformClient {
+  // metadata.id — the resource id the minted token's platform_client_id
+  // claim carries, and the axis both editions' liveness reads resolve by.
+  readonly id: string;
+  readonly credentials: PlatformClientCredentials;
+}
+
+// gRPC base URL of the cloud service under test, from the CLOUD_ENV contract
+// (published by the hermetic launcher or a readout-substrate bootstrap).
+export function cloudGrpcBaseUrl(): string {
+  return requireCloudEnv(CLOUD_ENV.address);
+}
+
+// Creates a PlatformClient in the given org as the primary conformance user.
+// allowedOrigins is the browser-context allowlist the origin arm enforces
+// against; omit it for clients whose tokens should pass from any context
+// (empty allowlist = open, the SharingOriginPolicy doctrine).
+export async function createEnforcementPlatformClient(options: {
+  org: string;
+  name: string;
+  allowedOrigins?: readonly string[];
+}): Promise<ProvisionedPlatformClient> {
+  const created = await primaryPlatformClientCommand().create({
+    apiVersion: "iam.stigmer.ai/v1",
+    kind: "PlatformClient",
+    metadata: { name: options.name, org: options.org },
+    spec: {
+      // The arms' minted identities are fresh user_ids that must not
+      // pre-exist — the identity-bootstrap posture.
+      autoProvisionAccounts: true,
+      allowedOrigins: [...(options.allowedOrigins ?? [])],
+    },
+  });
+  const id = created.platformClient?.metadata?.id;
+  const clientId = created.platformClient?.spec?.clientId;
+  if (
+    id === undefined ||
+    id === "" ||
+    clientId === undefined ||
+    clientId === "" ||
+    created.clientSecret === ""
+  ) {
+    throw new Error(
+      `PlatformClient create for ${options.name} returned no usable id/credentials`,
+    );
+  }
+  return { id, credentials: { clientId, clientSecret: created.clientSecret } };
+}
+
+// Deletes a PlatformClient by resource id as the primary conformance user —
+// the mutation whose revocation effect the deletion arm asserts.
+export async function deletePlatformClientById(id: string): Promise<void> {
+  await primaryPlatformClientCommand().delete({ resourceId: id });
+}
+
+function primaryPlatformClientCommand() {
+  const transport = createTransport(cloudGrpcBaseUrl(), {
+    bearerToken: requireCloudEnv(CLOUD_ENV.token),
+  });
+  return createClient(PlatformClientCommandController, transport);
+}
+
+function requireCloudEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === "") {
+    throw new Error(
+      `${name} is not set: platform-client provisioning needs the CLOUD_ENV contract. ` +
+        "These helpers are only reachable from suites gated on the platformClientTokens " +
+        "capability, whose targets always publish it — an unset variable here means a " +
+        "suite ran ungated on a target without the platform-client lane.",
+    );
+  }
+  return value;
+}

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -69,6 +69,11 @@ export class CloudTarget implements TargetProfile {
     // The Java billing engine authorizes execution credits natively; the TS
     // composition serves the same gates through the C5 billing facade.
     billingGates: true,
+    // The whole cloud suite authenticates with PlatformClient-minted user
+    // tokens, and the minting client's contract is enforced on every
+    // serving-edge request: by the Java interceptor natively, and by the
+    // composition's platform-client caller guard (entry 20260902.02).
+    platformClientTokens: true,
   };
 
   private grpcBaseUrl: string | undefined;

--- a/test/conformance/src/targets/local-execution.ts
+++ b/test/conformance/src/targets/local-execution.ts
@@ -54,6 +54,10 @@ export class LocalExecutionTarget implements TargetProfile {
     orgOAuthAppConfiguration: false,
     // No billing engine at all — executions run unmetered (DD-001 boundary).
     billingGates: false,
+    // No PlatformClient surface in this edition — the controllers are
+    // unrouted and the serving edge composes zero caller guards (the
+    // 20260902.02 empty state), so the enforcement arms skip.
+    platformClientTokens: false,
   };
 
   private temporal: RunningTemporal | undefined;

--- a/test/conformance/src/targets/local.ts
+++ b/test/conformance/src/targets/local.ts
@@ -41,6 +41,10 @@ export class LocalTarget implements TargetProfile {
     orgOAuthAppConfiguration: false,
     // No billing engine at all — executions run unmetered (DD-001 boundary).
     billingGates: false,
+    // No PlatformClient surface in this edition — the controllers are
+    // unrouted and the serving edge composes zero caller guards (the
+    // 20260902.02 empty state), so the enforcement arms skip.
+    platformClientTokens: false,
   };
 
   private server: RunningServer | undefined;

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -208,6 +208,25 @@ export interface CapabilityFlags {
   // execution runs unmetered. There is no refusal contract to pin, so the
   // billing-denial suite skips entirely (the scheduleFiring posture).
   billingGates: boolean;
+  // The platform-client caller-identity lane exists AND its minting-client
+  // contract is enforced at the serving edge: user tokens are minted by
+  // PlatformClients (mintUserToken), deleting the minting client revokes its
+  // outstanding user tokens on the next request (deletion-revocation,
+  // stigmer-cloud#342), and browser requests from origins outside the
+  // client's allowed_origins are refused (stigmer/stigmer#375). Both refusals
+  // carry byte-pinned copy shared by the Java interceptor
+  // (PlatformClientEnforcementInterceptor) and the composition's
+  // platform-client caller guard (entry 20260902.02) — the enforcement suite
+  // asserts the exact bytes on every target where this is true.
+  //
+  // False for the local OSS targets — BY DESIGN, not a gap: OSS routes no
+  // PlatformClient controllers at all (the PC surface is cloud IAM
+  // vocabulary), so there is no minting lane, no enforcement, and no refusal
+  // contract to pin; the enforcement arms skip entirely (the scheduleFiring
+  // posture). Deliberately NOT folded into multiTenant: tenant isolation and
+  // the minting client's contract are different concerns — a future target
+  // could carry one without the other.
+  platformClientTokens: boolean;
 }
 
 // Tenancy scope a test operates within. Locally this is just a unique org slug


### PR DESCRIPTION
## Summary

Stage 3 of entry 20260902.02 (platform-client enforcement + facade re-mint) — the cross-edition conformance arms that pin the minting PlatformClient's contract as executable contract on both editions. Follows Stage 1 (the OSS caller-guard seam, #963) and Stage 2 (the cloud guard + facade re-mint, stigmer-cloud#578).

Three arms, cloud editions only (the `platformClientTokens` capability — the local OSS targets route no PlatformClient controllers, so the arms skip, and all four local rosters stay byte-identical):

- **deletion-revocation** (stigmer-cloud#342): create a PlatformClient, mint a user token, delete the client — the next request refuses `UNAUTHENTICATED` with the byte-pinned copy. Liveness runs before the origin skip, so an attacker cannot sidestep revocation by omitting the header.
- **wrong-origin refused** (stigmer/stigmer#375): a browser request from an origin outside `allowed_origins` refuses `PERMISSION_DENIED` with the byte-pinned copy (interpolated origin included).
- **absent-origin passes**: no Origin header — the request succeeds even against an allowlisted client (absence never refuses; liveness still ran).

Coverage of both controls was zero before this suite — the exact gap through which the composition's enforcement went silently missing across five green readouts.

### What landed

- `src/targets/target.ts` — a new `platformClientTokens` capability flag with the doctrine comment every flag carries (true on `cloud`/`cloud-execution`, false on the three local targets).
- `src/suites/platformclient-enforcement.conformance.test.ts` — the three arms, `ctx.skip()`-gated on the capability, exact-`rawMessage` byte assertions.
- `src/support/platformclients.ts` — PlatformClient create/delete + a note on why these live outside `ConformanceClients` (the shared-contract surface stays unwidened by cloud-only vocabulary).
- `src/harness/clients.ts` — `TransportOptions` gains an `origin` stamping option for the browser-context arm.

## Test plan

- [x] Arms green on the hermetic Java target (`test:cloud`): 3/3.
- [x] Arms green on the TS composition (readout substrate, connect-only cloud target): 3/3.
- [x] Arm-integrity: each arm perturbed by one byte fails for the right reason, then restored byte-identical.
- [x] All four OSS local rosters unaffected (the gated arms report SKIPPED identically in sqlite and postgres lanes): CRUD 500/16 ×2, execution 160/3 ×2.
- [x] `tsc --noEmit` clean (zero new type errors).
- [x] Facade re-mint asserted live on the substrate: a PlatformClient-minted user token's billing-forward calls (E5 provisioner + pass-through) succeed against the joined Java service through the composition's claim-less re-mint.

Readout residuals (pre-existing, orthogonal to this OSS-test-only change, disclosed): the hermetic Java Class A carries 3 `direct-handler-authorization` authorization-drift reds (the nightly `ci.conformance-cloud` cron has been red since ~Aug 30); the composition Class A carries the C5-disclosed memory hybrid-bootstrap artifact; EC-1 carries the C5/parity-disclosed mcpserver-connect (#863) residuals.

Made with [Cursor](https://cursor.com)