### PR TITLE
test(conformance): C5 S3 — billing metric rows, two worker-row corrections, fake Stripe reconciliation reads, deterministic skill ZIP

### DIFF
--- a/test/conformance/inventory/cloud-capabilities.yaml
+++ b/test/conformance/inventory/cloud-capabilities.yaml
@@ -1206,7 +1206,7 @@ rows:
     lane: >-
       worker
     behavior: >-
-      The billing workers own exactly these Temporal schedule ids — reservation-expiry, grant-expiry, billing-usage-repricing, billing-reconciliation, billing-provider-reconciliation-anthropic, billing-provider-reconciliation-cursor — on queues reservation_expiry, grant_expiry, usage_repricing, billing_reconciliation, provider_reconciliation.
+      The billing workers own exactly these Temporal schedule ids — reservation-expiry, grant-expiry, billing-usage-repricing, billing-reconciliation, billing-provider-reconciliation-anthropic, billing-provider-reconciliation-cursor — and the byte-pinned workflow types billing/grant-expiry, billing/reservation-expiry, billing/reconciliation, billing/usage-repricing, billing/provider-reconciliation. Java ran them on five queues (reservation_expiry, grant_expiry, usage_repricing, billing_reconciliation, provider_reconciliation); the composition runs them on ONE composition-own queue, cloud-billing (C5 ruling S3-Q1, 2026-09-08) — the queue is server vocabulary, never a wire artifact.
     java_source: >-
       domain/billing/temporal/*/‹Starter›.java; resources application-temporal.yaml:64-67
     java_test: >-
@@ -1217,7 +1217,7 @@ rows:
     caller: none
     needs: [none]
     note: >-
-      C5 adopts the ids by name (DD-012); the composition's schedule reconciliation unit arms pin them. The conformance harness disables reconciliation and reservation-expiry on the hermetic launcher.
+      C5 adopts the ids (and types) by name (DD-012; landed 2026-09-08 in stigmer-cloud#680 and its stacked PR-B — `billing/workers/model.ts` is the list of record, pinned by the bundle proof). The Java integration harness disables reconciliation and reservation-expiry on the hermetic launcher.
   - id: billing.worker.reservation-expiry.releases-stale-holds
     surface: billing
     lane: >-
@@ -1268,7 +1268,7 @@ rows:
     lane: >-
       worker
     behavior: >-
-      The billing reconciliation sweep compares ledger sums to account balances and reports drift.
+      The billing reconciliation sweep is the money-IN backstop: a PENDING credit purchase older than the stale threshold is settled from its Stripe Checkout Session (complete+paid grants under the webhook's own key, expired marks expired, open is left; one with no session is marked failed past the orphan threshold), and a PENDING auto-recharge event is settled from its PaymentIntent or re-driven under its original idempotency key (compensated past the 20 h ceiling or without a saved card). Corrected 2026-09-08 (C5 S3): the earlier text described a ledger-vs-balance drift check Java never had — that instrument is C5 S4's balance reconciliation in the M1 tool.
     java_source: >-
       domain/billing/temporal/reconciliation/*.java
     java_test: >-
@@ -2567,3 +2567,97 @@ metrics:
     disposition: dropped
     note: >-
       Counts refusals of Java's second-client writes to the composition's cloud.cursor_* tables (the C4 Q7 gate, 20260905.02). The composition is the only writer post-X1; the gate retires with Java.
+  # ---- billing (C5 gate, S3-Q7 — 2026-09-08) --------------------------------
+  # Java emits 18 distinct stigmer.billing.* names across the six
+  # domain/billing/observability/*Metrics classes; the S0 plan's "19" was a
+  # miscount. Seventeen are billing-emitted and ported under the same names
+  # onto the composition's lazy-instrument idiom (billing/metrics.ts for the
+  # counters, billing/governance/governance-gauges.ts for the three polled
+  # gauges); every counter whose SigNoz alert needs a series before its first
+  # increment is pre-registered at zero on unit boot as Java's constructors
+  # did. The eighteenth is not billing's — see its note.
+  - name: stigmer.billing.pricing.baseline_fallback
+    surface: billing
+    java_source: domain/billing/observability/PricingGovernanceMetrics.java
+    disposition: ported
+    alerts: [pricing-baseline-fallback]
+  - name: stigmer.billing.pricing.price_not_found
+    surface: billing
+    java_source: domain/billing/observability/UsagePricingMetrics.java
+    disposition: ported
+    alerts: [billing-price-not-found]
+  - name: stigmer.billing.service_tier.mismatch
+    surface: billing
+    java_source: domain/billing/observability/UsagePricingMetrics.java
+    disposition: ported
+    alerts: [billing-service-tier-mismatch]
+  - name: stigmer.billing.thinking.mismatch
+    surface: billing
+    java_source: domain/billing/observability/UsagePricingMetrics.java
+    disposition: ported
+    alerts: [billing-thinking-mismatch]
+  - name: stigmer.billing.usage.metered_execution
+    surface: billing
+    java_source: domain/billing/observability/UsagePricingMetrics.java
+    disposition: ported
+  - name: stigmer.billing.repricing.still_unpriced
+    surface: billing
+    java_source: domain/billing/observability/UsagePricingMetrics.java
+    disposition: ported
+    alerts: [billing-repricing-still-unpriced]
+  - name: stigmer.billing.auto_recharge.rejected
+    surface: billing
+    java_source: domain/billing/observability/AutoRechargeMetrics.java
+    disposition: ported
+    alerts: [billing-auto-recharge-rejected]
+  - name: stigmer.billing.auto_recharge.late_success_repair
+    surface: billing
+    java_source: domain/billing/observability/AutoRechargeMetrics.java
+    disposition: ported
+    alerts: [billing-auto-recharge-late-success-repair]
+  - name: stigmer.billing.auto_recharge.gate_skipped
+    surface: billing
+    java_source: domain/billing/observability/AutoRechargeMetrics.java
+    disposition: ported
+  - name: stigmer.billing.auto_recharge.reconciled
+    surface: billing
+    java_source: domain/billing/observability/AutoRechargeMetrics.java
+    disposition: ported
+  - name: stigmer.billing.pricing.reconciliation.runs
+    surface: billing
+    java_source: domain/billing/observability/PricingGovernanceMetrics.java
+    disposition: ported
+    alerts: [pricing-reconciliation-silence-anthropic, pricing-reconciliation-silence-cursor]
+  - name: stigmer.billing.pricing.rate_corrected
+    surface: billing
+    java_source: domain/billing/observability/PricingGovernanceMetrics.java
+    disposition: ported
+  - name: stigmer.billing.pricing.rate_proposal_pending
+    surface: billing
+    java_source: domain/billing/observability/PricingGovernanceMetrics.java
+    disposition: ported
+  - name: stigmer.billing.pricing.governance_notification_failed
+    surface: billing
+    java_source: domain/billing/observability/PricingGovernanceMetrics.java
+    disposition: ported
+    alerts: [pricing-governance-notification-failed]
+  - name: stigmer.billing.pricing.reconciliation.last_run_unreconciled
+    surface: billing
+    java_source: domain/billing/observability/PricingReconciliationStatusMetrics.java
+    disposition: ported
+    alerts: [pricing-books-disagree-anthropic, pricing-books-disagree-cursor]
+  - name: stigmer.billing.pricing.signoff.pending
+    surface: billing
+    java_source: domain/billing/observability/PricingSignoffQueueMetrics.java
+    disposition: ported
+  - name: stigmer.billing.pricing.signoff.oldest_age_hours
+    surface: billing
+    java_source: domain/billing/observability/PricingSignoffQueueMetrics.java
+    disposition: ported
+    alerts: [pricing-signoff-waiting-too-long]
+  - name: stigmer.billing.model_pin.unknown
+    surface: billing
+    java_source: domain/agentic/agentexecution/PlatformModelPinStartupCheck.java
+    disposition: dropped
+    note: >-
+      Emitted by Java's agentic-domain BOOT CHECK (a channel, schedule or guest model pin the registry no longer knows), never by billing code — it carries the billing prefix only because the registry is billing's. The composition validates model pins at write time in the surfaces that own them (channels/model-pinning.ts; the OSS schedule and agentchannel steps) and has no boot-time sweep to attach the counter to; no alert reads it. Ruled dropped at C5's S3 gate (S3-Q7, 2026-09-08) with the door open: if the owner wants a boot check, it is a new item on the pin-owning surfaces, not a billing metric.

--- a/test/conformance/src/harness/fake-stripe.ts
+++ b/test/conformance/src/harness/fake-stripe.ts
@@ -78,6 +78,13 @@ export class FakeStripeApi {
   // Customers this fixture created, so a retrieve/update answers the shape
   // Java expects; payment methods are minted on first retrieve.
   private readonly customers = new Map<string, Record<string, unknown>>();
+  // Checkout Sessions and PaymentIntents this fixture created, so the
+  // reconciliation sweep's reads (C5 S3: GET /v1/checkout/sessions/{id},
+  // GET /v1/payment_intents/{id}) answer the object as last minted — status
+  // `open` / `processing` — instead of the unhandled 404 that turned every
+  // sweep run red on the S3 readout substrate.
+  private readonly checkoutSessions = new Map<string, Record<string, unknown>>();
+  private readonly paymentIntents = new Map<string, Record<string, unknown>>();
 
   async start(): Promise<void> {
     this.server = createServer((req, res) => {
@@ -114,6 +121,8 @@ export class FakeStripeApi {
     this.captured = [];
     this.failures = [];
     this.customers.clear();
+    this.checkoutSessions.clear();
+    this.paymentIntents.clear();
   }
 
   private nextId(prefix: string): string {
@@ -180,25 +189,39 @@ export class FakeStripeApi {
     }
     if (method === "POST" && path === "/v1/checkout/sessions") {
       const id = this.nextId("cs_test");
-      return {
-        status: 200,
+      const session = {
         id,
-        body: {
-          id,
-          object: "checkout.session",
-          created: now,
-          livemode: false,
-          mode: params["mode"] ?? "payment",
-          customer: params["customer"] ?? null,
-          payment_intent: null,
-          payment_status: "unpaid",
-          status: "open",
-          success_url: params["success_url"] ?? null,
-          cancel_url: params["cancel_url"] ?? null,
-          url: `https://checkout.stripe.test/c/pay/${id}`,
-          metadata: metadataOf(params),
-        },
+        object: "checkout.session",
+        created: now,
+        livemode: false,
+        mode: params["mode"] ?? "payment",
+        customer: params["customer"] ?? null,
+        payment_intent: null,
+        payment_status: "unpaid",
+        status: "open",
+        success_url: params["success_url"] ?? null,
+        cancel_url: params["cancel_url"] ?? null,
+        url: `https://checkout.stripe.test/c/pay/${id}`,
+        metadata: metadataOf(params),
       };
+      this.checkoutSessions.set(id, session);
+      return { status: 200, id, body: session };
+    }
+    // The reconciliation sweep's reads (C5 S3): a session or intent this
+    // fixture minted answers as it was minted (still `open` / `processing`,
+    // so the sweep leaves the row alone — Java's SKIPPED arm); an id the
+    // fixture never issued is Stripe's resource_missing.
+    const sessionMatch = /^\/v1\/checkout\/sessions\/([^/]+)$/.exec(path);
+    if (method === "GET" && sessionMatch !== null) {
+      const id = sessionMatch[1] ?? "";
+      const session = this.checkoutSessions.get(id);
+      return session === undefined ? stripeNotFound(`No such checkout.session: '${id}'`) : { status: 200, id, body: session };
+    }
+    const intentMatch = /^\/v1\/payment_intents\/([^/]+)$/.exec(path);
+    if (method === "GET" && intentMatch !== null) {
+      const id = intentMatch[1] ?? "";
+      const intent = this.paymentIntents.get(id);
+      return intent === undefined ? stripeNotFound(`No such payment_intent: '${id}'`) : { status: 200, id, body: intent };
     }
     if (method === "POST" && path === "/v1/billing_portal/sessions") {
       const id = this.nextId("bps");
@@ -218,22 +241,20 @@ export class FakeStripeApi {
     }
     if (method === "POST" && path === "/v1/payment_intents") {
       const id = this.nextId("pi");
-      return {
-        status: 200,
+      const intent = {
         id,
-        body: {
-          id,
-          object: "payment_intent",
-          created: now,
-          livemode: false,
-          amount: Number(params["amount"] ?? "0"),
-          currency: params["currency"] ?? "usd",
-          customer: params["customer"] ?? null,
-          payment_method: params["payment_method"] ?? null,
-          status: "processing",
-          metadata: metadataOf(params),
-        },
+        object: "payment_intent",
+        created: now,
+        livemode: false,
+        amount: Number(params["amount"] ?? "0"),
+        currency: params["currency"] ?? "usd",
+        customer: params["customer"] ?? null,
+        payment_method: params["payment_method"] ?? null,
+        status: "processing",
+        metadata: metadataOf(params),
       };
+      this.paymentIntents.set(id, intent);
+      return { status: 200, id, body: intent };
     }
     const pmMatch = /^\/v1\/payment_methods\/([^/]+)$/.exec(path);
     if (method === "GET" && pmMatch !== null) {

--- a/test/conformance/src/support/skills.ts
+++ b/test/conformance/src/support/skills.ts
@@ -34,14 +34,24 @@ export interface SkillArtifactOptions {
   description?: string;
 }
 
+// A fixed entry timestamp so two ZIPs of the same content are the SAME BYTES.
+// fflate stamps the CURRENT clock (DOS time, 2-second resolution) into every
+// entry header by default, so an artifact built seconds after another one
+// carries different bytes and a different content hash — the "re-push A" arm
+// of the content-addressed versioning suite failed exactly that way on the
+// 2026-09-08 C5 S3 composition readout. The content hash is the contract;
+// the clock is not part of the content.
+const FIXED_ZIP_MTIME = new Date("2026-01-01T00:00:00Z");
+
 // Builds a ZIP from an explicit file map. A neutral primitive (not "a valid
 // skill"), so the suite can compose malformed artifacts — e.g. a ZIP without a
 // SKILL.md, or with bad frontmatter — without re-importing fflate and without
-// blurring the valid/invalid boundary this module guards.
+// blurring the valid/invalid boundary this module guards. Deterministic: the
+// same map always yields the same bytes (see FIXED_ZIP_MTIME).
 export function zipFiles(files: Record<string, Uint8Array | string>): Uint8Array {
-  const entries: Record<string, Uint8Array> = {};
+  const entries: Record<string, [Uint8Array, { mtime: Date }]> = {};
   for (const [name, content] of Object.entries(files)) {
-    entries[name] = typeof content === "string" ? strToU8(content) : content;
+    entries[name] = [typeof content === "string" ? strToU8(content) : content, { mtime: FIXED_ZIP_MTIME }];
   }
   return zipSync(entries);
 }


### PR DESCRIPTION
## Summary

Test-only; no product code. The C5 S3 session (stigmer-cloud [#680](https://github.com/stigmer/stigmer-cloud/pull/680) and its stacked PR-B) ports Java's five billing Temporal workflows and the pricing-governance loop onto the composition; these are the OSS-side records and fixture repairs it owes.

**Inventory (`test/conformance/inventory/cloud-capabilities.yaml`)**
- The billing section of E1's metrics list: 18 rows — 17 `stigmer.billing.*` series `ported` under Java's names, `stigmer.billing.model_pin.unknown` `dropped` with its reason (it is Java's agentic-domain boot check, not billing's; ruling S3-Q7). Alerts named per row.
- `billing.worker.reconciliation.detects-drift`: the behavior now describes the sweep Java actually ran (the money-in backstop over stale purchases and auto-recharge events), not a ledger-vs-balance drift check Java never had.
- `billing.worker.schedule-ids.six-byte-pinned`: records the byte-pinned workflow types and the composition's single `cloud-billing` queue (ruling S3-Q1); the note points at the list of record.

**Fixtures**
- `FakeStripeApi` remembers the Checkout Sessions and PaymentIntents it mints and answers `GET /v1/checkout/sessions/{id}` and `GET /v1/payment_intents/{id}` — the reads the reconciliation sweep makes, which 404'd as `unhandled` on the S3 readout substrate and turned every sweep run red. `reset()` clears them.
- `zipFiles` pins the entry mtime: fflate stamps the current clock at 2 s resolution into every entry header, so two ZIPs of identical content built seconds apart had different bytes and different content hashes — the "re-push A is a no-op" arm of the skill versioning suite flaked on a slow host for exactly this reason. The content hash is the contract; the clock is not part of the content.

## Test plan

- [x] `npm run inventory:check` — 152 rows, 0 problems; metrics 37 (ported 34, dropped 3)
- [x] `tsc --noEmit` clean for the two edited files
- [x] Determinism proven: two `zipSync` calls 2.1 s apart with the pinned mtime yield byte-identical output
- [ ] Class A + EC-1 re-run against the composition on a quiet host (the stigmer-cloud PR-B readout carries it)

Made with [Cursor](https://cursor.com)