### PR TITLE
chore(bazel): regenerate BUILD for conformance-cloudenv's main_test.go

### DIFF
--- a/test/integration/cmd/conformance-cloudenv/BUILD.bazel
+++ b/test/integration/cmd/conformance-cloudenv/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "conformance-cloudenv_lib",
@@ -12,4 +12,10 @@ go_binary(
     name = "conformance-cloudenv",
     embed = [":conformance-cloudenv_lib"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "conformance-cloudenv_test",
+    srcs = ["main_test.go"],
+    embed = [":conformance-cloudenv_lib"],
 )


### PR DESCRIPTION
## Summary

- `ci.bazel`'s gazelle freshness step is red on `main` since `e243b85bb` (#982): `test/integration/cmd/conformance-cloudenv/main_test.go` (added by #956) has no `go_test` target, and the step had not run on the commits in between — #982 was the first to touch its trigger paths.
- This PR is exactly `./bazelw run //:gazelle`'s output: the `go_test` target and its `load` line. Nothing else.

## Test plan

- [x] `./bazelw run //:gazelle` in a fresh worktree at `e243b85bb` produces this diff and nothing more
- [x] `./bazelw build //test/integration/cmd/conformance-cloudenv:conformance-cloudenv_test` compiles the new target
- [ ] `ci.bazel` green on this PR

Found by the pre-roll review of stigmer-cloud entry `20260905.06.sp.metering-execution-context-via-seam`.

Made with [Cursor](https://cursor.com)