### PR TITLE
build(test/integration): add bootstrap_operator.go to the harness Bazel srcs

### DIFF
--- a/test/integration/harness/BUILD.bazel
+++ b/test/integration/harness/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "benchmark_report.go",
         "benchmark_stats.go",
         "billing_helpers.go",
+        "bootstrap_operator.go",
         "channel_conversation_seeder.go",
         "clients.go",
         "context.go",


### PR DESCRIPTION
## Summary
Adds `bootstrap_operator.go` (from #1001) to `test/integration/harness/BUILD.bazel`'s hand-listed `go_library` srcs.

## Context
`ci.bazel`'s graph build on `main` (`de03c3410`) fails: `test/integration/cmd/conformance-cloudenv/main.go:258: undefined: harness.SeedBootstrapOperator`. The Go toolchain and every Go/conformance lane were green because they compile by directory; Bazel compiles the listed srcs. My omission in #1001.

## Test plan
- `./bazelw build //test/integration/harness:harness //test/integration/cmd/conformance-cloudenv:conformance-cloudenv` — succeeds (460 actions).
- `ci.bazel` on this PR is the confirmation.

## Risks
- None beyond the one-line srcs entry.

Made with [Cursor](https://cursor.com)