### PR TITLE
test(conformance): add the direct-login suite for the platform tenant's tokens (S1 lane)

### DIFF
--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -169,6 +169,20 @@ CI: `.github/workflows/ci.conformance-cloud.yaml` builds the JAR from
 cloud-side drift, since path triggers in this repo cannot see stigmer-cloud
 merges.
 
+**The direct-login arms** (`direct-login.conformance.test.ts`, stigmer-cloud#604)
+drive the lane a console, desktop, CLI or MCP client actually rides: the raw
+access token the PLATFORM'S OWN identity tenant mints, verified and resolved
+to the caller's account at position 1. The suite forges nothing about the
+tenant — it mints through `CloudTarget.directLoginTenant()`, which exists only
+where the environment hands the harness the tenant's signing key
+(`STIGMER_CONFORMANCE_CLOUD_DIRECT_LOGIN_ISSUER` / `_SIGNING_KEY_BASE64` /
+`_KID` / `_API_AUDIENCE` / optional `_MCP_AUDIENCE`): the composition readout
+substrate's mock tenant (`stigmer-cloud` `backend/services/stigmer-server/spike/identity-tenant.ts`
+writes that group beside the composition's own `STIGMER_IDP_*` boot trio). The
+hermetic Java launcher (test security mode, no edge) and every deployed
+endpoint (a real tenant's key is never conformance's) leave the group unset,
+and the arms skip VISIBLY with the target's reason.
+
 ## Design
 
 ### Raw stubs, not the SDK

--- a/test/conformance/src/harness/clients.ts
+++ b/test/conformance/src/harness/clients.ts
@@ -59,6 +59,8 @@ import { OrganizationCommandController } from "@stigmer/protos/ai/stigmer/tenanc
 import { OrganizationQueryController } from "@stigmer/protos/ai/stigmer/tenancy/organization/v1/query_pb";
 import { Health } from "@stigmer/protos/grpc/health/v1/health_pb";
 import { ApiKeyCommandController } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/command_pb";
+import { IdentityAccountCommandController } from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/command_pb";
+import { IdentityAccountQueryController } from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/query_pb";
 import { ApiKeyQueryController } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/query_pb";
 import { ProjectCommandController } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/command_pb";
 import { ProjectQueryController } from "@stigmer/protos/ai/stigmer/tenancy/project/v1/query_pb";
@@ -84,6 +86,8 @@ export interface ConformanceClients {
   search: Client<typeof SearchService>;
   projectCommand: Client<typeof ProjectCommandController>;
   projectQuery: Client<typeof ProjectQueryController>;
+  identityAccountCommand: Client<typeof IdentityAccountCommandController>;
+  identityAccountQuery: Client<typeof IdentityAccountQueryController>;
   organizationCommand: Client<typeof OrganizationCommandController>;
   organizationQuery: Client<typeof OrganizationQueryController>;
   workflowCommand: Client<typeof WorkflowCommandController>;
@@ -190,6 +194,14 @@ export function makeClients(transport: Transport): ConformanceClients {
     apiKeyQuery: createClient(ApiKeyQueryController, transport),
     projectCommand: createClient(ProjectCommandController, transport),
     projectQuery: createClient(ProjectQueryController, transport),
+    identityAccountCommand: createClient(
+      IdentityAccountCommandController,
+      transport,
+    ),
+    identityAccountQuery: createClient(
+      IdentityAccountQueryController,
+      transport,
+    ),
     organizationCommand: createClient(OrganizationCommandController, transport),
     organizationQuery: createClient(OrganizationQueryController, transport),
     workflowCommand: createClient(WorkflowCommandController, transport),

--- a/test/conformance/src/harness/cloud-env.ts
+++ b/test/conformance/src/harness/cloud-env.ts
@@ -67,6 +67,24 @@ export const CLOUD_ENV = {
   // covered by test/integration-security; making the hermetic launcher run
   // production mode is a recorded follow-up (entry 20260904.02, D-S1).
   edgeAuthentication: "STIGMER_CONFORMANCE_CLOUD_EDGE_AUTHENTICATION",
+  // The platform identity tenant the server under test was booted against
+  // (its STIGMER_IDP_URL / Java idp-url), as the readout substrate's mock
+  // tenant declares it — so the direct-login suite can MINT the tokens a
+  // console, desktop, CLI or MCP client presents and drive the server's
+  // direct-login lane (stigmer-cloud#604, the S1 lane). The signing key is
+  // the private half of the key the tenant's JWKS publishes (base64 of a
+  // PKCS#8 PEM, the composition's `*_BASE64` custody pattern); the kid names
+  // it in that document. Deliberately UNSET wherever the suite cannot own
+  // the tenant's key — the hermetic launcher (test security mode, no edge)
+  // and any deployed endpoint (a real tenant's key is never handed to
+  // conformance) — so CloudTarget exposes no directLoginTenant and the
+  // suite skips VISIBLY. The API audience is required with the issuer; the
+  // MCP audience is optional (blank = the tenant mints for the API alone).
+  directLoginIssuer: "STIGMER_CONFORMANCE_CLOUD_DIRECT_LOGIN_ISSUER",
+  directLoginSigningKeyBase64: "STIGMER_CONFORMANCE_CLOUD_DIRECT_LOGIN_SIGNING_KEY_BASE64",
+  directLoginKid: "STIGMER_CONFORMANCE_CLOUD_DIRECT_LOGIN_KID",
+  directLoginApiAudience: "STIGMER_CONFORMANCE_CLOUD_DIRECT_LOGIN_API_AUDIENCE",
+  directLoginMcpAudience: "STIGMER_CONFORMANCE_CLOUD_DIRECT_LOGIN_MCP_AUDIENCE",
 } as const;
 
 // The two declared edge postures — see CLOUD_ENV.edgeAuthentication.

--- a/test/conformance/src/harness/direct-login-tenant.ts
+++ b/test/conformance/src/harness/direct-login-tenant.ts
@@ -1,0 +1,137 @@
+// The platform identity tenant's MINT for the direct-login suite
+// (stigmer-cloud#604, the S1 lane). Domain: conformance harness.
+//
+// The suite never forges the platform tenant's tokens from thin air: the
+// readout substrate runs a mock tenant whose JWKS the server under test
+// discovered at boot, and hands THIS process the private half of that key
+// through CLOUD_ENV.directLogin* (base64 PKCS#8 PEM, the composition's
+// `*_BASE64` custody pattern). What is minted is shaped exactly like what
+// Auth0 issues a first-party client for an API audience: RS256 under the
+// tenant's kid, `iss` exactly as published (trailing slash), `aud` in the
+// ARRAY form beside the tenant's userinfo entry, `iat`/`exp`, `scope`,
+// `azp`, `jti` — and NO profile claims (an access token, not an id token;
+// the profile comes from /userinfo, which is why a first login has to call
+// provisionMyAccount). Anything the suite wants to be WRONG about a token
+// (a foreign audience, an expired lifetime) is a parameter here; a token
+// signed by a stranger is minted by the suite with its own throwaway key
+// and this module's shape helpers.
+//
+// node:crypto only — jose is the OSS server's dependency, not the suite's.
+import { createSign, randomUUID } from "node:crypto";
+
+import type { DirectLoginTenant } from "../targets/target";
+
+import { CLOUD_ENV } from "./cloud-env";
+
+// What a console session lives for; the suite's tokens are short by construction.
+const DEFAULT_TTL_SECONDS = 5 * 60;
+
+export interface DirectLoginTenantMaterial {
+  readonly issuer: string;
+  readonly signingKeyPem: string;
+  readonly kid: string;
+  readonly apiAudience: string;
+  readonly mcpAudience: string | undefined;
+}
+
+// Reads the CLOUD_ENV.directLogin* group. Undefined when the issuer is unset
+// (the environment does not own a tenant key); a PARTIAL group throws — a
+// readout that set the issuer but forgot the key must not skip quietly.
+export function readDirectLoginTenantMaterial(
+  env: NodeJS.ProcessEnv = process.env,
+): DirectLoginTenantMaterial | undefined {
+  const issuer = env[CLOUD_ENV.directLoginIssuer] ?? "";
+  if (issuer === "") {
+    return undefined;
+  }
+  const required = (name: string): string => {
+    const value = env[name] ?? "";
+    if (value === "") {
+      throw new Error(
+        `${CLOUD_ENV.directLoginIssuer} is set but ${name} is not — the direct-login tenant group is all-or-nothing`,
+      );
+    }
+    return value;
+  };
+  const signingKeyPem = Buffer.from(
+    required(CLOUD_ENV.directLoginSigningKeyBase64),
+    "base64",
+  ).toString("utf8");
+  if (!signingKeyPem.includes("-----BEGIN")) {
+    throw new Error(
+      `${CLOUD_ENV.directLoginSigningKeyBase64} does not decode to a PEM private key`,
+    );
+  }
+  const mcpAudience = env[CLOUD_ENV.directLoginMcpAudience] ?? "";
+  return {
+    issuer,
+    signingKeyPem,
+    kid: required(CLOUD_ENV.directLoginKid),
+    apiAudience: required(CLOUD_ENV.directLoginApiAudience),
+    mcpAudience: mcpAudience === "" ? undefined : mcpAudience,
+  };
+}
+
+export function newDirectLoginTenant(
+  material: DirectLoginTenantMaterial,
+): DirectLoginTenant {
+  return {
+    issuer: material.issuer,
+    apiAudience: material.apiAudience,
+    mcpAudience: material.mcpAudience,
+    mint(input) {
+      return signDirectLoginToken({
+        privateKeyPem: material.signingKeyPem,
+        kid: material.kid,
+        claims: directLoginClaims({
+          issuer: material.issuer,
+          subject: input.subject,
+          audience: input.audience ?? [
+            material.apiAudience,
+            `${material.issuer}userinfo`,
+          ],
+          ttlSeconds: input.ttlSeconds ?? DEFAULT_TTL_SECONDS,
+        }),
+      });
+    },
+  };
+}
+
+// The claim set Auth0 mints for a first-party client — exported so the suite's
+// stranger-signed arm carries the same shape and fails for the signature alone.
+export function directLoginClaims(input: {
+  issuer: string;
+  subject: string;
+  audience: string | ReadonlyArray<string>;
+  ttlSeconds: number;
+}): Record<string, unknown> {
+  const iat = Math.floor(Date.now() / 1000);
+  return {
+    iss: input.issuer,
+    sub: input.subject,
+    aud:
+      typeof input.audience === "string" ? input.audience : [...input.audience],
+    iat,
+    exp: iat + input.ttlSeconds,
+    scope: "openid profile email offline_access",
+    azp: "conformance-first-party-client",
+    jti: randomUUID(),
+  };
+}
+
+// RS256 compact JWS over node:crypto.
+export function signDirectLoginToken(input: {
+  privateKeyPem: string;
+  kid: string;
+  claims: Record<string, unknown>;
+}): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT", kid: input.kid }),
+  ).toString("base64url");
+  const payload = Buffer.from(JSON.stringify(input.claims)).toString(
+    "base64url",
+  );
+  const signer = createSign("RSA-SHA256");
+  signer.update(`${header}.${payload}`);
+  return `${header}.${payload}.${signer.sign(input.privateKeyPem).toString("base64url")}`;
+}

--- a/test/conformance/src/suites/direct-login.conformance.test.ts
+++ b/test/conformance/src/suites/direct-login.conformance.test.ts
@@ -1,0 +1,249 @@
+// Direct-login conformance (stigmer-cloud#604 — the X1 checklist's S1 lane).
+// Pins what the serving edge does with the raw access token a console,
+// desktop, CLI or MCP client obtains from the PLATFORM'S OWN identity tenant
+// — the credential every first-party login presents, and the one lane five
+// green readouts never drove because the cloud target authenticates with
+// PlatformClient-minted tokens (the entry's origin story):
+//   - a token for a subject with NO account is ADMITTED, idp-shaped: whoAmI
+//     answers NOT_FOUND with the byte-pinned copy (the console's signal to
+//     call provisionMyAccount), never UNAUTHENTICATED — the Java mapper's
+//     raw-subject fallback, the composition's direct-idp miss arm;
+//   - a FIRST login end to end: provisionMyAccount creates a `direct`
+//     account for that subject from the tenant's /userinfo, the personal
+//     org it creates is OWNED BY the new account (findMyOrganizations as the
+//     same token lists it — the owner tuple names the ida_, not the raw
+//     subject, the defect entry 20260905.01 fixed), and the next whoAmI
+//     resolves the token to the account;
+//   - the tenant's MCP audience (the hosted MCP server forwards tokens
+//     minted for its own resource) is accepted beside the API audience;
+//   - a token for a FOREIGN audience, an EXPIRED token, and a token signed
+//     by a STRANGER under the tenant's issuer are refused UNAUTHENTICATED
+//     with the Java classifyAuthError copy, byte-pinned on both editions
+//     (GrpcSecurityConfigBase.classifyAuthError; the composition's
+//     iam/direct/verifier.ts constants are the same bytes by contract).
+// The suite forges nothing about the tenant: tokens come from the TARGET's
+// own mint (directLoginTenant — the readout substrate hands the harness the
+// mock tenant's key); only the stranger arm signs with a throwaway key,
+// under the same claim shape, so it fails for the signature alone.
+//
+// Where the target has no tenant to mint for — the local OSS targets by
+// design (capability false), the hermetic cloud launcher (test security
+// mode, no edge) and every deployed endpoint (a real tenant's key is never
+// conformance's) — the arms skip VISIBLY with the target's reason, never
+// asserting admission on an unobservable edge.
+import { generateKeyPairSync } from "node:crypto";
+
+import { Code } from "@connectrpc/connect";
+import { IdentityAccountProvisioningMode } from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/enum_pb";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { expectGrpcCode } from "../contract/errors";
+import {
+  directLoginClaims,
+  signDirectLoginToken,
+} from "../harness/direct-login-tenant";
+import {
+  createTarget,
+  type DirectLoginTenant,
+  type TargetProfile,
+} from "../targets";
+
+// Java classifyAuthError arms — byte-pinned cross-edition copy.
+const TOKEN_EXPIRED_MESSAGE = "token has expired";
+const TOKEN_AUDIENCE_MESSAGE =
+  "token audience does not match the expected audience";
+const TOKEN_SIGNATURE_MESSAGE = "token signature verification failed";
+// iam/account/handlers.ts whoAmI — the Java IdentityAccountWhoAmIHandler copy.
+const ACCOUNT_NOT_FOUND_MESSAGE =
+  "Identity account not found for the authenticated user";
+
+let target: TargetProfile;
+const directLoginEnabled = createTarget().capabilities.directLogin;
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+// The tenant, or a visible skip carrying the target's own reason.
+function tenantOrSkip(ctx: {
+  skip: (note?: string) => never;
+}): DirectLoginTenant {
+  const bypass = target.edgeAuthenticationBypass?.();
+  if (bypass !== undefined) {
+    ctx.skip(bypass);
+  }
+  const tenant = target.directLoginTenant?.();
+  if (tenant === undefined) {
+    ctx.skip(
+      target.directLoginUnavailable?.() ??
+        "the target exposes no direct-login tenant",
+    );
+  }
+  return tenant;
+}
+
+// Auth0's subject shape for a database user; unique per test so no run ever
+// meets a row a previous run left behind.
+function freshSubject(): string {
+  return `auth0|conformance-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+describe.skipIf(!directLoginEnabled)(
+  "direct login: the platform tenant's tokens",
+  () => {
+    it("admits a subject with no account idp-shaped — whoAmI answers NOT_FOUND with the byte-pinned copy, never UNAUTHENTICATED", async (ctx) => {
+      const tenant = tenantOrSkip(ctx);
+      const presenting = target.clientsPresenting(
+        tenant.mint({ subject: freshSubject() }),
+      );
+      const error = await expectGrpcCode(
+        () => presenting.identityAccountQuery.whoAmI({}),
+        Code.NotFound,
+        "whoAmI for a valid tenant token whose subject has no account",
+      );
+      expect(
+        error.rawMessage,
+        "the console branches on this copy to start provisioning",
+      ).toBe(ACCOUNT_NOT_FOUND_MESSAGE);
+    });
+
+    it("provisions a first login end to end: a direct account from /userinfo, a personal org OWNED BY the new account, and whoAmI resolving to it", async (ctx) => {
+      const tenant = tenantOrSkip(ctx);
+      const subject = freshSubject();
+      const asUser = target.clientsPresenting(tenant.mint({ subject }));
+
+      const account = await asUser.identityAccountCommand.provisionMyAccount(
+        {},
+      );
+      const accountId = account.metadata?.id ?? "";
+      try {
+        expect(
+          accountId,
+          "provisionMyAccount answers the created account",
+        ).not.toBe("");
+        expect(
+          account.spec?.idpId,
+          "the account is keyed by the token's subject",
+        ).toBe(subject);
+        expect(
+          account.spec?.provisioningMode,
+          "a platform-tenant login is a DIRECT account (never federated, never platform_client)",
+        ).toBe(IdentityAccountProvisioningMode.direct);
+        expect(
+          account.spec?.email,
+          "the profile came from the tenant's /userinfo — an access token carries none",
+        ).not.toBe("");
+
+        const resolved = await asUser.identityAccountQuery.whoAmI({});
+        expect(
+          resolved.metadata?.id,
+          "after provisioning the SAME token resolves to the account at position 1 — no second row",
+        ).toBe(accountId);
+
+        const mine = await asUser.organizationQuery.findMyOrganizations({});
+        expect(
+          mine.entries.some((org) => org.spec?.isPersonal === true),
+          "the personal org is visible to the account — its owner tuple names the ida_, not the raw subject",
+        ).toBe(true);
+      } finally {
+        // Leave nothing behind: the personal org (owned by the account) and the
+        // account (self-owned). Best-effort — a failed cleanup must not mask
+        // the assertion that failed.
+        try {
+          const mine = await asUser.organizationQuery.findMyOrganizations({});
+          for (const org of mine.entries) {
+            if (
+              org.spec?.isPersonal === true &&
+              org.metadata?.id !== undefined
+            ) {
+              await asUser.organizationCommand.delete({
+                value: org.metadata.id,
+              });
+            }
+          }
+          if (accountId !== "") {
+            await asUser.identityAccountCommand.delete({ value: accountId });
+          }
+        } catch {
+          // Residue is reported by the substrate's count instruments, not here.
+        }
+      }
+    });
+
+    it("accepts the tenant's MCP audience beside the API audience (the hosted MCP server forwards those tokens)", async (ctx) => {
+      const tenant = tenantOrSkip(ctx);
+      if (tenant.mcpAudience === undefined) {
+        ctx.skip(
+          "the tenant mints for the API audience alone (no MCP audience declared)",
+        );
+      }
+      const presenting = target.clientsPresenting(
+        tenant.mint({ subject: freshSubject(), audience: tenant.mcpAudience }),
+      );
+      // Admitted (idp-shaped) — the audience gate passed; NOT_FOUND is the
+      // lane's answer for an unknown subject, UNAUTHENTICATED would be the gate.
+      await expectGrpcCode(
+        () => presenting.identityAccountQuery.whoAmI({}),
+        Code.NotFound,
+        "whoAmI with a token minted for the MCP audience",
+      );
+    });
+
+    it("refuses a token minted for a foreign audience with the byte-pinned audience copy", async (ctx) => {
+      const tenant = tenantOrSkip(ctx);
+      const presenting = target.clientsPresenting(
+        tenant.mint({
+          subject: freshSubject(),
+          audience: "https://another-api.conformance.test/",
+        }),
+      );
+      const error = await expectGrpcCode(
+        () => presenting.identityAccountQuery.whoAmI({}),
+        Code.Unauthenticated,
+        "a tenant token naming an audience this API does not serve",
+      );
+      expect(error.rawMessage).toBe(TOKEN_AUDIENCE_MESSAGE);
+    });
+
+    it("refuses an expired token with the byte-pinned expiry copy", async (ctx) => {
+      const tenant = tenantOrSkip(ctx);
+      const presenting = target.clientsPresenting(
+        tenant.mint({ subject: freshSubject(), ttlSeconds: -120 }),
+      );
+      const error = await expectGrpcCode(
+        () => presenting.identityAccountQuery.whoAmI({}),
+        Code.Unauthenticated,
+        "a tenant token two minutes past its exp",
+      );
+      expect(error.rawMessage).toBe(TOKEN_EXPIRED_MESSAGE);
+    });
+
+    it("refuses a token signed by a stranger under the tenant's issuer with the byte-pinned signature copy", async (ctx) => {
+      const tenant = tenantOrSkip(ctx);
+      const stranger = generateKeyPairSync("rsa", { modulusLength: 2048 });
+      const forged = signDirectLoginToken({
+        privateKeyPem: stranger.privateKey
+          .export({ type: "pkcs8", format: "pem" })
+          .toString(),
+        kid: "conformance-stranger-key",
+        claims: directLoginClaims({
+          issuer: tenant.issuer,
+          subject: freshSubject(),
+          audience: [tenant.apiAudience, `${tenant.issuer}userinfo`],
+          ttlSeconds: 300,
+        }),
+      });
+      const error = await expectGrpcCode(
+        () => target.clientsPresenting(forged).identityAccountQuery.whoAmI({}),
+        Code.Unauthenticated,
+        "a token claiming the tenant's issuer but signed by a key its JWKS does not carry",
+      );
+      expect(error.rawMessage).toBe(TOKEN_SIGNATURE_MESSAGE);
+    });
+  },
+);

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -18,9 +18,19 @@ import {
   resolveEdgeAuthentication,
 } from "../harness/cloud-env";
 import { createTransport, makeClients, type ConformanceClients } from "../harness/clients";
+import {
+  newDirectLoginTenant,
+  readDirectLoginTenantMaterial,
+} from "../harness/direct-login-tenant";
 import { awaitGrpcReady } from "../harness/grpc-ready";
 import { uniqueName, uniqueOrg } from "../support/naming";
-import type { CapabilityFlags, PrivilegedScope, TargetProfile, TenancyContext } from "./target";
+import type {
+  CapabilityFlags,
+  DirectLoginTenant,
+  PrivilegedScope,
+  TargetProfile,
+  TenancyContext,
+} from "./target";
 
 const ORG_API_VERSION = "tenancy.stigmer.ai/v1";
 const ORG_KIND = "Organization";
@@ -84,6 +94,10 @@ export class CloudTarget implements TargetProfile {
     // through the registry point its cloud-core unit declares (entry
     // 20260904.02) — the same byte-pinned refusal on both.
     requiresAuthentication: true,
+    // The platform tenant's tokens are verified and their subject resolved to
+    // the ida_ at position 1: Java's Auth0 decoder + RequestCallerIdentityMapper
+    // natively, the composition's direct-idp verifier (stigmer-cloud#604).
+    directLogin: true,
   };
 
   private grpcBaseUrl: string | undefined;
@@ -99,6 +113,13 @@ export class CloudTarget implements TargetProfile {
   // deliberately never do (the stigmer#547 permanent-skip ruling), so the
   // method itself is absent there and privileged-lane assertions skip.
   provisionPrivilegedScope?: () => Promise<PrivilegedScope>;
+
+  // Present only when the environment hands over the platform tenant's
+  // signing key (CLOUD_ENV.directLogin*) — the readout substrate's mock
+  // tenant does; the hermetic launcher and every deployed endpoint never do
+  // (a real tenant's key is not conformance's to hold), so the method is
+  // absent there and the direct-login suite skips with the reason below.
+  directLoginTenant?: () => DirectLoginTenant;
 
   async setup(): Promise<void> {
     this.grpcBaseUrl = requireEnv(CLOUD_ENV.address);
@@ -116,6 +137,20 @@ export class CloudTarget implements TargetProfile {
       );
       this.provisionPrivilegedScope = () => this.createPrivilegedScope();
     }
+
+    const tenantMaterial = readDirectLoginTenantMaterial();
+    if (tenantMaterial !== undefined) {
+      const tenant = newDirectLoginTenant(tenantMaterial);
+      this.directLoginTenant = () => tenant;
+    }
+  }
+
+  directLoginUnavailable(): string {
+    return (
+      `${CLOUD_ENV.directLoginIssuer} is unset — this environment does not hand conformance the platform ` +
+      "tenant's signing key (the hermetic launcher runs in test security mode with no edge; a deployed " +
+      "endpoint's real tenant key is never conformance's to hold), so the direct-login lane cannot be driven here"
+    );
   }
 
   // Platform-operator power grants nothing at org level (the FGA model checks

--- a/test/conformance/src/targets/index.ts
+++ b/test/conformance/src/targets/index.ts
@@ -34,4 +34,4 @@ export function createTarget(): TargetProfile {
 }
 
 export type { TargetProfile } from "./target";
-export type { CapabilityFlags, TenancyContext } from "./target";
+export type { CapabilityFlags, DirectLoginTenant, TenancyContext } from "./target";

--- a/test/conformance/src/targets/local-execution.ts
+++ b/test/conformance/src/targets/local-execution.ts
@@ -61,6 +61,9 @@ export class LocalExecutionTarget implements TargetProfile {
     // Single-operator trusted-local posture, as on `local` — the runner's
     // STIGMER_TOKEN is a proxy bearer the server never verifies.
     requiresAuthentication: false,
+    // No platform identity tenant on the single-operator posture; the OSS
+    // OIDC lane is a different contract (target.ts).
+    directLogin: false,
   };
 
   private temporal: RunningTemporal | undefined;

--- a/test/conformance/src/targets/local.ts
+++ b/test/conformance/src/targets/local.ts
@@ -49,6 +49,9 @@ export class LocalTarget implements TargetProfile {
     // posture, zero verifiers — a tokenless request IS the operator (the
     // authentication suite pins that admission, entry 20260904.02).
     requiresAuthentication: false,
+    // No platform identity tenant on the single-operator posture; the OSS
+    // OIDC lane is a different contract (target.ts).
+    directLogin: false,
   };
 
   private server: RunningServer | undefined;

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -248,6 +248,35 @@ export interface CapabilityFlags {
   // multiTenant: a self-host with STIGMER_OIDC_ISSUER set requires
   // authentication with neither of those.
   requiresAuthentication: boolean;
+  // The edition has a lane for the PLATFORM'S OWN identity tenant: the raw
+  // access token a console, desktop, CLI or MCP client obtains from that
+  // tenant is verified at position 1 and its subject RESOLVED to the
+  // caller's identity-account id before authorization runs (Java's
+  // RequestCallerIdentityMapper; the TS composition's direct-idp verifier,
+  // stigmer-cloud#604). An unknown subject is admitted "idp-shaped" so
+  // whoAmI answers NOT_FOUND and provisionMyAccount can create the account
+  // — the console's first-login flow. True for cloud. False for the local
+  // OSS targets BY DESIGN: the OSS OIDC lane (STIGMER_OIDC_ISSUER) stamps
+  // the raw subject as the identity — a self-host contract, not this one —
+  // and the trusted-local posture has no tenant at all.
+  directLogin: boolean;
+}
+
+// A platform identity tenant the target can mint for — see
+// TargetProfile.directLoginTenant.
+export interface DirectLoginTenant {
+  // The issuer exactly as the tenant publishes it (Auth0: trailing slash).
+  readonly issuer: string;
+  // The audience every first-party client requests.
+  readonly apiAudience: string;
+  // The hosted MCP server's audience, when the tenant mints for one.
+  readonly mcpAudience: string | undefined;
+  // A token the tenant would issue: RS256 under the tenant's kid, `iss` as
+  // published, `aud` as given (default: the API audience, in the array
+  // form Auth0 mints beside its userinfo entry), no profile claims — an
+  // ACCESS token, not an id token. `ttlSeconds` may be negative to mint an
+  // already-expired token.
+  mint(input: { subject: string; audience?: string; ttlSeconds?: number }): string;
 }
 
 // Tenancy scope a test operates within. Locally this is just a unique org slug
@@ -314,6 +343,20 @@ export interface TargetProfile {
   // enforced — a readout that forgets the variable fails loudly, never
   // false-greens); the local targets' posture IS what their flag says.
   edgeAuthenticationBypass?(): string | undefined;
+
+  // The platform identity tenant the server under test trusts, as a MINT:
+  // the suite forges nothing — it asks the target for tokens shaped exactly
+  // like the ones the tenant issues (its published issuer, an audience it
+  // mints for, RS256 under a kid its JWKS carries) and drives the server's
+  // direct-login lane with them. Present only where the harness OWNS the
+  // tenant's signing key — the readout substrate's mock tenant, declared
+  // through CLOUD_ENV.directLogin* — never on a deployed endpoint (a real
+  // tenant's key is not conformance's to hold) and never on the hermetic
+  // launcher (test security mode has no edge). Where absent, the
+  // direct-login suite skips VISIBLY with the target's reason
+  // (directLoginUnavailable). Valid only after setup().
+  directLoginTenant?(): DirectLoginTenant;
+  directLoginUnavailable?(): string;
 
   // Provision an isolated tenancy scope for a test. cleanupTenancy releases it.
   provisionTenancy(): Promise<TenancyContext>;


### PR DESCRIPTION
## Summary

Adds the conformance suite's direct-login arms: the raw access token a console, desktop, CLI or MCP client obtains from the platform's own identity tenant, driven through the server's position-1 lane (verify → resolve `sub` to the account → idp-shaped admission for a first login). The OSS-side half of stigmer-cloud#604 (X1 checklist finding S1); the composition's lane ships in [stigmer-cloud#607](https://github.com/stigmer/stigmer-cloud/pull/607).

## Context

Five green cloud readouts never drove this lane because the cloud target authenticates with PlatformClient-minted tokens — which is how the composition reached the dark soak without any verifier for its own tenant. The suite now has an arm for it, gated the way the authentication suite gates its credential arms: a visible skip wherever the environment cannot own the tenant's key.

## Changes

- `CapabilityFlags.directLogin` — true on cloud; false on the local targets by design (the OSS OIDC lane stamps the raw subject — a self-host contract, not this one).
- `TargetProfile.directLoginTenant?()` / `directLoginUnavailable?()` — the cloud target exposes a mint only when `CLOUD_ENV.directLogin*` is set (`STIGMER_CONFORMANCE_CLOUD_DIRECT_LOGIN_ISSUER` / `_SIGNING_KEY_BASE64` / `_KID` / `_API_AUDIENCE` / optional `_MCP_AUDIENCE`); the group is all-or-nothing.
- `harness/direct-login-tenant.ts` — a `node:crypto` mint shaped like what Auth0 issues a first-party client (slashed `iss`, array `aud` beside the userinfo entry, `scope`/`azp`/`jti`, no profile claims — an access token, not an id token); the claim-shape and signing helpers are exported so the stranger-signature arm fails for the signature alone.
- `harness/clients.ts` — identity-account command/query clients on the bundle.
- `suites/direct-login.conformance.test.ts` — six arms: idp-shaped admission (`whoAmI` NOT_FOUND with the byte-pinned copy, never UNAUTHENTICATED); a first login end to end (`provisionMyAccount` from `/userinfo`, `provisioning_mode=direct`, the personal org visible to the new account — its owner tuple names the `ida_`, not the raw subject — `whoAmI` resolving to the account; cleaned up); the MCP audience accepted; a foreign audience, an expired token, and a stranger's signature refused with the Java `classifyAuthError` copy byte-pinned.
- README: the arms and their environment contract.

## Test plan

- Against the TS composition on the spike substrate (stigmer-cloud#607 branch; `spike/identity-tenant.ts` serving the mock tenant; the composition booted with `STIGMER_IDP_URL` at it): `vitest run -c vitest.cloud.config.ts src/suites/direct-login.conformance.test.ts` — **6 passed**, zero residue on the store after the cleanup.
- Local target: the file skips at describe level (`directLogin: false`). The local server does not boot on this machine at all (`no such module: fts5` — the untouched authentication suite fails identically), so no other local arm was exercised here.
- Hermetic Java target: skips visibly via `edgeAuthenticationBypass` (test security mode) — Java's lane is covered by `test/integration-security`.
- `tsc`: the two pre-existing errors in `memory` / `agentexecution` suites are untouched; every file this PR adds or edits typechecks.
