### PR TITLE
feat(backend/stigmer-server): declare the require-authentication posture from an extension; exempt gRPC health by name

### DIFF
--- a/.cursor/rules/backend/ts-server-guidelines.mdc
+++ b/.cursor/rules/backend/ts-server-guidelines.mdc
@@ -128,6 +128,24 @@ eventually violate creatively.
   health/reflection services) is the composition's business, decoded
   from `CallerIdentity.rawToken` — OSS runs every guard on every serving
   request and stays policy-free.
+- **The require-authentication posture has exactly two sources, OR'd in
+  compose.ts** (entry 20260904.02): the OSS OIDC issuer
+  (`STIGMER_OIDC_ISSUER`, O3) and a composed unit's
+  `ServerExtension.requireAuthentication: true` — a single-declaration
+  registry point in the edition's shape (one unit declares, a second
+  throws; the literal type forbids `false`). A composition whose own
+  verifiers are its only admission path declares it; it never borrows
+  the issuer knob (that registers the OSS verifiers ahead of its own). A
+  declared posture with zero composed verifiers is a boot throw. Under
+  the posture, tokenless requests are refused EXCEPT where
+  `isAuthenticationExempt` says so: `is_public` methods (our protos) and
+  the services in `AUTHENTICATION_EXEMPT_SERVICES` by name (third-party
+  protos — today the gRPC health service, because Kubernetes `grpc:`
+  probes are tokenless; stigmer#974). Registering a new third-party
+  service that must answer probes or anonymous callers adds it to that
+  set in the same change. Never add an env knob for the posture: a
+  self-host with no verifier has no use for it, and a forgotten knob is
+  exactly the failure this point exists to prevent.
 - **The composition root is staged plain functions** (config → storage →
   temporal → controllers → routes → listen). No DI framework. A missing
   dependency is a compile error or a loud boot throw, never a silent no-op.

--- a/backend/services/stigmer-server/docs/authorization-coverage.md
+++ b/backend/services/stigmer-server/docs/authorization-coverage.md
@@ -21,7 +21,7 @@ Verification notes: every registration map in `src/boot/compose.ts`'s routes clo
 
 ## 1. Health (`grpc.health.v1.Health`, `src/transport/health.ts`)
 
-The standard gRPC health protocol — an external proto with no Stigmer annotations.
+The standard gRPC health protocol — an external proto with no Stigmer annotations. Because it cannot carry `is_public`, the require-authentication posture exempts it BY SERVICE NAME (`AUTHENTICATION_EXEMPT_SERVICES` in `src/pipeline/interceptors/auth.ts`, the Java interceptor's by-name skip; entry 20260904.02, stigmer#974): a Kubernetes `grpc:` probe is a tokenless `check`, and a refused probe is a pod that never becomes Ready. The three methods stay authorization-`none` — the exemption is an authentication fact, not an authorization one.
 
 | Method | Annotation | Handler |
 |---|---|---|

--- a/backend/services/stigmer-server/src/boot/__tests__/auth-enabled-composition.test.ts
+++ b/backend/services/stigmer-server/src/boot/__tests__/auth-enabled-composition.test.ts
@@ -5,7 +5,9 @@
  *
  * The full credential loop this proves is the multi-user self-host story:
  *   1. tokenless requests are UNAUTHENTICATED "authentication token
- *      missing" (the Java copy) — except is_public methods (getServerInfo);
+ *      missing" (the Java copy) — except is_public methods (getServerInfo)
+ *      and the gRPC health service by name (a Kubernetes grpc probe;
+ *      stigmer#974, entry 20260904.02);
  *   2. an OIDC access token authenticates; the caller's sub becomes the
  *      audit identity on resources it creates;
  *   3. an API key minted over that OIDC session authenticates as its
@@ -31,6 +33,10 @@ import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { ApiKeyCommandController } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/command_pb";
 import { ApiKeyQueryController } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/query_pb";
 import { PlatformQueryController } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+import {
+  Health,
+  HealthCheckResponse_ServingStatus,
+} from "@stigmer/protos/grpc/health/v1/health_pb";
 
 import { loadConfig } from "../config.js";
 import { composeServer } from "../compose.js";
@@ -141,6 +147,12 @@ describe("the require-authentication posture on the wire", () => {
     const platform = createClient(PlatformQueryController, transportWith());
     const info = await platform.getServerInfo({});
     expect(info.edition).not.toBe("");
+  });
+
+  it("the gRPC health service stays reachable tokenless — a Kubernetes grpc probe survives the posture (stigmer#974)", async () => {
+    const health = createClient(Health, transportWith());
+    const response = await health.check({ service: "" });
+    expect(response.status).toBe(HealthCheckResponse_ServingStatus.SERVING);
   });
 
   it("a garbage bearer keeps the Q6 unclaimed-token rejection", async () => {

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -1078,7 +1078,7 @@ export async function composeServer(
   // prefix claim, the Java ProviderManager's order), then OIDC — ahead of
   // the extension entries ("OSS entries first", the registry contract),
   // and turns on the require-authentication posture. No issuer = zero OSS
-  // verifiers = the trusted-local posture, byte-identical wire behavior.
+  // verifiers; the wire posture is then the composition's to declare.
   // The runner's credential in this posture is an operator-minted API
   // token via STIGMER_TOKEN (ruling Q3) — no runner-specific verifier.
   const authEnabled = config.oidcIssuer !== "";
@@ -1092,15 +1092,48 @@ export async function composeServer(
         ...extensions.identityVerifiers,
       ]
     : extensions.identityVerifiers;
+  // The require-authentication posture has two sources OR'd here — the
+  // issuer arm above, and a composed unit's declaration (registry point,
+  // entry 20260904.02): a composition whose own verifiers are the only
+  // admission path cannot borrow the issuer knob (it would register the
+  // OSS verifiers ahead of its own and re-route who its users resolve
+  // to). Neither source = the OSS trusted-local posture, byte-identical
+  // wire behavior. A declared posture with ZERO composed verifiers is a
+  // boot fault, not a running server: nothing could ever authenticate,
+  // so every non-exempt request would be refused — the same class as a
+  // misconfigured registry (DD-006 §2b), caught before any side effect.
+  const requireAuthentication =
+    authEnabled || extensions.requireAuthentication !== undefined;
+  if (
+    extensions.requireAuthentication !== undefined &&
+    identityVerifiers.length === 0
+  ) {
+    throw new Error(
+      `extension '${extensions.requireAuthentication.declaredBy}' declares the require-authentication posture, but the composition registers no identity verifier — nothing could authenticate, so every non-public request would be refused; register a verifier or omit the declaration`,
+    );
+  }
+  const postureSources = [
+    ...(authEnabled ? ["oidc-issuer"] : []),
+    ...(extensions.requireAuthentication !== undefined
+      ? [`extension '${extensions.requireAuthentication.declaredBy}'`]
+      : []),
+  ];
+  logger.info("authentication posture resolved", {
+    posture: requireAuthentication ? "required" : "trusted-local",
+    source: postureSources.length > 0 ? postureSources.join(" + ") : "none",
+    verifiers: identityVerifiers.map((v) => v.name).join(", "),
+  });
 
   const server = createUnifiedPortServer({
     logger,
     routes,
     // The serving chain's position-1 identity source is the verifier
-    // chassis over the composed verifiers (O2; zero verifiers = the
-    // trusted-local posture, byte-identical wire behavior) followed by
-    // the composed caller guards (20260902.02; zero guards = today's
-    // behavior). The in-process transport above carries its own
+    // chassis over the composed verifiers (O2; zero verifiers and no
+    // declared posture = trusted-local, byte-identical wire behavior)
+    // under the resolved require-authentication posture (issuer OR unit
+    // declaration, above), followed by the composed caller guards
+    // (20260902.02; zero guards = today's behavior). The in-process
+    // transport above carries its own
     // position-1 source — the internal caller class only it can mint
     // (ruling Q4), and NO guards: the in-process exemption is structural
     // (caller-guards.ts). Position 0 is the error boundary (20260830.03):
@@ -1113,7 +1146,7 @@ export async function composeServer(
         identityVerifiers,
         extensions.callerGuards,
         logger,
-        authEnabled,
+        requireAuthentication,
       ),
       createErrorBoundaryInterceptor(
         logger,

--- a/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
@@ -6,6 +6,9 @@
  * port and the in-process transport — with the full interceptor chain
  * running on each lane (the SP-B parity doctrine extended to extension
  * services), and the registry-declared edition answers on getServerInfo.
+ * Later entries add their own composed arms below: caller guards
+ * (20260902.02), the require-authentication posture (20260904.02), the
+ * O5 drivers, the O4 slots and hooks, the C2 tuple lifecycle.
  *
  * The empty-set arm — no extensions composed, wire behavior byte-identical
  * to before the parameter existed — is pinned where it belongs: the
@@ -45,12 +48,17 @@ import {
 import { OrganizationSchema } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/api_pb";
 import { OrganizationCommandController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/command_pb";
 import { OrganizationQueryController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/query_pb";
+import {
+  Health,
+  HealthCheckResponse_ServingStatus,
+} from "@stigmer/protos/grpc/health/v1/health_pb";
 
 import type { ArtifactStorage } from "../../artifactstorage/artifact-storage.js";
 import { loadConfig } from "../../boot/config.js";
 import { composeServer } from "../../boot/compose.js";
 import type { ComposedServer } from "../../boot/compose.js";
 import { createLogger } from "../../boot/logger.js";
+import { AUTHENTICATION_TOKEN_MISSING_MESSAGE } from "../../pipeline/interceptors/auth.js";
 import type { PipelineStep } from "../../pipeline/pipeline.js";
 import type { GateSlotName } from "../gate-slots.js";
 import type { OrganizationDirectory } from "../organization-directory.js";
@@ -248,6 +256,170 @@ describe("extension composition (caller guards)", () => {
     const info = await client.getServerInfo({});
     expect(info.edition).toBe(ServerEdition.oss);
     expect(guardedProcedures.length).toBe(before);
+  });
+});
+
+/**
+ * The require-authentication registry point (entry 20260904.02): a unit
+ * whose own verifiers are the only admission path declares the posture
+ * WITHOUT an OSS OIDC issuer, and the serving chain refuses tokenless
+ * non-exempt requests exactly as the issuer arm does — the Java copy,
+ * is_public and the health service still reachable, a claimed credential
+ * admitted. The in-process transport is untouched by construction (it
+ * carries no require-auth arm). The zero-verifier invariant is the boot
+ * throw arm: a declared posture nothing could ever satisfy is a
+ * composition fault, never a running server that refuses everything.
+ */
+describe("extension composition (require-authentication posture)", () => {
+  let server: ComposedServer;
+  let dir: string;
+  let port: number;
+  const logLines: string[] = [];
+
+  const CLAIMED_TOKEN = "unit-test-credential";
+  const requiringExtension: ServerExtension = {
+    name: "fake-identity",
+    requireAuthentication: true,
+    identityVerifiers: [
+      {
+        name: "fake-verifier",
+        verify: (token) =>
+          Promise.resolve(
+            token === CLAIMED_TOKEN
+              ? {
+                  identityId: "ida_fake",
+                  callerClass: "user",
+                  issuer: "fake",
+                  rawToken: token,
+                }
+              : null,
+          ),
+      },
+    ],
+  };
+
+  function transportWith(token?: string): Transport {
+    return createGrpcTransport({
+      baseUrl: `http://127.0.0.1:${port}`,
+      interceptors:
+        token === undefined
+          ? []
+          : [
+              (next) => (request) => {
+                request.header.set("authorization", `Bearer ${token}`);
+                return next(request);
+              },
+            ],
+    });
+  }
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(tmpdir(), "require-auth-test-"));
+    server = await composeServer({
+      config: loadConfig({
+        STIGMER_MODEL_REGISTRY_REFRESH: "off",
+        DB_PATH: path.join(dir, "stigmer.db"),
+        ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+      }),
+      logger: createLogger({
+        level: "info",
+        pretty: false,
+        write: (line) => {
+          logLines.push(line);
+        },
+      }),
+      extensions: [requiringExtension],
+      portOverride: 0,
+      host: "127.0.0.1",
+    });
+    port = await server.start();
+  });
+
+  afterAll(async () => {
+    await server.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("a tokenless non-public RPC is UNAUTHENTICATED with the Java byte-pinned copy — no issuer configured", async () => {
+    const client = createClient(OrganizationQueryController, transportWith());
+    const failure = await client
+      .findMyOrganizations({})
+      .then(() => null)
+      .catch((error: unknown) => ConnectError.from(error));
+    expect(failure?.code).toBe(Code.Unauthenticated);
+    expect(failure?.rawMessage).toBe(AUTHENTICATION_TOKEN_MISSING_MESSAGE);
+  });
+
+  it("is_public methods stay reachable tokenless (getServerInfo)", async () => {
+    const client = createClient(PlatformQueryController, transportWith());
+    const info = await client.getServerInfo({});
+    expect(info.edition).toBe(ServerEdition.oss);
+  });
+
+  it("the gRPC health service stays reachable tokenless (the probe contract, stigmer#974)", async () => {
+    const health = createClient(Health, transportWith());
+    const response = await health.check({ service: "" });
+    expect(response.status).toBe(HealthCheckResponse_ServingStatus.SERVING);
+  });
+
+  it("a credential the composed verifier claims is admitted", async () => {
+    const client = createClient(
+      OrganizationQueryController,
+      transportWith(CLAIMED_TOKEN),
+    );
+    const orgs = await client.findMyOrganizations({});
+    expect(orgs.entries).toEqual([]);
+  });
+
+  it("the in-process transport carries no require-auth arm — server-internal hops are unaffected", async () => {
+    const client = createClient(
+      OrganizationQueryController,
+      server.inProcessTransport,
+    );
+    const orgs = await client.findMyOrganizations({});
+    expect(orgs.entries).toEqual([]);
+  });
+
+  it("boot logs the resolved posture and names the declaring unit", () => {
+    const line = logLines.find((entry) =>
+      entry.includes("authentication posture resolved"),
+    );
+    expect(line).toBeDefined();
+    const parsed = JSON.parse(line ?? "{}") as {
+      posture?: string;
+      source?: string;
+      verifiers?: string;
+    };
+    expect(parsed.posture).toBe("required");
+    expect(parsed.source).toBe("extension 'fake-identity'");
+    expect(parsed.verifiers).toBe("fake-verifier");
+  });
+
+  it("a declared posture with zero composed verifiers is a boot throw naming the unit", async () => {
+    const orphanDir = mkdtempSync(path.join(tmpdir(), "require-auth-orphan-"));
+    try {
+      await expect(
+        composeServer({
+          config: loadConfig({
+            STIGMER_MODEL_REGISTRY_REFRESH: "off",
+            DB_PATH: path.join(orphanDir, "stigmer.db"),
+            ARTIFACT_LOCAL_BASE_PATH: path.join(orphanDir, "artifacts"),
+          }),
+          logger: createLogger({
+            level: "error",
+            pretty: false,
+            write: () => {},
+          }),
+          extensions: [{ name: "verifierless", requireAuthentication: true }],
+          portOverride: 0,
+          host: "127.0.0.1",
+        }),
+      ).rejects.toThrowError(
+        /extension 'verifierless' declares the require-authentication posture, but the composition registers no identity verifier/,
+      );
+    } finally {
+      rmSync(orphanDir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/registry.test.ts
@@ -131,6 +131,7 @@ describe("resolveExtensions — defaults", () => {
     const resolved = resolveExtensions();
     expect(resolved.unitNames).toEqual([]);
     expect(resolved.edition).toBe(ServerEdition.oss);
+    expect(resolved.requireAuthentication).toBeUndefined();
     expect(resolved.authorizer).toBeUndefined();
     expect(resolved.identityVerifiers).toEqual([]);
     expect(resolved.callerGuards).toEqual([]);
@@ -169,6 +170,7 @@ describe("resolveExtensions — merge semantics", () => {
       {
         name: "beta",
         edition: ServerEdition.cloud,
+        requireAuthentication: true,
         authorizer: allowAll,
         identityVerifiers: [verifier("b1")],
         callerGuards: [callerGuard("g2"), callerGuard("g3")],
@@ -179,6 +181,7 @@ describe("resolveExtensions — merge semantics", () => {
     ]);
     expect(resolved.unitNames).toEqual(["alpha", "beta"]);
     expect(resolved.edition).toBe(ServerEdition.cloud);
+    expect(resolved.requireAuthentication).toEqual({ declaredBy: "beta" });
     expect(resolved.authorizer).toBe(allowAll);
     expect(resolved.identityVerifiers.map((v) => v.name)).toEqual([
       "a1",
@@ -378,6 +381,17 @@ describe("resolveExtensions — loud-fail throws (DD-006 §2b)", () => {
       ]),
     ).toThrowError(
       /extension 'second-edition' declares the server edition, but 'first-edition' already did/,
+    );
+  });
+
+  it("throws on a second require-authentication declaration, naming both units (20260904.02)", () => {
+    expect(() =>
+      resolveExtensions([
+        { name: "first-posture", requireAuthentication: true },
+        { name: "second-posture", requireAuthentication: true },
+      ]),
+    ).toThrowError(
+      /extension 'second-posture' declares the require-authentication posture, but 'first-posture' already did/,
     );
   });
 

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -28,7 +28,9 @@
  * transition sites (status-observers.ts), both O4; the O5 driver kinds
  * (catalog provider, artifact-storage registration, runner-credential
  * provider) and O6's sandbox provisioners are consumed at their
- * compose.ts construction sites.
+ * compose.ts construction sites; the require-authentication posture
+ * (20260904.02) is consumed where compose.ts builds the serving chain's
+ * identity source, OR'd with the OIDC-issuer arm.
  */
 import type { DescMessage } from "@bufbuild/protobuf";
 import type { ConnectRouter } from "@connectrpc/connect";
@@ -90,6 +92,25 @@ export interface ServerExtension {
    * addendum on blueprint §11 item 11.
    */
   readonly edition?: ServerEdition;
+  /**
+   * The require-authentication admission posture (single-declaration
+   * point, the edition's shape; entry 20260904.02). Declaring it turns
+   * the serving chain's tokenless-refusal arm on INDEPENDENTLY of the OSS
+   * OIDC issuer: a request with no credential on a non-`is_public` method
+   * is UNAUTHENTICATED "authentication token missing" (the Java
+   * interceptor's copy), instead of falling to the trusted-local
+   * single-operator identity. A composition whose identity verifiers ARE
+   * its only admission path declares this — the OSS issuer arm cannot be
+   * reused for it, because configuring the issuer also registers the OSS
+   * verifiers ahead of the composition's own (compose.ts).
+   *
+   * Typed as the literal `true`: the field is declared or omitted, never
+   * set to `false` — there is no "declared lenient" state to validate at
+   * boot. Exactly one unit may declare it (a second throws naming both);
+   * the declaring unit is named in the boot log and in the compose.ts
+   * invariant that refuses a posture with zero composed verifiers.
+   */
+  readonly requireAuthentication?: true;
   /** The authorization decision seam (single-instance point; consumed by O2). */
   readonly authorizer?: Authorizer;
   /** Ordered verifier-chain entries, appended in unit order (consumed by O2). */
@@ -129,6 +150,14 @@ export interface ResolvedExtensions {
   readonly unitNames: ReadonlyArray<string>;
   /** Defaults to ServerEdition.oss when no unit declares one. */
   readonly edition: ServerEdition;
+  /**
+   * The unit-declared require-authentication posture, or undefined when
+   * no unit declares it (the OSS trusted-local posture — unless the OIDC
+   * issuer arm turns it on; compose.ts ORs the two). Carries the
+   * declaring unit's name: the boot log and the zero-verifier invariant
+   * both name it.
+   */
+  readonly requireAuthentication: { readonly declaredBy: string } | undefined;
   /**
    * The single composed Authorizer, or undefined when none is registered —
    * O2's consumption site installs the OSS permissive single-team default
@@ -221,6 +250,7 @@ export function resolveExtensions(
 
   let edition: ServerEdition | undefined;
   let editionDeclaredBy: string | undefined;
+  let requireAuthenticationDeclaredBy: string | undefined;
   let authorizer: Authorizer | undefined;
   let authorizerDeclaredBy: string | undefined;
   let modelCatalogProvider: ModelCatalogProvider | undefined;
@@ -280,6 +310,15 @@ export function resolveExtensions(
       }
       edition = unit.edition;
       editionDeclaredBy = unit.name;
+    }
+
+    if (unit.requireAuthentication !== undefined) {
+      if (requireAuthenticationDeclaredBy !== undefined) {
+        throw new Error(
+          `extension '${unit.name}' declares the require-authentication posture, but '${requireAuthenticationDeclaredBy}' already did — exactly one extension may declare it`,
+        );
+      }
+      requireAuthenticationDeclaredBy = unit.name;
     }
 
     if (unit.authorizer !== undefined) {
@@ -471,6 +510,10 @@ export function resolveExtensions(
   return {
     unitNames,
     edition: edition ?? ServerEdition.oss,
+    requireAuthentication:
+      requireAuthenticationDeclaredBy !== undefined
+        ? { declaredBy: requireAuthenticationDeclaredBy }
+        : undefined,
     authorizer,
     identityVerifiers,
     callerGuards,

--- a/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/auth.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/auth.test.ts
@@ -4,7 +4,8 @@
  * fall-through for unclaimed tokens; any verifier configured = unclaimed
  * is UNAUTHENTICATED), the O3 require-authentication posture (rulings
  * Q1+Q2 — tokenless is UNAUTHENTICATED with the Java byte-pinned copy,
- * except is_public methods), the trusted-local modeled state in both
+ * except is_public methods and the gRPC health service by name — the
+ * 20260904.02 exemption predicate), the trusted-local modeled state in both
  * operator postures, the internal caller class's structural minting
  * invariant (ruling Q4 — a wire request can never carry it), the
  * caller-guard walk (20260902.02 ruling Q1 — guards run over the FINAL
@@ -19,6 +20,7 @@ import type { DescMethod } from "@bufbuild/protobuf";
 
 import { ApiKeyQueryController } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/query_pb";
 import { PlatformQueryController } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
+import { Health } from "@stigmer/protos/grpc/health/v1/health_pb";
 
 import type { CallerGuard } from "../../../extensions/caller-guards.js";
 import type {
@@ -26,10 +28,12 @@ import type {
   IdentityVerifier,
 } from "../../../extensions/identity.js";
 import {
+  AUTHENTICATION_EXEMPT_SERVICES,
   AUTHENTICATION_TOKEN_MISSING_MESSAGE,
   callerIdentityKey,
   createInProcessCallerInterceptor,
   createVerifierChainInterceptor,
+  isAuthenticationExempt,
   parseBearerToken,
   trustedLocalIdentity,
 } from "../auth.js";
@@ -245,6 +249,18 @@ describe("require-authentication posture (O3 rulings Q1+Q2)", () => {
     expect(identity).toEqual(trustedLocalIdentity());
   });
 
+  it("the gRPC health service stays reachable tokenless — the Java by-name skip (stigmer#974)", async () => {
+    // A Kubernetes `grpc:` probe is a tokenless Health/Check; the health
+    // proto is third-party and cannot carry is_public, so the exemption
+    // is by service name. Without it the posture crash-loops the pod.
+    const identity = await runInterceptor(
+      requiringChassis,
+      undefined,
+      Health.method.check,
+    );
+    expect(identity).toEqual(trustedLocalIdentity());
+  });
+
   it("a claimed credential authenticates exactly as in the lenient posture", async () => {
     const identity = await runInterceptor(requiringChassis, "Bearer tok");
     expect(identity).toEqual(CLAIMED);
@@ -258,6 +274,35 @@ describe("require-authentication posture (O3 rulings Q1+Q2)", () => {
     expect((error as ConnectError).rawMessage).toBe(
       "the presented token was not accepted by any configured identity verifier",
     );
+  });
+});
+
+describe("isAuthenticationExempt (the one exemption predicate, 20260904.02)", () => {
+  it("is_public methods are exempt (our protos carry the option)", () => {
+    expect(
+      isAuthenticationExempt(PlatformQueryController.method.getServerInfo),
+    ).toBe(true);
+  });
+
+  it("every method of the gRPC health service is exempt by service name (third-party proto)", () => {
+    for (const method of Object.values(Health.method)) {
+      expect(isAuthenticationExempt(method), method.name).toBe(true);
+    }
+  });
+
+  it("a config-annotated method is not exempt", () => {
+    expect(isAuthenticationExempt(ApiKeyQueryController.method.get)).toBe(
+      false,
+    );
+  });
+
+  it("the by-name set holds exactly the services OSS serves without our option", () => {
+    // Java's list has a second entry (ServerReflection); OSS registers no
+    // reflection service, so its presence here would be dead vocabulary —
+    // a future registration adds it in the same change.
+    expect([...AUTHENTICATION_EXEMPT_SERVICES]).toEqual([
+      "grpc.health.v1.Health",
+    ]);
   });
 });
 

--- a/backend/services/stigmer-server/src/pipeline/interceptors/auth.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/auth.ts
@@ -39,13 +39,21 @@
  *   - An ABSENT token falls to trusted-local UNLESS the composition asks
  *     for the require-authentication posture (O3 rulings Q1+Q2,
  *     20260827.06): with requireAuthentication on — compose.ts sets it
- *     exactly when STIGMER_OIDC_ISSUER is configured — a tokenless
- *     request is UNAUTHENTICATED "authentication token missing" (the
- *     Java interceptor's byte-pinned copy), EXCEPT on is_public-marked
- *     methods, mirroring the Java isPublic skip. Extension-only verifier
- *     sets (no issuer) keep the fall-to-trusted-local arm: strictness
- *     against PRESENTED tokens is a function of verifier count (Q6);
- *     strictness against ABSENT tokens is the composition's explicit ask.
+ *     when STIGMER_OIDC_ISSUER is configured OR when a composed extension
+ *     unit declares `requireAuthentication` (entry 20260904.02, the
+ *     cloud's ask: its verifiers are its only admission path, and the
+ *     issuer knob cannot stand in because it also registers the OSS
+ *     verifiers ahead of the composition's) — a tokenless request is
+ *     UNAUTHENTICATED "authentication token missing" (the Java
+ *     interceptor's byte-pinned copy), EXCEPT where isAuthenticationExempt
+ *     says so: is_public-marked methods (the Java isPublic skip) and the
+ *     gRPC health service by name (the Java by-name skip — a third-party
+ *     proto cannot carry our option, and a Kubernetes `grpc:` probe is a
+ *     tokenless Health/Check; without this arm the posture crash-loops the
+ *     pod, stigmer#974). Extension-only verifier sets that declare
+ *     nothing keep the fall-to-trusted-local arm: strictness against
+ *     PRESENTED tokens is a function of verifier count (Q6); strictness
+ *     against ABSENT tokens is the composition's explicit ask.
  *
  * # Trusted-local identity (the explicit modeled state)
  *
@@ -72,6 +80,7 @@ import type {
   UnaryRequest,
 } from "@connectrpc/connect";
 import { getOption } from "@bufbuild/protobuf";
+import type { DescMethod } from "@bufbuild/protobuf";
 
 import { is_public } from "@stigmer/protos/ai/stigmer/commons/rpc/method_options_pb";
 
@@ -90,6 +99,36 @@ import { operatorIdentitySnapshot } from "../steps/defaults.js";
  */
 export const AUTHENTICATION_TOKEN_MISSING_MESSAGE =
   "authentication token missing";
+
+/**
+ * Services reachable WITHOUT a credential under the require-authentication
+ * posture, by fully-qualified service name — the Java interceptor's
+ * by-name skip list (GrpcSecurityConfigBase), for services whose protos
+ * are not ours and so cannot carry the `is_public` method option. The
+ * standard gRPC health service is the one entry OSS serves: Kubernetes
+ * `grpc:` probes call Health/Check tokenless, and a refused probe is a
+ * pod that never becomes Ready (stigmer#974). Java's second entry,
+ * `grpc.reflection.v1alpha.ServerReflection`, is deliberately absent —
+ * OSS registers no reflection service; a future registration joins this
+ * set in the same change, or the posture refuses it.
+ */
+export const AUTHENTICATION_EXEMPT_SERVICES: ReadonlySet<string> = new Set([
+  "grpc.health.v1.Health",
+]);
+
+/**
+ * Whether a method stays reachable tokenless under the
+ * require-authentication posture: `is_public` on the method (our protos)
+ * or an exempt service by name (third-party protos). The ONE predicate
+ * the refusal arm consults, so both exemption doctrines read as a single
+ * decision and are pinned together.
+ */
+export function isAuthenticationExempt(method: DescMethod): boolean {
+  return (
+    getOption(method, is_public) ||
+    AUTHENTICATION_EXEMPT_SERVICES.has(method.parent.typeName)
+  );
+}
 
 /**
  * Context key for the request's caller identity. The default is
@@ -188,11 +227,15 @@ export function createVerifierChainInterceptor(
           Code.Unauthenticated,
         );
       }
-    } else if (requireAuthentication && !getOption(request.method, is_public)) {
+    } else if (
+      requireAuthentication &&
+      !isAuthenticationExempt(request.method)
+    ) {
       // Rulings Q1+Q2: the auth-enabled posture requires a credential on
-      // every non-public method — the Java interceptor's exact behavior
-      // and copy. is_public methods stay reachable tokenless (the Java
-      // isPublic skip), so unauthenticated health-style probes survive.
+      // every non-exempt method — the Java interceptor's exact behavior
+      // and copy. is_public methods and the health service stay reachable
+      // tokenless (the Java isPublic and by-name skips), so the console's
+      // anonymous reads and the pod's probes survive.
       throw new ConnectError(
         AUTHENTICATION_TOKEN_MISSING_MESSAGE,
         Code.Unauthenticated,

--- a/docs/guides/self-hosting/authentication.mdx
+++ b/docs/guides/self-hosting/authentication.mdx
@@ -79,6 +79,10 @@ From the next boot, every request needs a credential:
   `authentication token missing`. Requests with a bad credential get a specific
   reason (`token has expired`, `token signature verification failed`, and so
   on).
+- Two things stay reachable without a credential on purpose: the public
+  `getServerInfo` read your console and CLI use before login, and the standard
+  gRPC health service (`grpc.health.v1.Health`), so Kubernetes `grpc:` readiness
+  and liveness probes keep working exactly as before.
 
 Point your CLI at the stack as a named backend with its key:
 

--- a/test/conformance/src/harness/clients.ts
+++ b/test/conformance/src/harness/clients.ts
@@ -57,6 +57,7 @@ import { PlatformQueryController } from "@stigmer/protos/ai/stigmer/platform/v1/
 import { SearchService } from "@stigmer/protos/ai/stigmer/search/v1/query_pb";
 import { OrganizationCommandController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/command_pb";
 import { OrganizationQueryController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/query_pb";
+import { Health } from "@stigmer/protos/grpc/health/v1/health_pb";
 import { ApiKeyCommandController } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/command_pb";
 import { ApiKeyQueryController } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/query_pb";
 import { ProjectCommandController } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/command_pb";
@@ -112,6 +113,10 @@ export interface ConformanceClients {
   skillCommand: Client<typeof SkillCommandController>;
   skillQuery: Client<typeof SkillQueryController>;
   platformQuery: Client<typeof PlatformQueryController>;
+  // The standard gRPC health service — an external proto both editions serve
+  // on the RPC port. The authentication suite pins its tokenless reachability
+  // (the Kubernetes grpc-probe contract).
+  health: Client<typeof Health>;
   github: Client<typeof GitHubService>;
   oauthAppCommand: Client<typeof OAuthAppCommandController>;
   oauthAppQuery: Client<typeof OAuthAppQueryController>;
@@ -238,6 +243,7 @@ export function makeClients(transport: Transport): ConformanceClients {
     skillCommand: createClient(SkillCommandController, transport),
     skillQuery: createClient(SkillQueryController, transport),
     platformQuery: createClient(PlatformQueryController, transport),
+    health: createClient(Health, transport),
     github: createClient(GitHubService, transport),
     oauthAppCommand: createClient(OAuthAppCommandController, transport),
     oauthAppQuery: createClient(OAuthAppQueryController, transport),

--- a/test/conformance/src/harness/cloud-env.ts
+++ b/test/conformance/src/harness/cloud-env.ts
@@ -52,7 +52,46 @@ export const CLOUD_ENV = {
   // credentials to a real deployment is the permanent skip the stigmer#547
   // ruling recorded, so privileged-lane assertions skip there.
   operatorToken: "STIGMER_CONFORMANCE_CLOUD_OPERATOR_TOKEN",
+  // Whether the environment's serving edge authenticates callers at all —
+  // `enforced` (the DEFAULT when unset: production Java's interceptor, the
+  // TS composition's declared posture) or `bypassed-test-mode`. The hermetic
+  // launcher boots the JAR with STIGMER_SECURITY_MODE=test, which does NOT
+  // load GrpcSecurityConfigBase: a synthetic caller stands in for every
+  // request, credential or not — the door bootstrapPrimaryIdentity walks
+  // through below. Only global-setup-cloud.ts, the code that CHOSE that
+  // mode, declares the bypass; a pre-provisioned or deployed endpoint that
+  // forgets the variable gets the production contract and fails loudly if
+  // its edge is open (DD-012: never a false green). The authentication
+  // suite skips its credential arms VISIBLY where the edge is bypassed and
+  // asserts them everywhere else. Java's production-mode posture is
+  // covered by test/integration-security; making the hermetic launcher run
+  // production mode is a recorded follow-up (entry 20260904.02, D-S1).
+  edgeAuthentication: "STIGMER_CONFORMANCE_CLOUD_EDGE_AUTHENTICATION",
 } as const;
+
+// The two declared edge postures — see CLOUD_ENV.edgeAuthentication.
+export const EDGE_AUTHENTICATION = {
+  enforced: "enforced",
+  bypassedTestMode: "bypassed-test-mode",
+} as const;
+export type EdgeAuthentication =
+  (typeof EDGE_AUTHENTICATION)[keyof typeof EDGE_AUTHENTICATION];
+
+// Resolves the declared edge posture: unset = enforced (the production
+// contract). Any other value is a harness misconfiguration, thrown loudly
+// rather than coerced to either posture.
+export function resolveEdgeAuthentication(): EdgeAuthentication {
+  const raw = process.env[CLOUD_ENV.edgeAuthentication];
+  if (raw === undefined || raw === "" || raw === EDGE_AUTHENTICATION.enforced) {
+    return EDGE_AUTHENTICATION.enforced;
+  }
+  if (raw === EDGE_AUTHENTICATION.bypassedTestMode) {
+    return EDGE_AUTHENTICATION.bypassedTestMode;
+  }
+  throw new Error(
+    `${CLOUD_ENV.edgeAuthentication} must be "${EDGE_AUTHENTICATION.enforced}" or "${EDGE_AUTHENTICATION.bypassedTestMode}" when set; got "${raw}"`,
+  );
+}
 
 // The org whose FGA ownership tuples the launcher seeds for the synthetic test
 // identity (must match harness.TestOrg / fga_seeder.go in test/integration).
@@ -137,8 +176,9 @@ export async function spawnCloudEnvironment(): Promise<CloudEnvironment> {
 
 // One-time auth bootstrap, run once per suite invocation:
 // tokenless call (the launcher's test security mode maps it to the synthetic
-// FGA-seeded identity) -> create a PlatformClient in the seeded org -> mint a
-// real Stigmer JWT for a fresh primary user. Everything after this runs as
+// FGA-seeded identity — the edge posture CLOUD_ENV.edgeAuthentication
+// declares as bypassed) -> create a PlatformClient in the seeded org -> mint
+// a real Stigmer JWT for a fresh primary user. Everything after this runs as
 // that user through the production token-verification path.
 export async function bootstrapPrimaryIdentity(grpcBaseUrl: string): Promise<PrimaryIdentity> {
   const tokenlessTransport = createTransport(grpcBaseUrl);

--- a/test/conformance/src/harness/global-setup-cloud.ts
+++ b/test/conformance/src/harness/global-setup-cloud.ts
@@ -13,6 +13,7 @@
 import {
   bootstrapPrimaryIdentity,
   CLOUD_ENV,
+  EDGE_AUTHENTICATION,
   spawnCloudEnvironment,
   type CloudEnvironment,
 } from "./cloud-env";
@@ -36,6 +37,11 @@ export default async function setup(): Promise<() => Promise<void>> {
     process.env[CLOUD_ENV.platformClientId] = identity.platformClient.clientId;
     process.env[CLOUD_ENV.platformClientSecret] = identity.platformClient.clientSecret;
     process.env[CLOUD_ENV.operatorToken] = identity.operatorToken;
+    // This setup chose STIGMER_SECURITY_MODE=test for the JAR (the launcher's
+    // default — the tokenless bootstrap above depends on it), so it is the
+    // one place that may declare the edge bypassed. Pre-provisioned
+    // endpoints never reach this line and keep the enforced default.
+    process.env[CLOUD_ENV.edgeAuthentication] = EDGE_AUTHENTICATION.bypassedTestMode;
   } catch (err) {
     await environment.stop();
     throw err;

--- a/test/conformance/src/suites/authentication.conformance.test.ts
+++ b/test/conformance/src/suites/authentication.conformance.test.ts
@@ -1,0 +1,141 @@
+// Authentication posture conformance (entry 20260904.02).
+// Pins the serving edge's position-1 contract — what a request gets BEFORE
+// any handler runs, as a function of the credential it presents:
+//   - NO credential on a non-public method: refused UNAUTHENTICATED
+//     "authentication token missing" where the target requires
+//     authentication (the Java GrpcSecurityConfigBase copy, byte-pinned; the
+//     TS chassis reproduces it under the OIDC-issuer arm and under the
+//     require-authentication registry point the cloud composition declares);
+//     admitted as the single operator where it does not (the OSS
+//     trusted-local posture — a contract too, pinned so the TS server keeps
+//     it);
+//   - NO credential on an is_public method: answers on EVERY target (the
+//     Java isPublic skip; getServerInfo is what consoles and CLIs read
+//     before login);
+//   - NO credential on the standard gRPC health service: SERVING on EVERY
+//     target (the Java by-name skip — the health proto cannot carry our
+//     option, and a Kubernetes `grpc:` probe is exactly this call; a
+//     refused probe is a pod that never becomes Ready, stigmer#974);
+//   - a credential NOTHING claims: refused UNAUTHENTICATED where a verifier
+//     is composed (code only — Java's classifyAuthError copy and the TS
+//     chassis's differ by design); admitted as the operator on the
+//     verifier-less local targets (the O2 ruling-Q6 fall-through).
+// Coverage of the absent-token arm was ZERO before this suite: every
+// conformance RPC carried the primary credential, so a composition that
+// admitted anonymous callers as `system` passed five green readouts
+// (the entry's origin story). The arms below drive credential-less and
+// garbage-credential clients through the TARGET's own seams
+// (anonymousClients / clientsPresenting), never a hand-built transport.
+//
+// One environment cannot show the contract: the hermetic cloud launcher
+// boots Java in test security mode, where no edge authentication is loaded
+// and a synthetic caller stands in for every request. The two credential
+// arms skip VISIBLY there, carrying the target's stated reason
+// (edgeAuthenticationBypass) — never asserting admission, which would pin
+// a harness artifact as a contract (D-S1, entry 20260904.02). The
+// is_public and health arms hold on every environment regardless.
+import { Code } from "@connectrpc/connect";
+import { HealthCheckResponse_ServingStatus } from "@stigmer/protos/grpc/health/v1/health_pb";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { expectGrpcCode } from "../contract/errors";
+import { createTarget, type TargetProfile } from "../targets";
+
+// The Java interceptor's refusal copy, byte-pinned on both editions
+// (GrpcSecurityConfigBase.java; the TS chassis's
+// AUTHENTICATION_TOKEN_MISSING_MESSAGE is the same bytes by contract).
+const TOKEN_MISSING_MESSAGE = "authentication token missing";
+
+// Shaped like nothing any verifier issues — not a JWT, not an API key
+// prefix — so the arm exercises the unclaimed path on every target rather
+// than a verifier's own malformed-token rejection.
+const UNCLAIMABLE_CREDENTIAL = "conformance-unclaimable-credential";
+
+let target: TargetProfile;
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+// Skips the credential arm, with the target's own reason, where the
+// environment's edge is declared bypassed — a visible skip in the roster,
+// never a silent pass.
+function skipIfEdgeBypassed(ctx: { skip: (note?: string) => never }): void {
+  const reason = target.edgeAuthenticationBypass?.();
+  if (reason !== undefined) {
+    ctx.skip(reason);
+  }
+}
+
+describe("authentication posture: a request with no credential", () => {
+  it("is refused on a non-public method with the byte-pinned copy where authentication is required, admitted as the operator where it is not", async (ctx) => {
+    skipIfEdgeBypassed(ctx);
+    const anonymous = target.anonymousClients();
+    // findMyOrganizations takes Empty and runs no validation — a pure
+    // position-1 probe (the same reason the readiness gate uses it).
+    if (target.capabilities.requiresAuthentication) {
+      const error = await expectGrpcCode(
+        () => anonymous.organizationQuery.findMyOrganizations({}),
+        Code.Unauthenticated,
+        "tokenless findMyOrganizations under the require-authentication posture",
+      );
+      expect(
+        error.rawMessage,
+        "the refusal copy is a cross-edition wire constant — clients branch on it",
+      ).toBe(TOKEN_MISSING_MESSAGE);
+      return;
+    }
+    const response = await anonymous.organizationQuery.findMyOrganizations({});
+    expect(
+      Array.isArray(response.entries),
+      "trusted-local posture: the tokenless caller IS the operator and the read answers",
+    ).toBe(true);
+  });
+
+  it("still reaches an is_public method on every target (getServerInfo, the pre-login read)", async () => {
+    const info = await target.anonymousClients().platformQuery.getServerInfo({});
+    expect(info.edition, "getServerInfo answers the edition without a credential").not.toBe(0);
+  });
+
+  it("still reaches the gRPC health service on every target (the Kubernetes grpc-probe contract)", async () => {
+    // service "" = the server's overall health, the grpc-go convention
+    // Kubernetes probes use when no service name is configured.
+    const response = await target.anonymousClients().health.check({ service: "" });
+    expect(
+      response.status,
+      "a tokenless Health/Check must answer SERVING or every grpc probe fails and the pod never becomes Ready",
+    ).toBe(HealthCheckResponse_ServingStatus.SERVING);
+  });
+});
+
+describe("authentication posture: a request with a credential nothing claims", () => {
+  it("is refused UNAUTHENTICATED where a verifier is composed, admitted as the operator on verifier-less targets", async (ctx) => {
+    skipIfEdgeBypassed(ctx);
+    const presenting = target.clientsPresenting(UNCLAIMABLE_CREDENTIAL);
+    if (target.capabilities.requiresAuthentication) {
+      // Code only: the two editions word this refusal differently by
+      // design (Java classifies the parse failure; the TS chassis names the
+      // verifier walk). Both refuse — that is the contract.
+      await expectGrpcCode(
+        () => presenting.organizationQuery.findMyOrganizations({}),
+        Code.Unauthenticated,
+        "an unclaimable credential under the require-authentication posture",
+      );
+      return;
+    }
+    // Zero verifiers: nothing can claim the token, and the O2 ruling-Q6
+    // contract falls through SILENTLY to the trusted-local operator — the
+    // runner presents a proxy bearer on every control-plane RPC and the
+    // single-operator server must keep admitting it.
+    const response = await presenting.organizationQuery.findMyOrganizations({});
+    expect(
+      Array.isArray(response.entries),
+      "verifier-less posture: an unclaimed credential falls through to the operator",
+    ).toBe(true);
+  });
+});

--- a/test/conformance/src/targets/cloud-execution.ts
+++ b/test/conformance/src/targets/cloud-execution.ts
@@ -135,6 +135,18 @@ export class CloudExecutionTarget implements TargetProfile {
     return this.cloud.clients();
   }
 
+  anonymousClients(): ConformanceClients {
+    return this.cloud.anonymousClients();
+  }
+
+  clientsPresenting(bearerToken: string): ConformanceClients {
+    return this.cloud.clientsPresenting(bearerToken);
+  }
+
+  edgeAuthenticationBypass(): string | undefined {
+    return this.cloud.edgeAuthenticationBypass();
+  }
+
   async provisionTenancy(): Promise<TenancyContext> {
     const context = await this.cloud.provisionTenancy();
     await this.fundTenancy(context.org);

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -11,7 +11,12 @@
 // organization created via the production RPC, whose creation grants the
 // primary user ownership (IAM policies) and provisions a zero-balance billing
 // account — sufficient for the Class A (CRUD) domains.
-import { CLOUD_ENV, mintCloudUserToken } from "../harness/cloud-env";
+import {
+  CLOUD_ENV,
+  EDGE_AUTHENTICATION,
+  mintCloudUserToken,
+  resolveEdgeAuthentication,
+} from "../harness/cloud-env";
 import { createTransport, makeClients, type ConformanceClients } from "../harness/clients";
 import { awaitGrpcReady } from "../harness/grpc-ready";
 import { uniqueName, uniqueOrg } from "../support/naming";
@@ -74,6 +79,11 @@ export class CloudTarget implements TargetProfile {
     // serving-edge request: by the Java interceptor natively, and by the
     // composition's platform-client caller guard (entry 20260902.02).
     platformClientTokens: true,
+    // Every non-public RPC needs a credential: the Java interceptor's
+    // require-authentication posture natively, and the TS composition's
+    // through the registry point its cloud-core unit declares (entry
+    // 20260904.02) — the same byte-pinned refusal on both.
+    requiresAuthentication: true,
   };
 
   private grpcBaseUrl: string | undefined;
@@ -140,6 +150,38 @@ export class CloudTarget implements TargetProfile {
       throw new Error("CloudTarget.setup() must be called before clients()");
     }
     return this.conformanceClients;
+  }
+
+  anonymousClients(): ConformanceClients {
+    return makeClients(createTransport(this.requireBaseUrl("anonymousClients")));
+  }
+
+  clientsPresenting(bearerToken: string): ConformanceClients {
+    return makeClients(createTransport(this.requireBaseUrl("clientsPresenting"), { bearerToken }));
+  }
+
+  private requireBaseUrl(caller: string): string {
+    if (this.grpcBaseUrl === undefined) {
+      throw new Error(`CloudTarget.setup() must be called before ${caller}()`);
+    }
+    return this.grpcBaseUrl;
+  }
+
+  // The environment's declared edge posture (CLOUD_ENV.edgeAuthentication;
+  // unset = enforced). Read per call, not cached at setup: the value is
+  // published by the global setup before any worker runs and never changes
+  // within a run, and reading late keeps this target constructible in unit
+  // tests that never call setup().
+  edgeAuthenticationBypass(): string | undefined {
+    if (resolveEdgeAuthentication() === EDGE_AUTHENTICATION.enforced) {
+      return undefined;
+    }
+    return (
+      "the hermetic launcher runs stigmer-service with STIGMER_SECURITY_MODE=test — " +
+      "GrpcSecurityConfigBase is not loaded and a synthetic caller stands in for every request, " +
+      "so the edge's require-authentication posture is unobservable here " +
+      "(production Java's posture is covered by test/integration-security; entry 20260904.02 D-S1)"
+    );
   }
 
   async provisionTenancy(): Promise<TenancyContext> {

--- a/test/conformance/src/targets/local-execution.ts
+++ b/test/conformance/src/targets/local-execution.ts
@@ -58,6 +58,9 @@ export class LocalExecutionTarget implements TargetProfile {
     // unrouted and the serving edge composes zero caller guards (the
     // 20260902.02 empty state), so the enforcement arms skip.
     platformClientTokens: false,
+    // Single-operator trusted-local posture, as on `local` — the runner's
+    // STIGMER_TOKEN is a proxy bearer the server never verifies.
+    requiresAuthentication: false,
   };
 
   private temporal: RunningTemporal | undefined;
@@ -143,6 +146,21 @@ export class LocalExecutionTarget implements TargetProfile {
       throw new Error("LocalExecutionTarget.setup() must be called before clients()");
     }
     return this.conformanceClients;
+  }
+
+  anonymousClients(): ConformanceClients {
+    return makeClients(createTransport(this.serverBaseUrl()));
+  }
+
+  clientsPresenting(bearerToken: string): ConformanceClients {
+    return makeClients(createTransport(this.serverBaseUrl(), { bearerToken }));
+  }
+
+  private serverBaseUrl(): string {
+    if (this.server === undefined) {
+      throw new Error("LocalExecutionTarget.setup() must be called before building clients");
+    }
+    return this.server.baseUrl;
   }
 
   async provisionTenancy(): Promise<TenancyContext> {

--- a/test/conformance/src/targets/local.ts
+++ b/test/conformance/src/targets/local.ts
@@ -45,6 +45,10 @@ export class LocalTarget implements TargetProfile {
     // unrouted and the serving edge composes zero caller guards (the
     // 20260902.02 empty state), so the enforcement arms skip.
     platformClientTokens: false,
+    // Single-operator trusted-local posture: no issuer, no declared
+    // posture, zero verifiers — a tokenless request IS the operator (the
+    // authentication suite pins that admission, entry 20260904.02).
+    requiresAuthentication: false,
   };
 
   private server: RunningServer | undefined;
@@ -76,6 +80,17 @@ export class LocalTarget implements TargetProfile {
       throw new Error("LocalTarget.setup() must be called before clients()");
     }
     return this.conformanceClients;
+  }
+
+  // The ordinary clients already present nothing — this target runs without
+  // auth — but the seam is built the same way on every target so the
+  // authentication suite never reasons about which kind it has.
+  anonymousClients(): ConformanceClients {
+    return makeClients(createTransport(this.httpBaseUrl()));
+  }
+
+  clientsPresenting(bearerToken: string): ConformanceClients {
+    return makeClients(createTransport(this.httpBaseUrl(), { bearerToken }));
   }
 
   // The spawned server's unified port also serves the plain-HTTP lanes (the

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -227,6 +227,27 @@ export interface CapabilityFlags {
   // the minting client's contract are different concerns — a future target
   // could carry one without the other.
   platformClientTokens: boolean;
+  // Every non-public RPC requires a credential: a request with NO bearer is
+  // refused UNAUTHENTICATED "authentication token missing" (the copy both
+  // editions pin — the Java interceptor's, and the OSS chassis's byte-for-
+  // byte). What stays reachable tokenless on EVERY target regardless of
+  // this flag: is_public methods (getServerInfo) and the standard gRPC
+  // health service (Kubernetes grpc probes), which the authentication suite
+  // asserts unconditionally.
+  //
+  // True for cloud — the Java interceptor natively (GrpcSecurityConfigBase),
+  // and the TS composition through the require-authentication registry
+  // point its cloud-core unit declares (entry 20260904.02).
+  //
+  // False for the local OSS targets — BY DESIGN, not a gap: the single-
+  // operator trusted-local posture admits a tokenless request as the
+  // operator, and a presented-but-unclaimed token falls through to the same
+  // identity when no verifier is composed (the O2 ruling-Q6 contract). Where
+  // false, the suite pins that admission — the OSS contract the TS server
+  // must keep. Deliberately NOT folded into platformClientTokens or
+  // multiTenant: a self-host with STIGMER_OIDC_ISSUER set requires
+  // authentication with neither of those.
+  requiresAuthentication: boolean;
 }
 
 // Tenancy scope a test operates within. Locally this is just a unique org slug
@@ -263,6 +284,36 @@ export interface TargetProfile {
   teardown(): Promise<void>;
 
   clients(): ConformanceClients;
+
+  // Clients presenting NO credential at all — the anonymous caller the
+  // authentication suite drives at the serving edge (entry 20260904.02).
+  // Every target can build one (a transport with no bearer interceptor), so
+  // the method is required, not a capability; what the anonymous caller
+  // GETS is the requiresAuthentication flag's business. Suites never build
+  // transports themselves — the target owns how it is reached.
+  anonymousClients(): ConformanceClients;
+
+  // Clients presenting exactly the given bearer credential, claimed by
+  // nothing — the presented-but-unclaimed arm of the position-1 contract
+  // (refused where a verifier is composed; admitted as the operator on the
+  // verifier-less local targets). Required for the same reason as
+  // anonymousClients; the primary credential stays clients()'s.
+  clientsPresenting(bearerToken: string): ConformanceClients;
+
+  // Why THIS environment's serving edge cannot demonstrate the edition's
+  // requiresAuthentication contract, or undefined when it can. A harness
+  // fact, deliberately separate from the capability flag (which states the
+  // edition's contract): the hermetic cloud launcher boots Java in test
+  // security mode, where no edge authentication is loaded at all and a
+  // synthetic caller stands in for every request — the posture is real in
+  // production and unobservable there. The authentication suite skips its
+  // credential arms VISIBLY, with this reason, when one is returned; it
+  // never asserts admission on a bypassed edge (that would pin a harness
+  // artifact as a contract). Present only on the cloud targets, whose
+  // environment is declared through CLOUD_ENV.edgeAuthentication (default
+  // enforced — a readout that forgets the variable fails loudly, never
+  // false-greens); the local targets' posture IS what their flag says.
+  edgeAuthenticationBypass?(): string | undefined;
 
   // Provision an isolated tenancy scope for a test. cleanupTenancy releases it.
   provisionTenancy(): Promise<TenancyContext>;

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -581,6 +581,10 @@ const organizationDirectory: OrganizationDirectory = {
 export const fakeExtension: ServerExtension = {
   name: "consumer-fake",
   edition: ServerEdition.cloud,
+  // The 20260904.02 point: the unit's verifiers are its only admission
+  // path, so tokenless non-public requests are refused. Typed as the
+  // literal `true` — `false` does not compile; omit the field instead.
+  requireAuthentication: true,
   authorizer,
   identityVerifiers: [verifier],
   // The 20260902.02 seam: post-authentication caller guards, serving


### PR DESCRIPTION
## Summary

A composition can now ask the server for the require-authentication posture without configuring the OSS OIDC issuer, the posture no longer refuses gRPC health probes, and the conformance suite gains the absent-token arms it never had.

## Context

The server's only require-authentication switch was `STIGMER_OIDC_ISSUER`. A composition that brings its own identity verifiers cannot use it — setting the issuer also registers the OSS API-key and OIDC verifiers ahead of the composition's own and changes who its users resolve to. Without a way to ask, a request carrying no credential fell to the trusted-local single-operator identity on a server that was never single-operator.

Separately, the posture's tokenless-refusal arm exempted only `is_public` methods. The standard gRPC health service is a third-party proto and cannot carry that option, so a Kubernetes `grpc:` probe was refused UNAUTHENTICATED under `STIGMER_OIDC_ISSUER` and the pod could never become Ready. Closes #974.

## Changes

**Extension registry (`src/extensions/registry.ts`)**
- `ServerExtension.requireAuthentication?: true` — a single-declaration point in the edition's shape: exactly one unit may declare it, a second throws naming both. The literal type means "declare it or omit it"; there is no `false` arm to validate at boot. `ResolvedExtensions.requireAuthentication` carries the declaring unit's name.

**Composition root (`src/boot/compose.ts`)**
- The posture is the OIDC-issuer arm OR the unit declaration.
- A declared posture with zero composed identity verifiers is a boot throw naming the unit (nothing could authenticate; a running server would refuse everything).
- One `info` line at boot: the resolved posture, its source(s), the composed verifiers.

**Identity chassis (`src/pipeline/interceptors/auth.ts`)**
- `isAuthenticationExempt(method)`: `is_public` OR the method's service is in `AUTHENTICATION_EXEMPT_SERVICES` — the Java interceptor's by-name skip. The set holds `grpc.health.v1.Health`; reflection (Java's second entry) is deliberately absent because the server registers none, and the constant says so.

**Conformance (`test/conformance`)**
- `CapabilityFlags.requiresAuthentication` (true on cloud, false on the local targets, where the suite pins the single-operator admission instead).
- Two required `TargetProfile` seams so suites never build transports: `anonymousClients()`, `clientsPresenting(bearerToken)`. `ConformanceClients.health`.
- `suites/authentication.conformance.test.ts`, four arms: tokenless non-public RPC (refused with the byte-pinned `authentication token missing` / admitted), tokenless `getServerInfo` (answers everywhere), tokenless `Health/Check` (SERVING everywhere — the probe contract), garbage bearer (refused where a verifier is composed / admitted where none is).
- The hermetic cloud launcher boots Java in `STIGMER_SECURITY_MODE=test`, where no edge authentication is loaded. `CLOUD_ENV.edgeAuthentication` (default `enforced`; the launcher's global setup is the one place that declares `bypassed-test-mode`) and `TargetProfile.edgeAuthenticationBypass()` let the two credential arms skip visibly with the reason on that target — never asserting admission on a bypassed edge. A pre-provisioned endpoint that forgets the variable gets the production contract and fails loudly.

**Records**
- Guidelines: one bullet on the point, the exemption set, and why there is no env knob.
- `docs/guides/self-hosting/authentication.mdx`: what stays reachable without a credential.
- `docs/authorization-coverage.md`: the health service's by-name authentication exemption.
- `test/extension-consumer`: the proof declares the field.

## Implementation notes

- Singleton, not OR-merged boolean: the registry has two vocabularies (singletons that throw on a second declaration, lists that concatenate). A composition-wide posture is a singleton by that doctrine.
- No env knob: a self-host with no verifier has no use for it, and a forgotten knob is exactly the failure this point exists to prevent.
- The exemption is an authentication fact in the chassis, not a caller guard: a tokenless probe has no identity to guard.

## Wire-visible change

Under `STIGMER_OIDC_ISSUER`, a tokenless `grpc.health.v1.Health/Check` now answers SERVING where it was UNAUTHENTICATED. Every presented-token path is untouched.

## Test plan

- Server units: 2184 passed (new arms: registry single-declaration + second-declaration throw; `isAuthenticationExempt` per method; health under the issuer posture through the real stack; a unit-declared posture with no issuer refuses tokenless with the pinned copy, admits a claimed token, keeps `is_public`/health reachable, leaves the in-process transport untouched, logs the posture, and throws at boot with zero verifiers).
- `test/extension-consumer` typecheck green.
- Local rosters: `local` 504/16, `local-postgres` 504/16 (the +4 are the new arms), `local-execution` 160/3, `local-postgres-execution` 160/3 — byte-identical on every existing count.
- Hermetic Java target, the new suite: 2 passed / 2 skipped with the declared reason.

## Risks

Low. The only behaviour change without a new declaration is the health exemption under an OIDC issuer (a fix). Rollback is a revert; nothing persists.

Closes #974

Made with [Cursor](https://cursor.com)