### PR TITLE
test(conformance): run the hermetic Java launcher in production security mode

### DIFF
--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -147,12 +147,13 @@ npm run test:cloud -w @stigmer/conformance   # or: make test-conformance-cloud
 Its `globalSetup` (`global-setup-cloud.ts`) boots the environment **once per
 run** — a Go launcher (`test/integration/cmd/conformance-cloudenv`, reusing the
 integration harness) starts Testcontainers Postgres/Redis/MinIO/OpenFGA, a
-Temporal dev server, and the service fat JAR in test security mode with **real
-OpenFGA authorization** — then bootstraps a real identity (PlatformClient ->
-`mintUserToken`) and publishes endpoint + token to workers via env vars
-(`STIGMER_CONFORMANCE_CLOUD_*`). The `CloudTarget` itself is **connect-only**:
-point those env vars at any pre-provisioned endpoint and the globalSetup boot
-is skipped entirely.
+Temporal dev server, a mock platform identity tenant, and the service fat JAR
+in **production security mode** with **real OpenFGA authorization** — then
+bootstraps a real identity as the launcher's pre-seeded operator (a
+tenant-minted token -> PlatformClient -> `mintUserToken`) and publishes
+endpoint + token to workers via env vars (`STIGMER_CONFORMANCE_CLOUD_*`). The
+`CloudTarget` itself is **connect-only**: point those env vars at any
+pre-provisioned endpoint and the globalSetup boot is skipped entirely.
 
 Requirements: Docker, `go`, the `fga` CLI (`brew install openfga/tap/fga`), the
 `temporal` CLI, and the service JAR — `STIGMER_SERVICE_JAR`, or built in the
@@ -176,11 +177,13 @@ to the caller's account at position 1. The suite forges nothing about the
 tenant — it mints through `CloudTarget.directLoginTenant()`, which exists only
 where the environment hands the harness the tenant's signing key
 (`STIGMER_CONFORMANCE_CLOUD_DIRECT_LOGIN_ISSUER` / `_SIGNING_KEY_BASE64` /
-`_KID` / `_API_AUDIENCE` / optional `_MCP_AUDIENCE`): the composition readout
-substrate's mock tenant (`stigmer-cloud` `backend/services/stigmer-server/spike/identity-tenant.ts`
-writes that group beside the composition's own `STIGMER_IDP_*` boot trio). The
-hermetic Java launcher (test security mode, no edge) and every deployed
-endpoint (a real tenant's key is never conformance's) leave the group unset,
+`_KID` / `_API_AUDIENCE` / optional `_MCP_AUDIENCE`): the hermetic launcher's
+own tenant (published by the global setup from the launcher's ready line — the
+same key that minted the bootstrap operator's first token) and the composition
+readout substrate's mock tenant (`stigmer-cloud`
+`backend/services/stigmer-server/spike/identity-tenant.ts` writes that group
+beside the composition's own `STIGMER_IDP_*` boot trio). Every deployed
+endpoint (a real tenant's key is never conformance's) leaves the group unset,
 and the arms skip VISIBLY with the target's reason.
 
 **The cloud-capability suites** (E1 of the convergence program's DD-012 reset,
@@ -217,10 +220,38 @@ CRUD suites:
   target whose flag is true and whose lane is missing FAILS, never skips.
   That red is the implementing entry's acceptance.
 
-Authentication-class arms (401 without a bearer, foreign tokens, CORS,
-`denyAll`, the require-scope header) are unobservable in the launcher's test
-security mode and skip through `edgeAuthenticationBypass()` until the launcher
-runs production security (its own entry).
+**Launcher posture vs production.** The launcher boots Java the way production
+runs it wherever the harness can (stigmer-cloud entry `20260907.02`, closing
+D-S1 option (ii) of `20260904.02`): `STIGMER_SECURITY_MODE=production` — the
+real `GrpcSecurityConfigBase`, `HttpSecurityConfig` and Auth0
+`MachineAccountJwtProvider` load, trusting the launcher's in-process mock tenant
+(OIDC discovery, JWKS, `/oauth/token`, `/userinfo`) exactly as
+`test/integration-security` boots it; `STIGMER_PROXY_REQUIRE_SCOPE_HEADER=true`
+(production's default); a Stigmer-token audience stamped and verified leniently
+(production's pair). So the authentication-class arms — 401 without a bearer,
+foreign and expired tokens, the API-key lane, CORS, `denyAll`, the
+require-scope header, the direct-login tenant's six `classifyAuthError` arms —
+run against Java's real edge; there is no "bypassed edge" posture in the
+harness to skip on, by design (a target whose edge admits anonymous callers
+FAILS those arms). What still differs from production is written beside each
+override in `test/integration/harness/service.go` (`buildServiceEnv`) under one
+of three dispositions:
+
+- `production` — matches production: the security mode, the require-scope
+  header, the token audience.
+- `harness-constraint` — cannot match inside Testcontainers, reason stated:
+  `STIGMER_IDP_JWKS_VALIDATION_DISABLED` (the mock JWKS is plain HTTP), R2
+  path-style addressing (MinIO), `STIGMER_SANDBOX_TYPE=noop` and
+  `STIGMER_RUNNER_LAUNCHER_TYPE=noop` (no cluster).
+- `test-tuning` — a knob the Go suites turn to make a behavior reachable in
+  one test, with the arms that would notice named: the two billing sweeps off
+  (they would race the billing arms), `STIGMER_SHARING_MAX_TURNS_PER_SESSION=5`,
+  `STIGMER_SCHEDULES_MAX_CONSECUTIVE_FAILURES=2`,
+  `STIGMER_SCHEDULES_SESSION_DEFAULTS_HARNESS=native`.
+
+An override with no disposition is a defect in that file. The Go integration
+suites keep test security mode through their own `ServiceConfig`; only the
+conformance launcher's job is to observe the edge.
 
 ## Design
 

--- a/test/conformance/inventory/cloud-capabilities.yaml
+++ b/test/conformance/inventory/cloud-capabilities.yaml
@@ -22,12 +22,10 @@
 #   java_test    path under .../src/test/java/ai/stigmer, or `none`
 #   class        behavior | carve-out (a DD-012 byte-identical carve-out) | adversarial
 #   disposition  conformance | deviation | unit | smoke | debris-candidate | debris
-#   observability launcher | launcher-authz-only | composition-only | none
-#                (`launcher-authz-only`: needs production security mode — the
-#                hermetic launcher runs STIGMER_SECURITY_MODE=test, which does
-#                not load HttpSecurityConfig; those tests skip through
-#                TargetProfile.edgeAuthenticationBypass() until the launcher
-#                entry lands)
+#   observability launcher | composition-only | none
+#                (the hermetic launcher runs Java in PRODUCTION security mode
+#                since entry 20260907.02, so authentication-class rows are
+#                `launcher` like every other observable row)
 #   caller       primary | operator | outsider | anonymous | runner-token | none
 #   needs        fixtures/affordances the test requires
 #   note         optional context
@@ -1568,11 +1566,11 @@ rows:
       proxy/authorization/ProxyScopeAuthorizationTest.java
     class: adversarial
     disposition: conformance
-    observability: launcher-authz-only
+    observability: launcher
     caller: primary
     needs: [fake-llm-upstream]
     note: >-
-      The harness boots Java with STIGMER_PROXY_REQUIRE_SCOPE_HEADER=false (F6); the row skips with a stated reason until the launcher entry restores production posture.
+      The conformance launcher boots Java with STIGMER_PROXY_REQUIRE_SCOPE_HEADER=true, production's default (entry 20260907.02 restored the posture E1's F6 found relaxed); the Go integration suites keep false through ServiceConfig's zero value.
   - id: proxy.llm.authn.no-bearer-401
     surface: proxy
     lane: >-
@@ -1585,7 +1583,7 @@ rows:
       none
     class: adversarial
     disposition: conformance
-    observability: launcher-authz-only
+    observability: launcher
     caller: anonymous
     needs: [fake-llm-upstream]
   - id: proxy.llm.authn.foreign-or-expired-token-401
@@ -1600,7 +1598,7 @@ rows:
       none
     class: adversarial
     disposition: conformance
-    observability: launcher-authz-only
+    observability: launcher
     caller: anonymous
     needs: [fake-llm-upstream]
   - id: proxy.llm.authn.x-api-key-header-accepted
@@ -1615,7 +1613,7 @@ rows:
       none
     class: behavior
     disposition: conformance
-    observability: launcher-authz-only
+    observability: launcher
     caller: primary
     needs: [fake-llm-upstream, agent-execution]
   - id: proxy.llm.upstream.connection-refused-502
@@ -2015,7 +2013,7 @@ rows:
       none
     class: adversarial
     disposition: conformance
-    observability: launcher-authz-only
+    observability: launcher
     caller: anonymous
     needs: [none]
   - id: proxy.health.anonymous-up
@@ -2045,7 +2043,7 @@ rows:
       none
     class: adversarial
     disposition: conformance
-    observability: launcher-authz-only
+    observability: launcher
     caller: anonymous
     needs: [none]
   - id: proxy.authorization.decision-cache-five-minutes
@@ -2434,11 +2432,11 @@ rows:
       none
     class: carve-out
     disposition: conformance
-    observability: launcher-authz-only
+    observability: launcher
     caller: anonymous
     needs: [none]
     note: >-
-      HttpSecurityConfig is not loaded in test security mode; the row skips with the stated reason until the launcher entry lands. P1's handoff carries this — P1 verifies the allow-list in its own smoke (ruling Q8).
+      Measured on the hermetic launcher since entry 20260907.02 (production security mode loads HttpSecurityConfig). P1's smoke verifies the same allow-list against the deployed lane (ruling Q8).
   - id: public.edge.public-paths-anonymous
     surface: public
     lane: >-
@@ -2451,7 +2449,7 @@ rows:
       none
     class: behavior
     disposition: conformance
-    observability: launcher-authz-only
+    observability: launcher
     caller: anonymous
     needs: [none]
 

--- a/test/conformance/inventory/cloud-capabilities.yaml
+++ b/test/conformance/inventory/cloud-capabilities.yaml
@@ -947,10 +947,12 @@ rows:
     java_test: >-
       domain/billing/stripe/StripeWebhookControllerTest.java
     class: adversarial
-    disposition: conformance
+    disposition: deviation
     observability: launcher
     caller: anonymous
     needs: [fake-stripe]
+    note: >-
+      MEASURED 2026-09-07 on the production-mode launcher (entry 20260907.02): Java answers 401, not 400 — the framework's MissingRequestHeaderException 400 re-dispatches to /error, which HttpSecurityConfig's anyRequest().denyAll() turns into 401 for the anonymous caller (invisible under test security mode). The suite asserts 400 (the composition's answer) and carries Java in contract/deviations.ts as java.stripe-webhook.missing-signature-header-401; the entry retires with Java.
   - id: billing.stripe.webhook.anonymous-reachable
     surface: billing
     lane: >-

--- a/test/conformance/src/contract/deviations.ts
+++ b/test/conformance/src/contract/deviations.ts
@@ -5,56 +5,111 @@
 // happens to do today. Where a target legitimately deviates from the contract
 // because of a known bug, it gets a tracked entry here instead of the test
 // silently asserting the wrong behavior. When the target is fixed, the
-// assertion in expectCodeOrDeviation flips and the entry should be removed —
-// the registry can never hide a regression or bless a bug permanently.
-import { Code } from "@connectrpc/connect";
-import { expectGrpcCode } from "./errors";
+// `observed` assertion in assertContractOrDeviation fails and the entry must
+// be removed — the registry can never hide a regression or bless a bug
+// permanently.
+//
+// A deviation is whatever the contract can state — a gRPC code, an HTTP
+// status, a byte-pinned message, a visible side effect — so the registry
+// records the two readings as prose and the arm supplies the two assertions.
+// The first entries arrived when the hermetic Java launcher started running
+// production security mode (entry 20260907.02): three behaviors of the Java
+// service that the composition already answers per the contract.
 
 export interface KnownDeviation {
   // Stable identifier used by tests to opt a case into the registry.
   id: string;
-  // Target names that currently exhibit the deviation (e.g. "local").
+  // Target names that currently exhibit the deviation (TargetProfile.name).
   targets: string[];
-  // The code the contract requires.
-  expected: Code;
-  // The code the listed targets currently return.
-  actual: Code;
+  // What the contract requires, in one sentence.
+  contract: string;
+  // What the listed targets do instead, in one sentence.
+  observed: string;
   // Why the deviation exists.
   rationale: string;
   // Where to fix it / track it.
   tracking: string;
 }
 
-// No known deviations are currently tracked: every target returns the contract
-// gRPC code. Add an entry here (and route the assertion through
-// expectCodeOrDeviation) only when a target has a known, tracked bug that
-// returns the wrong code; remove it the moment the target is fixed.
-export const KNOWN_DEVIATIONS: KnownDeviation[] = [];
+// The hermetic Java targets. The Java service retires at R1; every entry
+// naming them is deleted with it.
+const JAVA_TARGETS = ["cloud", "cloud-execution"];
 
-// Asserts the contract code, transparently accommodating a registered deviation
-// for the active target. The deviation is reported (never silently swallowed),
-// and if the target starts returning the contract code the assertion fails,
-// signaling the entry is stale and should be deleted.
-export async function expectCodeOrDeviation(
+export const KNOWN_DEVIATIONS: KnownDeviation[] = [
+  {
+    id: "java.stripe-webhook.missing-signature-header-401",
+    targets: JAVA_TARGETS,
+    contract: "POST /webhook/stripe without a Stripe-Signature header answers 400 and grants nothing.",
+    observed: "Java answers 401 (and still grants nothing).",
+    rationale:
+      "Spring MVC raises MissingRequestHeaderException → sendError(400) → Tomcat re-dispatches to " +
+      "/error → HttpSecurityConfig's anyRequest().denyAll() refuses the anonymous caller → 401. Any " +
+      "framework-generated 4xx on Java's HTTP lanes becomes a 401 for anonymous callers; the " +
+      "controller's own ResponseEntity(400) paths are unaffected. Hidden under test security mode " +
+      "(permit-all). Stripe always sends the header, so production never takes this path.",
+    tracking:
+      "stigmer-cloud entry 20260907.02, review finding F-A (cited, not filed — retires with Java; " +
+      "the composition answers 400).",
+  },
+  {
+    id: "java.direct-login.personal-org-owner-is-raw-subject",
+    targets: JAVA_TARGETS,
+    contract:
+      "A first login's provisionMyAccount creates a personal organization OWNED BY the new identity " +
+      "account, visible to it on findMyOrganizations.",
+    observed:
+      "Java's personal org is owned by the raw idp subject (identity_account:<sub>), so the new " +
+      "account cannot see it and a retry cannot find it.",
+    rationale:
+      "EnsurePersonalOrganization calls organizationGrpcRepo.createAsCaller(org) while the caller is " +
+      "still the unresolved subject (the interceptor admits an unknown human sub as its raw idpId), so " +
+      "the org-create pipeline grants owner to that principal rather than the account it just created. " +
+      "The composition fixed the same bug on its side (entry 20260905.01, Q8).",
+    tracking:
+      "stigmer-cloud#672 — an X1 input: whether production's FGA store (which survives the cutover) " +
+      "holds raw-subject owner tuples is the first check.",
+  },
+  {
+    id: "java.direct-login.stranger-signature-copy",
+    targets: JAVA_TARGETS,
+    contract:
+      "A tenant-issuer token signed by a key the tenant's JWKS does not carry is refused " +
+      'UNAUTHENTICATED "token signature verification failed".',
+    observed: 'Java refuses UNAUTHENTICATED "invalid token" (the classifier fallback).',
+    rationale:
+      "GrpcSecurityConfigBase.classifyAuthError matches \"signature\", \"jwk\" or \"signing key\" in the " +
+      "exception description; the runtime Nimbus message is \"Signed JWT rejected: Another algorithm " +
+      "expected, or no matching key(s) found\" — none of those words. Java's own unit test fixture " +
+      "carries an older message shape (\"… in JWK set\") that would match.",
+    tracking:
+      "stigmer-cloud entry 20260907.02, review finding F-D (cited, not filed — message copy only; " +
+      "retires with Java; the composition answers the contract).",
+  },
+];
+
+// Runs the contract assertion, or — for a target registered as deviating —
+// the observed assertion, reporting the deviation (never silently). If a
+// registered target starts meeting the contract, `observed` fails, signaling
+// the entry is stale and should be deleted.
+export async function assertContractOrDeviation(
   targetName: string,
   deviationId: string,
-  op: () => Promise<unknown>,
-  context: string,
+  assertions: {
+    contract: () => Promise<void> | void;
+    observed: () => Promise<void> | void;
+  },
 ): Promise<void> {
   const deviation = KNOWN_DEVIATIONS.find((entry) => entry.id === deviationId);
   if (deviation === undefined) {
     throw new Error(`unknown deviation id: ${deviationId}`);
   }
-
-  const applies = deviation.targets.includes(targetName);
-  const codeToAssert = applies ? deviation.actual : deviation.expected;
-  await expectGrpcCode(op, codeToAssert, context);
-
-  if (applies) {
-    console.warn(
-      `[conformance] tracked deviation ${deviation.id} on ${targetName}: ` +
-        `contract=${Code[deviation.expected]} actual=${Code[deviation.actual]} ` +
-        `(${deviation.tracking})`,
-    );
+  if (!deviation.targets.includes(targetName)) {
+    await assertions.contract();
+    return;
   }
+  await assertions.observed();
+  console.warn(
+    `[conformance] tracked deviation ${deviation.id} on ${targetName}: ` +
+      `contract="${deviation.contract}" observed="${deviation.observed}" (${deviation.tracking})`,
+  );
 }

--- a/test/conformance/src/harness/cloud-env.ts
+++ b/test/conformance/src/harness/cloud-env.ts
@@ -1,12 +1,15 @@
 // Hermetic cloud environment: launcher process + identity bootstrap.
 // Domain: conformance harness (cloud target lifecycle).
 //
-// The heavy boot (Testcontainers infra + the Java stigmer-service fat JAR)
-// lives in a Go launcher that reuses the battle-tested integration harness
+// The heavy boot (Testcontainers infra + a mock platform identity tenant +
+// the Java stigmer-service fat JAR in PRODUCTION security mode) lives in a Go
+// launcher that reuses the battle-tested integration harness
 // (test/integration/cmd/conformance-cloudenv). This module owns the TS side:
-// spawning that launcher, performing the one-time auth bootstrap over gRPC,
-// and defining the env-var contract through which the cloud global setup
-// publishes the environment to test workers.
+// spawning that launcher, minting the pre-seeded bootstrap operator's first
+// token from the tenant material the launcher hands over, performing the
+// one-time auth bootstrap over gRPC as that operator, and defining the
+// env-var contract through which the cloud global setup publishes the
+// environment to test workers.
 //
 // Env vars are the interface deliberately: a future run against a deployed
 // environment sets the same variables directly and skips the launcher — the
@@ -24,6 +27,7 @@ import { IamPolicyCommandController } from "@stigmer/protos/ai/stigmer/iam/iampo
 import { PlatformClientCommandController } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/command_pb";
 import { PlatformClientTokenController } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/token_pb";
 import { createTransport, makeClients } from "./clients";
+import { newDirectLoginTenant } from "./direct-login-tenant";
 import { awaitGrpcReady } from "./grpc-ready";
 import { CONFORMANCE_OAUTH_REDIRECT_URI } from "./server-process";
 import { uniqueName } from "../support/naming";
@@ -52,34 +56,21 @@ export const CLOUD_ENV = {
   // credentials to a real deployment is the permanent skip the stigmer#547
   // ruling recorded, so privileged-lane assertions skip there.
   operatorToken: "STIGMER_CONFORMANCE_CLOUD_OPERATOR_TOKEN",
-  // Whether the environment's serving edge authenticates callers at all —
-  // `enforced` (the DEFAULT when unset: production Java's interceptor, the
-  // TS composition's declared posture) or `bypassed-test-mode`. The hermetic
-  // launcher boots the JAR with STIGMER_SECURITY_MODE=test, which does NOT
-  // load GrpcSecurityConfigBase: a synthetic caller stands in for every
-  // request, credential or not — the door bootstrapPrimaryIdentity walks
-  // through below. Only global-setup-cloud.ts, the code that CHOSE that
-  // mode, declares the bypass; a pre-provisioned or deployed endpoint that
-  // forgets the variable gets the production contract and fails loudly if
-  // its edge is open (DD-012: never a false green). The authentication
-  // suite skips its credential arms VISIBLY where the edge is bypassed and
-  // asserts them everywhere else. Java's production-mode posture is
-  // covered by test/integration-security; making the hermetic launcher run
-  // production mode is a recorded follow-up (entry 20260904.02, D-S1).
-  edgeAuthentication: "STIGMER_CONFORMANCE_CLOUD_EDGE_AUTHENTICATION",
   // The platform identity tenant the server under test was booted against
-  // (its STIGMER_IDP_URL / Java idp-url), as the readout substrate's mock
-  // tenant declares it — so the direct-login suite can MINT the tokens a
-  // console, desktop, CLI or MCP client presents and drive the server's
-  // direct-login lane (stigmer-cloud#604, the S1 lane). The signing key is
-  // the private half of the key the tenant's JWKS publishes (base64 of a
-  // PKCS#8 PEM, the composition's `*_BASE64` custody pattern); the kid names
-  // it in that document. Deliberately UNSET wherever the suite cannot own
-  // the tenant's key — the hermetic launcher (test security mode, no edge)
-  // and any deployed endpoint (a real tenant's key is never handed to
-  // conformance) — so CloudTarget exposes no directLoginTenant and the
-  // suite skips VISIBLY. The API audience is required with the issuer; the
-  // MCP audience is optional (blank = the tenant mints for the API alone).
+  // (its STIGMER_IDP_URL / Java idp-url), as the environment's mock tenant
+  // declares it — so the direct-login suite can MINT the tokens a console,
+  // desktop, CLI or MCP client presents and drive the server's direct-login
+  // lane (stigmer-cloud#604, the S1 lane). The signing key is the private
+  // half of the key the tenant's JWKS publishes (base64 of a PKCS#8 PEM, the
+  // composition's `*_BASE64` custody pattern); the kid names it in that
+  // document. Set by whoever owns the tenant: the hermetic launcher hands
+  // its in-process tenant's material over on the ready line (the same
+  // material minted the bootstrap operator's first token); the composition
+  // readout's spike tenant writes an env file. Deliberately UNSET on any
+  // deployed endpoint — a real tenant's key is never handed to conformance —
+  // so CloudTarget exposes no directLoginTenant and the suite skips VISIBLY.
+  // The API audience is required with the issuer; the MCP audience is
+  // optional (blank = the tenant mints for the API alone).
   directLoginIssuer: "STIGMER_CONFORMANCE_CLOUD_DIRECT_LOGIN_ISSUER",
   directLoginSigningKeyBase64: "STIGMER_CONFORMANCE_CLOUD_DIRECT_LOGIN_SIGNING_KEY_BASE64",
   directLoginKid: "STIGMER_CONFORMANCE_CLOUD_DIRECT_LOGIN_KID",
@@ -110,34 +101,10 @@ export const CLOUD_ENV = {
   fixturesControlUrl: "STIGMER_CONFORMANCE_CLOUD_FIXTURES_CONTROL_URL",
 } as const;
 
-// The two declared edge postures — see CLOUD_ENV.edgeAuthentication.
-export const EDGE_AUTHENTICATION = {
-  enforced: "enforced",
-  bypassedTestMode: "bypassed-test-mode",
-} as const;
-export type EdgeAuthentication =
-  (typeof EDGE_AUTHENTICATION)[keyof typeof EDGE_AUTHENTICATION];
-
-// Resolves the declared edge posture: unset = enforced (the production
-// contract). Any other value is a harness misconfiguration, thrown loudly
-// rather than coerced to either posture.
-export function resolveEdgeAuthentication(): EdgeAuthentication {
-  const raw = process.env[CLOUD_ENV.edgeAuthentication];
-  if (raw === undefined || raw === "" || raw === EDGE_AUTHENTICATION.enforced) {
-    return EDGE_AUTHENTICATION.enforced;
-  }
-  if (raw === EDGE_AUTHENTICATION.bypassedTestMode) {
-    return EDGE_AUTHENTICATION.bypassedTestMode;
-  }
-  throw new Error(
-    `${CLOUD_ENV.edgeAuthentication} must be "${EDGE_AUTHENTICATION.enforced}" or "${EDGE_AUTHENTICATION.bypassedTestMode}" when set; got "${raw}"`,
-  );
-}
-
-// The org whose FGA ownership tuples the launcher seeds for the synthetic test
-// identity (must match harness.TestOrg / fga_seeder.go in test/integration).
-// The bootstrap creates its PlatformClient here because it is the only org the
-// tokenless caller is guaranteed to own.
+// The org whose FGA ownership tuple the launcher seeds for the bootstrap
+// operator (must match harness.TestOrg / SeedBootstrapOperator in
+// test/integration). The bootstrap creates its PlatformClient here because it
+// is the only org that operator is guaranteed to own.
 const FGA_SEEDED_ORG = "test-org";
 
 const execFileAsync = promisify(execFile);
@@ -168,7 +135,23 @@ export interface CloudEnvironment {
   // The Cursor BiDi proxy's own h2c listener (Netty; Tomcat cannot serve
   // Connect bidi streams), published by the launcher's ready line since E1.
   readonly cursorBidiBaseUrl: string;
+  // The mock platform identity tenant the JAR discovered at boot — its
+  // private half, so this process can mint what the tenant would (entry
+  // 20260907.02). Test-only material that lives for the run.
+  readonly identityTenant: IdentityTenant;
   stop(): Promise<void>;
+}
+
+// The ready line's tenant group. `bootstrapSubject` is the `sub` of the one
+// pre-seeded platform operator (SeedBootstrapOperator in the launcher) —
+// the only identity that can act before any PlatformClient exists.
+export interface IdentityTenant {
+  readonly issuer: string;
+  readonly kid: string;
+  readonly privateKeyPem: string;
+  readonly apiAudience: string;
+  readonly mcpAudience: string;
+  readonly bootstrapSubject: string;
 }
 
 export interface PlatformClientCredentials {
@@ -222,24 +205,45 @@ export async function spawnCloudEnvironment(launcherEnv: Record<string, string> 
     grpcBaseUrl: `http://${readyLine.grpcAddress}`,
     httpBaseUrl: readyLine.httpAddress,
     cursorBidiBaseUrl: readyLine.cursorBidiAddress,
+    identityTenant: readyLine.identityTenant,
     stop: () => stopLauncher(child),
   };
 }
 
-// One-time auth bootstrap, run once per suite invocation:
-// tokenless call (the launcher's test security mode maps it to the synthetic
-// FGA-seeded identity — the edge posture CLOUD_ENV.edgeAuthentication
-// declares as bypassed) -> create a PlatformClient in the seeded org -> mint
-// a real Stigmer JWT for a fresh primary user. Everything after this runs as
-// that user through the production token-verification path.
-export async function bootstrapPrimaryIdentity(grpcBaseUrl: string): Promise<PrimaryIdentity> {
-  const tokenlessTransport = createTransport(grpcBaseUrl);
+// Mints the bootstrap operator's first credential: a first-party token from
+// the environment's tenant for the pre-seeded operator subject — the same
+// mint the direct-login suite uses, so the bootstrap presents exactly what a
+// console would after login. Production Java resolves the subject to the
+// seeded account, and the operator's FGA grants do the rest.
+export function mintBootstrapOperatorToken(tenant: IdentityTenant): string {
+  return newDirectLoginTenant({
+    issuer: tenant.issuer,
+    signingKeyPem: tenant.privateKeyPem,
+    kid: tenant.kid,
+    apiAudience: tenant.apiAudience,
+    mcpAudience: tenant.mcpAudience === "" ? undefined : tenant.mcpAudience,
+  }).mint({ subject: tenant.bootstrapSubject });
+}
+
+// One-time auth bootstrap, run once per suite invocation, AS the pre-seeded
+// bootstrap operator: readiness probe -> create a PlatformClient in the org
+// the operator owns -> mint a real Stigmer JWT for a fresh primary user ->
+// grant a second fresh user the operator role. Every call carries the
+// operator's Bearer — the edge is production Java's interceptor, and a
+// tokenless call would be refused UNAUTHENTICATED (the readiness probe
+// included: findMyOrganizations is not is_public). Everything after this
+// runs as the minted users through the production token-verification path.
+export async function bootstrapPrimaryIdentity(
+  grpcBaseUrl: string,
+  bootstrapOperatorToken: string,
+): Promise<PrimaryIdentity> {
+  const operatorTransport = createTransport(grpcBaseUrl, { bearerToken: bootstrapOperatorToken });
   await awaitGrpcReady(
-    makeClients(tokenlessTransport),
+    makeClients(operatorTransport),
     () => "(cloud environment: see the launcher's stderr and stigmer-service-*.log)",
   );
 
-  const platformClientCommand = createClient(PlatformClientCommandController, tokenlessTransport);
+  const platformClientCommand = createClient(PlatformClientCommandController, operatorTransport);
   const created = await platformClientCommand.create({
     apiVersion: "iam.stigmer.ai/v1",
     kind: "PlatformClient",
@@ -256,7 +260,7 @@ export async function bootstrapPrimaryIdentity(grpcBaseUrl: string): Promise<Pri
   const platformClient: PlatformClientCredentials = { clientId, clientSecret: created.clientSecret };
 
   const token = await mintCloudUserToken(grpcBaseUrl, platformClient, uniqueName("conf-user"));
-  const operatorToken = await bootstrapOperatorIdentity(grpcBaseUrl, tokenlessTransport, platformClient);
+  const operatorToken = await bootstrapOperatorIdentity(grpcBaseUrl, operatorTransport, platformClient);
   return { token, platformClient, operatorToken };
 }
 
@@ -264,20 +268,20 @@ export async function bootstrapPrimaryIdentity(grpcBaseUrl: string): Promise<Pri
 // (stigmer#547): mint a fresh user via the bootstrap PlatformClient, then
 // grant it `operator` on platform:stigmer with bootstrapPolicy — the exact
 // row + FGA-tuple shape the production BootstrapIdentitySeeder writes for the
-// machine account. The tokenless caller qualifies because the launcher's FGA
-// seeding makes the synthetic test identity a platform operator, which
-// derives can_bootstrap_iam. (The ordinary IamPolicy `create` RPC cannot
-// express this grant: the platform kind declares no grantable_roles and
-// `operator` is not an IamRole — bootstrapPolicy is the sanctioned lane.)
+// machine account. The bootstrap operator qualifies because the launcher
+// seeded it as a platform operator, which derives can_bootstrap_iam. (The
+// ordinary IamPolicy `create` RPC cannot express this grant: the platform
+// kind declares no grantable_roles and `operator` is not an IamRole —
+// bootstrapPolicy is the sanctioned lane.)
 async function bootstrapOperatorIdentity(
   grpcBaseUrl: string,
-  tokenlessTransport: ReturnType<typeof createTransport>,
+  operatorTransport: ReturnType<typeof createTransport>,
   platformClient: PlatformClientCredentials,
 ): Promise<string> {
   const operatorToken = await mintCloudUserToken(grpcBaseUrl, platformClient, uniqueName("conf-operator"));
   const operatorAccountId = jwtSubject(operatorToken);
 
-  const iamPolicyCommand = createClient(IamPolicyCommandController, tokenlessTransport);
+  const iamPolicyCommand = createClient(IamPolicyCommandController, operatorTransport);
   await iamPolicyCommand.bootstrapPolicy({
     principal: { kind: "identity_account", id: operatorAccountId },
     resource: { kind: "platform", id: "stigmer" },
@@ -329,6 +333,61 @@ interface ReadyLine {
   readonly grpcAddress: string;
   readonly httpAddress: string;
   readonly cursorBidiAddress: string;
+  readonly identityTenant: IdentityTenant;
+}
+
+// The launcher's readySignal, field for field (cmd/conformance-cloudenv).
+// Parsed strictly: the addresses and the whole tenant group are required, so
+// a launcher that forgot a field fails here with the field named rather than
+// failing later at the first mint or the first proxy call.
+function parseReadyLine(line: string): ReadyLine | undefined {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    // Not the ready-line; the launcher keeps stdout otherwise silent.
+    return undefined;
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return undefined;
+  }
+  const record = parsed as Record<string, unknown>;
+  const requiredString = (source: Record<string, unknown>, key: string, where: string): string => {
+    const value = source[key];
+    if (typeof value !== "string" || value === "") {
+      throw new Error(`launcher ready line is missing ${where}${key}`);
+    }
+    return value;
+  };
+  // Only a line that looks like the ready signal is validated; anything
+  // else on stdout is ignored, as before.
+  if (typeof record["grpcAddress"] !== "string") {
+    return undefined;
+  }
+  const tenantRaw = record["identityTenant"];
+  if (typeof tenantRaw !== "object" || tenantRaw === null) {
+    throw new Error("launcher ready line is missing identityTenant");
+  }
+  const tenant = tenantRaw as Record<string, unknown>;
+  const optionalString = (key: string): string => {
+    const value = tenant[key];
+    return typeof value === "string" ? value : "";
+  };
+  return {
+    grpcAddress: requiredString(record, "grpcAddress", ""),
+    httpAddress: requiredString(record, "httpAddress", ""),
+    cursorBidiAddress: requiredString(record, "cursorBidiAddress", ""),
+    identityTenant: {
+      issuer: requiredString(tenant, "issuer", "identityTenant."),
+      kid: requiredString(tenant, "kid", "identityTenant."),
+      privateKeyPem: requiredString(tenant, "privateKeyPem", "identityTenant."),
+      apiAudience: requiredString(tenant, "apiAudience", "identityTenant."),
+      // The MCP audience is the one optional field (a tenant may mint for
+      // the API alone).
+      mcpAudience: optionalString("mcpAudience"),
+      bootstrapSubject: requiredString(tenant, "bootstrapSubject", "identityTenant."),
+    },
+  };
 }
 
 async function waitForReadyLine(child: ChildProcess): Promise<ReadyLine> {
@@ -340,24 +399,12 @@ async function waitForReadyLine(child: ChildProcess): Promise<ReadyLine> {
   const ready = new Promise<ReadyLine>((resolveReady, rejectReady) => {
     lines.on("line", (line) => {
       try {
-        const parsed = JSON.parse(line) as {
-          grpcAddress?: unknown;
-          httpAddress?: unknown;
-          cursorBidiAddress?: unknown;
-        };
-        if (
-          typeof parsed.grpcAddress === "string" && parsed.grpcAddress !== "" &&
-          typeof parsed.httpAddress === "string" && parsed.httpAddress !== "" &&
-          typeof parsed.cursorBidiAddress === "string" && parsed.cursorBidiAddress !== ""
-        ) {
-          resolveReady({
-            grpcAddress: parsed.grpcAddress,
-            httpAddress: parsed.httpAddress,
-            cursorBidiAddress: parsed.cursorBidiAddress,
-          });
+        const parsed = parseReadyLine(line);
+        if (parsed !== undefined) {
+          resolveReady(parsed);
         }
-      } catch {
-        // Not the ready-line; the launcher keeps stdout otherwise silent.
+      } catch (err) {
+        rejectReady(err);
       }
     });
     child.once("exit", (code, signal) => {

--- a/test/conformance/src/harness/direct-login-tenant.ts
+++ b/test/conformance/src/harness/direct-login-tenant.ts
@@ -97,22 +97,34 @@ export function newDirectLoginTenant(
   };
 }
 
+// How long before its exp an already-expired token is dated as issued. A real
+// expired token was issued BEFORE it expired; a token whose exp precedes its
+// iat is not "expired", it is malformed — Spring's Jwt constructor refuses it
+// as "expiresAt must be after issuedAt", which classifies as `invalid token`,
+// not the expiry copy the suite pins. Found when the hermetic Java launcher
+// first ran production security mode (entry 20260907.02).
+const EXPIRED_TOKEN_LIFETIME_SECONDS = 60;
+
 // The claim set Auth0 mints for a first-party client — exported so the suite's
 // stranger-signed arm carries the same shape and fails for the signature alone.
+// A negative ttl mints an expired token with a plausible history (issued
+// EXPIRED_TOKEN_LIFETIME_SECONDS before it expired), never an exp-before-iat one.
 export function directLoginClaims(input: {
   issuer: string;
   subject: string;
   audience: string | ReadonlyArray<string>;
   ttlSeconds: number;
 }): Record<string, unknown> {
-  const iat = Math.floor(Date.now() / 1000);
+  const now = Math.floor(Date.now() / 1000);
+  const exp = now + input.ttlSeconds;
+  const iat = input.ttlSeconds > 0 ? now : exp - EXPIRED_TOKEN_LIFETIME_SECONDS;
   return {
     iss: input.issuer,
     sub: input.subject,
     aud:
       typeof input.audience === "string" ? input.audience : [...input.audience],
     iat,
-    exp: iat + input.ttlSeconds,
+    exp,
     scope: "openid profile email offline_access",
     azp: "conformance-first-party-client",
     jti: randomUUID(),

--- a/test/conformance/src/harness/global-setup-cloud.ts
+++ b/test/conformance/src/harness/global-setup-cloud.ts
@@ -16,10 +16,17 @@
 // dials. They boot FIRST (the service's base URLs are fixed at its boot), are
 // handed to the launcher on its environment, and are scripted by the workers
 // over the control URL this setup publishes.
+//
+// The identity tenant runs the other way (entry 20260907.02): the launcher
+// owns it — it is what the JAR TRUSTS at boot, not a service it dials — and
+// hands its material back on the ready line. This setup mints the pre-seeded
+// bootstrap operator's first token from it and publishes it as the
+// direct-login tenant, so the same key that bootstrapped the run is what the
+// direct-login suite mints with.
 import {
   bootstrapPrimaryIdentity,
   CLOUD_ENV,
-  EDGE_AUTHENTICATION,
+  mintBootstrapOperatorToken,
   spawnCloudEnvironment,
   type CloudEnvironment,
 } from "./cloud-env";
@@ -46,7 +53,11 @@ export default async function setup(): Promise<() => Promise<void>> {
   }
 
   try {
-    const identity = await bootstrapPrimaryIdentity(environment.grpcBaseUrl);
+    const tenant = environment.identityTenant;
+    const identity = await bootstrapPrimaryIdentity(
+      environment.grpcBaseUrl,
+      mintBootstrapOperatorToken(tenant),
+    );
     process.env[CLOUD_ENV.address] = environment.grpcBaseUrl;
     process.env[CLOUD_ENV.httpAddress] = environment.httpBaseUrl;
     // The cloud-capability lanes: on Java every HTTP lane but bidi is the
@@ -62,11 +73,14 @@ export default async function setup(): Promise<() => Promise<void>> {
     process.env[CLOUD_ENV.platformClientId] = identity.platformClient.clientId;
     process.env[CLOUD_ENV.platformClientSecret] = identity.platformClient.clientSecret;
     process.env[CLOUD_ENV.operatorToken] = identity.operatorToken;
-    // This setup chose STIGMER_SECURITY_MODE=test for the JAR (the launcher's
-    // default — the tokenless bootstrap above depends on it), so it is the
-    // one place that may declare the edge bypassed. Pre-provisioned
-    // endpoints never reach this line and keep the enforced default.
-    process.env[CLOUD_ENV.edgeAuthentication] = EDGE_AUTHENTICATION.bypassedTestMode;
+    // The launcher's tenant, published as the direct-login tenant (the
+    // composition readout's spike tenant writes the same five variables to
+    // an env file). Base64 of the PEM: the `*_BASE64` custody pattern.
+    process.env[CLOUD_ENV.directLoginIssuer] = tenant.issuer;
+    process.env[CLOUD_ENV.directLoginSigningKeyBase64] = Buffer.from(tenant.privateKeyPem, "utf8").toString("base64");
+    process.env[CLOUD_ENV.directLoginKid] = tenant.kid;
+    process.env[CLOUD_ENV.directLoginApiAudience] = tenant.apiAudience;
+    process.env[CLOUD_ENV.directLoginMcpAudience] = tenant.mcpAudience;
   } catch (err) {
     await environment.stop();
     await fixtures.stop();

--- a/test/conformance/src/inventory/inventory.ts
+++ b/test/conformance/src/inventory/inventory.ts
@@ -63,16 +63,13 @@ export const TESTED_DISPOSITIONS: ReadonlySet<Disposition> = new Set(["conforman
 // and behavior elsewhere.
 export const ROW_CLASSES = ["behavior", "carve-out", "adversarial"] as const;
 
-// Whether the hermetic Java launcher (STIGMER_SECURITY_MODE=test) can show
-// the behavior. `launcher-authz-only` rows need production security mode —
-// HttpSecurityConfig is not loaded in test mode — so their tests skip through
-// TargetProfile.edgeAuthenticationBypass() until the launcher entry lands.
-export const OBSERVABILITY = [
-  "launcher",
-  "launcher-authz-only",
-  "composition-only",
-  "none",
-] as const;
+// Whether the hermetic Java launcher can show the behavior. The launcher
+// boots Java in production security mode (entry 20260907.02), so every
+// edge-authentication row is `launcher` like any other observable row; there
+// is deliberately no value for "the launcher cannot observe this edge" — a
+// row that needed one would be a launcher defect to fix, not a state to
+// record.
+export const OBSERVABILITY = ["launcher", "composition-only", "none"] as const;
 
 export const CALLERS = ["primary", "operator", "outsider", "anonymous", "runner-token", "none"] as const;
 

--- a/test/conformance/src/suites/authentication.conformance.test.ts
+++ b/test/conformance/src/suites/authentication.conformance.test.ts
@@ -31,13 +31,12 @@
 // garbage-credential clients through the TARGET's own seams
 // (anonymousClients / clientsPresenting), never a hand-built transport.
 //
-// One environment cannot show the contract: the hermetic cloud launcher
-// boots Java in test security mode, where no edge authentication is loaded
-// and a synthetic caller stands in for every request. The two credential
-// arms skip VISIBLY there, carrying the target's stated reason
-// (edgeAuthenticationBypass) — never asserting admission, which would pin
-// a harness artifact as a contract (D-S1, entry 20260904.02). The
-// is_public and health arms hold on every environment regardless.
+// Every environment shows the contract. The hermetic cloud launcher boots
+// Java in PRODUCTION security mode against its own mock identity tenant
+// (entry 20260907.02, closing D-S1 option (ii) of 20260904.02), so the
+// credential arms measure Java's real interceptor there — the harness no
+// longer has a "bypassed edge" posture to skip on, by design: a target whose
+// edge admits anonymous callers FAILS these arms, never skips them.
 import { Code } from "@connectrpc/connect";
 import { HealthCheckResponse_ServingStatus } from "@stigmer/protos/grpc/health/v1/health_pb";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
@@ -68,19 +67,8 @@ afterAll(async () => {
   await target?.teardown();
 });
 
-// Skips the credential arm, with the target's own reason, where the
-// environment's edge is declared bypassed — a visible skip in the roster,
-// never a silent pass.
-function skipIfEdgeBypassed(ctx: { skip: (note?: string) => never }): void {
-  const reason = target.edgeAuthenticationBypass?.();
-  if (reason !== undefined) {
-    ctx.skip(reason);
-  }
-}
-
 describe("authentication posture: a request with no credential", () => {
-  it("is refused on a non-public method with the byte-pinned copy where authentication is required, admitted as the operator where it is not", async (ctx) => {
-    skipIfEdgeBypassed(ctx);
+  it("is refused on a non-public method with the byte-pinned copy where authentication is required, admitted as the operator where it is not", async () => {
     const anonymous = target.anonymousClients();
     // findMyOrganizations takes Empty and runs no validation — a pure
     // position-1 probe (the same reason the readiness gate uses it).
@@ -120,8 +108,7 @@ describe("authentication posture: a request with no credential", () => {
 });
 
 describe("authentication posture: a request with a credential nothing claims", () => {
-  it("is refused UNAUTHENTICATED where a verifier is composed, admitted as the operator on verifier-less targets", async (ctx) => {
-    skipIfEdgeBypassed(ctx);
+  it("is refused UNAUTHENTICATED where a verifier is composed, admitted as the operator on verifier-less targets", async () => {
     const presenting = target.clientsPresenting(UNCLAIMABLE_CREDENTIAL);
     if (target.capabilities.requiresAuthentication) {
       // Code only: the two editions word this refusal differently by
@@ -188,8 +175,7 @@ describe("authentication posture: a request with an API-key credential", () => {
     };
   }
 
-  it("a minted key authenticates as its owning account — a write through the key carries the owner's id", async (ctx) => {
-    skipIfEdgeBypassed(ctx);
+  it("a minted key authenticates as its owning account — a write through the key carries the owner's id", async () => {
     const key = await mintKey();
     expect(key.plaintext, "create returns the plaintext exactly once").toMatch(
       /^stk_/,
@@ -217,8 +203,7 @@ describe("authentication posture: a request with an API-key credential", () => {
     ).toBe(key.ownerId);
   });
 
-  it("a garbage stk_ credential is refused with the shared copy where authentication is required, admitted as the operator where it is not", async (ctx) => {
-    skipIfEdgeBypassed(ctx);
+  it("a garbage stk_ credential is refused with the shared copy where authentication is required, admitted as the operator where it is not", async () => {
     const presenting = target.clientsPresenting(
       "stk_conformance-not-a-real-key",
     );
@@ -242,7 +227,6 @@ describe("authentication posture: a request with an API-key credential", () => {
   });
 
   it("a deleted key is refused on the very next request where authentication is required", async (ctx) => {
-    skipIfEdgeBypassed(ctx);
     if (!target.capabilities.requiresAuthentication) {
       ctx.skip(
         "verifier-less target: revocation has no lane to act on (the credential falls through to the operator)",

--- a/test/conformance/src/suites/billing.conformance.test.ts
+++ b/test/conformance/src/suites/billing.conformance.test.ts
@@ -44,6 +44,7 @@ import { ModelPricingBaselineStatus } from "@stigmer/protos/ai/stigmer/billing/v
 import { UsageCompletionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/usage_pb";
 import { FixtureTracker } from "../harness/fixtures";
 import { FAKE_CARD, postStripeWebhook, signStripePayload, signedEvent, stripeEvent, type CapturedStripeRequest } from "../harness/fake-stripe";
+import { assertContractOrDeviation } from "../contract/deviations";
 import { expectGrpcCode } from "../contract/errors";
 import { requireCloudFixtures, type CloudFixturesClient } from "../support/cloud-fixtures-client";
 import { pollUntil } from "../support/execution-poll";
@@ -811,7 +812,10 @@ describe.skipIf(!ledgerServed)("Billing ledger conformance — the purchase mone
     expect(stale.status).toBe(400);
 
     const missing = await fetch(`${lane.baseUrl}/webhook/stripe`, { method: "POST", headers: { "content-type": "application/json" }, body: signStripePayload(JSON.stringify(event), lane.signingSecret).payload });
-    expect(missing.status).toBe(400);
+    await assertContractOrDeviation(target.name, "java.stripe-webhook.missing-signature-header-401", {
+      contract: () => expect(missing.status, "no Stripe-Signature header is a bad request").toBe(400),
+      observed: () => expect(missing.status, "Java: the framework 400 re-dispatches to /error, which denyAll turns into 401").toBe(401),
+    });
 
     expect(await balanceOf(org)).toBe(0n);
   });

--- a/test/conformance/src/suites/direct-login.conformance.test.ts
+++ b/test/conformance/src/suites/direct-login.conformance.test.ts
@@ -38,6 +38,7 @@ import { Code } from "@connectrpc/connect";
 import { IdentityAccountProvisioningMode } from "@stigmer/protos/ai/stigmer/iam/identityaccount/v1/enum_pb";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { assertContractOrDeviation } from "../contract/deviations";
 import { expectGrpcCode } from "../contract/errors";
 import {
   directLoginClaims,
@@ -54,6 +55,9 @@ const TOKEN_EXPIRED_MESSAGE = "token has expired";
 const TOKEN_AUDIENCE_MESSAGE =
   "token audience does not match the expected audience";
 const TOKEN_SIGNATURE_MESSAGE = "token signature verification failed";
+// Java classifyAuthError's fallback — what its runtime answers for the
+// stranger-signed arm (tracked deviation; see contract/deviations.ts).
+const INVALID_TOKEN_FALLBACK_MESSAGE = "invalid token";
 // iam/account/handlers.ts whoAmI — the Java IdentityAccountWhoAmIHandler copy.
 const ACCOUNT_NOT_FOUND_MESSAGE =
   "Identity account not found for the authenticated user";
@@ -143,10 +147,25 @@ describe.skipIf(!directLoginEnabled)(
         ).toBe(accountId);
 
         const mine = await asUser.organizationQuery.findMyOrganizations({});
-        expect(
-          mine.entries.some((org) => org.spec?.isPersonal === true),
-          "the personal org is visible to the account — its owner tuple names the ida_, not the raw subject",
-        ).toBe(true);
+        const personalVisible = mine.entries.some((org) => org.spec?.isPersonal === true);
+        await assertContractOrDeviation(
+          target.name,
+          "java.direct-login.personal-org-owner-is-raw-subject",
+          {
+            contract: () => {
+              expect(
+                personalVisible,
+                "the personal org is visible to the account — its owner tuple names the ida_, not the raw subject",
+              ).toBe(true);
+            },
+            observed: () => {
+              expect(
+                personalVisible,
+                "Java: the personal org's owner tuple names the raw subject, so the account cannot see it",
+              ).toBe(false);
+            },
+          },
+        );
       } finally {
         // Leave nothing behind: the personal org (owned by the account) and the
         // account (self-owned). Best-effort — a failed cleanup must not mask
@@ -240,7 +259,18 @@ describe.skipIf(!directLoginEnabled)(
         Code.Unauthenticated,
         "a token claiming the tenant's issuer but signed by a key its JWKS does not carry",
       );
-      expect(error.rawMessage).toBe(TOKEN_SIGNATURE_MESSAGE);
+      await assertContractOrDeviation(
+        target.name,
+        "java.direct-login.stranger-signature-copy",
+        {
+          contract: () => {
+            expect(error.rawMessage).toBe(TOKEN_SIGNATURE_MESSAGE);
+          },
+          observed: () => {
+            expect(error.rawMessage).toBe(INVALID_TOKEN_FALLBACK_MESSAGE);
+          },
+        },
+      );
     });
   },
 );

--- a/test/conformance/src/suites/direct-login.conformance.test.ts
+++ b/test/conformance/src/suites/direct-login.conformance.test.ts
@@ -27,10 +27,11 @@
 // under the same claim shape, so it fails for the signature alone.
 //
 // Where the target has no tenant to mint for — the local OSS targets by
-// design (capability false), the hermetic cloud launcher (test security
-// mode, no edge) and every deployed endpoint (a real tenant's key is never
-// conformance's) — the arms skip VISIBLY with the target's reason, never
-// asserting admission on an unobservable edge.
+// design (capability false) and every deployed endpoint (a real tenant's key
+// is never conformance's) — the arms skip VISIBLY with the target's reason,
+// never asserting admission on an unobservable edge. The hermetic cloud
+// launcher DOES hand over its tenant (the one its production-mode Java
+// discovered at boot; entry 20260907.02), so the arms measure Java there.
 import { generateKeyPairSync } from "node:crypto";
 
 import { Code } from "@connectrpc/connect";
@@ -73,10 +74,6 @@ afterAll(async () => {
 function tenantOrSkip(ctx: {
   skip: (note?: string) => never;
 }): DirectLoginTenant {
-  const bypass = target.edgeAuthenticationBypass?.();
-  if (bypass !== undefined) {
-    ctx.skip(bypass);
-  }
   const tenant = target.directLoginTenant?.();
   if (tenant === undefined) {
     ctx.skip(

--- a/test/conformance/src/suites/proxy.conformance.test.ts
+++ b/test/conformance/src/suites/proxy.conformance.test.ts
@@ -23,11 +23,11 @@
 // IS what the proxy relays or classifies.
 //
 // Authentication-class arms (401 without a bearer, foreign tokens,
-// x-api-key resolution, denyAll, require-scope-header) are unobservable in the
-// hermetic launcher's test security mode (HttpSecurityConfig is not loaded)
-// and skip through edgeAuthenticationBypass() until the launcher entry runs
-// production security (ruling Q1). Authorization arms (FGA 403) ARE observable
-// there and run.
+// x-api-key resolution, denyAll, require-scope-header) run on every cloud
+// environment: the hermetic launcher boots Java in production security mode
+// (HttpSecurityConfig loaded, require-scope-header at production's `true`)
+// since entry 20260907.02, so they measure Java's real edge alongside the
+// authorization arms (FGA 403).
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { CLOUD_ENV, mintCloudUserToken } from "../harness/cloud-env";
@@ -58,11 +58,6 @@ const EXECUTION_HEADER = "x-stigmer-execution-id";
 const WORKFLOW_EXECUTION_HEADER = "x-stigmer-workflow-execution-id";
 const MCP_SERVER_HEADER = "x-stigmer-mcp-server-id";
 const PLATFORM_CAPACITY_SENTINEL = "STIGMER_PLATFORM_MODEL_CAPACITY";
-
-function skipIfEdgeBypassed(ctx: { skip: (note?: string) => never }): void {
-  const reason = target.edgeAuthenticationBypass?.();
-  if (reason !== undefined) ctx.skip(reason);
-}
 
 async function fundedOrg(): Promise<TenancyContext> {
   if (target.provisionUnfundedTenancy === undefined || target.fundTenancy === undefined) {
@@ -172,8 +167,7 @@ describe.skipIf(!proxyServed)("Side-channel proxy conformance (sideChannelProxy 
       }
     });
 
-    it("[proxy.model-registry.anonymous-401] [proxy.edge.unknown-path-denied] the registry needs a bearer and unknown paths are denied at the edge", async (ctx) => {
-      skipIfEdgeBypassed(ctx);
+    it("[proxy.model-registry.anonymous-401] [proxy.edge.unknown-path-denied] the registry needs a bearer and unknown paths are denied at the edge", async () => {
       expect((await proxyFetch("/v1/proxy/model-registry", { token: null as unknown as undefined })).status).toBe(401);
       const denied = await proxyFetch("/actuator/env", { token: null as unknown as undefined });
       expect([401, 403]).toContain(denied.status);
@@ -320,8 +314,7 @@ describe.skipIf(!proxyServed)("Side-channel proxy conformance (sideChannelProxy 
       expect(await control.llm.requests()).toEqual([]);
     });
 
-    it("[proxy.llm.scope.missing-scope-header-403-when-required] [proxy.llm.authn.no-bearer-401] [proxy.llm.authn.foreign-or-expired-token-401] [proxy.llm.authn.x-api-key-header-accepted] the edge's authentication and require-scope arms", async (ctx) => {
-      skipIfEdgeBypassed(ctx);
+    it("[proxy.llm.scope.missing-scope-header-403-when-required] [proxy.llm.authn.no-bearer-401] [proxy.llm.authn.foreign-or-expired-token-401] [proxy.llm.authn.x-api-key-header-accepted] the edge's authentication and require-scope arms", async () => {
       const { org } = await fundedOrg();
       const executionId = await ownedExecution(org);
       expect((await proxyFetch("/v1/proxy/llm/anthropic/v1/messages", { method: "POST", body: "{}", token: null as unknown as undefined })).status).toBe(401);

--- a/test/conformance/src/suites/public-lane.conformance.test.ts
+++ b/test/conformance/src/suites/public-lane.conformance.test.ts
@@ -15,11 +15,11 @@
 // scripted. Gated on `publicLane` (true on cloud, false on the local OSS
 // targets by DD-001 — no marketing site fronts a self-host).
 //
-// CORS and the permitAll edge are authentication-class arms: the hermetic
-// launcher's test security mode does not load HttpSecurityConfig, so they
-// skip visibly through edgeAuthenticationBypass() until the launcher entry
-// runs production security (ruling Q1 of E1; P1 verifies the allow-list in
-// its own smoke).
+// CORS and the permitAll edge are authentication-class arms; they run on
+// every cloud environment since the hermetic launcher boots Java in
+// production security mode (HttpSecurityConfig loaded — entry 20260907.02,
+// E1's ruling Q1). P1's smoke verifies the same allow-list against the
+// deployed lane.
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { requireCloudFixtures, type CloudFixturesClient } from "../support/cloud-fixtures-client";
 import { createTarget, type TargetProfile } from "../targets";
@@ -70,11 +70,6 @@ async function submit(body: Record<string, unknown>): Promise<{ status: number; 
     body: JSON.stringify(body),
   });
   return { status: response.status, json: (await response.json()) as LeadResponse };
-}
-
-function skipIfEdgeBypassed(ctx: { skip: (note?: string) => never }): void {
-  const reason = target.edgeAuthenticationBypass?.();
-  if (reason !== undefined) ctx.skip(reason);
 }
 
 describe.skipIf(!publicServed)("Public lane conformance — the marketing site's endpoints (publicLane targets)", () => {
@@ -202,8 +197,7 @@ describe.skipIf(!publicServed)("Public lane conformance — the marketing site's
     expect(await control.discord.posts(), "exactly one attempt, no retry").toHaveLength(1);
   });
 
-  it("[public.cors.allow-list-and-methods] [public.edge.public-paths-anonymous] the allow-listed origins get CORS headers and the lane is anonymous while the proxy lane on the same listener is not", async (ctx) => {
-    skipIfEdgeBypassed(ctx);
+  it("[public.cors.allow-list-and-methods] [public.edge.public-paths-anonymous] the allow-listed origins get CORS headers and the lane is anonymous while the proxy lane on the same listener is not", async () => {
     for (const origin of ["https://stigmer.ai", "https://www.stigmer.ai", "http://localhost:3000"]) {
       const response = await fetch(`${baseUrl}/api/v1/public/model-pricing`, { headers: { origin } });
       expect(response.status).toBe(200);

--- a/test/conformance/src/targets/cloud-execution.ts
+++ b/test/conformance/src/targets/cloud-execution.ts
@@ -125,10 +125,6 @@ export class CloudExecutionTarget implements TargetProfile {
     return this.cloud.clientsPresenting(bearerToken);
   }
 
-  edgeAuthenticationBypass(): string | undefined {
-    return this.cloud.edgeAuthenticationBypass();
-  }
-
   // The cloud-capability lanes are the same environment's; delegated so the
   // Class B billing arms (settle, the STOP/WARNING thresholds, usage landing
   // from the proxy) reach them exactly as the Class A arms do.

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -11,12 +11,7 @@
 // organization created via the production RPC, whose creation grants the
 // primary user ownership (IAM policies) and provisions a zero-balance billing
 // account — sufficient for the Class A (CRUD) domains.
-import {
-  CLOUD_ENV,
-  EDGE_AUTHENTICATION,
-  mintCloudUserToken,
-  resolveEdgeAuthentication,
-} from "../harness/cloud-env";
+import { CLOUD_ENV, mintCloudUserToken } from "../harness/cloud-env";
 import { createTransport, makeClients, type ConformanceClients } from "../harness/clients";
 import {
   newDirectLoginTenant,
@@ -132,10 +127,11 @@ export class CloudTarget implements TargetProfile {
   provisionPrivilegedScope?: () => Promise<PrivilegedScope>;
 
   // Present only when the environment hands over the platform tenant's
-  // signing key (CLOUD_ENV.directLogin*) — the readout substrate's mock
-  // tenant does; the hermetic launcher and every deployed endpoint never do
-  // (a real tenant's key is not conformance's to hold), so the method is
-  // absent there and the direct-login suite skips with the reason below.
+  // signing key (CLOUD_ENV.directLogin*) — the hermetic launcher's own
+  // tenant and the composition readout's mock tenant both do; a deployed
+  // endpoint never does (a real tenant's key is not conformance's to hold),
+  // so the method is absent there and the direct-login suite skips with the
+  // reason below.
   directLoginTenant?: () => DirectLoginTenant;
 
   async setup(): Promise<void> {
@@ -165,8 +161,8 @@ export class CloudTarget implements TargetProfile {
   directLoginUnavailable(): string {
     return (
       `${CLOUD_ENV.directLoginIssuer} is unset — this environment does not hand conformance the platform ` +
-      "tenant's signing key (the hermetic launcher runs in test security mode with no edge; a deployed " +
-      "endpoint's real tenant key is never conformance's to hold), so the direct-login lane cannot be driven here"
+      "tenant's signing key (a deployed endpoint's real tenant key is never conformance's to hold), " +
+      "so the direct-login lane cannot be driven here"
     );
   }
 
@@ -217,23 +213,6 @@ export class CloudTarget implements TargetProfile {
       throw new Error(`CloudTarget.setup() must be called before ${caller}()`);
     }
     return this.grpcBaseUrl;
-  }
-
-  // The environment's declared edge posture (CLOUD_ENV.edgeAuthentication;
-  // unset = enforced). Read per call, not cached at setup: the value is
-  // published by the global setup before any worker runs and never changes
-  // within a run, and reading late keeps this target constructible in unit
-  // tests that never call setup().
-  edgeAuthenticationBypass(): string | undefined {
-    if (resolveEdgeAuthentication() === EDGE_AUTHENTICATION.enforced) {
-      return undefined;
-    }
-    return (
-      "the hermetic launcher runs stigmer-service with STIGMER_SECURITY_MODE=test — " +
-      "GrpcSecurityConfigBase is not loaded and a synthetic caller stands in for every request, " +
-      "so the edge's require-authentication posture is unobservable here " +
-      "(production Java's posture is covered by test/integration-security; entry 20260904.02 D-S1)"
-    );
   }
 
   // The cloud-capability HTTP lanes, read per call from the CLOUD_ENV contract

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -387,32 +387,18 @@ export interface TargetProfile {
   // anonymousClients; the primary credential stays clients()'s.
   clientsPresenting(bearerToken: string): ConformanceClients;
 
-  // Why THIS environment's serving edge cannot demonstrate the edition's
-  // requiresAuthentication contract, or undefined when it can. A harness
-  // fact, deliberately separate from the capability flag (which states the
-  // edition's contract): the hermetic cloud launcher boots Java in test
-  // security mode, where no edge authentication is loaded at all and a
-  // synthetic caller stands in for every request — the posture is real in
-  // production and unobservable there. The authentication suite skips its
-  // credential arms VISIBLY, with this reason, when one is returned; it
-  // never asserts admission on a bypassed edge (that would pin a harness
-  // artifact as a contract). Present only on the cloud targets, whose
-  // environment is declared through CLOUD_ENV.edgeAuthentication (default
-  // enforced — a readout that forgets the variable fails loudly, never
-  // false-greens); the local targets' posture IS what their flag says.
-  edgeAuthenticationBypass?(): string | undefined;
-
   // The platform identity tenant the server under test trusts, as a MINT:
   // the suite forges nothing — it asks the target for tokens shaped exactly
   // like the ones the tenant issues (its published issuer, an audience it
   // mints for, RS256 under a kid its JWKS carries) and drives the server's
   // direct-login lane with them. Present only where the harness OWNS the
-  // tenant's signing key — the readout substrate's mock tenant, declared
-  // through CLOUD_ENV.directLogin* — never on a deployed endpoint (a real
-  // tenant's key is not conformance's to hold) and never on the hermetic
-  // launcher (test security mode has no edge). Where absent, the
-  // direct-login suite skips VISIBLY with the target's reason
-  // (directLoginUnavailable). Valid only after setup().
+  // tenant's signing key, declared through CLOUD_ENV.directLogin* — the
+  // hermetic launcher's in-process tenant (the same key that minted the
+  // bootstrap operator's first token) and the composition readout's mock
+  // tenant — never on a deployed endpoint (a real tenant's key is not
+  // conformance's to hold). Where absent, the direct-login suite skips
+  // VISIBLY with the target's reason (directLoginUnavailable). Valid only
+  // after setup().
   directLoginTenant?(): DirectLoginTenant;
   directLoginUnavailable?(): string;
 

--- a/test/integration-security/suite_test.go
+++ b/test/integration-security/suite_test.go
@@ -169,7 +169,7 @@ func TestMain(m *testing.M) {
 		"auth0_issuer", mockAuth0.Issuer,
 	)
 
-	// --- Seed the bootstrap identity in the app-postgres store ---
+	// --- Seed the bootstrap operator (identity row + FGA grants) ---
 	// This must run after service boot (Flyway creates the table during
 	// startup) and before the first authenticated call (the interceptor
 	// chain resolves JWT subjects per-request). The machine account identity
@@ -178,51 +178,28 @@ func TestMain(m *testing.M) {
 	// BootstrapIdentitySeeder creates it at startup with the well-known id
 	// "machine" (T06 — the same code path production and fresh installs
 	// run). Only the human bootstrap account remains a genuine pre-auth
-	// chicken-and-egg.
+	// chicken-and-egg — the same one the conformance launcher seeds through
+	// the same helper for its production-mode boot.
 	identitySeeder = harness.NewIdentitySeeder(testHarness.AppPostgres)
-	err = identitySeeder.SeedIdentityAccount(ctx, harness.SeedIdentityAccountInput{
-		ID:        bootstrapIdentityAccountID,
-		IdpID:     bootstrapIdpID,
-		Email:     bootstrapEmail,
-		Name:      "Security Test Bootstrap",
-		FirstName: "Security",
-		LastName:  "Bootstrap",
+	err = harness.SeedBootstrapOperator(ctx, testHarness.AppPostgres, testHarness.OpenFGA, harness.BootstrapOperatorInput{
+		IdentityAccountID: bootstrapIdentityAccountID,
+		IdpID:             bootstrapIdpID,
+		Email:             bootstrapEmail,
+		Name:              "Security Test Bootstrap",
+		FirstName:         "Security",
+		LastName:          "Bootstrap",
+		Org:               testOrg,
 	})
 	if err != nil {
-		suiteLogger.Error("failed to seed bootstrap identity", "error", err)
+		suiteLogger.Error("failed to seed bootstrap operator", "error", err)
 		testHarness.Stop(ctx)
 		os.Exit(1)
 	}
-	suiteLogger.Info("seeded bootstrap identity account",
+	suiteLogger.Info("seeded bootstrap operator",
 		"id", bootstrapIdentityAccountID,
 		"idp_id", bootstrapIdpID,
+		"fga", testHarness.OpenFGA != nil,
 	)
-
-	// --- Seed FGA tuples for the bootstrap user ---
-	// The machine account's operator grant is NOT seeded here:
-	// BootstrapIdentitySeeder writes it at startup, and OpenFGA's raw Write API
-	// rejects duplicate tuples with a 400. The human bootstrap user still needs
-	// operator permissions to create IdentityProviders and PlatformClients.
-	if testHarness.OpenFGA != nil {
-		tuples := []harness.RelationshipTuple{
-			{
-				User:     "identity_account:" + bootstrapIdentityAccountID,
-				Relation: "operator",
-				Object:   "platform:stigmer",
-			},
-			{
-				User:     "identity_account:" + bootstrapIdentityAccountID,
-				Relation: "owner",
-				Object:   "organization:" + testOrg,
-			},
-		}
-		if fgaErr := testHarness.OpenFGA.WriteTuples(ctx, tuples); fgaErr != nil {
-			suiteLogger.Error("failed to seed FGA tuples", "error", fgaErr)
-			testHarness.Stop(ctx)
-			os.Exit(1)
-		}
-		suiteLogger.Info("seeded FGA tuples for bootstrap user")
-	}
 
 	// --- Create bootstrap authenticated connection ---
 	bootstrapToken, err := mockAuth0.SignJWT(bootstrapIdpID, testAudience, nil)

--- a/test/integration/cmd/conformance-cloudenv/main.go
+++ b/test/integration/cmd/conformance-cloudenv/main.go
@@ -1,20 +1,39 @@
 // Command conformance-cloudenv boots the hermetic cloud environment for the
 // conformance suite's cloud target: Testcontainers infrastructure (Postgres,
-// Redis, MinIO, OpenFGA), a Temporal dev server, and the stigmer-service fat
-// JAR in test security mode with real OpenFGA authorization.
+// Redis, MinIO, OpenFGA), a Temporal dev server, a mock platform identity
+// tenant, and the stigmer-service fat JAR in PRODUCTION security mode with
+// real OpenFGA authorization.
 //
 // It is spawned by the conformance suite's cloud global setup
 // (test/conformance/src/harness/global-setup-cloud.ts), which waits for a
 // single JSON ready-line on stdout and later terminates the process with
 // SIGTERM. Human-readable progress goes to stderr so stdout stays a clean
-// machine channel.
+// machine channel — and, since the ready line carries the tenant's signing
+// key, stdout is the ONLY place that key may appear. Nothing here logs it.
 //
 // Reuses the integration-test harness wholesale — one battle-tested boot
 // implementation, two consumers (Go integration tests and the TS conformance
-// suite) — with one deliberate divergence: OpenFGA is mandatory here. The
-// integration harness degrades to permit-all authorization when FGA is
-// unavailable, but a permit-all cloud target would silently invalidate every
-// multi-tenant conformance assertion, so this launcher fails loudly instead.
+// suite) — with two deliberate divergences from the Go suites' defaults:
+//
+//   - OpenFGA is mandatory. The integration harness degrades to permit-all
+//     authorization when FGA is unavailable, but a permit-all cloud target
+//     would silently invalidate every multi-tenant conformance assertion, so
+//     this launcher fails loudly instead.
+//   - The JAR runs the production security chain (GrpcSecurityConfigBase,
+//     HttpSecurityConfig, the Auth0 MachineAccountJwtProvider), trusting a
+//     mock identity tenant this process serves, exactly the way
+//     test/integration-security boots it. The Go suites keep test security
+//     mode; the conformance suite's job is to observe the edge (entry
+//     20260907.02 — D-S1 option (ii) of 20260904.02), so a synthetic
+//     tokenless caller would be the one thing it must not have.
+//
+// Production mode has a chicken-and-egg the harness resolves the way the
+// security suite does: before any credential can be accepted, one human
+// platform operator must already exist. SeedBootstrapOperator writes that
+// account and its FGA grants after the JAR boots; the ready line names its
+// subject and hands over the tenant material, and the TS side mints the
+// operator's first token itself and bootstraps everything else through
+// production RPCs.
 package main
 
 import (
@@ -35,6 +54,25 @@ import (
 // cache plus the JVM start. Generous because CI caches may be empty.
 const bootTimeout = 10 * time.Minute
 
+// The mock platform identity tenant's audiences — what the JAR is configured
+// to accept on inbound tenant tokens (AUTH0_API_AUDIENCE / AUTH0_MCP_AUDIENCE)
+// and what the TS side stamps on the tokens it mints. Reserved test names so
+// a token from this run can never be mistaken for a production one.
+const (
+	tenantAPIAudience = "https://api.conformance.stigmer.test"
+	tenantMCPAudience = "https://mcp.conformance.stigmer.test"
+)
+
+// The pre-auth bootstrap operator. Its IdpID is the `sub` the TS side mints
+// for it; the account id is what every FGA grant names. Both are constants:
+// the run's isolation comes from the fresh Postgres and FGA store, not from
+// unique names.
+const (
+	bootstrapOperatorAccountID = "conformance-bootstrap-operator"
+	bootstrapOperatorSubject   = "conformance-bootstrap-operator|tenant"
+	bootstrapOperatorEmail     = "bootstrap-operator@conformance.stigmer.test"
+)
+
 // readySignal is the single JSON line printed to stdout once the environment
 // accepts gRPC traffic. The TS global setup parses it to locate the service.
 // The HTTP address carries the Spring routes the gRPC port does not — the
@@ -43,10 +81,27 @@ const bootTimeout = 10 * time.Minute
 // side-channel proxy, the Stripe webhook and the public lane. The bidi
 // address is the Cursor BiDi proxy's own Netty listener (h2c), which Tomcat
 // cannot serve; the TS side publishes both to the suites through CLOUD_ENV.
+// The identity tenant group is what lets the TS side mint tokens the JAR
+// trusts: the bootstrap operator's first token, and the direct-login suite's
+// first-party tokens (CLOUD_ENV.directLogin*).
 type readySignal struct {
-	GrpcAddress       string `json:"grpcAddress"`
-	HTTPAddress       string `json:"httpAddress"`
-	CursorBidiAddress string `json:"cursorBidiAddress"`
+	GrpcAddress       string              `json:"grpcAddress"`
+	HTTPAddress       string              `json:"httpAddress"`
+	CursorBidiAddress string              `json:"cursorBidiAddress"`
+	IdentityTenant    identityTenantReady `json:"identityTenant"`
+}
+
+// identityTenantReady is the ready line's tenant group — the private half of
+// the tenant the JAR discovered at boot, plus the operator subject the seeding
+// above made resolvable. PrivateKeyPEM is a PKCS#8 PEM, the format the TS
+// direct-login mint consumes.
+type identityTenantReady struct {
+	Issuer           string `json:"issuer"`
+	KeyID            string `json:"kid"`
+	PrivateKeyPEM    string `json:"privateKeyPem"`
+	APIAudience      string `json:"apiAudience"`
+	MCPAudience      string `json:"mcpAudience"`
+	BootstrapSubject string `json:"bootstrapSubject"`
 }
 
 func main() {
@@ -117,6 +172,17 @@ func run(logger *slog.Logger) error {
 		return errors.New("openfga container did not start despite model dir and CLI being present")
 	}
 
+	// The mock identity tenant must be serving before the JAR starts:
+	// GrpcSecurityConfigBase runs OIDC discovery while its beans initialize,
+	// and a failed discovery fails the boot. An empty issuer makes the
+	// server's own URL the issuer (trailing slash, Auth0's shape).
+	tenant, err := harness.NewMockOIDCServer("", tenantAPIAudience)
+	if err != nil {
+		return fmt.Errorf("start mock identity tenant: %w", err)
+	}
+	defer tenant.Close()
+	logger.Info("mock identity tenant serving", "issuer", tenant.Issuer)
+
 	svc, err := harness.StartJavaService(bootCtx, harness.ServiceConfig{
 		JarPath:         jarPath,
 		AppPGHost:       h.AppPostgres.Host,
@@ -136,7 +202,24 @@ func run(logger *slog.Logger) error {
 		VaultAddr:       h.OpenBao.Addr,
 		VaultToken:      h.OpenBao.RootToken,
 		LogDir:          h.LogDir(),
-		Security:        harness.SecurityModeTest,
+		// Production security, trusting the tenant above. The token URL is
+		// where the JAR's MachineAccountJwtProvider fetches the machine
+		// account's client_credentials JWT (sub = AUTH0_CLIENT_ID@clients,
+		// the row BootstrapIdentitySeeder writes at boot).
+		Security:         harness.SecurityModeProduction,
+		Auth0IssuerURL:   tenant.Issuer,
+		Auth0Audience:    tenantAPIAudience,
+		Auth0McpAudience: tenantMCPAudience,
+		Auth0TokenURL:    tenant.URL + "/oauth/token",
+		// Production's token-shape posture for Stigmer-minted tokens: stamped
+		// with an environment audience, verified leniently (a token without
+		// an aud still verifies) — the prod overlay's posture; the value is
+		// per-environment by design, so it is the harness's own, shared with
+		// the security suite.
+		JWTAudience:     harness.StigmerJWTAudience,
+		RequireAudience: false,
+		// Production's proxy edge: a call with no scope header is refused.
+		ProxyRequireScopeHeader: true,
 		// The conformance global setup (cloud-env.ts) sets this on the
 		// launcher's environment from the suite's own redirect-URI constant —
 		// the single source of truth the OAuth suites assert against. Passed
@@ -169,14 +252,37 @@ func run(logger *slog.Logger) error {
 	// lifecycle alongside the containers.
 	h.Service = svc
 
-	if err := harness.SeedBaseFGATuples(bootCtx, fga); err != nil {
-		return fmt.Errorf("seed base FGA tuples: %w", err)
+	// After boot (Flyway has created s_iam.identity_account), before the
+	// first authenticated call (subjects resolve per request): the one
+	// pre-auth account production mode cannot create for itself.
+	if err := harness.SeedBootstrapOperator(bootCtx, h.AppPostgres, fga, harness.BootstrapOperatorInput{
+		IdentityAccountID: bootstrapOperatorAccountID,
+		IdpID:             bootstrapOperatorSubject,
+		Email:             bootstrapOperatorEmail,
+		Name:              "Conformance Bootstrap Operator",
+		FirstName:         "Conformance",
+		LastName:          "Bootstrap",
+		Org:               harness.TestOrg,
+	}); err != nil {
+		return fmt.Errorf("seed bootstrap operator: %w", err)
 	}
 
+	material, err := tenant.Material()
+	if err != nil {
+		return fmt.Errorf("export identity tenant material: %w", err)
+	}
 	ready, err := json.Marshal(readySignal{
 		GrpcAddress:       svc.GRPCAddress(),
 		HTTPAddress:       svc.HTTPAddress(),
 		CursorBidiAddress: svc.BiDiProxyAddress(),
+		IdentityTenant: identityTenantReady{
+			Issuer:           material.Issuer,
+			KeyID:            material.KeyID,
+			PrivateKeyPEM:    material.PrivateKeyPEM,
+			APIAudience:      tenantAPIAudience,
+			MCPAudience:      tenantMCPAudience,
+			BootstrapSubject: bootstrapOperatorSubject,
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("marshal ready signal: %w", err)
@@ -186,6 +292,8 @@ func run(logger *slog.Logger) error {
 		"grpc_address", svc.GRPCAddress(),
 		"http_address", svc.HTTPAddress(),
 		"cursor_bidi_address", svc.BiDiProxyAddress(),
+		"identity_tenant", material.Issuer,
+		"security_mode", "production",
 		"service_log", svc.LogPath(),
 	)
 

--- a/test/integration/harness/bootstrap_operator.go
+++ b/test/integration/harness/bootstrap_operator.go
@@ -1,0 +1,81 @@
+package harness
+
+import (
+	"context"
+	"fmt"
+)
+
+// BootstrapOperatorInput names the pre-auth operator a production-security-mode
+// boot needs before its first authenticated call.
+type BootstrapOperatorInput struct {
+	// IdentityAccountID is the internal identity account id (metadata.id) —
+	// the principal every FGA tuple below names.
+	IdentityAccountID string
+	// IdpID is the JWT "sub" the mock identity tenant mints for this operator
+	// (spec.idpId). The production interceptor resolves Auth0 subjects to
+	// accounts through this field, so it must equal the minted claim exactly.
+	IdpID string
+	// Email, Name, FirstName, LastName fill the account document; none is
+	// load-bearing for authorization.
+	Email     string
+	Name      string
+	FirstName string
+	LastName  string
+	// Org is the organization the operator owns (organization:<Org>) — the
+	// only org a fresh boot is guaranteed to let it create resources in.
+	Org string
+}
+
+// SeedBootstrapOperator seeds the one identity a production-security-mode Java
+// boot cannot create for itself: a human platform operator that exists before
+// any credential has been accepted. It writes the identity_account row
+// directly (IdentitySeeder — the sole legitimate pre-auth back door) and the
+// three FGA tuples production would have granted that account:
+//
+//   - operator on platform:stigmer (can_bootstrap_iam, can_impersonate, ...)
+//   - owner of organization:<Org> (owner > admin > member > viewer)
+//   - owner of its own identity_account (what provisionMyAccount's SELF tuple
+//     grants; without it self-updates fail PERMISSION_DENIED)
+//
+// Two consumers, one implementation: test/integration-security boots the JAR
+// in production mode for its JWT arms, and the conformance launcher
+// (cmd/conformance-cloudenv) boots it the same way so the edge posture is
+// observable to the cross-edition suite. Both then mint a tenant JWT with
+// sub = IdpID and drive every further step through production RPCs.
+//
+// The machine account's grants are NOT seeded here: BootstrapIdentitySeeder
+// writes them at startup and OpenFGA's raw Write API rejects duplicates.
+//
+// fga may be nil (the security suite treats OpenFGA as optional); the identity
+// row is still seeded so the interceptor resolves the subject.
+func SeedBootstrapOperator(ctx context.Context, pg *AppPostgresContainer, fga *OpenFGAContainer, in BootstrapOperatorInput) error {
+	if in.IdentityAccountID == "" || in.IdpID == "" || in.Org == "" {
+		return fmt.Errorf("seed bootstrap operator: IdentityAccountID, IdpID and Org are required (got %q, %q, %q)",
+			in.IdentityAccountID, in.IdpID, in.Org)
+	}
+
+	if err := NewIdentitySeeder(pg).SeedIdentityAccount(ctx, SeedIdentityAccountInput{
+		ID:        in.IdentityAccountID,
+		IdpID:     in.IdpID,
+		Email:     in.Email,
+		Name:      in.Name,
+		FirstName: in.FirstName,
+		LastName:  in.LastName,
+	}); err != nil {
+		return fmt.Errorf("seed bootstrap operator identity: %w", err)
+	}
+
+	if fga == nil {
+		return nil
+	}
+	principal := "identity_account:" + in.IdentityAccountID
+	tuples := []RelationshipTuple{
+		{User: principal, Relation: "operator", Object: platformStigmer},
+		{User: principal, Relation: "owner", Object: "organization:" + in.Org},
+		{User: principal, Relation: "owner", Object: principal},
+	}
+	if err := fga.WriteTuples(ctx, tuples); err != nil {
+		return fmt.Errorf("seed bootstrap operator FGA tuples: %w", err)
+	}
+	return nil
+}

--- a/test/integration/harness/identity_seeder.go
+++ b/test/integration/harness/identity_seeder.go
@@ -14,7 +14,9 @@ import (
 // subjects to internal identity accounts via the persistence layer — so the
 // bootstrap identity must exist before any authenticated call can succeed.
 // That chicken-and-egg is the ONLY legitimate reason to seed a Tier-1 kind
-// behind the service's back, and only the integration-security suite has it.
+// behind the service's back; the integration-security suite and the
+// conformance launcher (both production-mode boots) have it, through
+// SeedBootstrapOperator.
 //
 // Everything else must seed through the front door instead
 // (CreateIdentityAccount / GrantOrgRole): direct writes are storage-coupled

--- a/test/integration/harness/mock_jwks_server.go
+++ b/test/integration/harness/mock_jwks_server.go
@@ -3,12 +3,15 @@ package harness
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"math/big"
 	"net"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,9 +20,12 @@ import (
 
 // MockJWKSServer serves a JWKS endpoint and signs JWTs for testing
 // IdentityProvider federation without an external IdP. When started via
-// StartMockOIDCServer it also serves OpenID Connect discovery, enabling
-// Spring Security's JwtDecoders.fromOidcIssuerLocation() to bootstrap
-// against a local HTTP server instead of a real Auth0 tenant.
+// StartMockOIDCServer / NewMockOIDCServer it also plays the platform identity
+// tenant: OpenID Connect discovery (so Spring Security's
+// JwtDecoders.fromOidcIssuerLocation() bootstraps against a local HTTP server
+// instead of a real Auth0 tenant), the client_credentials token endpoint the
+// service's MachineAccountJwtProvider calls, and the bearer-checked /userinfo
+// the service's provisionMyAccount reads a first-login profile from.
 type MockJWKSServer struct {
 	URL      string
 	JWKSURL  string
@@ -113,12 +119,7 @@ func StartMockOIDCServer(t testing.TB, issuer, audience string) *MockJWKSServer 
 		m.Issuer = baseURL + "/"
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/jwks", m.handleJWKS)
-	mux.HandleFunc("/.well-known/openid-configuration", m.handleOIDCDiscovery)
-	mux.HandleFunc("/oauth/token", m.handleOAuthToken)
-
-	m.server = &http.Server{Handler: mux}
+	m.server = &http.Server{Handler: m.oidcMux()}
 
 	go m.server.Serve(listener)
 
@@ -129,6 +130,44 @@ func StartMockOIDCServer(t testing.TB, issuer, audience string) *MockJWKSServer 
 	t.Logf("mock OIDC server started: discovery=%s/.well-known/openid-configuration, jwks=%s, issuer=%s",
 		m.URL, m.JWKSURL, m.Issuer)
 	return m
+}
+
+// oidcMux is the platform-tenant route table, shared by both OIDC
+// constructors so the two boot paths (testing.TB and TestMain) cannot drift.
+func (m *MockJWKSServer) oidcMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/jwks", m.handleJWKS)
+	mux.HandleFunc("/.well-known/openid-configuration", m.handleOIDCDiscovery)
+	mux.HandleFunc("/oauth/token", m.handleOAuthToken)
+	mux.HandleFunc("/userinfo", m.handleUserInfo)
+	return mux
+}
+
+// IdentityTenantMaterial is the private half of the tenant: what a test
+// process needs to mint tokens this server's JWKS verifies, exactly as the
+// tenant itself would. Hand it only to the process that owns the run.
+type IdentityTenantMaterial struct {
+	// Issuer is the `iss` claim and the discovery document's issuer.
+	Issuer string
+	// KeyID is the `kid` the JWKS publishes for the signing key.
+	KeyID string
+	// PrivateKeyPEM is the RSA signing key as a PKCS#8 PEM — the format the
+	// conformance suite's direct-login mint consumes (node:crypto createSign).
+	PrivateKeyPEM string
+}
+
+// Material exports the tenant's signing material. Test-only by construction:
+// the key is generated per server and dies with the process.
+func (m *MockJWKSServer) Material() (IdentityTenantMaterial, error) {
+	der, err := x509.MarshalPKCS8PrivateKey(m.privateKey)
+	if err != nil {
+		return IdentityTenantMaterial{}, fmt.Errorf("marshal tenant signing key: %w", err)
+	}
+	return IdentityTenantMaterial{
+		Issuer:        m.Issuer,
+		KeyID:         m.keyID,
+		PrivateKeyPEM: string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})),
+	}, nil
 }
 
 func (m *MockJWKSServer) handleJWKS(w http.ResponseWriter, _ *http.Request) {
@@ -211,6 +250,82 @@ func (m *MockJWKSServer) handleOAuthToken(w http.ResponseWriter, r *http.Request
 	json.NewEncoder(w).Encode(resp)
 }
 
+// handleUserInfo is the OIDC UserInfo endpoint the Java service's
+// provisionMyAccount reads a first-login profile from (its URL is derived from
+// security.authentication.idp-url, i.e. this server). The bearer must be a
+// token THIS tenant signed — a stranger's token or none answers 401, the way
+// Auth0 does — and the profile is a deterministic function of `sub`, so a
+// test that mints a subject knows the email the account will carry. The field
+// set is exactly what the service's UserInfoClient parses.
+func (m *MockJWKSServer) handleUserInfo(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	authz := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authz, "Bearer ") {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_request"`)
+		http.Error(w, "missing bearer", http.StatusUnauthorized)
+		return
+	}
+	sub, err := m.subjectOfOwnToken(strings.TrimPrefix(authz, "Bearer "))
+	if err != nil {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token"`)
+		http.Error(w, "invalid token: "+err.Error(), http.StatusUnauthorized)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(userInfoProfile(sub))
+}
+
+// subjectOfOwnToken verifies a compact JWS against this server's key and
+// issuer and returns its subject. Audience is deliberately not checked:
+// /userinfo is called with the same access token the API received, whose
+// audience is the API's, not this endpoint's.
+func (m *MockJWKSServer) subjectOfOwnToken(token string) (string, error) {
+	parsed, err := jwt.Parse(token, func(t *jwt.Token) (any, error) {
+		if t.Method.Alg() != jwt.SigningMethodRS256.Alg() {
+			return nil, fmt.Errorf("unexpected alg %q", t.Method.Alg())
+		}
+		return &m.privateKey.PublicKey, nil
+	}, jwt.WithIssuer(m.Issuer))
+	if err != nil {
+		return "", err
+	}
+	sub, err := parsed.Claims.GetSubject()
+	if err != nil || sub == "" {
+		return "", fmt.Errorf("token carries no subject")
+	}
+	return sub, nil
+}
+
+// userInfoProfile derives the profile for a subject. The email's local part is
+// the subject with every non-mailbox character folded to '-', so
+// "auth0|abc" becomes "auth0-abc@<domain>" — legible in a failing test and
+// unique per subject.
+func userInfoProfile(sub string) map[string]string {
+	local := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '.', r == '_', r == '-':
+			return r
+		default:
+			return '-'
+		}
+	}, sub)
+	return map[string]string{
+		"sub":         sub,
+		"email":       local + "@" + mockTenantEmailDomain,
+		"name":        "Tenant " + sub,
+		"given_name":  "Tenant",
+		"family_name": sub,
+		"picture":     "",
+	}
+}
+
+// mockTenantEmailDomain is the mailbox domain /userinfo profiles carry; a
+// reserved test TLD so no seeded account can ever collide with a real one.
+const mockTenantEmailDomain = "tenant.stigmer.test"
+
 // NewMockJWKSServer creates a MockJWKSServer without a testing.TB dependency.
 // The caller must call Close() when done. Use this from TestMain where
 // *testing.T is not available.
@@ -273,12 +388,7 @@ func NewMockOIDCServer(issuer, audience string) (*MockJWKSServer, error) {
 		m.Issuer = baseURL + "/"
 	}
 
-	mux := http.NewServeMux()
-	mux.HandleFunc("/jwks", m.handleJWKS)
-	mux.HandleFunc("/.well-known/openid-configuration", m.handleOIDCDiscovery)
-	mux.HandleFunc("/oauth/token", m.handleOAuthToken)
-
-	m.server = &http.Server{Handler: mux}
+	m.server = &http.Server{Handler: m.oidcMux()}
 	go m.server.Serve(listener)
 	return m, nil
 }

--- a/test/integration/harness/service.go
+++ b/test/integration/harness/service.go
@@ -247,6 +247,16 @@ type ServiceConfig struct {
 	// token with a missing or non-matching aud is rejected (strict). When false
 	// (default), verification is lenient: tokens with no aud are still accepted.
 	RequireAudience bool
+
+	// ProxyRequireScopeHeader sets STIGMER_PROXY_REQUIRE_SCOPE_HEADER. When
+	// true — production's default (application.yaml) — a proxy call carrying
+	// none of the X-Stigmer-*-Id scope headers is refused 403 rather than
+	// admitted unscoped and unmetered. The Go suites keep the zero value
+	// (false): their proxy tests were written before the header existed and
+	// exercise the lanes unscoped. The conformance launcher sets true so the
+	// edge answers the production contract the `proxy.llm.scope.*` arms pin
+	// (entry 20260907.02, E1's F6).
+	ProxyRequireScopeHeader bool
 }
 
 // StartJavaService launches the stigmer-service fat JAR as a child process
@@ -398,6 +408,22 @@ func (s *JavaService) Stop() error {
 	return err
 }
 
+// buildServiceEnv is the ONE place the harness overrides Java's environment,
+// so it is also where each override answers "how does this differ from
+// production, and why is that acceptable?" (entry 20260907.02; the production
+// overlay is stigmer-cloud backend/services/stigmer-service/_kustomize/overlays/
+// prod/service.yaml, read through _ops/x1-cutover/env-parity.md). Every
+// deviation below carries one of three dispositions:
+//
+//   - production: matches production's posture (the conformance launcher's
+//     Security, ProxyRequireScopeHeader and JWTAudience choices land here);
+//   - harness-constraint: cannot match production inside Testcontainers, and
+//     the reason is stated (a plain-HTTP mock JWKS, MinIO's addressing, no
+//     cluster, no third-party admin API);
+//   - test-tuning: a knob the Go suites deliberately turn to make a behavior
+//     reachable in one test, with the arms that would notice named.
+//
+// An override with no disposition is a defect in this file, not a convention.
 func buildServiceEnv(cfg ServiceConfig) []string {
 	fgaEnabled := cfg.OpenFGAAPIURL != "" && cfg.OpenFGAStoreID != "" && cfg.OpenFGAModelID != ""
 	productionSecurity := cfg.Security == SecurityModeProduction
@@ -456,9 +482,10 @@ func buildServiceEnv(cfg ServiceConfig) []string {
 		fmt.Sprintf("AGENT_EXECUTION_ARTIFACT_R2_ENDPOINT=%s", r2Endpoint(cfg)),
 		fmt.Sprintf("AGENT_EXECUTION_ARTIFACT_R2_ACCESS_KEY_ID=%s", r2AccessKey(cfg)),
 		fmt.Sprintf("AGENT_EXECUTION_ARTIFACT_R2_SECRET_ACCESS_KEY=%s", r2SecretKey(cfg)),
-		// MinIO can't resolve a bucket subdomain, so the presigners must use
-		// path-style addressing or presigned uploads fail with SignatureDoesNotMatch.
-		// Production R2 keeps the virtual-host default (flags are false there).
+		// harness-constraint: MinIO can't resolve a bucket subdomain, so the
+		// presigners must use path-style addressing or presigned uploads fail
+		// with SignatureDoesNotMatch. Production R2 keeps the virtual-host
+		// default (flags are false there).
 		"AGENT_EXECUTION_ARTIFACT_R2_PATH_STYLE_ACCESS_ENABLED=true",
 		// Same for the skill artifact presigner (the transfer lane, stigmer-cloud#438).
 		"SKILL_ARTIFACT_R2_PATH_STYLE_ACCESS_ENABLED=true",
@@ -484,42 +511,60 @@ func buildServiceEnv(cfg ServiceConfig) []string {
 		"VAULT_AUTH_METHOD=token",
 		fmt.Sprintf("VAULT_TOKEN=%s", cfg.VaultToken),
 
-		// Disable optional features
+		// Observability follows the OTLP endpoint (production: on).
 		fmt.Sprintf("OBSERVABILITY_ENABLED=%t", cfg.OTLPEndpoint != ""),
+		// test-tuning: the two billing Temporal schedules stay off. The
+		// reconciliation sweep queries Stripe for PENDING purchases whose
+		// webhook was missed (every 5 min) and the expiry sweep releases
+		// ACTIVE reservations past expires_at (every 10 min); production runs
+		// both. Here they would race the billing arms — a sweep releasing a
+		// hold an arm is asserting on, or reconciling a purchase the fake
+		// Stripe is mid-scripting — so the conformance suite drives the same
+		// sweeps deterministically through their operator RPCs.
 		"STIGMER_BILLING_RECONCILIATION_ENABLED=false",
 		"STIGMER_BILLING_RESERVATION_EXPIRY_ENABLED=false",
 
-		// Shared-agent launch gate: lower the per-session turn limit so the
-		// integration test can trip it without 30 real execution creates.
-		// Other limits keep production defaults (tests use fresh cookies, so
-		// per-guest buckets never collide across tests).
+		// test-tuning: shared-agent launch gate — lower the per-session turn
+		// limit so the integration test can trip it without 30 real execution
+		// creates. Other limits keep production defaults (tests use fresh
+		// cookies, so per-guest buckets never collide across tests). Only the
+		// sharing-cap arm observes the number.
 		"STIGMER_SHARING_MAX_TURNS_PER_SESSION=5",
+		// harness-constraint: no Kubernetes here; production launches runners
+		// through the sandbox provisioner. The suites run their own runner
+		// process against the service instead.
 		"STIGMER_RUNNER_LAUNCHER_TYPE=noop",
 
-		// Scheduled runs ride the harness this suite actually operates:
-		// production defaults schedule sessions to cursor (DD-012 D-F),
-		// but the suite's runnable path is the native unified runner —
+		// test-tuning: scheduled runs ride the harness this suite actually
+		// operates — production defaults schedule sessions to cursor (DD-012
+		// D-F), but the suite's runnable path is the native unified runner;
 		// without this override a triggered fire would dispatch a cursor
-		// execution no local runner can complete.
+		// execution no local runner can complete. The schedule-firing arms
+		// observe the harness, never the default.
 		"STIGMER_SCHEDULES_SESSION_DEFAULTS_HARNESS=native",
 
-		// Failure-streak auto-pause (DD-013): two failed fires instead of
-		// the production five, so the tracking wire test proves the
-		// pause without five trigger round-trips. Only the tracking test
-		// accumulates failures — every other schedule test fires
-		// successfully or never fires.
+		// test-tuning: failure-streak auto-pause (DD-013) — two failed fires
+		// instead of the production five, so the tracking wire test proves
+		// the pause without five trigger round-trips. Only the tracking test
+		// accumulates failures — every other schedule test fires successfully
+		// or never fires.
 		"STIGMER_SCHEDULES_MAX_CONSECUTIVE_FAILURES=2",
 
 		fmt.Sprintf("STIGMER_ACTIVITY_ROUTING=%s", activityRouting(cfg)),
 		fmt.Sprintf("STIGMER_WORKFLOW_ACTIVITY_ROUTING=%s", workflowActivityRouting(cfg)),
 		fmt.Sprintf("STIGMER_DEFAULT_EXECUTION_TARGET=%s", defaultExecutionTarget(cfg)),
+		// harness-constraint when noop (the default here): no cluster to
+		// provision sandboxes in; production is `kubernetes`.
 		fmt.Sprintf("STIGMER_SANDBOX_TYPE=%s", sandboxType(cfg)),
 
-		"STIGMER_PROXY_REQUIRE_SCOPE_HEADER=false",
+		// production when true (the conformance launcher); the Go suites'
+		// false is test-tuning — see ServiceConfig.ProxyRequireScopeHeader.
+		fmt.Sprintf("STIGMER_PROXY_REQUIRE_SCOPE_HEADER=%t", cfg.ProxyRequireScopeHeader),
 
-		// Skip JWKS URI reachability check for IdentityProvider create/update.
-		// Test JWKS servers run on plain HTTP localhost which fails the HTTPS
-		// requirement in ValidateJwksReachability.
+		// harness-constraint: skip the JWKS URI reachability check for
+		// IdentityProvider create/update. Test JWKS servers (the mock tenant,
+		// the federated mock IdP) run on plain HTTP localhost, which fails the
+		// HTTPS requirement in ValidateJwksReachability.
 		"STIGMER_IDP_JWKS_VALIDATION_DISABLED=true",
 
 		// RSA-2048 PKCS#8 DER signing key for PlatformClient token minting (test-only).
@@ -562,9 +607,10 @@ func buildServiceEnv(cfg ServiceConfig) []string {
 	}
 
 	if productionSecurity {
-		// Production security mode: load the real GrpcSecurityConfigBase,
-		// FederatedJwtAuthenticationProvider, and Auth0 JwtDecoder.
-		// Auth0 config points at the mock OIDC server.
+		// production: the real GrpcSecurityConfigBase, HttpSecurityConfig,
+		// FederatedJwtAuthenticationProvider and Auth0 JwtDecoder load; the
+		// only deviation is WHICH tenant they trust — the mock OIDC server
+		// the caller started before the JAR (discovery runs at bean init).
 		env = append(env, "STIGMER_SECURITY_MODE=production")
 
 		auth0Domain := "test.auth0.com"
@@ -590,10 +636,12 @@ func buildServiceEnv(cfg ServiceConfig) []string {
 			env = append(env, fmt.Sprintf("AUTH0_TOKEN_URL=%s", cfg.Auth0TokenURL))
 		}
 	} else {
-		// Test security mode: bypass Auth0 JWT validation with a synthetic
-		// caller. GrpcSecurityConfigBase and MachineAccountJwtProvider are
-		// not loaded. The permit-all TestIamPolicyGrpcRepo is used unless
-		// real FGA is enabled.
+		// test-tuning (the Go suites): bypass Auth0 JWT validation with a
+		// synthetic caller. GrpcSecurityConfigBase, HttpSecurityConfig and
+		// MachineAccountJwtProvider are not loaded; the edge posture is
+		// unobservable — which is why the conformance launcher no longer
+		// boots this way (entry 20260907.02). The permit-all
+		// TestIamPolicyGrpcRepo is used unless real FGA is enabled.
 		env = append(env, "STIGMER_SECURITY_MODE=test")
 		env = append(env,
 			"AUTH0_DOMAIN=test.auth0.com",


### PR DESCRIPTION
## Summary
The conformance suite's hermetic Java launcher now boots `stigmer-service` in **production security mode** against an in-process mock identity tenant, so the 14 authentication-class arms that skipped through `edgeAuthenticationBypass()` run against Java's real edge. The "bypassed edge" posture is deleted from the harness end to end, every harness override of Java's environment carries a written disposition against the production overlay, and the deviation registry is generalized to record the three Java behaviors the measurement found.

## Context
D-S1 (entry 20260904.02) recorded that the launcher's test security mode makes authentication unobservable and named "run the launcher in production security mode" as its own entry; E1 (20260906.04) ruled it as Q1. Until now the composition was accepted against authentication arms written from Java's source that had never been seen to pass on Java. stigmer-cloud entry `20260907.02.sp.hermetic-launcher-production-posture`; readout `x1-cutover/conformance-readouts/2026-09-07-hermetic-java-production-posture.md`.

## Changes
- **Go harness** (`test/integration/harness`): `SeedBootstrapOperator` extracted from `test/integration-security`'s inline block (both consumers call it); `/userinfo` and `Material()` on the mock OIDC server; `ServiceConfig.ProxyRequireScopeHeader`; every `buildServiceEnv` override annotated `production` / `harness-constraint` / `test-tuning`.
- **Launcher** (`cmd/conformance-cloudenv`): tenant before the JAR; `SecurityModeProduction`, `JWTAudience` lenient, `ProxyRequireScopeHeader: true`; the bootstrap operator seeded after boot; `readySignal.identityTenant` (the key rides stdout only — never stderr, which CI uploads).
- **Conformance harness**: the bootstrap runs over the operator's Bearer (readiness probe included — `findMyOrganizations` is not `is_public`); `CLOUD_ENV.directLogin*` published from the ready line; `EDGE_AUTHENTICATION`, `resolveEdgeAuthentication`, `edgeAuthenticationBypass` and the four suites' skip helpers deleted; the inventory's `launcher-authz-only` observability value deleted and its 8 rows flipped.
- **Deviation registry**: `KnownDeviation` carries `contract`/`observed` as prose; `assertContractOrDeviation` replaces the code-only helper (which had no callers). Three entries for the cloud targets: `java.stripe-webhook.missing-signature-header-401`, `java.direct-login.personal-org-owner-is-raw-subject` (stigmer-cloud#672), `java.direct-login.stranger-signature-copy`. Inventory row `billing.stripe.signature.missing-header-400` → `deviation`.
- **Suite fix**: `directLoginClaims` mints expired tokens with `iat` before `exp` (an `exp < iat` token is malformed, not expired — Spring refused it as `invalid token`).
- README §Cloud target: production posture, the disposition list, the direct-login tenant on the hermetic launcher.

## Implementation notes
- The tenant is Go-owned inside the launcher, not a TS fixture: E1's fixtures fake what Java *dials out to*; the tenant is what Java *trusts at boot* and belongs to the boot recipe — the split the Go security suite already draws. A TS tenant would have been the codebase's third mock issuer and still needed Go-side Postgres seeding.
- No Java changes: `stigmer.security.mode` is one property with both sides already built. The Go integration suites keep test mode through their own `ServiceConfig`.
- The three deviations are Java behaviors the composition already answers per the contract; F-B may reach past Java's retirement into the production FGA store (which survives X1) — filed as stigmer-cloud#672 with a read-only production check as its first step.

## Breaking changes
- None on the wire. `CLOUD_ENV.STIGMER_CONFORMANCE_CLOUD_EDGE_AUTHENTICATION` no longer exists; the launcher's ready line gains a required `identityTenant` group (the TS side refuses a launcher that omits it).

## Test plan
- Hermetic Java Class A: **568 / 0 / 38 (606)** — E1 baseline 556 / 0 / 52; skips down by exactly the 14 arms; 0 regressions; three tracked deviations reported in the run log.
- Hermetic Java Class B: **160 / 0 / 1 (161)** — every billing gate and runner proxy call green with the scope header required.
- `test/integration-security`: **17 / 17** through the shared helper (production mode, mock tenant).
- Local Class A (`make test-conformance`): **507 / 0 / 95 (602) on `main` and on this branch — byte-identical.**
- `make check-conformance-inventory`: 152 rows (conformance 113, deviation 1, unit 28, smoke 5, debris 5), 114 covered, 0 problems. `npm run typecheck -w @stigmer/conformance`: exactly the 19 pre-existing errors (stigmer#999); every touched file clean. `go vet` clean on `test/integration` and `test/integration-security`.

## Risks
- `ci.conformance-cloud` now boots Java in production mode nightly; the first nightly is the confirmation. Rollback is reverting this PR — the Go suites are untouched.
- The Java service retires at R1; the three registry entries and the launcher's tenant go with it.

## Checklist
- [x] Docs updated (`test/conformance/README.md`)
- [x] Tests added/updated (the 14 arms now run; three deviations registered; one suite fix)
- [x] Backward compatible (Go suites unchanged; local rosters byte-identical)
