### PR TITLE
feat(marketing): add YouTube thumbnail still for the intro film

### DIFF
--- a/marketing/package.json
+++ b/marketing/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "studio": "remotion studio src/index.ts",
     "render": "remotion render src/index.ts IntroToStigmer out/intro-to-stigmer.mp4",
+    "render:thumbnail": "remotion still src/index.ts Thumbnail out/thumbnail.png",
     "narrate": "node scripts/narrate.mjs",
     "presenter": "node scripts/presenter.mjs",
     "music": "node scripts/music.mjs",

--- a/marketing/src/Root.tsx
+++ b/marketing/src/Root.tsx
@@ -1,6 +1,7 @@
-import { Composition, getStaticFiles, staticFile } from "remotion";
+import { Composition, Still, getStaticFiles, staticFile } from "remotion";
 import { FPS, HEIGHT, WIDTH } from "../films/intro/manifest";
 import { IntroFilm } from "./films/intro/IntroFilm";
+import { THUMB_HEIGHT, THUMB_WIDTH, Thumbnail } from "./films/intro/Thumbnail";
 import type { NarrationManifest } from "./films/intro/durations";
 import { totalDuration } from "./films/intro/durations";
 import type { FilmData } from "./films/intro/scenes/RecordedScene";
@@ -48,30 +49,47 @@ const loadFilmData = async (): Promise<FilmData> => {
 };
 
 export const Root = () => (
-  <Composition
-    id="IntroToStigmer"
-    component={IntroFilm}
-    width={WIDTH}
-    height={HEIGHT}
-    fps={FPS}
-    defaultProps={{
-      narration: null,
-      presenterScenes: [],
-      filmData: { recordedShots: [], agentYaml: null, transcript: null },
-      hasMusic: false,
-    }}
-    calculateMetadata={async () => {
-      const narration = await loadNarration();
-      return {
-        durationInFrames: totalDuration(narration),
+  <>
+    <Composition
+      id="IntroToStigmer"
+      component={IntroFilm}
+      width={WIDTH}
+      height={HEIGHT}
+      fps={FPS}
+      defaultProps={{
+        narration: null,
+        presenterScenes: [],
+        filmData: { recordedShots: [], agentYaml: null, transcript: null },
+        hasMusic: false,
+      }}
+      calculateMetadata={async () => {
+        const narration = await loadNarration();
+        return {
+          durationInFrames: totalDuration(narration),
+          props: {
+            narration,
+            presenterScenes: presenterScenes(),
+            filmData: await loadFilmData(),
+            // Same degrade contract as every asset: no bed file, no bed.
+            hasMusic: getStaticFiles().some((f) => f.name === "music/bed.mp3"),
+          },
+        };
+      }}
+    />
+    {/* The film's YouTube thumbnail (see Thumbnail.tsx for the doctrine). */}
+    <Still
+      id="Thumbnail"
+      component={Thumbnail}
+      width={THUMB_WIDTH}
+      height={THUMB_HEIGHT}
+      defaultProps={{ hasPresenter: false }}
+      calculateMetadata={async ({ props }) => ({
         props: {
-          narration,
-          presenterScenes: presenterScenes(),
-          filmData: await loadFilmData(),
-          // Same degrade contract as every asset: no bed file, no bed.
-          hasMusic: getStaticFiles().some((f) => f.name === "music/bed.mp3"),
+          ...props,
+          // Same degrade contract as the film: no clip, brand-only layout.
+          hasPresenter: getStaticFiles().some((f) => f.name === "presenter/s6-close.mp4"),
         },
-      };
-    }}
-  />
+      })}
+    />
+  </>
 );

--- a/marketing/src/films/intro/Thumbnail.tsx
+++ b/marketing/src/films/intro/Thumbnail.tsx
@@ -1,0 +1,111 @@
+import { AbsoluteFill, OffthreadVideo, staticFile } from "remotion";
+import { theme } from "../../theme";
+import { GRID, TYPE } from "./graphics/motion";
+import { StigmerMark } from "./graphics/StigmerMark";
+
+/**
+ * The film's YouTube thumbnail — a Still, so it stays in-repo and
+ * re-renderable (the same doctrine as the docs' "rendered, never
+ * hand-captured" rule). Deliberately static: the graphics' `enter()`
+ * springs are 0 at frame 0, which is the only frame a still has, so
+ * motion helpers would render everything invisible here.
+ *
+ * The layout is the headline-dominant candidate chosen at the thumbnail
+ * gate (stigmer-cloud project 20260902.01.stigmer-intro-video): oversized
+ * headline left, the presenter right, the mark as a corner signature —
+ * sized to stay readable at YouTube's ~320px search-result card.
+ *
+ * The presenter image is a single frame of the gitignored HeyGen clip
+ * (assets/presenter/), resolved with the film's degrade contract: when
+ * the clip is absent the still renders the brand-only layout rather
+ * than a broken frame.
+ */
+
+export type ThumbnailProps = {
+  /** Computed at metadata time from getStaticFiles(); never set by hand. */
+  hasPresenter: boolean;
+};
+
+/** YouTube's minimum canvas; the film's TYPE scale is authored at 1080p. */
+export const THUMB_WIDTH = 1280;
+export const THUMB_HEIGHT = 720;
+const S = THUMB_HEIGHT / 1080;
+
+/**
+ * The frame of s6-close used as the portrait: ~9s in, her open-hands
+ * "here it is" beat — the most inviting moment across the three clips
+ * (chosen at the thumbnail gate).
+ */
+const PRESENTER_CLIP = "presenter/s6-close.mp4";
+const PRESENTER_FRAME = 270;
+
+export const Thumbnail = ({ hasPresenter }: ThumbnailProps) => (
+  <AbsoluteFill
+    style={{ background: theme.colors.ink, fontFamily: theme.fonts.sans }}
+  >
+    {hasPresenter ? (
+      <>
+        <PresenterSide />
+        <AbsoluteFill style={{ justifyContent: "center", paddingLeft: 18 * GRID * S, width: "62%" }}>
+          <Headline fontSize={TYPE.display * S * 1.25} />
+        </AbsoluteFill>
+        <div style={{ position: "absolute", top: 4 * GRID, left: 4 * GRID }}>
+          <StigmerMark size={8 * GRID} />
+        </div>
+      </>
+    ) : (
+      <BrandOnly />
+    )}
+  </AbsoluteFill>
+);
+
+/**
+ * Abigail on the right: the 16:9 clip frame is pushed right and scaled so
+ * she sits in the right third, then a left gradient carves out a solid
+ * ink column for the copy. Gradient (not a hard seam) keeps her office
+ * set reading as one continuous backdrop.
+ */
+const PresenterSide = () => (
+  <>
+    <AbsoluteFill style={{ transform: "translateX(24%) scale(1.3)" }}>
+      <OffthreadVideo
+        src={staticFile(PRESENTER_CLIP)}
+        startFrom={PRESENTER_FRAME}
+        muted
+      />
+    </AbsoluteFill>
+    <AbsoluteFill
+      style={{
+        background: `linear-gradient(90deg, ${theme.colors.ink} 34%, ${theme.colors.ink}e6 44%, transparent 72%)`,
+      }}
+    />
+  </>
+);
+
+const Headline = ({ fontSize }: { fontSize: number }) => (
+  <div style={{ fontSize, fontWeight: 700, letterSpacing: "-0.02em", lineHeight: 1.08 }}>
+    <div style={{ color: theme.colors.paper }}>Define once.</div>
+    <div style={{ color: theme.colors.accent }}>Run anywhere.</div>
+  </div>
+);
+
+/** Degrade layout in the end card's language — needs no generated media. */
+const BrandOnly = () => (
+  <AbsoluteFill style={{ justifyContent: "center", alignItems: "center", textAlign: "center" }}>
+    <div style={{ display: "flex", alignItems: "center", gap: 3 * GRID }}>
+      <StigmerMark size={16 * GRID} />
+      <div
+        style={{
+          fontSize: TYPE.display * S,
+          fontWeight: 700,
+          letterSpacing: "-0.02em",
+          color: theme.colors.paper,
+        }}
+      >
+        Stigmer
+      </div>
+    </div>
+    <div style={{ height: 5 * GRID }} />
+    <Headline fontSize={TYPE.headline * S * 1.2} />
+  </AbsoluteFill>
+);


### PR DESCRIPTION
## Summary
Adds the Intro to Stigmer film's YouTube thumbnail as a Remotion `<Still>` in the `marketing/` workspace, so the thumbnail is in-repo and re-renderable from source — same doctrine as the rest of the film (no hand-captured or one-off image assets).

## Context
The film (PR #970) is gate-passed and ready to publish; the publish kit specified a thumbnail produced from a dedicated Remotion still composition. This PR carries the remaining code for project 20260902.01.stigmer-intro-video.

## Changes
- `marketing/src/films/intro/Thumbnail.tsx` — the still: headline-dominant layout (chosen at the owner gate from three rendered candidates), presenter frame from the gitignored `assets/presenter/s6-close.mp4`, mark as a corner signature
- `marketing/src/Root.tsx` — registers the `Thumbnail` still beside the film composition; `hasPresenter` computed at metadata time with the film's existing degrade contract
- `marketing/package.json` — `render:thumbnail` script mirroring the existing `render` script

## Implementation notes
- Reuses the film's design system (`theme.ts`, `TYPE`/`GRID` from `graphics/motion.ts`, `StigmerMark`) — no new styles
- Deliberately static: the graphics' `enter()` springs are 0 at frame 0 (a still's only frame), so motion helpers are not used
- Degrade contract verified: with `assets/presenter/` absent the still renders a brand-only layout, never a broken frame

## Breaking changes
- None

## Test plan
- `npm run typecheck` in `marketing/` — clean
- `npm run render:thumbnail` — renders 1280x720 PNG, frame-verified at full size and at YouTube's ~320px card size
- Degrade path rendered with presenter assets hidden — brand-only layout confirmed

## Checklist
- [x] Backward compatible
- [x] Re-renderable from source (no committed media)

Made with [Cursor](https://cursor.com)