### PR TITLE
test(conformance): land the C5-ruled billing rows as arms — auto-recharge, payment-method webhooks, pricing governance

### DIFF
--- a/test/conformance/inventory/cloud-capabilities.yaml
+++ b/test/conformance/inventory/cloud-capabilities.yaml
@@ -423,18 +423,18 @@ rows:
     lane: >-
       rpc.setAutoRechargeConfig
     behavior: >-
-      setAutoRechargeConfig persists the threshold and top-up amounts onto the account (visible on getBillingAccount) and answers INVALID_ARGUMENT for an invalid configuration.
+      setAutoRechargeConfig persists the threshold, top-up and monthly-cap amounts onto the account (visible on getBillingAccount) whether enabling or disabling; disabling still refuses a negative amount INVALID_ARGUMENT; enabling requires a saved payment method FIRST (FAILED_PRECONDITION "A saved payment method is required to enable auto-recharge. Purchase a credit pack first.") and then validates the amounts in order — threshold positive, amount positive, cap at least the amount — each INVALID_ARGUMENT with the engine's copy; a refused enable changes nothing.
     java_source: >-
-      domain/billing/request/handler/SetAutoRechargeConfigHandler.java:89-95; domain/billing/service/AutoRechargeService.java
+      domain/billing/request/handler/SetAutoRechargeConfigHandler.java:74-102; domain/billing/service/BillingAccountService.java:87-151
     java_test: >-
-      domain/billing/service/AutoRechargeServiceTest.java
+      domain/billing/service/BillingAccountServiceTest.java
     class: behavior
-    disposition: debris-candidate
+    disposition: conformance
     observability: launcher
     caller: primary
-    needs: [unfunded-org]
+    needs: [unfunded-org, fake-stripe]
     note: >-
-      Auto-recharge (this RPC plus the two payment_intent.* webhook handlers) is a feature with no known production user; presented for the owner's Q6 ruling.
+      RULED PORTED 2026-09-06 (C5 gate, Q1, re-ruled in session): the read-only census found zero usage, but auto-recharge is a LIVE PRODUCT SURFACE — the console renders AutoRechargeCard and the Python, Java and Go SDKs expose setAutoRechargeConfig — so a cut would have been a product decision. The arm needs the fake Stripe because the only way an account gets a saved card from outside Java is the payment_method.attached webhook. The NOT_FOUND branch for an org without an account is unreachable black-box (E5 provisions every org an account; a foreign org is PERMISSION_DENIED first).
   - id: billing.rpc.set-auto-recharge-config.outsider-permission-denied
     surface: billing
     lane: >-
@@ -446,10 +446,12 @@ rows:
     java_test: >-
       none
     class: carve-out
-    disposition: debris-candidate
+    disposition: conformance
     observability: launcher
     caller: outsider
     needs: [unfunded-org]
+    note: >-
+      RULED PORTED 2026-09-06 (C5 gate, Q1) with its lane.
 
   # --- engine lanes (platform can_execute_billing_ops) -----------------------
   - id: billing.rpc.engine-lanes.ordinary-caller-permission-denied
@@ -624,63 +626,86 @@ rows:
     lane: >-
       rpc.upsertModelPricingBaseline
     behavior: >-
-      An operator's upsertModelPricingBaseline for a new model id is listed by listModelPricingBaselines with the given prices; an invalid entry answers INVALID_ARGUMENT.
+      An operator's upsertModelPricingBaseline for a new model key is listed ACTIVE by listModelPricingBaselines with the given prices and the server's stamps (baseline_id, decided_by, effective_at; supersedes_baseline_id empty); a second upsert of the same key supersedes the first — one ACTIVE per key, the prior revision SUPERSEDED and chained through supersedes_baseline_id, both visible with include_history (ACTIVE first); a variant declaring a Cursor token rate answers INVALID_ARGUMENT "Variant '<key>' declares a Cursor Token Rate — variants inherit the base entry's rate; set it on the base pricing block instead.".
     java_source: >-
-      domain/billing/request/handler/UpsertModelPricingBaselineHandler.java:102; domain/billing/service/ModelPricingBaselineService.java
+      domain/billing/request/handler/UpsertModelPricingBaselineHandler.java:99-173; domain/billing/request/handler/ListModelPricingBaselinesHandler.java:76-84
     java_test: >-
       domain/billing/request/handler/UpsertModelPricingBaselineHandlerTest.java; domain/billing/request/handler/ListModelPricingBaselinesHandlerTest.java
     class: behavior
-    disposition: debris-candidate
+    disposition: conformance
     observability: launcher
     caller: operator
     needs: [none]
     note: >-
-      The pricing-governance operator lanes (upsert/retire/decide/list/governance) are operator tooling with a console; presented for the Q6 ruling as one group.
+      RULED PORTED 2026-09-06 (C5 gate, Q1): the pricing-governance operator lanes (upsert/retire/decide/list/governance) are operator tooling with a console and travel with the provider-reconciliation subsystem (F7). Baselines are PLATFORM-GLOBAL state, not org state — the arm keys on a run-unique model id and retires it on cleanup so nothing outlives the test.
   - id: billing.rpc.retire-model-pricing-baseline.unknown-not-found
     surface: billing
     lane: >-
       rpc.retireModelPricingBaseline
     behavior: >-
-      retireModelPricingBaseline for an unknown model id answers NOT_FOUND; for a known one the entry stops appearing as active in listModelPricingBaselines.
+      retireModelPricingBaseline with no ACTIVE baseline for the key answers NOT_FOUND "No ACTIVE baseline found for <model>/<provider>/<harness> — it may already be retired, or the key is misspelled."; for a known key the document turns RETIRED (visible with include_history) and stops appearing in the ACTIVE list; retiring it again is the same NOT_FOUND.
     java_source: >-
-      domain/billing/request/handler/RetireModelPricingBaselineHandler.java:88
+      domain/billing/request/handler/RetireModelPricingBaselineHandler.java:88-89
     java_test: >-
       domain/billing/request/handler/RetireModelPricingBaselineHandlerTest.java
     class: behavior
-    disposition: debris-candidate
+    disposition: conformance
     observability: launcher
     caller: operator
     needs: [none]
-  - id: billing.rpc.decide-model-pricing-override.unknown-and-already-decided
+    note: >-
+      RULED PORTED 2026-09-06 (C5 gate, Q1) with its lane.
+  - id: billing.rpc.decide-model-pricing-override.unknown-not-found
     surface: billing
     lane: >-
       rpc.decideModelPricingOverride
     behavior: >-
-      decideModelPricingOverride for an unknown override answers NOT_FOUND and for an already-decided one FAILED_PRECONDITION.
+      decideModelPricingOverride for an override nobody proposed answers NOT_FOUND "No pricing override found with id <override_id>", approving or rejecting alike.
     java_source: >-
-      domain/billing/request/handler/DecideModelPricingOverrideHandler.java:88-93; domain/billing/service/ModelPricingOverrideService.java
+      domain/billing/request/handler/DecideModelPricingOverrideHandler.java:88-89
     java_test: >-
       none
     class: behavior
-    disposition: debris-candidate
+    disposition: conformance
     observability: launcher
     caller: operator
     needs: [none]
+    note: >-
+      RULED PORTED 2026-09-06 (C5 gate, Q1). Split 2026-09-07 (E1 T02) from the former `unknown-and-already-decided` row: the already-decided half is not drivable from outside — no RPC creates a pending override, only the Temporal provider-reconciliation corrector does — so it is the `unit` row below.
+  - id: billing.rpc.decide-model-pricing-override.already-decided-failed-precondition
+    surface: billing
+    lane: >-
+      rpc.decideModelPricingOverride
+    behavior: >-
+      decideModelPricingOverride on an override whose status is not PENDING_SIGNOFF answers FAILED_PRECONDITION "Pricing override <id> is <status>, not PENDING_SIGNOFF — only pending proposals can be decided."; a concurrent decision loses the CAS with ABORTED.
+    java_source: >-
+      domain/billing/request/handler/DecideModelPricingOverrideHandler.java:90-93; domain/billing/service/ModelPricingOverrideService.java
+    java_test: >-
+      none
+    class: behavior
+    disposition: unit
+    observability: none
+    caller: operator
+    needs: [none]
+    note: >-
+      Split 2026-09-07 (E1 T02): a pending override exists only after the provider-reconciliation corrector (default off; fed by the Anthropic / Cursor admin APIs) proposes one, so the launcher cannot observe this branch. NEITHER edition has a test today — Java carries no DecideModelPricingOverrideHandler test — so C5's vitest table is the first proof anywhere.
   - id: billing.rpc.get-model-pricing-governance.returns-queue
     surface: billing
     lane: >-
       rpc.getModelPricingGovernance
     behavior: >-
-      getModelPricingGovernance returns the pending override queue and reconciliation status shapes the proto declares (empty on a fresh environment).
+      getModelPricingGovernance returns one entry per model in the effective registry (the base variant only; sorted by harness, provider, model; baseline_* and effective_* rates equal while the entry has no active override; active_overrides listed) and the pending_overrides proposal queue — empty on a fresh environment, since only the provider-reconciliation corrector proposes.
     java_source: >-
       domain/billing/request/handler/GetModelPricingGovernanceHandler.java
     java_test: >-
       none
     class: behavior
-    disposition: debris-candidate
+    disposition: conformance
     observability: launcher
     caller: operator
     needs: [none]
+    note: >-
+      RULED PORTED 2026-09-06 (C5 gate, Q1) with its lane. Behavior corrected 2026-09-07 (E1 T02): the row said the response is "empty on a fresh environment" — it is not; `entries` carries every seeded registry model (ModelPricingBaselineSeeder runs on every boot), only `pending_overrides` is empty.
 
   # --- local OSS posture (ruling Q10) ----------------------------------------
   - id: billing.rpc.oss-boundary.every-billing-rpc-unimplemented
@@ -1072,93 +1097,101 @@ rows:
     behavior: >-
       An otherwise valid checkout.session.completed whose api_version is not stripe-java 32.1.0's pin answers 200 and grants nothing — getObject() deserializes nothing (finding F12).
     java_source: >-
-      domain/billing/stripe/StripeWebhookService.java:580-582
+      domain/billing/stripe/StripeWebhookService.java:578-592
     java_test: >-
       none
     class: behavior
-    disposition: debris-candidate
+    disposition: debris
     observability: launcher
     caller: anonymous
     needs: [unfunded-org, fake-stripe]
-    disputed: >-
-      A silent 200 that grants nothing is arguably a bug (Stripe retries nothing on 200); recommended disposition is `debris` — C5 (stripe-node) must NOT replicate the strictness, and the fake always stamps the pin.
+    note: >-
+      RULED debris 2026-09-06 (C5 gate, Q1d): a silent 200 that grants nothing is stripe-java's release-train strictness (getObject() answers empty unless the event's api_version shares the SDK's train), not a behavior of the product — C5 (stripe-node) parses regardless and must NOT replicate it. The fake stamps the pin on every event so no other row trips on this.
   - id: billing.stripe.customer-updated.syncs-default-payment-method
     surface: billing
     lane: >-
       stripe.customer-updated
     behavior: >-
-      customer.updated carrying invoice_settings.default_payment_method sets (or clears) the account's default payment method, visible on getBillingAccount.
+      customer.updated carrying invoice_settings.default_payment_method makes Java retrieve that payment method (GET /v1/payment_methods/{id}) and record it as the account's default (id, brand, last4, exp_month, exp_year — visible on getBillingAccount); carrying none clears the account's default; a customer Java never minted is a silent 200 with no retrieve.
     java_source: >-
-      domain/billing/stripe/StripeWebhookService.java:88
+      domain/billing/stripe/StripeWebhookService.java:258-297,512-542
     java_test: >-
-      domain/billing/stripe/StripeWebhookServiceTest.java
+      none
     class: behavior
-    disposition: debris-candidate
+    disposition: conformance
     observability: launcher
     caller: anonymous
     needs: [unfunded-org, fake-stripe]
     note: >-
-      Default-payment-method bookkeeping serves auto-recharge only; presented with it for Q6.
+      RULED PORTED 2026-09-06 (C5 gate, Q1) with auto-recharge, which it serves. Java carries NO unit test for this handler (StripeWebhookServiceTest covers the checkout events only) — this arm is the only proof on either side. Java reads the card's exp_month/exp_year unguarded; the fake's card carries them (FAKE_CARD).
   - id: billing.stripe.payment-method-attached.sets-default-when-none
     surface: billing
     lane: >-
       stripe.payment-method-attached
     behavior: >-
-      payment_method.attached for a card sets it as the account's default when none is set and updates the Stripe customer's default (POST /v1/customers/{id} on the fake).
+      payment_method.attached for a card sets it as the account's default ONLY when none is set (a second card does not displace the first) and makes it the customer's default on Stripe (POST /v1/customers/{id} invoice_settings[default_payment_method], once); a method without a card (us_bank_account) and a customer Java never minted are silent 200s with no write.
     java_source: >-
-      domain/billing/stripe/StripeWebhookService.java:90,520,557
+      domain/billing/stripe/StripeWebhookService.java:306-362,548-562
     java_test: >-
-      domain/billing/stripe/StripeWebhookServiceTest.java
+      none
     class: behavior
-    disposition: debris-candidate
+    disposition: conformance
     observability: launcher
     caller: anonymous
     needs: [unfunded-org, fake-stripe]
+    note: >-
+      RULED PORTED 2026-09-06 (C5 gate, Q1) with auto-recharge, which it serves. Java carries NO unit test for this handler — this arm is the only proof on either side. It is also how every auto-recharge arm gives its org a saved card.
   - id: billing.stripe.payment-intent-succeeded.recharge-provisions-credits
     surface: billing
     lane: >-
       stripe.payment-intent-succeeded
     behavior: >-
-      payment_intent.succeeded carrying metadata stigmer_recharge_event_id provisions the recharge's credits; without the metadata the event is ignored.
+      payment_intent.succeeded carrying metadata stigmer_recharge_event_id provisions the recharge's credits exactly once — an auto_recharge_credit ledger entry under idempotency key auto_recharge_<event_id>, the balance up by the recharge amount; the same event replayed or a fresh event for the same recharge grants nothing more; without the metadata (a checkout's intent) or naming a recharge Java never created the event is a silent 200.
     java_source: >-
-      domain/billing/stripe/StripeWebhookService.java:92,383
+      domain/billing/stripe/StripeWebhookService.java:371-406; domain/billing/service/AutoRechargeService.java:263-319
     java_test: >-
-      domain/billing/stripe/StripeWebhookServiceTest.java; domain/billing/service/AutoRechargeServiceTest.java
+      domain/billing/service/AutoRechargeServiceTest.java
     class: behavior
-    disposition: debris-candidate
+    disposition: conformance
     observability: launcher
     caller: anonymous
     needs: [unfunded-org, fake-stripe]
+    note: >-
+      RULED PORTED 2026-09-06 (C5 gate, Q1): auto-recharge is a live product surface. The arm drives the whole journey as the platform operator — the trigger is synchronous inside recordLlmCallUsage when the post-debit signal is low_balance_warning, so the operator's engine RPCs are the only black-box way to reach it; the PaymentIntent lands on the fake from Java's background executor and the arm polls for it. Java's webhook handler has no unit test of its own; AutoRechargeServiceTest covers provisionRechargeCredits.
   - id: billing.stripe.payment-intent-failed.recharge-compensated
     surface: billing
     lane: >-
       stripe.payment-intent-failed
     behavior: >-
-      payment_intent.payment_failed carrying stigmer_recharge_event_id releases the recharge's monthly-cap slot with the payment error message (or "Payment failed").
+      payment_intent.payment_failed carrying stigmer_recharge_event_id marks the recharge FAILED and releases its monthly-cap slot (current_month_charged_micros back down by the amount) with no grant; with the recharge no longer pending, the next debit past the threshold triggers a fresh recharge under a new event id.
     java_source: >-
-      domain/billing/stripe/StripeWebhookService.java:94,426
+      domain/billing/stripe/StripeWebhookService.java:414-454; domain/billing/service/AutoRechargeService.java (compensateFailedRecharge)
     java_test: >-
       domain/billing/service/AutoRechargeServiceTest.java
     class: behavior
-    disposition: debris-candidate
+    disposition: conformance
     observability: launcher
     caller: anonymous
     needs: [unfunded-org, fake-stripe]
+    note: >-
+      RULED PORTED 2026-09-06 (C5 gate, Q1) with its lane. The arm proves the release is real by re-triggering, not by reading the counter alone. The month-rollover guard on the release depends on wall-clock time and is a `unit` concern.
   - id: billing.stripe.outbound.idempotency-key-on-recharge-payment-intent
     surface: billing
     lane: >-
       stripe.outbound
     behavior: >-
-      The auto-recharge PaymentIntent create carries the event's idempotency key as the Stripe Idempotency-Key header.
+      The auto-recharge PaymentIntent create carries Idempotency-Key auto_recharge_<event_id> (the event's own key) and the shape Java sends — amount in cents (micros / 10_000), currency usd, the saved payment method, the org's customer, off_session=true, confirm=true, metadata stigmer_org_id / stigmer_recharge_event_id / stigmer_credits_micros — and the month's slot is claimed (current_month_charged_micros) before any money moves.
     java_source: >-
-      domain/billing/service/AutoRechargeService.java:222-227
+      domain/billing/service/AutoRechargeService.java:214-238,387-409
     java_test: >-
       domain/billing/service/AutoRechargeServiceTest.java
     class: carve-out
-    disposition: debris-candidate
+    disposition: conformance
     observability: launcher
     caller: none
     needs: [fake-stripe]
+    note: >-
+      RULED PORTED 2026-09-06 (C5 gate, Q1). A DD-012 carve-out: the key must be byte-identical across editions so a retry can never charge twice.
 
   # ===========================================================================
   # BILLING — workers, schedules, notifier (Temporal vocabulary is a carve-out)

--- a/test/conformance/src/harness/__tests__/cloud-fixtures.test.ts
+++ b/test/conformance/src/harness/__tests__/cloud-fixtures.test.ts
@@ -5,7 +5,7 @@
 import { createHmac } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { startCloudFixtures, type CloudFixtures } from "../cloud-fixtures";
-import { signStripePayload, stripeEvent, STRIPE_JAVA_API_VERSION } from "../fake-stripe";
+import { FAKE_CARD, signStripePayload, stripeEvent, STRIPE_JAVA_API_VERSION } from "../fake-stripe";
 import { anthropicText, openAiText } from "../llm-wire";
 import { CloudFixturesClient } from "../../support/cloud-fixtures-client";
 
@@ -163,6 +163,19 @@ describe("fake Stripe API", () => {
     const missing = await fetch(`${fixtures.addresses.stripeApiUrl}/v1/customers/cus_nope`);
     expect(missing.status).toBe(404);
     expect(((await missing.json()) as { error: { code: string } }).error.code).toBe("resource_missing");
+    await control.stripe.reset();
+  });
+
+  it("answers a payment-method retrieve with the one card it knows, expiry included (the Java customer.updated handler reads exp_month/exp_year unguarded)", async () => {
+    const response = await fetch(`${fixtures.addresses.stripeApiUrl}/v1/payment_methods/pm_any`);
+    expect(response.status).toBe(200);
+    const method = (await response.json()) as { id: string; object: string; type: string; card: typeof FAKE_CARD };
+    expect(method.id).toBe("pm_any");
+    expect(method.object).toBe("payment_method");
+    expect(method.type).toBe("card");
+    expect(method.card).toEqual(FAKE_CARD);
+    expect(method.card.exp_month).toBeGreaterThan(0);
+    expect(method.card.exp_year).toBeGreaterThan(new Date().getFullYear());
     await control.stripe.reset();
   });
 

--- a/test/conformance/src/harness/fake-stripe.ts
+++ b/test/conformance/src/harness/fake-stripe.ts
@@ -41,6 +41,14 @@ import { writeJson } from "./llm-wire";
 // constant pool on 2026-09-06. Bump with the Java dependency.
 export const STRIPE_JAVA_API_VERSION = "2026-04-22.dahlia";
 
+// The one card this fixture knows. Every payment method it answers carries
+// it, so the suite asserts the default-payment-method bookkeeping against the
+// same constant. The expiry fields are load-bearing: Stripe always returns
+// them for a card, and the Java `customer.updated` handler reads them
+// unguarded (`getExpMonth().intValue()`) — a fixture card without them turns
+// that webhook into a 500.
+export const FAKE_CARD = { brand: "visa", last4: "4242", exp_month: 12, exp_year: 2030 } as const;
+
 export interface CapturedStripeRequest {
   readonly method: string;
   readonly path: string;
@@ -233,7 +241,7 @@ export class FakeStripeApi {
       return {
         status: 200,
         id,
-        body: { id, object: "payment_method", type: "card", customer: null, card: { brand: "visa", last4: "4242" } },
+        body: { id, object: "payment_method", type: "card", customer: null, card: FAKE_CARD },
       };
     }
     return stripeNotFound(`FakeStripeApi: unhandled ${method} ${path}`);

--- a/test/conformance/src/suites-execution/billing-gates.conformance.test.ts
+++ b/test/conformance/src/suites-execution/billing-gates.conformance.test.ts
@@ -111,6 +111,23 @@ describe.skipIf(!gatesEnabled)("Billing gates — settle, the approval STOP gate
     });
   }
 
+  // Settle runs in the workflow's finally block AFTER the terminal status is
+  // written, so a phase observer returns while the hold is still reserved.
+  // Any arm that reasons about the balance of a finished run must wait for
+  // the hold to be gone first — draining against a stale `available` and then
+  // having the release land admits what the arm expected to be refused (the
+  // rearm arm did exactly that once on CI, stigmer run 34028008217).
+  async function awaitSettled(org: string): Promise<Awaited<ReturnType<typeof balance>>> {
+    const deadline = Date.now() + 15_000;
+    let after = await balance(org);
+    while (after.reservedMicros !== 0n && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 500));
+      after = await balance(org);
+    }
+    expect(after.reservedMicros, "no reservation remains held after settle").toBe(0n);
+    return after;
+  }
+
   async function provisionAgent(org: string): Promise<string> {
     const agent = await clients.agentCommand.create(makeAgent({ org, name: uniqueName("agent") }));
     fixtures.defer(() => clients.agentCommand.delete({ value: agent.metadata!.id }));
@@ -143,15 +160,7 @@ describe.skipIf(!gatesEnabled)("Billing gates — settle, the approval STOP gate
     const final = await awaitTerminal(clients, created.metadata!.id);
     expect(final.status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
 
-    // Settle runs in the workflow's finally block after the terminal status;
-    // give the observer a moment, then require the hold to be gone.
-    const deadline = Date.now() + 15_000;
-    let after = await balance(org);
-    while (after.reservedMicros !== 0n && Date.now() < deadline) {
-      await new Promise((r) => setTimeout(r, 500));
-      after = await balance(org);
-    }
-    expect(after.reservedMicros, "no reservation remains held after settle").toBe(0n);
+    const after = await awaitSettled(org);
     expect(after.availableMicros, "the run cost at most what it used; the hold itself is not spent").toBeLessThanOrEqual(before.availableMicros);
   });
 
@@ -193,6 +202,10 @@ describe.skipIf(!gatesEnabled)("Billing gates — settle, the approval STOP gate
     const executionId = created.metadata!.id;
     fixtures.defer(() => clients.agentExecutionCommand.delete({ value: executionId }));
     await awaitPhase(clients, executionId, ExecutionPhase.EXECUTION_FAILED);
+    // The row is about a SETTLED failed run: wait for the hold to return
+    // before draining, or the release lands after the drain and re-funds the
+    // org under the arm's feet.
+    await awaitSettled(org);
 
     await drainPast(org, 1n);
     const refused = await expectGrpcCode(

--- a/test/conformance/src/suites/billing.conformance.test.ts
+++ b/test/conformance/src/suites/billing.conformance.test.ts
@@ -729,6 +729,70 @@ describe.skipIf(!ledgerServed)("Billing ledger conformance — the purchase mone
     expect(await balanceOf(org)).toBe(0n);
   });
 
+  // --- the default-payment-method bookkeeping (ruled PORTED at C5's gate).
+  // Java has no unit test for either handler; these arms are the only proof
+  // on either side.
+
+  it("[billing.stripe.payment-method-attached.sets-default-when-none] payment_method.attached becomes the account's default card only when none is set, tells Stripe so, ignores a second card and a non-card, and does nothing for a customer Java does not know", async () => {
+    const { org } = await unfundedOrg();
+    const customerId = await seedStripeCustomer(clients, org);
+    expect((await clients.billingQuery.getBillingAccount({ orgId: org })).defaultPaymentMethod, "no default before any card").toBeUndefined();
+
+    const first = uniqueName("pm_conf_first");
+    expect((await post(paymentMethodAttached(first, customerId))).status).toBe(200);
+    const account = await clients.billingQuery.getBillingAccount({ orgId: org });
+    expect(account.defaultPaymentMethod?.paymentMethodId).toBe(first);
+    expect(account.defaultPaymentMethod?.brand).toBe(FAKE_CARD.brand);
+    expect(account.defaultPaymentMethod?.last4).toBe(FAKE_CARD.last4);
+    expect(account.defaultPaymentMethod?.expMonth).toBe(FAKE_CARD.exp_month);
+    expect(account.defaultPaymentMethod?.expYear).toBe(FAKE_CARD.exp_year);
+    // Java also makes the card the customer's default ON STRIPE.
+    const customerUpdates = (await control.stripe.requests()).filter((r) => r.method === "POST" && r.path === `/v1/customers/${customerId}`);
+    expect(customerUpdates.map((r) => r.params["invoice_settings[default_payment_method]"])).toEqual([first]);
+
+    // A second card does not displace the first — and Stripe is not told again.
+    const second = uniqueName("pm_conf_second");
+    expect((await post(paymentMethodAttached(second, customerId))).status).toBe(200);
+    expect((await clients.billingQuery.getBillingAccount({ orgId: org })).defaultPaymentMethod?.paymentMethodId).toBe(first);
+    expect((await control.stripe.requests()).filter((r) => r.method === "POST" && r.path === `/v1/customers/${customerId}`)).toHaveLength(1);
+
+    // A non-card method carries no card and is ignored; an unknown customer is a silent 200.
+    const other = await unfundedOrg();
+    const otherCustomer = await seedStripeCustomer(clients, other.org);
+    expect((await post(paymentMethodAttached(uniqueName("pm_conf_bank"), otherCustomer, { type: "us_bank_account" }))).status).toBe(200);
+    expect((await clients.billingQuery.getBillingAccount({ orgId: other.org })).defaultPaymentMethod).toBeUndefined();
+    const unknown = await post(paymentMethodAttached(uniqueName("pm_conf_stray"), "cus_conf_nobody"));
+    expect(unknown.status).toBe(200);
+    expect(unknown.body).toBe("ok");
+  });
+
+  it("[billing.stripe.customer-updated.syncs-default-payment-method] customer.updated with a default payment method makes Java retrieve the card and record it; with none it clears the account's default; an unknown customer is a silent 200", async () => {
+    const { org } = await unfundedOrg();
+    const customerId = await seedStripeCustomer(clients, org);
+
+    const paymentMethodId = uniqueName("pm_conf_sync");
+    expect((await post(customerUpdated(customerId, paymentMethodId))).status).toBe(200);
+    const retrieved = (await control.stripe.requests()).find((r) => r.method === "GET" && r.path === `/v1/payment_methods/${paymentMethodId}`);
+    expect(retrieved, "Java retrieves the method Stripe named — the card details are not on the event").toBeDefined();
+    const synced = await clients.billingQuery.getBillingAccount({ orgId: org });
+    expect(synced.defaultPaymentMethod?.paymentMethodId).toBe(paymentMethodId);
+    expect(synced.defaultPaymentMethod?.brand).toBe(FAKE_CARD.brand);
+    expect(synced.defaultPaymentMethod?.last4).toBe(FAKE_CARD.last4);
+    expect(synced.defaultPaymentMethod?.expMonth).toBe(FAKE_CARD.exp_month);
+    expect(synced.defaultPaymentMethod?.expYear).toBe(FAKE_CARD.exp_year);
+
+    // Stripe reports the default removed → the account's default is cleared.
+    expect((await post(customerUpdated(customerId, null))).status).toBe(200);
+    expect((await clients.billingQuery.getBillingAccount({ orgId: org })).defaultPaymentMethod, "a cleared default is gone, not zeroed").toBeUndefined();
+
+    // A customer Java never minted: 200, nothing looked up.
+    const before = (await control.stripe.requests()).length;
+    const unknown = await post(customerUpdated("cus_conf_nobody", uniqueName("pm_conf_stray")));
+    expect(unknown.status).toBe(200);
+    expect(unknown.body).toBe("ok");
+    expect((await control.stripe.requests()).length, "no payment-method retrieve for an unknown customer").toBe(before);
+  });
+
   it("[billing.stripe.signature.wrong-secret-400-invalid-signature] [billing.stripe.signature.tampered-payload-400] [billing.stripe.signature.stale-timestamp-400] [billing.stripe.signature.missing-header-400] bad signatures are refused 400 and grant nothing", async () => {
     const { org } = await unfundedOrg();
     const { sessionId } = await purchase(org);
@@ -1030,6 +1094,92 @@ describe.skipIf(!ledgerServed)("Billing ledger conformance — the engine and pr
     expect(mine?.baselineInputMicrosPerMillion).toBe(3_000_000n);
     expect(mine?.effectiveOutputMicrosPerMillion).toBe(9_000_000n);
     expect(mine?.activeOverrides).toEqual([]);
+  });
+});
+
+describe.skipIf(!ledgerServed)("Billing ledger conformance — auto-recharge, the operator-driven money path against the fake Stripe", () => {
+  afterEach(async () => {
+    await control.stripe.reset();
+  });
+
+  it("[billing.stripe.outbound.idempotency-key-on-recharge-payment-intent] [billing.stripe.payment-intent-succeeded.recharge-provisions-credits] a debit past the threshold makes Java create the recharge PaymentIntent under its event's idempotency key and claim the month; payment_intent.succeeded then grants the credits exactly once, and a succeeded intent without the recharge metadata grants nothing", async () => {
+    const op = await operator();
+    const { org, customerId, paymentMethodId, paymentIntent, rechargeEventId } = await armRecharge(op);
+    const paymentIntentId = paymentIntent.response.id ?? "";
+    expect(paymentIntentId).toMatch(/^pi_conf_/);
+
+    // What Java sent Stripe: an off-session confirmed charge on the saved
+    // card, keyed so a retry can never charge twice (a DD-012 carve-out —
+    // the key must be byte-identical across editions).
+    expect(paymentIntent.idempotencyKey).toBe(`auto_recharge_${rechargeEventId}`);
+    expect(paymentIntent.params["amount"], "Stripe wants cents; the engine keeps micros").toBe(String(RECHARGE.amountMicros / 10_000n));
+    expect(paymentIntent.params["currency"]).toBe("usd");
+    expect(paymentIntent.params["customer"]).toBe(customerId);
+    expect(paymentIntent.params["payment_method"]).toBe(paymentMethodId);
+    expect(paymentIntent.params["off_session"]).toBe("true");
+    expect(paymentIntent.params["confirm"]).toBe("true");
+    expect(paymentIntent.params["metadata[stigmer_org_id]"]).toBe(org);
+    expect(paymentIntent.params["metadata[stigmer_credits_micros]"]).toBe(String(RECHARGE.amountMicros));
+
+    // The month's slot is claimed at trigger time, before any money moves.
+    const claimed = await op.clients.billingQuery.getBillingAccount({ orgId: org });
+    expect(claimed.autoRecharge?.currentMonthChargedMicros).toBe(RECHARGE.amountMicros);
+    const before = (await op.clients.billingQuery.getCreditBalance({ orgId: org })).availableMicros;
+
+    // A succeeded intent that is not a recharge (a checkout's, say) is ignored;
+    // one naming a recharge Java never created is a silent 200 too.
+    expect((await post(paymentIntentSucceeded(paymentIntentId))).status).toBe(200);
+    expect((await post(paymentIntentSucceeded(paymentIntentId, uniqueName("evt-nobody-created")))).status).toBe(200);
+    expect((await op.clients.billingQuery.getCreditBalance({ orgId: org })).availableMicros, "nothing granted without the recharge's own id").toBe(before);
+
+    // The real one: credits land on the ledger under the recharge's key.
+    const settled = paymentIntentSucceeded(paymentIntentId, rechargeEventId);
+    const response = await post(settled);
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("ok");
+    const after = await op.clients.billingQuery.getCreditBalance({ orgId: org });
+    expect(after.availableMicros - before).toBe(RECHARGE.amountMicros);
+    const ledger = await op.clients.billingQuery.getCreditLedger({ orgId: org });
+    const grant = ledger.entries.find((entry) => entry.idempotencyKey === `auto_recharge_${rechargeEventId}`);
+    expect(grant, "the grant carries the recharge event's idempotency key").toBeDefined();
+    expect(grant?.type).toBe(LedgerEntryType.auto_recharge_credit);
+    expect(grant?.amountMicros).toBe(RECHARGE.amountMicros);
+
+    // Once: the same event replayed, and a fresh event for the same recharge, grant nothing more.
+    expect((await post(settled)).status).toBe(200);
+    expect((await post(paymentIntentSucceeded(paymentIntentId, rechargeEventId))).status).toBe(200);
+    expect((await op.clients.billingQuery.getCreditBalance({ orgId: org })).availableMicros).toBe(after.availableMicros);
+    expect((await op.clients.billingQuery.getCreditLedger({ orgId: org })).entries.filter((e) => e.type === LedgerEntryType.auto_recharge_credit)).toHaveLength(1);
+  });
+
+  it("[billing.stripe.payment-intent-failed.recharge-compensated] payment_intent.payment_failed releases the month's slot and grants nothing, and the next debit past the threshold is free to trigger a fresh recharge", async () => {
+    const op = await operator();
+    const { org, executionId, paymentIntent, rechargeEventId } = await armRecharge(op);
+    const paymentIntentId = paymentIntent.response.id ?? "";
+    expect((await op.clients.billingQuery.getBillingAccount({ orgId: org })).autoRecharge?.currentMonthChargedMicros).toBe(RECHARGE.amountMicros);
+    const before = (await op.clients.billingQuery.getCreditBalance({ orgId: org })).availableMicros;
+
+    const response = await post(paymentIntentPaymentFailed(paymentIntentId, rechargeEventId, "Your card was declined."));
+    expect(response.status).toBe(200);
+    expect(response.body).toBe("ok");
+    const compensated = await op.clients.billingQuery.getBillingAccount({ orgId: org });
+    expect(compensated.autoRecharge?.currentMonthChargedMicros ?? 0n, "the failed charge gives its slot back").toBe(0n);
+    expect((await op.clients.billingQuery.getCreditBalance({ orgId: org })).availableMicros).toBe(before);
+    expect((await op.clients.billingQuery.getCreditLedger({ orgId: org })).entries.some((e) => e.type === LedgerEntryType.auto_recharge_credit), "no grant for a failed charge").toBe(false);
+
+    // The release is real, not cosmetic: with the failed event no longer
+    // pending, the next low-balance debit triggers a NEW recharge under a new
+    // event id and claims the month again.
+    await debitOnce(op, executionId, 2);
+    const second = await awaitStripeRequest(
+      (r) => r.method === "POST" && r.path === "/v1/payment_intents" && r.idempotencyKey !== paymentIntent.idempotencyKey,
+      `second auto-recharge PaymentIntent for ${org}`,
+    );
+    const secondEventId = second.params["metadata[stigmer_recharge_event_id]"];
+    expect(secondEventId).toBeDefined();
+    expect(secondEventId).not.toBe(rechargeEventId);
+    expect(second.idempotencyKey).toBe(`auto_recharge_${secondEventId}`);
+    expect((await op.clients.billingQuery.getBillingAccount({ orgId: org })).autoRecharge?.currentMonthChargedMicros).toBe(RECHARGE.amountMicros);
   });
 });
 

--- a/test/conformance/src/suites/billing.conformance.test.ts
+++ b/test/conformance/src/suites/billing.conformance.test.ts
@@ -502,6 +502,18 @@ describe.skipIf(!ledgerServed)("Billing ledger conformance — accounts, balance
       expect(entry.outputPriceMicrosPerMillion).toBeGreaterThanOrEqual(0n);
     }
   });
+
+  it("[billing.rpc.set-auto-recharge-config.outsider-permission-denied] an outsider's setAutoRechargeConfig is refused with the proto's copy", async () => {
+    const { org } = await unfundedOrg();
+    const other = await outsider();
+    // Structurally valid and disabled — the refusal must be the authorization's.
+    const denied = await expectGrpcCode(
+      () => other.billingCommand.setAutoRechargeConfig({ orgId: org, enabled: false, thresholdMicros: 0n, rechargeAmountMicros: 0n, monthlyCapMicros: 0n }),
+      Code.PermissionDenied,
+      "outsider setAutoRechargeConfig",
+    );
+    expect(denied.rawMessage).toBe(COPY.manageAutoRecharge);
+  });
 });
 
 describe.skipIf(!ledgerServed)("Billing ledger conformance — the purchase money path against the fake Stripe", () => {
@@ -593,6 +605,60 @@ describe.skipIf(!ledgerServed)("Billing ledger conformance — the purchase mone
     expect(portal.portalUrl).toMatch(/^https:\/\/billing\.stripe\.test\//);
     const request = (await control.stripe.requests()).find((r) => r.path === "/v1/billing_portal/sessions");
     expect(request?.params["return_url"]).toBe("https://x.test/back");
+  });
+
+  it("[billing.rpc.set-auto-recharge-config.persists-and-validates] auto-recharge persists disabled at once, refuses to enable without a saved card, then validates the amounts in the engine's order and persists an enabled configuration", async () => {
+    const { org } = await unfundedOrg();
+    const config = (enabled: boolean, thresholdMicros: bigint, rechargeAmountMicros: bigint, monthlyCapMicros: bigint) => ({ orgId: org, enabled, thresholdMicros, rechargeAmountMicros, monthlyCapMicros });
+
+    // Disabled writes the amounts as given and reads back at once.
+    const disabled = await clients.billingCommand.setAutoRechargeConfig(config(false, 7_000_000n, 25_000_000n, 50_000_000n));
+    expect(disabled.autoRecharge?.enabled ?? false).toBe(false);
+    expect(disabled.autoRecharge?.thresholdMicros).toBe(7_000_000n);
+    expect(disabled.autoRecharge?.rechargeAmountMicros).toBe(25_000_000n);
+    expect(disabled.autoRecharge?.monthlyCapMicros).toBe(50_000_000n);
+    const readBack = await clients.billingQuery.getBillingAccount({ orgId: org });
+    expect(readBack.autoRecharge?.thresholdMicros).toBe(7_000_000n);
+
+    // Disabled still rejects a negative amount.
+    const negative = await expectGrpcCode(() => clients.billingCommand.setAutoRechargeConfig(config(false, -1n, 0n, 0n)), Code.InvalidArgument, "disable with a negative threshold");
+    expect(negative.rawMessage).toBe(DOMAIN_COPY.autoRechargeThresholdNotNegative);
+
+    // Enabling needs a saved card BEFORE the amounts are looked at: a bad
+    // amount without a card is refused for the card, not the amount.
+    const noCard = await expectGrpcCode(() => clients.billingCommand.setAutoRechargeConfig(config(true, 0n, 20_000_000n, 40_000_000n)), Code.FailedPrecondition, "enable without a saved card");
+    expect(noCard.rawMessage).toBe(DOMAIN_COPY.autoRechargeNeedsPaymentMethod);
+
+    // With a card, the amount ladder in the engine's order.
+    const customerId = await seedStripeCustomer(clients, org);
+    await seedDefaultPaymentMethod(clients, org, customerId);
+    const ladder: Array<[string, Parameters<typeof clients.billingCommand.setAutoRechargeConfig>[0], string]> = [
+      ["threshold 0", config(true, 0n, 20_000_000n, 40_000_000n), DOMAIN_COPY.autoRechargeThresholdPositive],
+      ["amount 0", config(true, 5_000_000n, 0n, 40_000_000n), DOMAIN_COPY.autoRechargeAmountPositive],
+      ["cap below amount", config(true, 5_000_000n, 20_000_000n, 19_999_999n), DOMAIN_COPY.autoRechargeCapAtLeastAmount],
+    ];
+    for (const [label, input, copy] of ladder) {
+      const refused = await expectGrpcCode(() => clients.billingCommand.setAutoRechargeConfig(input), Code.InvalidArgument, `enable with ${label}`);
+      expect(refused.rawMessage, label).toBe(copy);
+    }
+    const stillDisabled = await clients.billingQuery.getBillingAccount({ orgId: org });
+    expect(stillDisabled.autoRecharge?.enabled ?? false, "a refused enable changes nothing").toBe(false);
+
+    // A cap equal to the amount is the boundary the copy names ("at least").
+    const enabled = await clients.billingCommand.setAutoRechargeConfig(config(true, 5_000_000n, 20_000_000n, 20_000_000n));
+    expect(enabled.autoRecharge?.enabled).toBe(true);
+    expect(enabled.autoRecharge?.thresholdMicros).toBe(5_000_000n);
+    expect(enabled.autoRecharge?.rechargeAmountMicros).toBe(20_000_000n);
+    expect(enabled.autoRecharge?.monthlyCapMicros).toBe(20_000_000n);
+    expect(enabled.autoRecharge?.currentMonthChargedMicros ?? 0n, "enabling claims nothing on the month").toBe(0n);
+    const persisted = await clients.billingQuery.getBillingAccount({ orgId: org });
+    expect(persisted.autoRecharge?.enabled).toBe(true);
+    expect(persisted.autoRecharge?.rechargeAmountMicros).toBe(20_000_000n);
+
+    // Disabling again keeps the amounts it is given (the console's "pause" — the proto's "disabling preserves config").
+    const paused = await clients.billingCommand.setAutoRechargeConfig(config(false, 5_000_000n, 20_000_000n, 20_000_000n));
+    expect(paused.autoRecharge?.enabled ?? false).toBe(false);
+    expect(paused.autoRecharge?.rechargeAmountMicros).toBe(20_000_000n);
   });
 
   // The webhook half: the suite is Stripe here (the builders at module scope),
@@ -822,6 +888,148 @@ describe.skipIf(!ledgerServed)("Billing ledger conformance — the engine and pr
     });
     expect(report.llmCallCount).toBe(2);
     expect(report.executionCount).toBe(1);
+  });
+
+  // --- the pricing-governance lanes (ruled PORTED at C5's gate: operator
+  // tooling with a console). Baselines are PLATFORM-GLOBAL state, not org
+  // state: every arm keys its baseline on a run-unique model id and retires it
+  // on cleanup, so nothing it creates outlives the test or reaches another
+  // file's registry assertions.
+
+  // A structurally valid baseline for a run-unique model. The registry's
+  // composed catalog picks it up on upsert; retire removes it again.
+  function conformanceBaseline(modelId: string, inputMicros = 1_000_000n, outputMicros = 5_000_000n) {
+    return {
+      modelId,
+      provider: "anthropic",
+      harness: "native",
+      displayName: `Conformance ${modelId}`,
+      speedTier: "balanced",
+      costTier: "standard",
+      pricing: { inputPriceMicrosPerMillion: inputMicros, outputPriceMicrosPerMillion: outputMicros },
+    };
+  }
+
+  async function upsertBaseline(op: PrivilegedScope, modelId: string, inputMicros?: bigint, outputMicros?: bigint) {
+    const revision = await op.clients.billingCommand.upsertModelPricingBaseline({ baseline: conformanceBaseline(modelId, inputMicros, outputMicros), revisionNote: "conformance" });
+    fixtures.defer(() => op.clients.billingCommand.retireModelPricingBaseline({ modelId, provider: "anthropic", harness: "native" }).then(() => undefined, () => undefined));
+    return revision;
+  }
+
+  it("[billing.rpc.upsert-model-pricing-baseline.round-trips-through-list] an operator's upsert is listed ACTIVE with the server's stamps, a second upsert of the same key supersedes the first, and a variant carrying a Cursor rate is refused", async () => {
+    const op = await operator();
+    const modelId = uniqueName("conf-model");
+
+    const first = await upsertBaseline(op, modelId, 1_000_000n, 5_000_000n);
+    expect(first.baselineId, "the server mints the baseline id").not.toBe("");
+    expect(first.status).toBe(ModelPricingBaselineStatus.pricing_baseline_active);
+    expect(first.supersedesBaselineId, "a fresh key supersedes nothing").toBe("");
+    expect(first.decidedBy, "the deciding operator is stamped").not.toBe("");
+    expect(first.pricing?.effectiveAt, "effective_at is stamped by the server").toBeDefined();
+    expect(first.pricing?.inputPriceMicrosPerMillion).toBe(1_000_000n);
+
+    const active = await op.clients.billingQuery.listModelPricingBaselines({});
+    const listed = active.baselines.find((b) => b.modelId === modelId);
+    expect(listed?.baselineId).toBe(first.baselineId);
+    expect(listed?.pricing?.outputPriceMicrosPerMillion).toBe(5_000_000n);
+    for (const baseline of active.baselines) expect(baseline.status, `${baseline.modelId} in the ACTIVE list`).toBe(ModelPricingBaselineStatus.pricing_baseline_active);
+
+    // The same key again is a revision: the prior document is superseded and chained, not duplicated.
+    const second = await op.clients.billingCommand.upsertModelPricingBaseline({ baseline: conformanceBaseline(modelId, 2_000_000n, 5_000_000n), revisionNote: "conformance revision" });
+    expect(second.baselineId).not.toBe(first.baselineId);
+    expect(second.supersedesBaselineId).toBe(first.baselineId);
+    const activeNow = (await op.clients.billingQuery.listModelPricingBaselines({})).baselines.filter((b) => b.modelId === modelId);
+    expect(activeNow.map((b) => b.baselineId), "exactly one ACTIVE document per key").toEqual([second.baselineId]);
+    const history = (await op.clients.billingQuery.listModelPricingBaselines({ includeHistory: true })).baselines.filter((b) => b.modelId === modelId);
+    expect(history.map((b) => [b.baselineId, b.status]), "history lists the ACTIVE revision first, then the superseded one").toEqual([
+      [second.baselineId, ModelPricingBaselineStatus.pricing_baseline_active],
+      [first.baselineId, ModelPricingBaselineStatus.pricing_baseline_superseded],
+    ]);
+
+    // Variants inherit the base entry's Cursor rate; declaring one on a variant is the handler's own INVALID_ARGUMENT.
+    const refused = await expectGrpcCode(
+      () =>
+        op.clients.billingCommand.upsertModelPricingBaseline({
+          baseline: {
+            ...conformanceBaseline(modelId),
+            pricingVariants: { thinking: { pricing: { inputPriceMicrosPerMillion: 1n, outputPriceMicrosPerMillion: 1n, cursorTokenRateMicrosPerMillion: 7n } } },
+          },
+        }),
+      Code.InvalidArgument,
+      "variant with a Cursor token rate",
+    );
+    expect(refused.rawMessage).toBe(DOMAIN_COPY.variantDeclaresCursorRate("thinking"));
+  });
+
+  it("[billing.rpc.retire-model-pricing-baseline.unknown-not-found] retiring an unknown key is NOT_FOUND with the handler's copy; retiring a known one removes it from the ACTIVE list, and retiring it again is NOT_FOUND", async () => {
+    const op = await operator();
+    const unknown = uniqueName("conf-never-upserted");
+    const missing = await expectGrpcCode(
+      () => op.clients.billingCommand.retireModelPricingBaseline({ modelId: unknown, provider: "anthropic", harness: "native" }),
+      Code.NotFound,
+      "retire an unknown key",
+    );
+    expect(missing.rawMessage).toBe(DOMAIN_COPY.noActiveBaseline(unknown, "anthropic", "native"));
+
+    const modelId = uniqueName("conf-model");
+    const upserted = await upsertBaseline(op, modelId);
+    const retired = await op.clients.billingCommand.retireModelPricingBaseline({ modelId, provider: "anthropic", harness: "native", revisionNote: "conformance retire" });
+    expect(retired.baselineId).toBe(upserted.baselineId);
+    expect(retired.status).toBe(ModelPricingBaselineStatus.pricing_baseline_retired);
+    const active = await op.clients.billingQuery.listModelPricingBaselines({});
+    expect(active.baselines.some((b) => b.modelId === modelId), "a retired key is not ACTIVE").toBe(false);
+    const history = await op.clients.billingQuery.listModelPricingBaselines({ includeHistory: true });
+    expect(history.baselines.find((b) => b.baselineId === upserted.baselineId)?.status).toBe(ModelPricingBaselineStatus.pricing_baseline_retired);
+
+    const again = await expectGrpcCode(
+      () => op.clients.billingCommand.retireModelPricingBaseline({ modelId, provider: "anthropic", harness: "native" }),
+      Code.NotFound,
+      "retire an already-retired key",
+    );
+    expect(again.rawMessage).toBe(DOMAIN_COPY.noActiveBaseline(modelId, "anthropic", "native"));
+  });
+
+  it("[billing.rpc.decide-model-pricing-override.unknown-not-found] deciding an override nobody proposed is NOT_FOUND with the handler's copy", async () => {
+    // Only the provider-reconciliation corrector proposes overrides, so the
+    // already-decided FAILED_PRECONDITION half of this lane is a `unit` row
+    // (billing.rpc.decide-model-pricing-override.already-decided-failed-precondition).
+    const op = await operator();
+    const overrideId = uniqueName("ovr-conf");
+    for (const approve of [true, false]) {
+      const missing = await expectGrpcCode(
+        () => op.clients.billingCommand.decideModelPricingOverride({ overrideId, approve, decisionNote: "conformance" }),
+        Code.NotFound,
+        `decide unknown override (approve=${approve})`,
+      );
+      expect(missing.rawMessage).toBe(DOMAIN_COPY.noOverride(overrideId));
+    }
+  });
+
+  it("[billing.rpc.get-model-pricing-governance.returns-queue] the governance view lists one entry per effective-registry model, sorted, with baseline and effective rates equal while no override is active, and an empty proposal queue on a fresh environment", async () => {
+    const op = await operator();
+    const modelId = uniqueName("conf-model");
+    await upsertBaseline(op, modelId, 3_000_000n, 9_000_000n);
+
+    const governance = await op.clients.billingQuery.getModelPricingGovernance({});
+    expect(governance.entries.length, "the seeded registry is never empty").toBeGreaterThan(0);
+    expect(governance.pendingOverrides, "nothing proposes overrides on a fresh environment but the reconciliation corrector").toEqual([]);
+
+    const keys = governance.entries.map((e) => `${e.harness}\u0000${e.provider}\u0000${e.modelId}`);
+    expect(keys, "sorted by harness, provider, model").toEqual([...keys].sort());
+    for (const entry of governance.entries) {
+      expect(entry.modelId).not.toBe("");
+      expect(entry.variant, "the view is the base variant only").toBe("");
+      if (entry.activeOverrides.length === 0) {
+        expect(entry.effectiveInputMicrosPerMillion, `${entry.modelId} input`).toBe(entry.baselineInputMicrosPerMillion);
+        expect(entry.effectiveOutputMicrosPerMillion, `${entry.modelId} output`).toBe(entry.baselineOutputMicrosPerMillion);
+      }
+    }
+
+    const mine = governance.entries.find((e) => e.modelId === modelId && e.harness === "native");
+    expect(mine, "the upserted baseline is an entry").toBeDefined();
+    expect(mine?.baselineInputMicrosPerMillion).toBe(3_000_000n);
+    expect(mine?.effectiveOutputMicrosPerMillion).toBe(9_000_000n);
+    expect(mine?.activeOverrides).toEqual([]);
   });
 });
 

--- a/test/conformance/src/suites/billing.conformance.test.ts
+++ b/test/conformance/src/suites/billing.conformance.test.ts
@@ -25,14 +25,28 @@
 // orgOAuthAppConfiguration posture). Pinned once per RPC below.
 //
 // The fixtures are shared across every file in a cloud run
-// (fileParallelism: false), so this suite resets them in afterEach.
+// (fileParallelism: false), so each block that drives the fake Stripe resets
+// it in its own afterEach — the blocks that never touch Stripe do not pay for
+// a reset they do not need.
+//
+// The auto-recharge rows (entry 20260906.04, T02 — ruled PORTED at C5's gate
+// after the read-only census found the feature is a live product surface)
+// need Java's whole money path in one test: a Stripe customer, a saved
+// payment method, a debit that trips the low-balance signal, the PaymentIntent
+// Java creates on its background executor, and the webhook the suite posts
+// back as Stripe. `armRecharge()` below is that journey; the arithmetic that
+// makes the debit trip the signal is written down there once.
 import { Code } from "@connectrpc/connect";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { LedgerEntryType } from "@stigmer/protos/ai/stigmer/billing/v1/enum_pb";
+import { ModelPricingBaselineStatus } from "@stigmer/protos/ai/stigmer/billing/v1/model_pricing_baseline_pb";
+import { UsageCompletionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/usage_pb";
 import { FixtureTracker } from "../harness/fixtures";
-import { postStripeWebhook, signStripePayload, signedEvent, stripeEvent } from "../harness/fake-stripe";
+import { FAKE_CARD, postStripeWebhook, signStripePayload, signedEvent, stripeEvent, type CapturedStripeRequest } from "../harness/fake-stripe";
 import { expectGrpcCode } from "../contract/errors";
 import { requireCloudFixtures, type CloudFixturesClient } from "../support/cloud-fixtures-client";
+import { pollUntil } from "../support/execution-poll";
 import { uniqueName } from "../support/naming";
 import { createTarget, type TargetProfile } from "../targets";
 import type { ConformanceClients } from "../harness/clients";
@@ -43,12 +57,17 @@ const ledgerServed = createTarget().capabilities.billingLedger;
 
 let target: TargetProfile;
 let clients: ConformanceClients;
+// The run's fixture control client — the fake Stripe's captures and scripted
+// failures. Resolved once the target confirms it serves the ledger (the local
+// OSS targets publish no fixtures and never reach the Stripe blocks).
+let control: CloudFixturesClient;
 const fixtures = new FixtureTracker();
 
 beforeAll(async () => {
   target = createTarget();
   await target.setup();
   clients = target.clients();
+  if (ledgerServed) control = requireCloudFixtures();
 });
 
 afterEach(async () => {
@@ -73,8 +92,33 @@ const COPY = {
   pricingEdit: "only platform operators can edit the model registry baseline",
   pricingGovernance: "only platform operators can view pricing governance",
   pricingBaselineView: "only platform operators can view the model registry baseline",
+  manageAutoRecharge: "unauthorized to manage auto-recharge for this organization",
   insufficientCredits: "Insufficient credits to start execution",
   noAccount: "No billing account for this organization",
+} as const;
+
+// The engine's OWN validation copy — service code, not a proto option, so a
+// different provenance from COPY above and pinned in its own table: C5 ports
+// the domain exactly, and the console / SDKs surface these strings to the
+// user, which makes the bytes the contract. Sources are the Java
+// `domain/billing` service classes named on each line.
+const DOMAIN_COPY = {
+  // BillingAccountService.setAutoRechargeConfig (validation runs in this order when enabling)
+  autoRechargeNeedsPaymentMethod: "A saved payment method is required to enable auto-recharge. Purchase a credit pack first.",
+  autoRechargeThresholdPositive: "threshold_micros must be positive when enabling auto-recharge",
+  autoRechargeAmountPositive: "recharge_amount_micros must be positive when enabling auto-recharge",
+  autoRechargeCapAtLeastAmount: "monthly_cap_micros must be at least recharge_amount_micros",
+  autoRechargeThresholdNotNegative: "threshold_micros must not be negative",
+  // SetAutoRechargeConfigHandler / GetBillingAccountHandler: the account lookup precedes every other check
+  noAccountFor: (org: string) => `No billing account for ${org}`,
+  // UpsertModelPricingBaselineHandler: variants inherit the base entry's Cursor rate
+  variantDeclaresCursorRate: (variant: string) =>
+    `Variant '${variant}' declares a Cursor Token Rate — variants inherit the base entry's rate; set it on the base pricing block instead.`,
+  // RetireModelPricingBaselineHandler
+  noActiveBaseline: (modelId: string, provider: string, harness: string) =>
+    `No ACTIVE baseline found for ${modelId}/${provider}/${harness} — it may already be retired, or the key is misspelled.`,
+  // DecideModelPricingOverrideHandler
+  noOverride: (overrideId: string) => `No pricing override found with id ${overrideId}`,
 } as const;
 
 // A Class A billing test needs an org (funded or not), an outsider, and — for
@@ -116,15 +160,181 @@ async function operator(): Promise<PrivilegedScope> {
 }
 
 // Funds an org AS the given caller — the operator's scope org is owned by the
-// operator, not by the primary user the target's fundTenancy acts as.
-async function fundAs(as: ConformanceClients, org: string): Promise<void> {
+// operator, not by the primary user the target's fundTenancy acts as. The
+// amount is a parameter because the auto-recharge journey needs a balance
+// SMALL enough for one debit to trip the low-balance signal.
+async function fundAs(as: ConformanceClients, org: string, amountMicros = 100_000_000n): Promise<void> {
   await as.billingCommand.getOrCreateBillingAccount({ orgId: org });
-  await as.billingCommand.adjustCredits({ orgId: org, amountMicros: 100_000_000n, reason: "conformance operator seed", idempotencyKey: uniqueName("op-seed") });
+  await as.billingCommand.adjustCredits({ orgId: org, amountMicros, reason: "conformance operator seed", idempotencyKey: uniqueName("op-seed") });
 }
 
 async function balanceOf(org: string): Promise<bigint> {
   const balance = await clients.billingQuery.getCreditBalance({ orgId: org });
   return balance.availableMicros;
+}
+
+// ---------------------------------------------------------------------------
+// The Stripe half. Outbound, Java dials the run's fake (harness/fake-stripe.ts)
+// and the suite reads what landed there; inbound, the suite IS Stripe — it
+// authors the event payloads below and signs them with the secret the server
+// was booted with. The fake owns Stripe's response shapes; the suite owns the
+// events it posts, so the builders live here beside the arms that use them.
+
+async function post(event: ReturnType<typeof stripeEvent>, options: { secret?: string; timestamp?: number } = {}) {
+  const lane = target.stripeWebhook!();
+  return postStripeWebhook(lane.baseUrl, signedEvent(event, options.secret ?? lane.signingSecret, options.timestamp));
+}
+
+function checkoutCompleted(sessionId: string, type = "checkout.session.completed", id?: string) {
+  return stripeEvent(type, { id: sessionId, object: "checkout.session", payment_intent: `pi_conf_${sessionId}`, customer: null, payment_status: "paid", status: "complete" }, id === undefined ? {} : { id });
+}
+
+// `customer.updated` carries the customer with its invoice settings; Java
+// reads `invoice_settings.default_payment_method` and, when set, retrieves
+// the payment method from the (fake) API before writing it onto the account.
+function customerUpdated(customerId: string, defaultPaymentMethodId: string | null) {
+  return stripeEvent("customer.updated", { id: customerId, object: "customer", invoice_settings: { default_payment_method: defaultPaymentMethodId } });
+}
+
+// `payment_method.attached` carries the payment method itself — Java reads
+// the card from the event, never from the API. `card` defaults to the fake's
+// one card; pass `type: "us_bank_account"` (no card) for the non-card arm.
+function paymentMethodAttached(paymentMethodId: string, customerId: string, options: { type?: string; card?: typeof FAKE_CARD | null } = {}) {
+  const type = options.type ?? "card";
+  const card = options.card === undefined ? (type === "card" ? FAKE_CARD : null) : options.card;
+  return stripeEvent("payment_method.attached", { id: paymentMethodId, object: "payment_method", type, customer: customerId, ...(card === null ? {} : { card }) });
+}
+
+// The two PaymentIntent events Java handles for auto-recharge. Java keys on
+// `metadata.stigmer_recharge_event_id`; without it the event is a checkout's
+// PaymentIntent and is deliberately ignored (the purchase path is settled by
+// checkout.session.completed, not by the intent).
+function paymentIntentSucceeded(paymentIntentId: string, rechargeEventId?: string, id?: string) {
+  return stripeEvent("payment_intent.succeeded", { id: paymentIntentId, object: "payment_intent", status: "succeeded", metadata: rechargeMetadata(rechargeEventId) }, id === undefined ? {} : { id });
+}
+
+function paymentIntentPaymentFailed(paymentIntentId: string, rechargeEventId?: string, message = "Your card was declined.") {
+  return stripeEvent("payment_intent.payment_failed", {
+    id: paymentIntentId,
+    object: "payment_intent",
+    status: "requires_payment_method",
+    metadata: rechargeMetadata(rechargeEventId),
+    last_payment_error: { code: "card_declined", message },
+  });
+}
+
+function rechargeMetadata(rechargeEventId: string | undefined): Record<string, string> {
+  return rechargeEventId === undefined ? {} : { stigmer_recharge_event_id: rechargeEventId };
+}
+
+// Java mints the org's Stripe customer on its first checkout; the fake's
+// captured `POST /v1/customers` answer is the id. Customer creation and use
+// must share one test — the fake forgets its customers on reset().
+async function seedStripeCustomer(as: ConformanceClients, org: string): Promise<string> {
+  await as.billingCommand.createCreditCheckoutSession({ orgId: org, packId: "starter", successUrl: "https://x.test/ok", cancelUrl: "https://x.test/c" });
+  const created = (await control.stripe.requests()).filter((r) => r.method === "POST" && r.path === "/v1/customers").at(-1);
+  const customerId = created?.response.id;
+  if (customerId === undefined) throw new Error(`seedStripeCustomer(${org}): the checkout created no Stripe customer on the fake`);
+  return customerId;
+}
+
+// The only way an account gets a saved payment method from outside Java is
+// the webhook: Stripe tells Java a method was attached. Returns the id the
+// account now shows; the row's own arm asserts the finer contract.
+async function seedDefaultPaymentMethod(as: ConformanceClients, org: string, customerId: string): Promise<string> {
+  const paymentMethodId = uniqueName("pm_conf");
+  const response = await post(paymentMethodAttached(paymentMethodId, customerId));
+  expect(response.status, `payment_method.attached for ${org}: ${response.body}`).toBe(200);
+  const account = await as.billingQuery.getBillingAccount({ orgId: org });
+  expect(account.defaultPaymentMethod?.paymentMethodId, "the attached card is the account's default").toBe(paymentMethodId);
+  return paymentMethodId;
+}
+
+// Java creates the auto-recharge PaymentIntent on a background executor after
+// the debit returns, so the suite polls the fake for the capture rather than
+// reading it once. The timeout message lists what DID land, so a miss says
+// which call Java made instead.
+async function awaitStripeRequest(predicate: (request: CapturedStripeRequest) => boolean, label: string): Promise<CapturedStripeRequest> {
+  const requests = await pollUntil(
+    () => control.stripe.requests(),
+    (captured) => captured.some(predicate),
+    (last, timeoutMs) => `${label}: no matching Stripe request within ${timeoutMs}ms; captured: ${(last ?? []).map((r) => `${r.method} ${r.path}`).join(", ") || "(none)"}`,
+    { timeoutMs: 10_000, pollMs: 100 },
+  );
+  const match = requests.find(predicate);
+  if (match === undefined) throw new Error(`${label}: matched then vanished`);
+  return match;
+}
+
+// The auto-recharge journey, up to the PaymentIntent Java creates.
+//
+// Why these numbers (Java: CreditLedgerService.determineSignal,
+// ExecutionBillingService.reportLlmCallUsage, AutoRechargeService.evaluateAndTrigger):
+//   fund $3 → authorizeExecution takes the $1 default hold → available $2.
+//   One priced call (claude-sonnet-4-6/native is seeded at $3/$15 per
+//   million; 100k in + 10k out ≈ $0.45 before policy markup) debits the hold,
+//   leaving ~$0.55 of headroom. The post-debit signal is
+//   available + headroom ≈ $2.55 ≤ the $5 low-balance default → warning, which
+//   is what makes Java evaluate auto-recharge at all. evaluateAndTrigger then
+//   compares available ($2) — NOT the headroom figure — with the threshold
+//   ($5): below, so it claims a slot on the monthly cap ($20 of $40) and hands
+//   the PaymentIntent create to its executor. `usageStatus: COMPLETE` is what
+//   makes the call billable; without it Java records the call and debits
+//   nothing.
+const RECHARGE = {
+  fundMicros: 3_000_000n,
+  thresholdMicros: 5_000_000n,
+  amountMicros: 20_000_000n,
+  capMicros: 40_000_000n,
+  usage: { inputTokens: 100_000n, outputTokens: 10_000n },
+} as const;
+
+interface ArmedRecharge {
+  readonly org: string;
+  readonly customerId: string;
+  readonly paymentMethodId: string;
+  readonly executionId: string;
+  // What Java sent the fake for the recharge.
+  readonly paymentIntent: CapturedStripeRequest;
+  // The id the webhook must carry back for Java to settle this recharge.
+  readonly rechargeEventId: string;
+}
+
+async function armRecharge(op: PrivilegedScope): Promise<ArmedRecharge> {
+  const org = op.context.org;
+  await fundAs(op.clients, org, RECHARGE.fundMicros);
+  const customerId = await seedStripeCustomer(op.clients, org);
+  const paymentMethodId = await seedDefaultPaymentMethod(op.clients, org, customerId);
+  await op.clients.billingCommand.setAutoRechargeConfig({
+    orgId: org,
+    enabled: true,
+    thresholdMicros: RECHARGE.thresholdMicros,
+    rechargeAmountMicros: RECHARGE.amountMicros,
+    monthlyCapMicros: RECHARGE.capMicros,
+  });
+  const executionId = uniqueName("exec-recharge");
+  const authorized = await op.clients.billingCommand.authorizeExecution({ orgId: org, executionId, harness: "native" });
+  expect(authorized.authorized, "the $3 org is admitted").toBe(true);
+  await debitOnce(op, executionId, 1);
+  const paymentIntent = await awaitStripeRequest((r) => r.method === "POST" && r.path === "/v1/payment_intents", `auto-recharge PaymentIntent for ${org}`);
+  const rechargeEventId = paymentIntent.params["metadata[stigmer_recharge_event_id]"];
+  if (rechargeEventId === undefined) throw new Error(`the recharge PaymentIntent carries no stigmer_recharge_event_id: ${JSON.stringify(paymentIntent.params)}`);
+  return { org, customerId, paymentMethodId, executionId, paymentIntent, rechargeEventId };
+}
+
+// One billable LLM call on an authorized execution — the debit that trips
+// the signal. `sequence` must be unique per execution.
+async function debitOnce(op: PrivilegedScope, executionId: string, sequence: number): Promise<void> {
+  await op.clients.billingCommand.recordLlmCallUsage({
+    executionId,
+    sequence,
+    provider: "anthropic",
+    resolvedModel: "claude-sonnet-4-6",
+    requestedModel: "claude-sonnet-4-6",
+    harness: "native",
+    tokens: RECHARGE.usage,
+    usageStatus: UsageCompletionStatus.COMPLETE,
+  });
 }
 
 describe.skipIf(!ledgerServed)("Billing ledger conformance — accounts, balances and the ledger (billingLedger targets)", () => {
@@ -295,12 +505,6 @@ describe.skipIf(!ledgerServed)("Billing ledger conformance — accounts, balance
 });
 
 describe.skipIf(!ledgerServed)("Billing ledger conformance — the purchase money path against the fake Stripe", () => {
-  let control: CloudFixturesClient;
-
-  beforeAll(() => {
-    control = requireCloudFixtures();
-  });
-
   afterEach(async () => {
     await control.stripe.reset();
   });
@@ -391,17 +595,8 @@ describe.skipIf(!ledgerServed)("Billing ledger conformance — the purchase mone
     expect(request?.params["return_url"]).toBe("https://x.test/back");
   });
 
-  // The webhook half: the suite is Stripe here, signing events with the
-  // secret the server was booted with and posting them to the lane.
-  async function post(event: ReturnType<typeof stripeEvent>, options: { secret?: string; timestamp?: number } = {}) {
-    const lane = target.stripeWebhook!();
-    return postStripeWebhook(lane.baseUrl, signedEvent(event, options.secret ?? lane.signingSecret, options.timestamp));
-  }
-
-  function checkoutCompleted(sessionId: string, type = "checkout.session.completed", id?: string) {
-    return stripeEvent(type, { id: sessionId, object: "checkout.session", payment_intent: `pi_conf_${sessionId}`, customer: null, payment_status: "paid", status: "complete" }, id === undefined ? {} : { id });
-  }
-
+  // The webhook half: the suite is Stripe here (the builders at module scope),
+  // posting the events a purchase produces back to the lane.
   async function purchase(org: string): Promise<{ sessionId: string; creditsMicros: bigint }> {
     const created = await clients.billingCommand.createCreditCheckoutSession({ orgId: org, packId: "starter", successUrl: "https://x.test/ok", cancelUrl: "https://x.test/c" });
     const session = (await control.stripe.requests()).find((r) => r.path === "/v1/checkout/sessions");


### PR DESCRIPTION
## Summary

The eleven billing rows E1 presented as `debris-candidate` and C5's plan gate ruled **PORTED** (2026-09-06) become conformance arms in `test/conformance`, green on the hermetic Java launcher; the `api_version` row is cut as ruled; the one Class B arm that raced settle on #990's push-to-main run is fixed. E1 follow-up (task T02 of `20260906.04.sp.cloud-capability-conformance-suites`).

## Context

DD-012's posture is that the conformance suite IS the acceptance instrument: green on hermetic Java first (Java's behavior is the spec), honestly red on the composition until the porting entry turns it green. On `main` the eleven ruled rows still carried `debris-candidate` and had no tests, and C5's plan expected to write them mid-port ("a test-only OSS PR rides S2"). E1 owns the instrument; C5's S2 now inherits a fixed target.

The rulings this PR makes durable — C5 gate Q0/Q1 (`stigmer-cloud/_projects/2026-09/20260906.05.sp.billing-native-extension/tasks/T01_1_review.md`): auto-recharge is a live product surface (the console's `AutoRechargeCard`; `setAutoRechargeConfig` in three SDKs), the pricing-governance lanes are operator tooling with a console; `billing.stripe.api-version.mismatch-silently-no-ops` is stripe-java's release-train strictness, not product behavior.

## Changes

**Inventory** (`inventory/cloud-capabilities.yaml`) — 152 rows: conformance 114, unit 28, smoke 5, debris 5, `debris-candidate` 0; `inventory:check` 0 problems.
- Eleven rows → `conformance`, each `note` now the dated ruling and each `behavior` the contract the arm pins.
- `decide-model-pricing-override` split: `.unknown-not-found` is drivable → `conformance`; `.already-decided-failed-precondition` is not (no RPC creates a pending override — only the Temporal provider-reconciliation corrector, default off) → `unit`, with the note that NEITHER edition tests it today.
- `get-model-pricing-governance.returns-queue`'s behavior corrected: `entries` carries every seeded registry model (the seeder runs on every boot); only `pending_overrides` is empty on a fresh environment.
- `api_version` → `debris` (`disputed` removed).

**Arms** (`suites/billing.conformance.test.ts`, +10 arms; the whole file's helpers at module scope):
- `setAutoRechargeConfig`: disabled persists at once and still rejects negatives; enabling needs a saved card BEFORE the amounts are looked at (`FAILED_PRECONDITION`); the amount ladder in the engine's order, byte-pinned; an enable persists; the outsider refusal with the proto's copy.
- Pricing governance (operator): upsert listed ACTIVE with the server's stamps, a re-upsert supersedes and chains through `supersedes_baseline_id`, a variant Cursor rate is refused; retire unknown / known / again; decide unknown; the governance view's shape. Baselines are platform-global, so every arm keys on a run-unique model and retires it on cleanup.
- `payment_method.attached` sets the default card only when none is set and tells Stripe (`POST /v1/customers/{id}` once); a second card and a `us_bank_account` are ignored. `customer.updated` makes Java retrieve the named method and record it, or clears the default.
- The auto-recharge journey, driven as the platform operator (the trigger is synchronous inside `recordLlmCallUsage`): a debit past the threshold makes Java create the PaymentIntent under `Idempotency-Key: auto_recharge_<eventId>` (a DD-012 carve-out) with the full shape pinned, and claim the month; `payment_intent.succeeded` grants once under that key — replays and metadata-less / unknown-event intents grant nothing; `payment_intent.payment_failed` releases the slot, proven real by the next debit triggering a fresh recharge.
- Two copy tables by provenance: `COPY` (proto `error_msg`) and `DOMAIN_COPY` (the engine's own validation copy) — the distinction C5 must preserve.

**Fixture** (`harness/fake-stripe.ts`): `FAKE_CARD` — the payment-method retrieve carries `exp_month`/`exp_year`. Stripe always returns them for a card; Java's `customer.updated` handler reads them unguarded, so the expiry-less fixture card turned that webhook into a 500. One unit arm pins the shape.

**Class B** (`suites-execution/billing-gates.conformance.test.ts`): `awaitSettled()` — the rearm arm waits for the failed run's hold to return before draining. The workflow writes the terminal status before its `finally` releases the hold; the arm drained against a stale `available`, the release landed, and `rearmForRecovery` admitted ([run 34028008217](https://github.com/stigmer/stigmer/actions/runs/34028008217); green on the nightly of the same SHA).

## Implementation notes

- Event builders stay suite-local beside `checkoutCompleted()`: the fake owns Stripe's OUTBOUND response shapes, the suite owns the INBOUND events it authors.
- The recharge arithmetic is written once in `armRecharge()`: fund $3 → the $1 default hold → available $2; one priced call (100k in / 10k out on `claude-sonnet-4-6`, ≈ $0.45) debits the hold; the post-debit signal `available + headroom ≤ $5` trips the warning; `evaluateAndTrigger` compares `available` ($2) with the threshold ($5). `usageStatus: COMPLETE` is what makes the call billable.
- The recharge arms get their own `describe` block with its own fake-Stripe reset, mirroring the purchase block; the blocks that never touch Stripe pay for no reset.
- `debris-candidate` stays in the schema enum as the ceremony's waiting state for future inventories.

## Test plan

Hermetic Java (`STIGMER_SERVICE_JAR` from stigmer-cloud `main` — the JAR carries `stigmer.stripe.api-base`; no Java source changed since):
- Class A `npm run test:cloud`: **556 passed / 0 failed / 52 skipped on 608** — the existing 546 arms: 0 failures; the 10 new arms green (the journey arm 330 ms incl. the poll for Java's background PaymentIntent).
- Class B billing files: **5 / 0**; `billing-gates` re-run 3 more times: 3 / 3 green.
- Local OSS target, the billing file: 1 passed (the Q10 pin) / 43 skipped — the new arms skip visibly where `billingLedger` is false.
- `npm run inventory:check` 0 problems; `npm run test:unit` 29 / 29; `tsc --noEmit` clean for the touched files (pre-existing errors in `mcp-server`/`sdk/typescript` are on `main`).

The Class A / Class B numbers were taken on the pre-rebase tree; the rebase onto #993 touched only the proxy rows, `inventory.ts` and `target.ts`. `ci.conformance-cloud` runs both classes on this PR.

The composition readout was NOT re-run this session: the primary checkout's composition build predates P1's and C5's merges, so a run on it would not measure today's `main`. Expected on a fresh substrate: the six RPC arms pass through the facade to Java; the four webhook-driven arms and the journey go red on the missing Stripe webhook lane (C5 S2's).

## Risks

Test-only change in the OSS repo; no production code in either repo. Rollback is a revert. The eleven rows are red on the composition by design until C5's S2 — the nightly `ci.conformance-cloud` runs hermetic Java, not the composition, so no CI lane turns red.

Closes #994
