### PR TITLE
fix(stigmer-server): the API-key verifier rides the authentication posture, not the OIDC issuer

### DIFF
--- a/.cursor/rules/backend/ts-server-guidelines.mdc
+++ b/.cursor/rules/backend/ts-server-guidelines.mdc
@@ -151,9 +151,17 @@ eventually violate creatively.
   `ServerExtension.requireAuthentication: true` — a single-declaration
   registry point in the edition's shape (one unit declares, a second
   throws; the literal type forbids `false`). A composition whose own
-  verifiers are its only admission path declares it; it never borrows
-  the issuer knob (that registers the OSS verifiers ahead of its own). A
-  declared posture with zero composed verifiers is a boot throw. Under
+  verifiers resolve its users declares it; it never borrows the issuer
+  knob (that registers the OSS OIDC verifier ahead of its own and
+  resolves callers to the token's `sub`). **The OSS API-key verifier
+  rides the POSTURE, not the issuer** (stigmer#984): whenever either
+  source is on, `apikey` is composed FIRST (Java's provider order — the
+  apikey domain is open-source tier and mints `stk_` keys in every
+  composition, so a server with an authentication posture honors the
+  keys it issues); the OIDC verifier is the issuer arm's alone. A
+  declared posture whose unit registers no verifier of its own is a boot
+  throw — the API-key lane alone cannot admit the first caller (O3
+  ruling Q1's bootstrap problem). Under
   the posture, tokenless requests are refused EXCEPT where
   `isAuthenticationExempt` says so: `is_public` methods (our protos) and
   the services in `AUTHENTICATION_EXEMPT_SERVICES` by name (third-party

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -1076,43 +1076,53 @@ export async function composeServer(
   const inProcessWiring = createInProcessClients(routes, logger);
   inProcess = inProcessWiring.clients;
 
-  // The auth-enabled modeled state (O3 rulings Q1+Q2): a configured OIDC
-  // issuer registers the two OSS verifiers — API tokens first (cheap
-  // prefix claim, the Java ProviderManager's order), then OIDC — ahead of
-  // the extension entries ("OSS entries first", the registry contract),
-  // and turns on the require-authentication posture. No issuer = zero OSS
-  // verifiers; the wire posture is then the composition's to declare.
-  // The runner's credential in this posture is an operator-minted API
-  // token via STIGMER_TOKEN (ruling Q3) — no runner-specific verifier.
+  // The require-authentication posture has two sources OR'd here: the
+  // OSS OIDC issuer (O3 rulings Q1+Q2) and a composed unit's declaration
+  // (registry point, entry 20260904.02). Neither source = the OSS
+  // trusted-local posture, byte-identical wire behavior.
   const authEnabled = config.oidcIssuer !== "";
-  const identityVerifiers = authEnabled
-    ? [
-        newApiKeyIdentityVerifier(store),
-        newOidcIdentityVerifier({
-          issuer: config.oidcIssuer,
-          audience: config.oidcAudience,
-        }),
-        ...extensions.identityVerifiers,
-      ]
-    : extensions.identityVerifiers;
-  // The require-authentication posture has two sources OR'd here — the
-  // issuer arm above, and a composed unit's declaration (registry point,
-  // entry 20260904.02): a composition whose own verifiers are the only
-  // admission path cannot borrow the issuer knob (it would register the
-  // OSS verifiers ahead of its own and re-route who its users resolve
-  // to). Neither source = the OSS trusted-local posture, byte-identical
-  // wire behavior. A declared posture with ZERO composed verifiers is a
-  // boot fault, not a running server: nothing could ever authenticate,
-  // so every non-exempt request would be refused — the same class as a
-  // misconfigured registry (DD-006 §2b), caught before any side effect.
   const requireAuthentication =
     authEnabled || extensions.requireAuthentication !== undefined;
+  // What the posture registers, in Java's ProviderManager order (opaque
+  // keys first — the cheapest claim — then the JWT lanes), ahead of the
+  // extension entries ("OSS entries first", the registry contract):
+  //   - the API-key verifier rides the POSTURE, not the issuer
+  //     (stigmer#984): the apikey domain is open-source tier and mints
+  //     `stk_` keys in every composition, so any composition with an
+  //     authentication posture must honor the keys it issues. Gating it on
+  //     the issuer left a posture-declaring composition minting keys
+  //     nothing verified.
+  //   - the OIDC verifier rides the ISSUER alone: it resolves callers to
+  //     the token's `sub`, which is the wrong principal for a composition
+  //     whose own lanes resolve users to their account ids — that is why a
+  //     declared posture never borrows the issuer knob.
+  // The runner's credential in either posture is an operator-minted API
+  // token via STIGMER_TOKEN (O3 ruling Q3) — no runner-specific verifier.
+  const identityVerifiers = [
+    ...(requireAuthentication ? [newApiKeyIdentityVerifier(store)] : []),
+    ...(authEnabled
+      ? [
+          newOidcIdentityVerifier({
+            issuer: config.oidcIssuer,
+            audience: config.oidcAudience,
+          }),
+        ]
+      : []),
+    ...extensions.identityVerifiers,
+  ];
+  // A declared posture whose unit registers no verifier OF ITS OWN is a
+  // boot fault, not a running server. The API-key lane alone cannot admit
+  // the first caller — minting a key requires an authenticated caller, so
+  // an apikey-only chain locks everyone out forever (O3 ruling Q1's
+  // first-key bootstrap problem, which is why apikey-only mode was
+  // deferred). The same class as a misconfigured registry (DD-006 §2b),
+  // caught before any side effect.
   if (
     extensions.requireAuthentication !== undefined &&
-    identityVerifiers.length === 0
+    extensions.identityVerifiers.length === 0
   ) {
     throw new Error(
-      `extension '${extensions.requireAuthentication.declaredBy}' declares the require-authentication posture, but the composition registers no identity verifier — nothing could authenticate, so every non-public request would be refused; register a verifier or omit the declaration`,
+      `extension '${extensions.requireAuthentication.declaredBy}' declares the require-authentication posture, but registers no identity verifier of its own — the OSS API-key lane alone cannot admit the first caller (nobody could mint a key), so every non-public request would be refused; register a verifier or omit the declaration`,
     );
   }
   const postureSources = [

--- a/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
+++ b/backend/services/stigmer-server/src/extensions/__tests__/extension-composition.test.ts
@@ -41,6 +41,8 @@ import { BillingQueryController } from "@stigmer/protos/ai/stigmer/billing/v1/qu
 import { BillingAccountSchema } from "@stigmer/protos/ai/stigmer/billing/v1/billing_account_pb";
 import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
 import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { ApiKeyCommandController } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/command_pb";
+import { ApiKeyQueryController } from "@stigmer/protos/ai/stigmer/iam/apikey/v1/query_pb";
 import {
   PlatformQueryController,
   ServerEdition,
@@ -261,14 +263,23 @@ describe("extension composition (caller guards)", () => {
 
 /**
  * The require-authentication registry point (entry 20260904.02): a unit
- * whose own verifiers are the only admission path declares the posture
+ * whose own verifiers are the admission path declares the posture
  * WITHOUT an OSS OIDC issuer, and the serving chain refuses tokenless
  * non-exempt requests exactly as the issuer arm does — the Java copy,
  * is_public and the health service still reachable, a claimed credential
  * admitted. The in-process transport is untouched by construction (it
- * carries no require-auth arm). The zero-verifier invariant is the boot
- * throw arm: a declared posture nothing could ever satisfy is a
- * composition fault, never a running server that refuses everything.
+ * carries no require-auth arm).
+ *
+ * The API-key lane rides the POSTURE, not the issuer (stigmer#984): a
+ * server that mints `stk_` keys under a declared posture must honor them,
+ * so the OSS apikey verifier is composed FIRST whenever the posture is on
+ * — a key minted over the unit's own credential authenticates as its
+ * owner, and a garbage `stk_` bearer gets the lane's own refusal, never
+ * the chassis's unclaimed-token copy. The zero-verifier invariant stays
+ * the boot throw arm, scoped to the unit's OWN verifiers: the API-key
+ * lane alone cannot admit the first caller (nobody could mint a key), so
+ * a posture with nothing else is a composition fault, never a running
+ * server that refuses everything.
  */
 describe("extension composition (require-authentication posture)", () => {
   let server: ComposedServer;
@@ -380,7 +391,99 @@ describe("extension composition (require-authentication posture)", () => {
     expect(orgs.entries).toEqual([]);
   });
 
-  it("boot logs the resolved posture and names the declaring unit", () => {
+  it("a credential nothing claims keeps the chassis's unclaimed-token refusal", async () => {
+    const client = createClient(
+      OrganizationQueryController,
+      transportWith("not-a-credential"),
+    );
+    const failure = await client
+      .findMyOrganizations({})
+      .then(() => null)
+      .catch((error: unknown) => ConnectError.from(error));
+    expect(failure?.code).toBe(Code.Unauthenticated);
+    expect(failure?.rawMessage).toBe(
+      "the presented token was not accepted by any configured identity verifier",
+    );
+  });
+
+  describe("the API-key lane rides the declared posture (stigmer#984)", () => {
+    let apiKeyPlaintext: string;
+    let apiKeyId: string;
+
+    it("a key minted over the unit's credential is owned by that identity", async () => {
+      const command = createClient(
+        ApiKeyCommandController,
+        transportWith(CLAIMED_TOKEN),
+      );
+      const created = await command.create({
+        apiVersion: "iam.stigmer.ai/v1",
+        kind: "ApiKey",
+        metadata: { name: "posture key", org: "local" },
+        spec: {},
+      });
+      apiKeyPlaintext = created.spec?.keyHash ?? "";
+      apiKeyId = created.metadata?.id ?? "";
+      expect(apiKeyPlaintext.startsWith("stk_")).toBe(true);
+      expect(created.status?.audit?.specAudit?.createdBy?.id).toBe("ida_fake");
+    });
+
+    it("the minted key authenticates as its owning identity — no OIDC issuer anywhere", async () => {
+      const query = createClient(
+        ApiKeyQueryController,
+        transportWith(apiKeyPlaintext),
+      );
+      const fetched = await query.get({ value: apiKeyId });
+      expect(fetched.metadata?.id).toBe(apiKeyId);
+
+      // A write over the key stamps the OWNER on the audit: the key is the
+      // user, not a second principal (the OSS verifier's contract, kept).
+      const command = createClient(
+        ApiKeyCommandController,
+        transportWith(apiKeyPlaintext),
+      );
+      const second = await command.create({
+        apiVersion: "iam.stigmer.ai/v1",
+        kind: "ApiKey",
+        metadata: { name: "minted over the api key", org: "local" },
+        spec: {},
+      });
+      expect(second.status?.audit?.specAudit?.createdBy?.id).toBe("ida_fake");
+    });
+
+    it("a garbage stk_ bearer gets the lane's own refusal, not the chassis's unclaimed copy", async () => {
+      const client = createClient(
+        OrganizationQueryController,
+        transportWith("stk_not-a-real-key"),
+      );
+      const failure = await client
+        .findMyOrganizations({})
+        .then(() => null)
+        .catch((error: unknown) => ConnectError.from(error));
+      expect(failure?.code).toBe(Code.Unauthenticated);
+      expect(failure?.rawMessage).toBe("invalid token");
+    });
+
+    it("deleting the key revokes it on the very next request", async () => {
+      const command = createClient(
+        ApiKeyCommandController,
+        transportWith(CLAIMED_TOKEN),
+      );
+      await command.delete({ value: apiKeyId });
+
+      const query = createClient(
+        ApiKeyQueryController,
+        transportWith(apiKeyPlaintext),
+      );
+      const failure = await query
+        .findAll({})
+        .then(() => null)
+        .catch((error: unknown) => ConnectError.from(error));
+      expect(failure?.code).toBe(Code.Unauthenticated);
+      expect(failure?.rawMessage).toBe("invalid token");
+    });
+  });
+
+  it("boot logs the resolved posture, names the declaring unit, and lists the API-key lane first", () => {
     const line = logLines.find((entry) =>
       entry.includes("authentication posture resolved"),
     );
@@ -392,10 +495,10 @@ describe("extension composition (require-authentication posture)", () => {
     };
     expect(parsed.posture).toBe("required");
     expect(parsed.source).toBe("extension 'fake-identity'");
-    expect(parsed.verifiers).toBe("fake-verifier");
+    expect(parsed.verifiers).toBe("apikey, fake-verifier");
   });
 
-  it("a declared posture with zero composed verifiers is a boot throw naming the unit", async () => {
+  it("a declared posture whose unit registers no verifier of its own is a boot throw naming the unit — the API-key lane alone cannot bootstrap", async () => {
     const orphanDir = mkdtempSync(path.join(tmpdir(), "require-auth-orphan-"));
     try {
       await expect(
@@ -415,7 +518,7 @@ describe("extension composition (require-authentication posture)", () => {
           host: "127.0.0.1",
         }),
       ).rejects.toThrowError(
-        /extension 'verifierless' declares the require-authentication posture, but the composition registers no identity verifier/,
+        /extension 'verifierless' declares the require-authentication posture, but registers no identity verifier of its own/,
       );
     } finally {
       rmSync(orphanDir, { recursive: true, force: true });

--- a/backend/services/stigmer-server/src/extensions/registry.ts
+++ b/backend/services/stigmer-server/src/extensions/registry.ts
@@ -99,16 +99,21 @@ export interface ServerExtension {
    * OIDC issuer: a request with no credential on a non-`is_public` method
    * is UNAUTHENTICATED "authentication token missing" (the Java
    * interceptor's copy), instead of falling to the trusted-local
-   * single-operator identity. A composition whose identity verifiers ARE
-   * its only admission path declares this — the OSS issuer arm cannot be
-   * reused for it, because configuring the issuer also registers the OSS
-   * verifiers ahead of the composition's own (compose.ts).
+   * single-operator identity. A composition whose own identity verifiers
+   * resolve its users declares this — the OSS issuer arm cannot be reused
+   * for it, because configuring the issuer also registers the OSS OIDC
+   * verifier ahead of the composition's own (compose.ts). Declaring the
+   * posture DOES compose the OSS API-key verifier, first in the chain
+   * (stigmer#984): the apikey domain mints `stk_` keys in every
+   * composition, and a server with an authentication posture honors the
+   * keys it issues.
    *
    * Typed as the literal `true`: the field is declared or omitted, never
    * set to `false` — there is no "declared lenient" state to validate at
    * boot. Exactly one unit may declare it (a second throws naming both);
    * the declaring unit is named in the boot log and in the compose.ts
-   * invariant that refuses a posture with zero composed verifiers.
+   * invariant that refuses a posture whose unit registers no verifier of
+   * its own (the API-key lane alone cannot mint the first key).
    */
   readonly requireAuthentication?: true;
   /** The authorization decision seam (single-instance point; consumed by O2). */

--- a/backend/services/stigmer-server/src/pipeline/interceptors/auth.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/auth.ts
@@ -41,9 +41,10 @@
  *     20260827.06): with requireAuthentication on — compose.ts sets it
  *     when STIGMER_OIDC_ISSUER is configured OR when a composed extension
  *     unit declares `requireAuthentication` (entry 20260904.02, the
- *     cloud's ask: its verifiers are its only admission path, and the
- *     issuer knob cannot stand in because it also registers the OSS
- *     verifiers ahead of the composition's) — a tokenless request is
+ *     cloud's ask: its own lanes resolve its users, and the issuer knob
+ *     cannot stand in because it also registers the OSS OIDC verifier
+ *     ahead of them; the OSS API-key lane, by contrast, rides EITHER
+ *     posture source — stigmer#984) — a tokenless request is
  *     UNAUTHENTICATED "authentication token missing" (the Java
  *     interceptor's byte-pinned copy), EXCEPT where isAuthenticationExempt
  *     says so: is_public-marked methods (the Java isPublic skip) and the

--- a/test/conformance/src/suites/authentication.conformance.test.ts
+++ b/test/conformance/src/suites/authentication.conformance.test.ts
@@ -19,7 +19,11 @@
 //   - a credential NOTHING claims: refused UNAUTHENTICATED where a verifier
 //     is composed (code only — Java's classifyAuthError copy and the TS
 //     chassis's differ by design); admitted as the operator on the
-//     verifier-less local targets (the O2 ruling-Q6 fall-through).
+//     verifier-less local targets (the O2 ruling-Q6 fall-through);
+//   - an API-KEY credential (stigmer#984): a server-minted `stk_` key
+//     authenticates AS its owner wherever a posture is on — a write through
+//     it is audited to the owning account; garbage or deleted keys refuse
+//     with the byte-pinned `invalid token` both editions share.
 // Coverage of the absent-token arm was ZERO before this suite: every
 // conformance RPC carried the primary credential, so a composition that
 // admitted anonymous callers as `system` passed five green readouts
@@ -36,9 +40,11 @@
 // is_public and health arms hold on every environment regardless.
 import { Code } from "@connectrpc/connect";
 import { HealthCheckResponse_ServingStatus } from "@stigmer/protos/grpc/health/v1/health_pb";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 
 import { expectGrpcCode } from "../contract/errors";
+import { FixtureTracker } from "../harness/fixtures";
+import { uniqueName } from "../support/naming";
 import { createTarget, type TargetProfile } from "../targets";
 
 // The Java interceptor's refusal copy, byte-pinned on both editions
@@ -137,5 +143,125 @@ describe("authentication posture: a request with a credential nothing claims", (
       Array.isArray(response.entries),
       "verifier-less posture: an unclaimed credential falls through to the operator",
     ).toBe(true);
+  });
+});
+
+// The API-key credential (stigmer#984; the cloud's stigmer-cloud#627): an
+// `stk_` key the server itself minted must authenticate AS its owning
+// account wherever an authentication posture is on — the SDKs, the CLI and
+// the hosted MCP server present exactly this credential. The proof is
+// edition-agnostic: a write made THROUGH the key carries the key owner's
+// id on its audit, the same principal the primary credential carries.
+// Where authentication is required, a garbage or deleted key is refused
+// with the byte-pinned copy both editions share (`invalid token` — the
+// Java classifyAuthError fallback and the TS apikey verifier's
+// INVALID_TOKEN_MESSAGE are the same bytes by contract). On verifier-less
+// local targets the key is one more unclaimed credential and falls through
+// to the operator (ruling Q6) — pinned as that contract, not as key
+// verification.
+describe("authentication posture: a request with an API-key credential", () => {
+  const fixtures = new FixtureTracker();
+  const INVALID_TOKEN_MESSAGE = "invalid token";
+
+  afterEach(async () => {
+    await fixtures.cleanup();
+  });
+
+  async function mintKey(): Promise<{
+    id: string;
+    plaintext: string;
+    ownerId: string;
+  }> {
+    const { org } = await target.provisionTenancy();
+    const created = await target.clients().apiKeyCommand.create({
+      apiVersion: "iam.stigmer.ai/v1",
+      kind: "ApiKey",
+      metadata: { name: uniqueName("auth-key"), org },
+      spec: {},
+    });
+    const id = created.metadata?.id ?? "";
+    fixtures.defer(() => target.clients().apiKeyCommand.delete({ value: id }));
+    return {
+      id,
+      plaintext: created.spec?.keyHash ?? "",
+      ownerId: created.status?.audit?.specAudit?.createdBy?.id ?? "",
+    };
+  }
+
+  it("a minted key authenticates as its owning account — a write through the key carries the owner's id", async (ctx) => {
+    skipIfEdgeBypassed(ctx);
+    const key = await mintKey();
+    expect(key.plaintext, "create returns the plaintext exactly once").toMatch(
+      /^stk_/,
+    );
+    expect(key.ownerId, "the key's audit names its owner").not.toBe("");
+
+    const asKey = target.clientsPresenting(key.plaintext);
+    const fetched = await asKey.apiKeyQuery.get({ value: key.id });
+    expect(fetched.metadata?.id, "a read through the key answers").toBe(key.id);
+
+    const { org } = await target.provisionTenancy();
+    const mintedOverKey = await asKey.apiKeyCommand.create({
+      apiVersion: "iam.stigmer.ai/v1",
+      kind: "ApiKey",
+      metadata: { name: uniqueName("over-key"), org },
+      spec: {},
+    });
+    const overKeyId = mintedOverKey.metadata?.id ?? "";
+    fixtures.defer(() =>
+      target.clients().apiKeyCommand.delete({ value: overKeyId }),
+    );
+    expect(
+      mintedOverKey.status?.audit?.specAudit?.createdBy?.id,
+      "the key IS the owner — a write over it is audited to the owning account, never to a second principal",
+    ).toBe(key.ownerId);
+  });
+
+  it("a garbage stk_ credential is refused with the shared copy where authentication is required, admitted as the operator where it is not", async (ctx) => {
+    skipIfEdgeBypassed(ctx);
+    const presenting = target.clientsPresenting(
+      "stk_conformance-not-a-real-key",
+    );
+    if (target.capabilities.requiresAuthentication) {
+      const error = await expectGrpcCode(
+        () => presenting.organizationQuery.findMyOrganizations({}),
+        Code.Unauthenticated,
+        "a garbage stk_ credential under the require-authentication posture",
+      );
+      expect(
+        error.rawMessage,
+        "the API-key lane's refusal is a cross-edition wire constant",
+      ).toBe(INVALID_TOKEN_MESSAGE);
+      return;
+    }
+    const response = await presenting.organizationQuery.findMyOrganizations({});
+    expect(
+      Array.isArray(response.entries),
+      "verifier-less posture: an stk_ credential is unclaimed and falls through to the operator",
+    ).toBe(true);
+  });
+
+  it("a deleted key is refused on the very next request where authentication is required", async (ctx) => {
+    skipIfEdgeBypassed(ctx);
+    if (!target.capabilities.requiresAuthentication) {
+      ctx.skip(
+        "verifier-less target: revocation has no lane to act on (the credential falls through to the operator)",
+      );
+    }
+    const key = await mintKey();
+    await target.clients().apiKeyCommand.delete({ value: key.id });
+
+    const error = await expectGrpcCode(
+      () =>
+        target
+          .clientsPresenting(key.plaintext)
+          .organizationQuery.findMyOrganizations({}),
+      Code.Unauthenticated,
+      "a deleted key on the request after its deletion",
+    );
+    expect(
+      error.rawMessage,
+      "revocation is deletion, effective on the next request, with the shared copy",
+    ).toBe(INVALID_TOKEN_MESSAGE);
   });
 });


### PR DESCRIPTION
## Summary

The OSS API-key verifier now composes whenever the server has an authentication posture — from the OIDC issuer OR from a unit's `requireAuthentication` declaration — first in the chain. Until now it registered only under `STIGMER_OIDC_ISSUER`, so a posture-declaring composition minted `stk_` keys and accepted none of them.

## Context

The `apikey` domain is open-source tier and serves in every composition, so every composition mints `stk_` keys. O3's plan gate (entry 20260827.06, Q1) tied both OSS verifiers to the issuer knob and deferred "apikey-only mode" over the first-key bootstrap problem — a ruling made before the require-authentication registry point existed (entry 20260904.02). A composition that declares the posture brings its own bootstrap lane, so the API-key verifier can ride beside it; the boot guard, re-scoped to the declaring unit's OWN verifiers, keeps O3's protection exactly. The cloud composition is the first to hit the gap: after the X1 cutover every SDK, CLI and hosted-MCP caller presenting a key would be refused at the door (stigmer-cloud#627).

## Changes

- `boot/compose.ts` — the apikey verifier is composed FIRST under either posture source (Java's provider order: opaque keys, then the JWT lanes); the OIDC verifier stays the issuer arm's alone; the zero-verifier boot guard now checks the declaring unit's own verifiers and says why (the API-key lane alone cannot admit the first caller). The comment block is rewritten around what the posture registers and why.
- Doctrine moved with the code in all four places that said a posture "never borrows the issuer knob (that registers the OSS verifiers ahead of its own)": `.cursor/rules/backend/ts-server-guidelines.mdc`, the `compose.ts` block, the `pipeline/interceptors/auth.ts` intent header, the `extensions/registry.ts` point. The reason behind that sentence was always the OIDC verifier's principal, never the API-key lane.
- `extensions/__tests__/extension-composition.test.ts` — red-first arms under an extension-declared posture with no issuer: a key minted over the unit's credential admits its `stk_` bearer as the owner; a garbage `stk_` gets the lane's own `invalid token` (not the chassis's unclaimed-token copy); delete revokes on the next request; the boot log lists `apikey` first; the boot throw still fires for a unit with no verifier of its own.
- `test/conformance/src/suites/authentication.conformance.test.ts` — an api-key credential arm on the existing `clientsPresenting` seam: a write through the key is audited to the owning account (the edition-agnostic identity proof); garbage and deleted keys refuse with the byte-pinned `invalid token` where authentication is required; visible skips where no verifier is composed.

## Implementation notes

- No wire change for the two existing postures: no posture → still zero verifiers, trusted-local; issuer-configured → the apikey verifier was already first.
- No cache in front of the key lookup (the O3 ruling — revocation lands on the next request). `Store.findByField("spec.keyHash")` is a full-kind scan on both drivers; physical indexing is the driver's phase-2 concern per the store interface doc and is tracked separately.
- The boot-throw message changed wording (`registers no identity verifier of its own`); it is a boot fault string, not a wire contract.

## Breaking changes

- None on the wire. Any composition declaring `requireAuthentication` now honors `stk_` keys it mints — the intended behavior, previously absent.

## Test plan

- Red first: the five new/changed arms failed against unchanged `compose.ts` with exactly the predicted messages; green after the change.
- `tsc --noEmit` clean; the full `stigmer-server` suite: 166 files, 2194 passed, 0 failed.
- Conformance `local` slice for the authentication suite: 6 passed, 1 visible skip (revocation has no lane on a verifier-less target). The require-authentication arms exercise on the deployed cloud composition readout.
- Live proof rides the cloud entry (`20260906.01.sp.api-key-verifier-lane`): the dark composition's boot log lists `apikey, stigmer-platform-token, direct-idp, federated-idp`; the dark-sandbox smoke gains an `apikey` arm.

## Checklist

- [x] Tests written red-first and green
- [x] Guidelines and inline doctrine updated in the same change
- [x] No proto change; no wire change for existing postures

Closes #984

Made with [Cursor](https://cursor.com)