### PR TITLE
test(conformance): annotate the three Stripe inventory rows with the filed Java findings

### DIFF
--- a/test/conformance/inventory/cloud-capabilities.yaml
+++ b/test/conformance/inventory/cloud-capabilities.yaml
@@ -1124,6 +1124,7 @@ rows:
     needs: [unfunded-org, fake-stripe]
     note: >-
       RULED PORTED 2026-09-06 (C5 gate, Q1) with auto-recharge, which it serves. Java carries NO unit test for this handler (StripeWebhookServiceTest covers the checkout events only) — this arm is the only proof on either side. Java reads the card's exp_month/exp_year unguarded; the fake's card carries them (FAKE_CARD).
+      FILED 2026-09-07 stigmer-cloud#666: Java claims the dedup row BEFORE this handler runs, so a handler failure (the unguarded expiry read is the realistic one) answers 500 and every Stripe redelivery is skipped as a duplicate — this lane has no reconciliation sweep, so the loss is permanent; C5's S2 gate rules record-then-process vs a retryable dedup. The arm's assertions hold under either design.
   - id: billing.stripe.payment-method-attached.sets-default-when-none
     surface: billing
     lane: >-
@@ -1141,6 +1142,7 @@ rows:
     needs: [unfunded-org, fake-stripe]
     note: >-
       RULED PORTED 2026-09-06 (C5 gate, Q1) with auto-recharge, which it serves. Java carries NO unit test for this handler — this arm is the only proof on either side. It is also how every auto-recharge arm gives its org a saved card.
+      FILED 2026-09-07 stigmer-cloud#666: the same dedup-before-handler exposure as customer.updated (the expiry read at StripeWebhookService.java:354 is unguarded here too), the same missing sweep; C5's S2 gate rules on both lanes together. The arm's assertions hold under either design.
   - id: billing.stripe.payment-intent-succeeded.recharge-provisions-credits
     surface: billing
     lane: >-
@@ -1158,6 +1160,7 @@ rows:
     needs: [unfunded-org, fake-stripe]
     note: >-
       RULED PORTED 2026-09-06 (C5 gate, Q1): auto-recharge is a live product surface. The arm drives the whole journey as the platform operator — the trigger is synchronous inside recordLlmCallUsage when the post-debit signal is low_balance_warning, so the operator's engine RPCs are the only black-box way to reach it; the PaymentIntent lands on the fake from Java's background executor and the arm polls for it. Java's webhook handler has no unit test of its own; AutoRechargeServiceTest covers provisionRechargeCredits.
+      FILED 2026-09-07 stigmer-cloud#667: because the trigger runs only behind that low_balance_warning gate — whose threshold is the fixed $5 low_balance_threshold_micros no RPC sets — a user threshold above $5 is silently capped at $5, contrary to threshold_micros's proto contract ("when available balance drops below this amount"). This arm uses T = $5 and stays green under either behavior. The composition's S1 engine already carries the same gate (execution-billing-engine.ts:655-661), latent until S2 implements the trigger; C5's S2 gate rules parity vs contract.
   - id: billing.stripe.payment-intent-failed.recharge-compensated
     surface: billing
     lane: >-


### PR DESCRIPTION
## Summary
Annotates three Stripe rows of the cloud-capability inventory with the Java findings E1 filed today, so the session that ports the webhook lane reads the exposure on the row it is porting.

## Context
E1's T02 verified two Java billing behaviors as defects and filed them on the cloud side: the webhook lane claims its dedup row before the handler runs, so a handler failure makes every Stripe redelivery a skipped duplicate ([stigmer-cloud#666](https://github.com/stigmer/stigmer-cloud/issues/666)); and the auto-recharge trigger runs only behind the fixed $5 low-balance gate, so a user threshold above $5 is silently capped at $5 ([stigmer-cloud#667](https://github.com/stigmer/stigmer-cloud/issues/667)). The inventory's `note:` field already carries dated rulings for these rows; a filed defect on the row's Java source is the same kind of dated fact.

## Changes
- `billing.stripe.customer-updated.syncs-default-payment-method` and `billing.stripe.payment-method-attached.sets-default-when-none`: one `FILED 2026-09-07 stigmer-cloud#666` sentence each — the dedup-before-handler exposure, the missing sweep, and that the arms hold under either design.
- `billing.stripe.payment-intent-succeeded.recharge-provisions-credits`: one `FILED 2026-09-07 stigmer-cloud#667` sentence — the $5 gate, the proto contract it contradicts, that the arm uses T = $5 and stays green either way, and that the composition's S1 engine already carries the same gate.

## Implementation notes
- Notes only. No arm, disposition, tag or `java_source` changes; the checker validates dispositions and tags, so `inventory:check` is unaffected by construction.

## Breaking changes
- None

## Test plan
- `make check-conformance-inventory` in a fresh worktree (after `npm ci` + `make build-ts-stubs`): `152 rows (conformance 114, unit 28, smoke 5, debris 5); 114 tested rows covered; 0 problem(s)`; unit 29/29.

## Risks
- None beyond wording; revert is the three-line diff.

## Checklist
- [x] Docs updated (the inventory is the record)
- [ ] Tests added/updated (not applicable — notes only)
- [x] Backward compatible

Closes #996
