### PR TITLE
fix(test/conformance): make the Class B lane a trustworthy signal — one child-process discipline, a race kind in the deviation registry, the submit-approval seam

### DIFF
--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -304,16 +304,34 @@ codebase writes anyway.
 Tests assert the **intended** contract, not whatever an implementation happens
 to do today. When a target legitimately deviates because of a known bug, it gets
 a tracked entry in the **known-deviation registry** (`deviations.ts`) instead of
-the test quietly asserting the wrong behavior. `expectCodeOrDeviation(...)`:
+the test quietly asserting the wrong behavior. An entry records both readings as
+prose — `contract` and `observed` — and the arm supplies the two assertions.
+There are two kinds, because there are two kinds of bug:
 
-- asserts the contract code for targets without a registered deviation;
-- asserts the recorded (wrong) code for targets that have one, and reports it;
-- **fails** if a deviating target starts returning the contract code — that
-  signals the bug is fixed and the entry should be deleted.
+- **Deterministic** (`assertContractOrDeviation`): the target ALWAYS answers the
+  observed reading. The arm runs only the `observed` assertion there, so the day
+  the target is fixed that assertion fails and the entry must be deleted. Three
+  entries today, all Java's, from the launcher entry that first ran Java in
+  production security mode (stigmer-cloud `20260907.02`).
+- **Race** (`assertContractOrKnownRace`): the target SOMETIMES answers the
+  observed reading, on a timing it does not control. The arm asserts the
+  contract first, on every target; only an assertion failure on a registered
+  target opens the race path, where `observed` must PROVE the specific race (a
+  failure there is an unknown symptom and stays red), the firing is reported on
+  one grep-able `[conformance] tracked race …` line, and — where the entry names
+  a remedy — the arm applies it and asserts the contract exactly once more. A
+  race entry cannot self-expire, so it states when it is deleted. Two entries
+  today, both Java's execution target, from the Class B lane-integrity entry
+  (stigmer-cloud `20260908.01`): the approval write lost to the workflow's
+  WAITING heartbeat, applied at the submit seam
+  (`support/agentexecutions.ts` → `submitApprovalPerContract`), and the trailing
+  terminal write that closes a subscription the pinned S4 quirk says stays open.
 
-So the registry can never hide a regression or bless a bug permanently. There
-are currently no tracked deviations: every target returns the contract code.
-The previous local-target entries — duplicate-create / missing-name / missing-spec
+Neither kind is a retry budget, a sleep or a skip: the contract assertion runs
+on every target every time, and nothing in the registry is reached unless the
+target is registered AND (for a race) the contract just failed. The registry
+can never hide a regression or bless a bug permanently. The local targets carry
+no entries: the previous ones — duplicate-create / missing-name / missing-spec
 returning `Unknown`, and `getVersion` with a malformed hash returning `NotFound`
 — were resolved (stigmer/stigmer#192) by enforcing protovalidate at the gRPC
 transport boundary and by making the affected pipeline steps return typed gRPC
@@ -485,7 +503,7 @@ on `local-execution`. See the project's
 
 ```
 src/
-  harness/          ts-build, ports, server-process, grpc-ready, clients, fixtures, global-setup
+  harness/          ts-build, ports, child-process (the one stop + tee discipline), server-process, grpc-ready, clients, fixtures, global-setup
                     + execution: temporal, runner-build, runner-process, mock-llm, mcp-server, global-setup-execution
                     + cloud: cloud-env, global-setup-cloud
   targets/          target (interface + capabilities), local, local-execution, cloud, cloud-execution, index
@@ -506,7 +524,12 @@ src/
    execution domain, `src/suites-execution/<domain>.conformance.test.ts` driven
    by the `local-execution` target.
 3. Assert the intended contract; register any genuine implementation bug as a
-   known deviation rather than asserting the wrong behavior.
+   known deviation rather than asserting the wrong behavior — deterministic if
+   the target always answers wrong, race if it sometimes does (and then the
+   `observed` assertion must prove that specific race, never merely "not the
+   contract").
+4. An approval submit goes through `submitApprovalPerContract`, never a bare
+   `submitApproval` followed by an `expect` on `pending_approvals`.
 
 ## Adding a cloud capability
 

--- a/test/conformance/src/contract/__tests__/deviations.test.ts
+++ b/test/conformance/src/contract/__tests__/deviations.test.ts
@@ -1,0 +1,175 @@
+// Unit arms for the known-deviation registry's two helpers: the deterministic
+// one runs exactly one reading; the race one runs the contract everywhere and
+// opens its path only for a registered target, only on an assertion failure,
+// only when the observed reading PROVES the race — and re-tries the contract
+// exactly once when the arm brings a remedy. Pure: no target.
+// Domain: conformance contract.
+import { ConnectError, Code } from "@connectrpc/connect";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  assertContractOrDeviation,
+  assertContractOrKnownRace,
+  KNOWN_DEVIATIONS,
+  SUBMIT_APPROVAL_LOST_UPDATE_RACE,
+} from "../deviations";
+
+const DETERMINISTIC_ID = "java.direct-login.stranger-signature-copy";
+const RACE_ID = SUBMIT_APPROVAL_LOST_UPDATE_RACE;
+const RACE_TARGET = "cloud-execution";
+const TS_TARGET = "local-execution";
+
+// A failure the way vitest's expect produces one — the only kind that opens
+// the race path.
+function failAssertion(message: string): never {
+  expect(false, message).toBe(true);
+  throw new Error("unreachable");
+}
+
+describe("the registry", () => {
+  it("names each race's retirement — a race entry cannot expire on its own", () => {
+    for (const entry of KNOWN_DEVIATIONS) {
+      if (entry.kind === "race") {
+        expect(entry.retires, `${entry.id} says when it is deleted`).toMatch(/R1/);
+      }
+    }
+  });
+
+  it("refuses an unknown id and refuses an entry handed to the wrong helper", async () => {
+    await expect(
+      assertContractOrDeviation(TS_TARGET, "no.such.id", { contract: () => {}, observed: () => {} }),
+    ).rejects.toThrow("unknown deviation id: no.such.id");
+    await expect(
+      assertContractOrDeviation(TS_TARGET, RACE_ID, { contract: () => {}, observed: () => {} }),
+    ).rejects.toThrow(`deviation ${RACE_ID} is race, not deterministic; use assertContractOrKnownRace`);
+    await expect(
+      assertContractOrKnownRace(TS_TARGET, DETERMINISTIC_ID, { contract: () => {}, observed: () => {} }),
+    ).rejects.toThrow(`deviation ${DETERMINISTIC_ID} is deterministic, not race; use assertContractOrDeviation`);
+  });
+});
+
+describe("assertContractOrDeviation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("runs only the contract on an unregistered target", async () => {
+    const contract = vi.fn();
+    const observed = vi.fn();
+    await assertContractOrDeviation(TS_TARGET, DETERMINISTIC_ID, { contract, observed });
+    expect(contract).toHaveBeenCalledTimes(1);
+    expect(observed).not.toHaveBeenCalled();
+  });
+
+  it("runs only the observed reading on a registered target and reports it", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const contract = vi.fn();
+    const observed = vi.fn();
+    await assertContractOrDeviation("cloud", DETERMINISTIC_ID, { contract, observed });
+    expect(contract).not.toHaveBeenCalled();
+    expect(observed).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`tracked deviation ${DETERMINISTIC_ID} on cloud`));
+  });
+});
+
+describe("assertContractOrKnownRace", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is the contract alone on an unregistered target — a failure there is red, never a race", async () => {
+    const observed = vi.fn();
+    await expect(
+      assertContractOrKnownRace(TS_TARGET, RACE_ID, {
+        contract: () => failAssertion("the TS server met the contract"),
+        observed,
+      }),
+    ).rejects.toThrow("the TS server met the contract");
+    expect(observed).not.toHaveBeenCalled();
+  });
+
+  it("is silent on a registered target whose contract holds", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const observed = vi.fn();
+    await assertContractOrKnownRace(RACE_TARGET, RACE_ID, { contract: () => {}, observed });
+    expect(observed).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("on a registered failure proves the race, reports one line, remedies, and re-asserts the contract once", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let attempts = 0;
+    const observed = vi.fn();
+    const remedy = vi.fn();
+    await assertContractOrKnownRace(RACE_TARGET, RACE_ID, {
+      contract: () => {
+        attempts++;
+        if (attempts === 1) failAssertion("pending still 1");
+      },
+      observed,
+      remedy,
+    });
+    expect(attempts).toBe(2);
+    expect(observed).toHaveBeenCalledTimes(1);
+    expect(remedy).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`tracked race ${RACE_ID} on ${RACE_TARGET}`));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("remedy="));
+  });
+
+  it("fails the arm when the remedied contract fails again — never a second retry", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    let attempts = 0;
+    await expect(
+      assertContractOrKnownRace(RACE_TARGET, RACE_ID, {
+        contract: () => {
+          attempts++;
+          failAssertion(`attempt ${attempts} failed`);
+        },
+        observed: () => {},
+        remedy: () => {},
+      }),
+    ).rejects.toThrow("attempt 2 failed");
+    expect(attempts).toBe(2);
+  });
+
+  it("without a remedy, the observed reading is the whole story", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let attempts = 0;
+    await assertContractOrKnownRace(RACE_TARGET, RACE_ID, {
+      contract: () => {
+        attempts++;
+        failAssertion("closed, not timeout");
+      },
+      observed: () => {},
+    });
+    expect(attempts).toBe(1);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays red when the observed reading does not prove the race — an unknown symptom", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const remedy = vi.fn();
+    await expect(
+      assertContractOrKnownRace(RACE_TARGET, RACE_ID, {
+        contract: () => failAssertion("pending still 1"),
+        observed: () => failAssertion("no decision in the stream either"),
+        remedy,
+      }),
+    ).rejects.toThrow("no decision in the stream either");
+    expect(remedy).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("lets a non-assertion error through untouched — a ConnectError is not a race", async () => {
+    const observed = vi.fn();
+    await expect(
+      assertContractOrKnownRace(RACE_TARGET, RACE_ID, {
+        contract: () => {
+          throw new ConnectError("unauthorized", Code.PermissionDenied);
+        },
+        observed,
+      }),
+    ).rejects.toBeInstanceOf(ConnectError);
+    expect(observed).not.toHaveBeenCalled();
+  });
+});

--- a/test/conformance/src/contract/deviations.ts
+++ b/test/conformance/src/contract/deviations.ts
@@ -4,19 +4,35 @@
 // The suite asserts the INTENDED contract, not whatever a given implementation
 // happens to do today. Where a target legitimately deviates from the contract
 // because of a known bug, it gets a tracked entry here instead of the test
-// silently asserting the wrong behavior. When the target is fixed, the
-// `observed` assertion in assertContractOrDeviation fails and the entry must
-// be removed — the registry can never hide a regression or bless a bug
-// permanently.
+// silently asserting the wrong behavior. A deviation is whatever the contract
+// can state — a gRPC code, an HTTP status, a byte-pinned message, a visible
+// side effect — so the registry records the two readings as prose and the arm
+// supplies the two assertions.
 //
-// A deviation is whatever the contract can state — a gRPC code, an HTTP
-// status, a byte-pinned message, a visible side effect — so the registry
-// records the two readings as prose and the arm supplies the two assertions.
-// The first entries arrived when the hermetic Java launcher started running
-// production security mode (entry 20260907.02): three behaviors of the Java
-// service that the composition already answers per the contract.
+// Two kinds, because two kinds of bug exist:
+//
+// - DETERMINISTIC: the target ALWAYS answers the observed reading. The arm runs
+//   only the `observed` assertion there, so the day the target is fixed that
+//   assertion fails and the entry must be deleted — the registry can never hide
+//   a regression or bless a bug permanently. The first entries arrived when the
+//   hermetic Java launcher started running production security mode (entry
+//   20260907.02).
+// - RACE: the target SOMETIMES answers the observed reading, on a timing it
+//   does not control. The arm tries the contract first; only when that
+//   assertion fails does it run the `observed` assertion, which must PROVE the
+//   specific known race (a failure there is an unknown symptom and stays red),
+//   report the firing on one grep-able line, and — where the entry names a
+//   remedy — apply it and re-try the contract exactly once. A race entry cannot
+//   self-expire (a fixed target simply stops firing), so it states when it is
+//   deleted instead. The first entries arrived with the Class B lane-integrity
+//   work (entry 20260908.01), which found the cloud-execution lane red on half
+//   its runs for exactly this reason.
+//
+// What neither kind is: a retry budget, a sleep, or a skip. The contract
+// assertion runs on every target every time; nothing here is reached unless
+// the target is registered AND (for a race) the contract just failed.
 
-export interface KnownDeviation {
+interface DeviationRecord {
   // Stable identifier used by tests to opt a case into the registry.
   id: string;
   // Target names that currently exhibit the deviation (TargetProfile.name).
@@ -31,12 +47,38 @@ export interface KnownDeviation {
   tracking: string;
 }
 
+export interface DeterministicDeviation extends DeviationRecord {
+  kind: "deterministic";
+}
+
+export interface RaceDeviation extends DeviationRecord {
+  kind: "race";
+  // What a production caller does when the race fires, in one sentence. The
+  // arm supplies the act; the registry says why it is legitimate to perform
+  // it inside a conformance run. Absent when the observed reading is final.
+  remedy?: string;
+  // When the entry is deleted, since it cannot expire on its own.
+  retires: string;
+}
+
+export type KnownDeviation = DeterministicDeviation | RaceDeviation;
+
 // The hermetic Java targets. The Java service retires at R1; every entry
 // naming them is deleted with it.
 const JAVA_TARGETS = ["cloud", "cloud-execution"];
+// The Java execution target alone: races between the runner's status writes
+// and a caller's RPC need a runner, so Class A never reaches them.
+const JAVA_EXECUTION_TARGET = ["cloud-execution"];
+
+// Race ids, exported so the one seam that applies each (support/agentexecutions.ts
+// for the first; the two subscribe arms for the second) cannot drift from the
+// registry by a typo.
+export const SUBMIT_APPROVAL_LOST_UPDATE_RACE = "java.agentexecution.submit-approval.lost-update-race";
+export const SUBSCRIBE_TRAILING_TERMINAL_WRITE_RACE = "java.execution-subscribe.trailing-terminal-write-closes";
 
 export const KNOWN_DEVIATIONS: KnownDeviation[] = [
   {
+    kind: "deterministic",
     id: "java.stripe-webhook.missing-signature-header-401",
     targets: JAVA_TARGETS,
     contract: "POST /webhook/stripe without a Stripe-Signature header answers 400 and grants nothing.",
@@ -52,6 +94,7 @@ export const KNOWN_DEVIATIONS: KnownDeviation[] = [
       "the composition answers 400).",
   },
   {
+    kind: "deterministic",
     id: "java.direct-login.personal-org-owner-is-raw-subject",
     targets: JAVA_TARGETS,
     contract:
@@ -70,6 +113,7 @@ export const KNOWN_DEVIATIONS: KnownDeviation[] = [
       "holds raw-subject owner tuples is the first check.",
   },
   {
+    kind: "deterministic",
     id: "java.direct-login.stranger-signature-copy",
     targets: JAVA_TARGETS,
     contract:
@@ -85,12 +129,62 @@ export const KNOWN_DEVIATIONS: KnownDeviation[] = [
       "stigmer-cloud entry 20260907.02, review finding F-D (cited, not filed — message copy only; " +
       "retires with Java; the composition answers the contract).",
   },
+  {
+    kind: "race",
+    id: SUBMIT_APPROVAL_LOST_UPDATE_RACE,
+    targets: JAVA_EXECUTION_TARGET,
+    contract:
+      "submitApproval's response reflects the decision synchronously — pending_approvals recomputed — " +
+      "and the decided tool call carries its approval_action in the transcript for the rest of the run.",
+    observed:
+      "The decision survives in the approval-event stream but not in the transcript: either the " +
+      "response still lists the tool call as pending and no Temporal signal fires (the response face), " +
+      "or the response passes and the run completes with the tool call never decided in the transcript " +
+      "(the audit face — five of the six approval reds on main, 2026-08-27 → 09-07).",
+    rationale:
+      "Both editions' workflows persist WAITING_FOR_APPROVAL a second time right before the signal " +
+      "wait (byte-pinned: invoke-agent-execution.ts / InvokeAgentExecutionWorkflowImpl). Java's " +
+      "UpdateStatusHandler reads the document for ApprovalFieldPreserver and later writes the whole " +
+      "messages list with no lock spanning the two, so SubmitApproval's targeted $set landing in " +
+      "between is lost; Java's own PendingApprovalProjector logs the divergence " +
+      "(hitl_pending_approvals_projection_divergence, only-in-scan:<tool_call_id>). The OSS server's " +
+      "submit is one read-modify-write under the store write lock with preserveApprovalFields inside " +
+      "it, so the race is unreachable there. A caller that answers within ~10 ms of the gate — an SDK " +
+      "or a bot, never a human — is the exposed population.",
+    remedy:
+      "Re-submit the same decision once — what a production approver does when the gate stays armed.",
+    tracking:
+      "stigmer-cloud#683 (a Java finding, retires with Java, an X1 input); the evidence table and Java " +
+      "timelines in stigmer-cloud entry 20260908.01's tasks/T01_2_execution.md.",
+    retires: "R1 — deleted with the Java targets; the OSS store lock makes the entry unreachable elsewhere.",
+  },
+  {
+    kind: "race",
+    id: SUBSCRIBE_TRAILING_TERMINAL_WRITE_RACE,
+    targets: JAVA_EXECUTION_TARGET,
+    contract:
+      "A subscription opened on an already-terminal run receives the snapshot and is never closed by " +
+      "the server (the pinned wave-2 S4 quirk: the terminal-close check fires only on broker updates).",
+    observed:
+      "Java sometimes closes it after delivering the terminal snapshot: the workflow's fallback persist " +
+      "writes the terminal status a second time after the runner's own write, and that late broker " +
+      "update trips the terminal-close check for a subscriber that arrived in between.",
+    rationale:
+      "The double terminal write is Java's; the OSS store serializes the same two writes so the " +
+      "subscriber never sees a trailing update. The pin's purpose — the TS port reproducing the quirk " +
+      "consciously — is served; whether the quirk should become a contract (close after a terminal " +
+      "snapshot) is a separate ruling the entry raises and does not take.",
+    tracking:
+      "stigmer-cloud entry 20260908.01 — ten of the twenty-eight Class B reds in its evidence table; " +
+      "stigmer#919.",
+    retires: "R1 — deleted with the Java targets.",
+  },
 ];
 
-// Runs the contract assertion, or — for a target registered as deviating —
-// the observed assertion, reporting the deviation (never silently). If a
-// registered target starts meeting the contract, `observed` fails, signaling
-// the entry is stale and should be deleted.
+// Runs the contract assertion, or — for a target registered as deterministically
+// deviating — the observed assertion, reporting the deviation (never silently).
+// If a registered target starts meeting the contract, `observed` fails,
+// signaling the entry is stale and should be deleted.
 export async function assertContractOrDeviation(
   targetName: string,
   deviationId: string,
@@ -99,10 +193,7 @@ export async function assertContractOrDeviation(
     observed: () => Promise<void> | void;
   },
 ): Promise<void> {
-  const deviation = KNOWN_DEVIATIONS.find((entry) => entry.id === deviationId);
-  if (deviation === undefined) {
-    throw new Error(`unknown deviation id: ${deviationId}`);
-  }
+  const deviation = lookupDeviation(deviationId, "deterministic");
   if (!deviation.targets.includes(targetName)) {
     await assertions.contract();
     return;
@@ -112,4 +203,74 @@ export async function assertContractOrDeviation(
     `[conformance] tracked deviation ${deviation.id} on ${targetName}: ` +
       `contract="${deviation.contract}" observed="${deviation.observed}" (${deviation.tracking})`,
   );
+}
+
+// Runs the contract assertion on every target. On a target registered for the
+// named race, an ASSERTION failure (and only that — any other error propagates)
+// opens the race path: `observed` must hold, proving this is the known race and
+// not a new symptom; the firing is reported on one line; if the arm supplies a
+// remedy, it runs and the contract is asserted once more, this time for real.
+export async function assertContractOrKnownRace(
+  targetName: string,
+  deviationId: string,
+  assertions: {
+    contract: () => Promise<void> | void;
+    observed: () => Promise<void> | void;
+    remedy?: () => Promise<void> | void;
+  },
+): Promise<void> {
+  const race = lookupDeviation(deviationId, "race");
+  try {
+    await assertions.contract();
+    return;
+  } catch (err) {
+    if (!race.targets.includes(targetName) || !isAssertionFailure(err)) throw err;
+  }
+  await assertions.observed();
+  console.warn(
+    `[conformance] tracked race ${race.id} on ${targetName}: ` +
+      `contract="${race.contract}" observed="${race.observed}"` +
+      (race.remedy !== undefined ? ` remedy="${race.remedy}"` : "") +
+      ` (${race.tracking})`,
+  );
+  if (assertions.remedy !== undefined) {
+    await assertions.remedy();
+    await assertions.contract();
+  }
+}
+
+function lookupDeviation<K extends KnownDeviation["kind"]>(
+  deviationId: string,
+  kind: K,
+): Extract<KnownDeviation, { kind: K }> {
+  const entry = KNOWN_DEVIATIONS.find((candidate) => candidate.id === deviationId);
+  if (entry === undefined) {
+    throw new Error(`unknown deviation id: ${deviationId}`);
+  }
+  if (entry.kind !== kind) {
+    throw new Error(
+      `deviation ${deviationId} is ${entry.kind}, not ${kind}; use ${helperFor(entry.kind)}`,
+    );
+  }
+  return entry as Extract<KnownDeviation, { kind: K }>;
+}
+
+function helperFor(kind: KnownDeviation["kind"]): string {
+  switch (kind) {
+    case "deterministic":
+      return "assertContractOrDeviation";
+    case "race":
+      return "assertContractOrKnownRace";
+    default: {
+      const exhaustive: never = kind;
+      throw new Error(`unhandled deviation kind ${String(exhaustive)}`);
+    }
+  }
+}
+
+// vitest's expect throws chai's AssertionError; a ConnectError, a timeout, or
+// a thrown Error from the arm's own plumbing is not an assertion and must not
+// open the race path.
+function isAssertionFailure(err: unknown): boolean {
+  return err instanceof Error && err.name === "AssertionError";
 }

--- a/test/conformance/src/harness/__tests__/child-process.test.ts
+++ b/test/conformance/src/harness/__tests__/child-process.test.ts
@@ -1,0 +1,208 @@
+// Unit arms for the harness's one child-process discipline: a stop resolves
+// only on exit and escalates to SIGKILL on a bounded grace; the output tee
+// ends its file sink only after the child's stdio has closed, so a chunk
+// emitted during the child's shutdown lands in the file instead of throwing
+// `ERR_STREAM_WRITE_AFTER_END` (the Class B teardown red of entry 20260908.01).
+// Pure: a fake child, a temp file, fake timers. No target.
+// Domain: conformance harness (process lifecycle).
+import { EventEmitter } from "node:events";
+import { readFile, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PassThrough } from "node:stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stopChild, teeChildOutput, type ChildHandle } from "../child-process";
+
+// The narrowest thing that satisfies ChildHandle. `kill` records signals and
+// leaves exiting to the test, which is what lets each arm choose its ordering.
+class FakeChild extends EventEmitter {
+  exitCode: number | null = null;
+  signalCode: NodeJS.Signals | null = null;
+  readonly stdout = new PassThrough();
+  readonly stderr = new PassThrough();
+  readonly signals: string[] = [];
+
+  kill(signal?: NodeJS.Signals | number): boolean {
+    this.signals.push(String(signal ?? "SIGTERM"));
+    return true;
+  }
+
+  // Exit as a signalled process would: the exit event first, stdio close after
+  // the pipes drain (a separate tick, as in Node).
+  exitBySignal(signal: NodeJS.Signals): void {
+    this.signalCode = signal;
+    this.emit("exit", null, signal);
+  }
+
+  closeStdio(): void {
+    this.stdout.end();
+    this.stderr.end();
+    this.emit("close", this.exitCode, this.signalCode);
+  }
+
+  asHandle(): ChildHandle {
+    return this as unknown as ChildHandle;
+  }
+}
+
+// Lets stream `data` events and settled promises land. Real setImmediate: the
+// fake timers below take only the timeout pair, so this stays a real tick.
+async function flush(): Promise<void> {
+  await new Promise<void>((resolveFlushed) => setImmediate(resolveFlushed));
+}
+
+// Only the grace timers are faked; streams and flush() keep the real loop.
+const FAKE_TIMEOUTS_ONLY: NonNullable<Parameters<typeof vi.useFakeTimers>[0]> = {
+  toFake: ["setTimeout", "clearTimeout"],
+};
+
+describe("stopChild", () => {
+  beforeEach(() => {
+    vi.useFakeTimers(FAKE_TIMEOUTS_ONLY);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("sends the requested signal and resolves only once the child has exited", async () => {
+    const child = new FakeChild();
+    let settled = false;
+    const stopping = stopChild(child.asHandle(), { signal: "SIGTERM", graceMs: 1_000 }).then(() => {
+      settled = true;
+    });
+    await flush();
+    expect(child.signals).toEqual(["SIGTERM"]);
+    expect(settled, "a stop is not done before exit").toBe(false);
+
+    child.exitBySignal("SIGTERM");
+    await stopping;
+    expect(settled).toBe(true);
+    expect(child.signals, "no SIGKILL when the child left within the grace").toEqual(["SIGTERM"]);
+  });
+
+  it("escalates to SIGKILL after the grace, telling the caller once", async () => {
+    const child = new FakeChild();
+    const onForceKill = vi.fn();
+    const stopping = stopChild(child.asHandle(), { signal: "SIGTERM", graceMs: 1_000, onForceKill });
+    await flush();
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(child.signals).toEqual(["SIGTERM"]);
+    expect(onForceKill).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(onForceKill).toHaveBeenCalledTimes(1);
+
+    child.exitBySignal("SIGKILL");
+    await stopping;
+  });
+
+  it("does not arm a grace when the signal is already SIGKILL", async () => {
+    const child = new FakeChild();
+    const onForceKill = vi.fn();
+    const stopping = stopChild(child.asHandle(), { signal: "SIGKILL", graceMs: 10, onForceKill });
+    await flush();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(child.signals).toEqual(["SIGKILL"]);
+    expect(onForceKill).not.toHaveBeenCalled();
+    child.exitBySignal("SIGKILL");
+    await stopping;
+  });
+
+  it("is a no-op on a child that has already exited", async () => {
+    const child = new FakeChild();
+    child.exitCode = 0;
+    await stopChild(child.asHandle(), { signal: "SIGTERM", graceMs: 1_000 });
+    expect(child.signals).toEqual([]);
+  });
+});
+
+describe("teeChildOutput", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "conformance-child-process-"));
+  });
+  afterEach(async () => {
+    vi.useRealTimers();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("writes a chunk emitted between the stop signal and stdio close to the file — the ordering that used to throw write-after-end", async () => {
+    const child = new FakeChild();
+    const file = join(dir, "runner.log");
+    const tee = teeChildOutput(child.asHandle(), { tailBytes: 8_000, file });
+
+    child.stdout.write("Worker ready, polling for tasks\n");
+    await flush();
+
+    // The caller's stop: signal, await exit, THEN close the tee. The runner's
+    // shutdown line arrives after `exit` and before `close` — exactly where
+    // the old runner-process.ts had already ended its sink.
+    const stopping = stopChild(child.asHandle(), { signal: "SIGTERM", graceMs: 1_000 });
+    await flush();
+    child.exitBySignal("SIGTERM");
+    await stopping;
+
+    const closing = tee.close();
+    child.stderr.write("worker drained, shutting down\n");
+    await flush();
+    child.closeStdio();
+    await closing;
+
+    const written = await readFile(file, "utf8");
+    expect(written).toBe("Worker ready, polling for tasks\nworker drained, shutting down\n");
+    expect(tee.tail()).toBe(written);
+  });
+
+  it("bounds the in-memory tail to tailBytes and hands each chunk to onChunk", async () => {
+    const child = new FakeChild();
+    const seen: string[] = [];
+    const tee = teeChildOutput(child.asHandle(), { tailBytes: 10, onChunk: (text) => seen.push(text) });
+    child.stdout.write("0123456789");
+    child.stdout.write("abcdef");
+    await flush();
+    expect(tee.tail()).toBe("6789abcdef");
+    expect(seen).toEqual(["0123456789", "abcdef"]);
+    await tee.close();
+  });
+
+  it("ends the sink anyway once the close grace expires, and drops a straggling chunk instead of throwing", async () => {
+    vi.useFakeTimers(FAKE_TIMEOUTS_ONLY);
+    const child = new FakeChild();
+    const file = join(dir, "server.log");
+    const tee = teeChildOutput(child.asHandle(), { tailBytes: 8_000, file });
+    child.stdout.write("listening\n");
+    await flush();
+    child.exitBySignal("SIGKILL");
+
+    // A grandchild holds the pipes: `close` never comes.
+    let closed = false;
+    const closing = tee.close(50).then(() => {
+      closed = true;
+    });
+    await vi.advanceTimersByTimeAsync(49);
+    expect(closed).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await closing;
+    expect(closed).toBe(true);
+
+    expect(() => child.stdout.write("late\n")).not.toThrow();
+    await flush();
+    expect(tee.tail(), "the tail still sees the straggler").toBe("listening\nlate\n");
+    expect(await readFile(file, "utf8"), "the file does not").toBe("listening\n");
+  });
+
+  it("close() is idempotent and a no-op without a file", async () => {
+    const child = new FakeChild();
+    const tee = teeChildOutput(child.asHandle(), { tailBytes: 100 });
+    await tee.close();
+    await tee.close();
+
+    const withFile = teeChildOutput(new FakeChild().asHandle(), { tailBytes: 100, file: join(dir, "twice.log") });
+    const first = withFile.close(10);
+    const second = withFile.close(10);
+    expect(second).toBe(first);
+    await first;
+  });
+});

--- a/test/conformance/src/harness/child-process.ts
+++ b/test/conformance/src/harness/child-process.ts
@@ -1,0 +1,163 @@
+// One discipline for the two things every harness child process needs at the
+// end of its life: being stopped, and having its output kept for diagnosis.
+// Domain: conformance harness (process lifecycle).
+//
+// The harness spawns four kinds of child — the TS server (server-process.ts),
+// the runner (runner-process.ts), the Temporal dev server (temporal.ts) and
+// the cloud launcher (cloud-env.ts) — and until entry 20260908.01 each stopped
+// its child its own way. Two of the four were wrong in ways that only showed
+// under CI's STIGMER_CONFORMANCE_LOG_DIR tee: the runner's stop() ended the
+// log sink and deleted the workspace the instant it sent SIGTERM, while the
+// runner was still writing its shutdown lines — `ERR_STREAM_WRITE_AFTER_END`
+// from the `data` handler, an uncaught exception that failed a Class B run
+// whose 160 arms had all passed (stigmer runs 33248911981, 34127147561,
+// 34160368541). The server's stop() SIGKILLed without awaiting exit and never
+// ended its tee. The launcher's stop had the right shape. This module IS that
+// shape, once, with the two non-negotiables stated:
+//
+// - A stop is not done until the child has EXITED. Deleting its state dir or
+//   ending its log sink before then races the child's own last acts.
+// - The log sink ends only after the child's stdio has CLOSED — Node's `close`
+//   event, which fires after `exit` once every pipe has drained. Until then a
+//   chunk can still arrive, and a chunk written to an ended stream throws.
+//
+// The signal each child receives is the caller's decision and is preserved
+// here as an argument, not normalized: SIGTERM where the child has a graceful
+// shutdown worth waiting for (the runner drains its worker; the launcher tears
+// down containers and the JVM), SIGKILL where it does not (the TS server
+// against throwaway state).
+import type { ChildProcess } from "node:child_process";
+import type { EventEmitter } from "node:events";
+import { once } from "node:events";
+import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
+import { dirname } from "node:path";
+
+// The slice of ChildProcess these helpers touch. Narrow on purpose: the unit
+// arms drive a fake child that implements exactly this, and a caller cannot
+// reach anything else through it.
+export type ChildHandle = EventEmitter &
+  Pick<ChildProcess, "exitCode" | "signalCode" | "kill" | "stdout" | "stderr">;
+
+export interface StopChildOptions {
+  // The signal that asks the child to leave. See the header for which one.
+  signal: "SIGTERM" | "SIGKILL";
+  // How long the child gets to exit after `signal` before the SIGKILL
+  // fallback. Ignored when `signal` is already SIGKILL.
+  graceMs: number;
+  // Fires once if the grace expires and SIGKILL is sent. The caller says what
+  // may have leaked, in its own words — a forced kill is always worth a loud
+  // line, and only the caller knows what its child owned.
+  onForceKill?: () => void;
+}
+
+// Signals the child and resolves once it has exited. Idempotent on a child
+// that has already exited (no signal is sent).
+export async function stopChild(child: ChildHandle, opts: StopChildOptions): Promise<void> {
+  if (hasExited(child)) return;
+
+  const exited = once(child, "exit");
+  child.kill(opts.signal);
+
+  let fallback: NodeJS.Timeout | undefined;
+  if (opts.signal !== "SIGKILL") {
+    fallback = setTimeout(() => {
+      opts.onForceKill?.();
+      child.kill("SIGKILL");
+    }, opts.graceMs);
+    fallback.unref();
+  }
+  try {
+    await exited;
+  } finally {
+    if (fallback !== undefined) clearTimeout(fallback);
+  }
+}
+
+export interface TeeChildOutputOptions {
+  // Bytes of combined stdout/stderr kept in memory for `tail()`.
+  tailBytes: number;
+  // When set, every byte is also appended to this file (its directory is
+  // created). The tee that survives teardown: the in-memory tail is only ever
+  // surfaced on spawn failure, which leaves a mid-run failure undiagnosable.
+  file?: string;
+  // Sees each chunk's text as it arrives — readiness markers live here.
+  onChunk?: (text: string) => void;
+}
+
+export interface ChildOutputTee {
+  // The last `tailBytes` of combined output.
+  tail(): string;
+  // Ends the file sink once the child's stdio has closed, so nothing can be
+  // written after the end. Call it after `stopChild` has resolved. Bounded:
+  // if `close` has not fired within `closeGraceMs` (a grandchild holding the
+  // pipes open, say) the sink is ended anyway and any later chunk is dropped
+  // rather than thrown. Idempotent; a no-op without a file.
+  close(closeGraceMs?: number): Promise<void>;
+}
+
+// How long close() waits for the child's stdio to close before ending the
+// sink regardless. A process that has exited normally closes its pipes within
+// milliseconds; the bound exists for the inherited-pipe case.
+const DEFAULT_CLOSE_GRACE_MS = 5_000;
+
+export function teeChildOutput(child: ChildHandle, opts: TeeChildOutputOptions): ChildOutputTee {
+  let tail = "";
+  let sink: WriteStream | undefined;
+  if (opts.file !== undefined) {
+    mkdirSync(dirname(opts.file), { recursive: true });
+    sink = createWriteStream(opts.file, { flags: "a" });
+  }
+
+  const append = (chunk: Buffer): void => {
+    const text = chunk.toString("utf8");
+    tail = (tail + text).slice(-opts.tailBytes);
+    // The guard is the belt to close()'s braces: after a bounded close() has
+    // ended the sink, a straggling chunk is dropped, never thrown.
+    if (sink !== undefined && !sink.writableEnded) sink.write(chunk);
+    opts.onChunk?.(text);
+  };
+  child.stdout?.on("data", append);
+  child.stderr?.on("data", append);
+
+  let stdioClosed = false;
+  child.once("close", () => {
+    stdioClosed = true;
+  });
+
+  let closing: Promise<void> | undefined;
+  const close = async (closeGraceMs = DEFAULT_CLOSE_GRACE_MS): Promise<void> => {
+    if (sink === undefined) return;
+    if (!stdioClosed) await waitForStdioClose(child, closeGraceMs);
+    // Nothing else ends the sink, and the `closing ??=` below makes this the
+    // only end() call, so the callback form is the whole finish handshake.
+    const ending = sink;
+    await new Promise<void>((resolveEnded) => ending.end(() => resolveEnded()));
+  };
+
+  return {
+    tail: () => tail,
+    close: (closeGraceMs) => {
+      closing ??= close(closeGraceMs);
+      return closing;
+    },
+  };
+}
+
+function hasExited(child: ChildHandle): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+// Resolves on the child's `close` or after `ms`, whichever is first, leaving no
+// listener and no timer behind either way.
+function waitForStdioClose(child: ChildHandle, ms: number): Promise<void> {
+  return new Promise((resolveClosed) => {
+    const finish = (): void => {
+      clearTimeout(timer);
+      child.off("close", finish);
+      resolveClosed();
+    };
+    const timer = setTimeout(finish, ms);
+    timer.unref();
+    child.once("close", finish);
+  });
+}

--- a/test/conformance/src/harness/cloud-env.ts
+++ b/test/conformance/src/harness/cloud-env.ts
@@ -15,7 +15,6 @@
 // environment sets the same variables directly and skips the launcher — the
 // CloudTarget never knows how the environment came to exist.
 import { execFile, spawn, type ChildProcess } from "node:child_process";
-import { once } from "node:events";
 import { mkdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { createInterface } from "node:readline";
@@ -26,6 +25,7 @@ import { createClient } from "@connectrpc/connect";
 import { IamPolicyCommandController } from "@stigmer/protos/ai/stigmer/iam/iampolicy/v1/command_pb";
 import { PlatformClientCommandController } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/command_pb";
 import { PlatformClientTokenController } from "@stigmer/protos/ai/stigmer/iam/platformclient/v1/token_pb";
+import { stopChild } from "./child-process";
 import { createTransport, makeClients } from "./clients";
 import { newDirectLoginTenant } from "./direct-login-tenant";
 import { awaitGrpcReady } from "./grpc-ready";
@@ -452,24 +452,17 @@ async function waitForReadyLine(child: ChildProcess): Promise<ReadyLine> {
 // at the cost of leaking whatever was not yet stopped — containers (visible,
 // reapable with `docker ps`) AND the naked service JVM, which nothing lists
 // (stigmer/stigmer#801) — so the fallback firing is always worth a loud line.
-async function stopLauncher(child: ChildProcess): Promise<void> {
-  if (child.exitCode !== null || child.signalCode !== null) return;
-
-  const exited = once(child, "exit");
-  child.kill("SIGTERM");
-
-  const timer = setTimeout(() => {
-    console.error(
-      `[cloud-env] launcher did not exit within ${SHUTDOWN_GRACE_MS}ms of SIGTERM — ` +
-        "SIGKILL fallback; containers and the service JVM may have leaked " +
-        "(check `docker ps` and `pgrep -f stigmer_service_fatjar`; stigmer/stigmer#801)",
-    );
-    child.kill("SIGKILL");
-  }, SHUTDOWN_GRACE_MS);
-  timer.unref();
-  try {
-    await exited;
-  } finally {
-    clearTimeout(timer);
-  }
+// The shape is the harness's one stop discipline (child-process.ts); this was
+// its origin.
+function stopLauncher(child: ChildProcess): Promise<void> {
+  return stopChild(child, {
+    signal: "SIGTERM",
+    graceMs: SHUTDOWN_GRACE_MS,
+    onForceKill: () =>
+      console.error(
+        `[cloud-env] launcher did not exit within ${SHUTDOWN_GRACE_MS}ms of SIGTERM — ` +
+          "SIGKILL fallback; containers and the service JVM may have leaked " +
+          "(check `docker ps` and `pgrep -f stigmer_service_fatjar`; stigmer/stigmer#801)",
+      ),
+  });
 }

--- a/test/conformance/src/harness/runner-process.ts
+++ b/test/conformance/src/harness/runner-process.ts
@@ -25,11 +25,11 @@
 // cloud-execution target points artifacts at the hermetic Java service's HTTP
 // port (MinIO-backed) while LLM traffic stays on the mock.
 import { spawn } from "node:child_process";
-import { createWriteStream, mkdirSync, type WriteStream } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { stopChild, teeChildOutput } from "./child-process";
 import { runnerDir } from "./runner-build";
 
 // The runner bundles its Temporal workflows on boot, so first-poll readiness is
@@ -37,6 +37,11 @@ import { runnerDir } from "./runner-build";
 const READY_TIMEOUT_MS = 60_000;
 const READY_POLL_MS = 100;
 const LOG_TAIL_BYTES = 8_000;
+// SIGTERM starts the runner's graceful shutdown (main.ts: `manager.shutdown()`
+// drains the Temporal worker). Every suite awaits its executions' terminal
+// phase before teardown, so the drain has nothing in flight and exit is
+// prompt; the bound only exists so a wedged drain cannot hang the vitest run.
+const SHUTDOWN_GRACE_MS = 30_000;
 
 // Printed by the runner immediately before it begins polling (runner/src/runner.ts).
 const READY_MARKER = "Worker ready, polling for tasks";
@@ -183,7 +188,6 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
     },
   });
 
-  let logSink: WriteStream | undefined;
   // STIGMER_CONFORMANCE_LOG_DIR: the same teardown-surviving tee the
   // server harness offers, for diagnosing writer-ordering races that need
   // the runner's cancellation/persist lines (see server-process.ts).
@@ -195,21 +199,14 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
           `runner-${Date.now()}.log`,
         )
       : undefined);
-  if (teeFile !== undefined) {
-    mkdirSync(dirname(teeFile), { recursive: true });
-    logSink = createWriteStream(teeFile, { flags: "a" });
-  }
-
-  let logTail = "";
   let ready = false;
-  const appendLog = (chunk: Buffer): void => {
-    const text = chunk.toString("utf8");
-    logTail = (logTail + text).slice(-LOG_TAIL_BYTES);
-    logSink?.write(chunk);
-    if (text.includes(READY_MARKER)) ready = true;
-  };
-  child.stdout.on("data", appendLog);
-  child.stderr.on("data", appendLog);
+  const output = teeChildOutput(child, {
+    tailBytes: LOG_TAIL_BYTES,
+    file: teeFile,
+    onChunk: (text) => {
+      if (text.includes(READY_MARKER)) ready = true;
+    },
+  });
 
   let exit: { code: number | null; signal: NodeJS.Signals | null } | null = null;
   child.on("exit", (code, signal) => {
@@ -218,10 +215,20 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
 
   const stop = async (): Promise<void> => {
     // SIGTERM triggers the runner's graceful shutdown (drains the worker).
-    if (exit === null) {
-      child.kill("SIGTERM");
-    }
-    logSink?.end();
+    // The order is the discipline child-process.ts documents: exit first,
+    // then the tee (its sink ends only once stdio has closed — the runner's
+    // shutdown lines land in the file instead of throwing write-after-end),
+    // then the directories the runner was still using.
+    await stopChild(child, {
+      signal: "SIGTERM",
+      graceMs: SHUTDOWN_GRACE_MS,
+      onForceKill: () =>
+        console.error(
+          `[runner] did not exit within ${SHUTDOWN_GRACE_MS}ms of SIGTERM — SIGKILL fallback; ` +
+            "its Temporal worker may have left an in-flight activity to time out",
+        ),
+    });
+    await output.close();
     await rm(workspaceDir, { recursive: true, force: true });
     // Only remove a store we minted; a server-shared dir is the server's to clean.
     if (ownedArtifactDir !== undefined) {
@@ -233,7 +240,7 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
     await waitForReady(
       () => ready,
       () => exit,
-      () => logTail,
+      () => output.tail(),
     );
   } catch (err) {
     await stop();
@@ -241,7 +248,7 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
   }
 
   return {
-    logTail: () => logTail,
+    logTail: () => output.tail(),
     stop,
   };
 }

--- a/test/conformance/src/harness/server-process.ts
+++ b/test/conformance/src/harness/server-process.ts
@@ -6,12 +6,12 @@
 // files can boot servers concurrently without colliding. TCP-readiness only
 // proves the listener is up; the gRPC-level readiness gate lives in the target.
 import { spawn } from "node:child_process";
-import { createWriteStream } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { connect } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
+import { stopChild, teeChildOutput } from "./child-process";
 import { getFreePort } from "./ports";
 
 const TCP_READY_TIMEOUT_MS = 20_000;
@@ -105,26 +105,16 @@ export async function spawnServer(
     },
   });
 
-  let logTail = "";
   // Debug lever: STIGMER_CONFORMANCE_LOG_DIR tees the child's full output
-  // to a per-process file that SURVIVES teardown — the in-memory logTail
+  // to a per-process file that SURVIVES teardown — the in-memory tail
   // only surfaces on spawn failure, which makes intermittent mid-suite
   // races (writer-ordering flakes) undiagnosable without it.
-  const teeStream = process.env.STIGMER_CONFORMANCE_LOG_DIR
-    ? createWriteStream(
-        join(
-          process.env.STIGMER_CONFORMANCE_LOG_DIR,
-          `server-${port}-${Date.now()}.log`,
-        ),
-        { flags: "a" },
-      )
-    : undefined;
-  const appendLog = (chunk: Buffer): void => {
-    logTail = (logTail + chunk.toString("utf8")).slice(-LOG_TAIL_BYTES);
-    teeStream?.write(chunk);
-  };
-  child.stdout.on("data", appendLog);
-  child.stderr.on("data", appendLog);
+  const output = teeChildOutput(child, {
+    tailBytes: LOG_TAIL_BYTES,
+    file: process.env.STIGMER_CONFORMANCE_LOG_DIR
+      ? join(process.env.STIGMER_CONFORMANCE_LOG_DIR, `server-${port}-${Date.now()}.log`)
+      : undefined,
+  });
 
   let exit: { code: number | null; signal: NodeJS.Signals | null } | null = null;
   child.on("exit", (code, signal) => {
@@ -132,14 +122,17 @@ export async function spawnServer(
   });
 
   const stop = async (): Promise<void> => {
-    if (exit === null) {
-      child.kill("SIGKILL");
-    }
+    // SIGKILL, not SIGTERM: the server holds only throwaway state and has
+    // nothing worth draining. The order is the discipline child-process.ts
+    // documents — exit, then the tee, then the state dir the process was
+    // still using.
+    await stopChild(child, { signal: "SIGKILL", graceMs: 0 });
+    await output.close();
     await rm(stateDir, { recursive: true, force: true });
   };
 
   try {
-    await waitForTcp(port, () => exit, () => logTail);
+    await waitForTcp(port, () => exit, () => output.tail());
   } catch (err) {
     await stop();
     throw err;
@@ -150,7 +143,7 @@ export async function spawnServer(
     port,
     artifactBaseDir,
     artifactServeUrl,
-    logTail: () => logTail,
+    logTail: () => output.tail(),
     stop,
   };
 }

--- a/test/conformance/src/harness/temporal.ts
+++ b/test/conformance/src/harness/temporal.ts
@@ -24,10 +24,10 @@
 // on the frontend port. Gating on `operator cluster health` == SERVING means
 // spawnTemporal only returns once every port is held, closing that steal race.
 import { execFile, spawn } from "node:child_process";
-import { once } from "node:events";
 import { connect } from "node:net";
 import { setTimeout as delay } from "node:timers/promises";
 import { promisify } from "node:util";
+import { stopChild, teeChildOutput } from "./child-process";
 import { getFreePort } from "./ports";
 
 const execFileAsync = promisify(execFile);
@@ -75,12 +75,8 @@ export async function spawnTemporal(): Promise<RunningTemporal> {
     { stdio: ["ignore", "pipe", "pipe"] },
   );
 
-  let logTail = "";
-  const appendLog = (chunk: Buffer): void => {
-    logTail = (logTail + chunk.toString("utf8")).slice(-LOG_TAIL_BYTES);
-  };
-  child.stdout.on("data", appendLog);
-  child.stderr.on("data", appendLog);
+  const output = teeChildOutput(child, { tailBytes: LOG_TAIL_BYTES });
+  const logTail = (): string => output.tail();
 
   let exit: { code: number | null; signal: NodeJS.Signals | null } | null = null;
   child.on("exit", (code, signal) => {
@@ -91,16 +87,14 @@ export async function spawnTemporal(): Promise<RunningTemporal> {
     // Await the actual exit (not just fire-and-forget SIGKILL) so the dev
     // server's ports are released before the next serial suite file boots its
     // own Temporal; a lingering, still-dying process can otherwise hold a port
-    // the next stack tries to allocate.
-    if (exit === null) {
-      child.kill("SIGKILL");
-      await once(child, "exit").catch(() => {});
-    }
+    // the next stack tries to allocate. An `error` event on the dying child is
+    // not a teardown failure.
+    await stopChild(child, { signal: "SIGKILL", graceMs: 0 }).catch(() => {});
   };
 
   try {
-    await waitForTcp(port, () => exit, () => logTail);
-    await waitForServing(hostPort, () => exit, () => logTail);
+    await waitForTcp(port, () => exit, logTail);
+    await waitForServing(hostPort, () => exit, logTail);
   } catch (err) {
     await stop();
     throw err;
@@ -109,7 +103,7 @@ export async function spawnTemporal(): Promise<RunningTemporal> {
   return {
     hostPort,
     namespace: NAMESPACE,
-    logTail: () => logTail,
+    logTail,
     stop,
   };
 }

--- a/test/conformance/src/suites-execution/agentexecution-approval.conformance.test.ts
+++ b/test/conformance/src/suites-execution/agentexecution-approval.conformance.test.ts
@@ -45,6 +45,16 @@
 //   validation); unknown tool_call_id on a gated execution -> InvalidArgument;
 //   missing execution -> NotFound; submit on a terminal execution ->
 //   FailedPrecondition.
+//
+// Every gate-resolving submit goes through submitApprovalPerContract (the seam
+// in support/agentexecutions.ts) since entry 20260908.01: the synchronous
+// contract above is asserted there once, and the one known Java race against
+// it — SubmitApproval's targeted write lost to the workflow's second WAITING
+// persist, the decision surviving only in the approval-event stream — is
+// proven, reported and remedied there (contract/deviations.ts,
+// SUBMIT_APPROVAL_LOST_UPDATE_RACE). The REJECT arm's audit assertions are the
+// same race's other face and route through the same entry. TS targets never
+// enter that path.
 import { Code } from "@connectrpc/connect";
 import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import {
@@ -53,6 +63,7 @@ import {
   ToolCallStatus,
 } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { assertContractOrKnownRace, SUBMIT_APPROVAL_LOST_UPDATE_RACE } from "../contract/deviations";
 import { expectGrpcCode } from "../contract/errors";
 import type { ConformanceClients } from "../harness/clients";
 import { FixtureTracker } from "../harness/fixtures";
@@ -62,11 +73,14 @@ import type { MockLlmProxy, ToolUseBlock } from "../harness/mock-llm";
 import { anthropicText, anthropicToolUses } from "../harness/mock-llm";
 import { makeAgent } from "../support/agents";
 import {
+  allToolCalls,
   awaitPhase,
   awaitTerminal,
+  expectDecisionLostFromTranscript,
   makeAgentExecution,
   requireLlmProxy,
   requireMcpFixture,
+  submitApprovalPerContract,
 } from "../support/agentexecutions";
 import { makeHttpMcpServer } from "../support/mcpservers";
 import { uniqueName } from "../support/naming";
@@ -159,13 +173,18 @@ describe("AgentExecution submitApproval — gate resolution", () => {
     const { executionId, gated } = await runToGate(org, agentId, [echoBlock("call_echo_approve", "hello")]);
 
     const toolCallId = gated.status!.pendingApprovals[0]!.toolCallId;
-    const resp = await clients.agentExecutionCommand.submitApproval({
-      agentExecutionId: executionId,
-      toolCallId,
-      action: ApprovalAction.APPROVE,
-    });
     // The single gate is fully resolved synchronously: the approved entry is gone.
-    expect(resp.status?.pendingApprovals.length, "approve clears the pending gate").toBe(0);
+    await submitApprovalPerContract(target, clients, {
+      executionId,
+      expectedRemaining: 0,
+      label: "approve clears the pending gate",
+      submit: () =>
+        clients.agentExecutionCommand.submitApproval({
+          agentExecutionId: executionId,
+          toolCallId,
+          action: ApprovalAction.APPROVE,
+        }),
+    });
 
     const final = await awaitTerminal(clients, executionId);
     expect(
@@ -180,12 +199,17 @@ describe("AgentExecution submitApproval — gate resolution", () => {
     const { executionId, gated } = await runToGate(org, agentId, [echoBlock("call_echo_skip", "hello")]);
 
     const toolCallId = gated.status!.pendingApprovals[0]!.toolCallId;
-    const resp = await clients.agentExecutionCommand.submitApproval({
-      agentExecutionId: executionId,
-      toolCallId,
-      action: ApprovalAction.SKIP,
+    await submitApprovalPerContract(target, clients, {
+      executionId,
+      expectedRemaining: 0,
+      label: "skip clears the pending gate",
+      submit: () =>
+        clients.agentExecutionCommand.submitApproval({
+          agentExecutionId: executionId,
+          toolCallId,
+          action: ApprovalAction.SKIP,
+        }),
     });
-    expect(resp.status?.pendingApprovals.length, "skip clears the pending gate").toBe(0);
 
     const final = await awaitTerminal(clients, executionId);
     expect(final.status?.phase, "skipped execution should COMPLETE").toBe(ExecutionPhase.EXECUTION_COMPLETED);
@@ -197,13 +221,18 @@ describe("AgentExecution submitApproval — gate resolution", () => {
     const { executionId, gated } = await runToGate(org, agentId, [echoBlock("call_echo_reject", "hello")]);
 
     const toolCallId = gated.status!.pendingApprovals[0]!.toolCallId;
-    const resp = await clients.agentExecutionCommand.submitApproval({
-      agentExecutionId: executionId,
-      toolCallId,
-      action: ApprovalAction.REJECT,
-      comment: "not this time",
+    await submitApprovalPerContract(target, clients, {
+      executionId,
+      expectedRemaining: 0,
+      label: "reject clears the pending gate",
+      submit: () =>
+        clients.agentExecutionCommand.submitApproval({
+          agentExecutionId: executionId,
+          toolCallId,
+          action: ApprovalAction.REJECT,
+          comment: "not this time",
+        }),
     });
-    expect(resp.status?.pendingApprovals.length, "reject clears the pending gate").toBe(0);
 
     // REJECT denies the tool and continues: the objection is fed back to the LLM,
     // which adapts, and the execution COMPLETES (issue #197 — the proto enum, the
@@ -214,17 +243,23 @@ describe("AgentExecution submitApproval — gate resolution", () => {
     // The rejected tool call is terminalized deterministically — never left stuck
     // at WAITING_APPROVAL — carrying the REJECT decision for audit. This is stable
     // across resume because it is derived from the recorded approval_action, not
-    // from the resumed stream's (unstable) run_id.
-    const rejectedTc = final.status?.messages
-      .flatMap((m) => m.toolCalls)
-      .find((tc) => tc.id === toolCallId);
+    // from the resumed stream's (unstable) run_id. On the Java target this is the
+    // AUDIT face of the submit-approval race (contract/deviations.ts): the
+    // response passed, the run completed, and the decision survives only in the
+    // approval-event stream — there is no remedy, the observed reading is final.
+    const rejectedTc = allToolCalls(final).find((tc) => tc.id === toolCallId);
     expect(rejectedTc, "the rejected echo tool call is present in the transcript").toBeDefined();
-    expect(rejectedTc!.status, "rejected tool call resolves to SKIPPED, not WAITING").toBe(
-      ToolCallStatus.TOOL_CALL_SKIPPED,
-    );
-    expect(rejectedTc!.approvalAction, "the REJECT decision is preserved for audit").toBe(
-      ApprovalAction.REJECT,
-    );
+    await assertContractOrKnownRace(target.name, SUBMIT_APPROVAL_LOST_UPDATE_RACE, {
+      contract: () => {
+        expect(rejectedTc!.status, "rejected tool call resolves to SKIPPED, not WAITING").toBe(
+          ToolCallStatus.TOOL_CALL_SKIPPED,
+        );
+        expect(rejectedTc!.approvalAction, "the REJECT decision is preserved for audit").toBe(
+          ApprovalAction.REJECT,
+        );
+      },
+      observed: () => expectDecisionLostFromTranscript(final),
+    });
   });
 
   it("APPROVE_ALL resolves every co-pending gate in a single decision", async () => {
@@ -239,13 +274,18 @@ describe("AgentExecution submitApproval — gate resolution", () => {
     expect(gated.status?.pendingApprovals.length, "both echo calls are co-pending").toBe(2);
 
     // One APPROVE_ALL on the first resolves the whole gate — no second submit.
-    const resp = await clients.agentExecutionCommand.submitApproval({
-      agentExecutionId: executionId,
-      toolCallId: gated.status!.pendingApprovals[0]!.toolCallId,
-      action: ApprovalAction.APPROVE_ALL,
-    });
     // One decision empties the read model: the co-pending entry was resolved too.
-    expect(resp.status?.pendingApprovals.length, "APPROVE_ALL resolves both gates at once").toBe(0);
+    await submitApprovalPerContract(target, clients, {
+      executionId,
+      expectedRemaining: 0,
+      label: "APPROVE_ALL resolves both gates at once",
+      submit: () =>
+        clients.agentExecutionCommand.submitApproval({
+          agentExecutionId: executionId,
+          toolCallId: gated.status!.pendingApprovals[0]!.toolCallId,
+          action: ApprovalAction.APPROVE_ALL,
+        }),
+    });
 
     // Reaching COMPLETED proves the second tool call was auto-approved (a plain
     // APPROVE would have re-gated and this would never settle).
@@ -288,11 +328,20 @@ describe("AgentExecution submitApproval — spec bypass and read model", () => {
     expect(pending.toolName, "pending approval names the tool").toBe(ECHO_TOOL_NAME);
     expect(pending.mcpServerSlug, "pending approval carries the server slug").toBe(mcpSlug);
 
-    // Settle so the run terminates cleanly.
-    await clients.agentExecutionCommand.submitApproval({
-      agentExecutionId: executionId,
-      toolCallId: pending.toolCallId,
-      action: ApprovalAction.APPROVE,
+    // Settle so the run terminates cleanly. Through the seam even though this
+    // arm asserts nothing about the response: a decision the Java race drops
+    // would otherwise surface as awaitTerminal timing out, a red with a
+    // misleading face.
+    await submitApprovalPerContract(target, clients, {
+      executionId,
+      expectedRemaining: 0,
+      label: "the settling approve clears the gate",
+      submit: () =>
+        clients.agentExecutionCommand.submitApproval({
+          agentExecutionId: executionId,
+          toolCallId: pending.toolCallId,
+          action: ApprovalAction.APPROVE,
+        }),
     });
     await awaitTerminal(clients, executionId);
   });
@@ -315,9 +364,13 @@ describe("AgentExecution submitApproval — spec bypass and read model", () => {
         toolCallId: firstId,
         action: ApprovalAction.APPROVE,
       });
-    const firstResp = await approveFirst();
     // One of two co-pending gates resolved: the other is still pending.
-    expect(firstResp.status?.pendingApprovals.length, "one gate remains after first approve").toBe(1);
+    await submitApprovalPerContract(target, clients, {
+      executionId,
+      expectedRemaining: 1,
+      label: "one gate remains after first approve",
+      submit: approveFirst,
+    });
 
     // Same {tool_call_id, action} again while the gate is still open: a no-op
     // that returns the current state (still one pending), not an error.
@@ -326,10 +379,16 @@ describe("AgentExecution submitApproval — spec bypass and read model", () => {
     expect(secondResp.status?.pendingApprovals[0]?.toolCallId, "the remaining gate is unchanged").toBe(secondId);
 
     // Resolve the rest of the gate and confirm the run still completes.
-    await clients.agentExecutionCommand.submitApproval({
-      agentExecutionId: executionId,
-      toolCallId: secondId,
-      action: ApprovalAction.APPROVE,
+    await submitApprovalPerContract(target, clients, {
+      executionId,
+      expectedRemaining: 0,
+      label: "the second approve clears the gate",
+      submit: () =>
+        clients.agentExecutionCommand.submitApproval({
+          agentExecutionId: executionId,
+          toolCallId: secondId,
+          action: ApprovalAction.APPROVE,
+        }),
     });
     const final = await awaitTerminal(clients, executionId);
     expect(final.status?.phase, "execution completes after idempotent + final approval").toBe(
@@ -407,11 +466,18 @@ describe("AgentExecution submitApproval — negatives", () => {
       "unknown tool_call_id",
     );
 
-    // Settle the real gate so the run terminates cleanly.
-    await clients.agentExecutionCommand.submitApproval({
-      agentExecutionId: executionId,
-      toolCallId: gated.status!.pendingApprovals[0]!.toolCallId,
-      action: ApprovalAction.APPROVE,
+    // Settle the real gate so the run terminates cleanly (through the seam, so
+    // a Java-dropped decision does not surface as a timeout here).
+    await submitApprovalPerContract(target, clients, {
+      executionId,
+      expectedRemaining: 0,
+      label: "the settling approve clears the gate",
+      submit: () =>
+        clients.agentExecutionCommand.submitApproval({
+          agentExecutionId: executionId,
+          toolCallId: gated.status!.pendingApprovals[0]!.toolCallId,
+          action: ApprovalAction.APPROVE,
+        }),
     });
     await awaitTerminal(clients, executionId);
   });

--- a/test/conformance/src/suites-execution/agentexecution.conformance.test.ts
+++ b/test/conformance/src/suites-execution/agentexecution.conformance.test.ts
@@ -55,6 +55,7 @@ import { UploadAttachmentRequestSchema } from "@stigmer/protos/ai/stigmer/agenti
 import { Harness } from "@stigmer/protos/ai/stigmer/agentic/session/v1/enum_pb";
 import { Code } from "@connectrpc/connect";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { assertContractOrKnownRace, SUBSCRIBE_TRAILING_TERMINAL_WRITE_RACE } from "../contract/deviations";
 import { expectGrpcCode } from "../contract/errors";
 import { assertResourceParity } from "../contract/parity";
 import type { ConformanceClients } from "../harness/clients";
@@ -954,8 +955,19 @@ describe("AgentExecution conformance — subscribe & populated read surfaces (CW
       (signal) => clients.agentExecutionQuery.subscribe({ value: created.metadata!.id }, { signal }),
       { timeoutMs: 3_000 },
     );
-    expect(stream.outcome, "no server close — the bounded reader had to abort").toBe("timeout");
-    expect(stream.messages).toHaveLength(1);
+    // On the Java target a trailing duplicate terminal write can arrive as a
+    // broker update after the snapshot and trip the check — the tracked race
+    // (contract/deviations.ts); the observed reading is final, no remedy.
+    await assertContractOrKnownRace(target.name, SUBSCRIBE_TRAILING_TERMINAL_WRITE_RACE, {
+      contract: () => {
+        expect(stream.outcome, "no server close — the bounded reader had to abort").toBe("timeout");
+        expect(stream.messages).toHaveLength(1);
+      },
+      observed: () => {
+        expect(stream.outcome, "Java's trailing terminal write closed the stream").toBe("closed");
+        expect(stream.messages.length, "the snapshot, then the trailing update").toBeGreaterThanOrEqual(1);
+      },
+    });
     expect(stream.messages[0]?.status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
   });
 

--- a/test/conformance/src/suites-execution/billing-gates.conformance.test.ts
+++ b/test/conformance/src/suites-execution/billing-gates.conformance.test.ts
@@ -28,7 +28,7 @@ import { FixtureTracker } from "../harness/fixtures";
 import { ECHO_TOOL_NAME, type McpToolFixture } from "../harness/mcp-server";
 import { anthropicText, anthropicToolUses, type MockLlmProxy } from "../harness/mock-llm";
 import { makeAgent } from "../support/agents";
-import { awaitPhase, awaitTerminal, makeAgentExecution, requireLlmProxy, requireMcpFixture } from "../support/agentexecutions";
+import { awaitPhase, awaitTerminal, makeAgentExecution, requireLlmProxy, requireMcpFixture, submitApprovalPerContract } from "../support/agentexecutions";
 import { makeHttpMcpServer } from "../support/mcpservers";
 import { uniqueName } from "../support/naming";
 import { createTarget, type TargetProfile } from "../targets";
@@ -186,8 +186,12 @@ describe.skipIf(!gatesEnabled)("Billing gates — settle, the approval STOP gate
     expect(refused.rawMessage).toBe(APPROVAL_STOP_COPY);
 
     await refund(org);
-    const approved = await clients.agentExecutionCommand.submitApproval({ agentExecutionId: executionId, toolCallId, action: ApprovalAction.APPROVE });
-    expect(approved.status?.pendingApprovals.length).toBe(0);
+    await submitApprovalPerContract(target, clients, {
+      executionId,
+      expectedRemaining: 0,
+      label: "the approve clears the gate once funded",
+      submit: () => clients.agentExecutionCommand.submitApproval({ agentExecutionId: executionId, toolCallId, action: ApprovalAction.APPROVE }),
+    });
     const final = await awaitTerminal(clients, executionId);
     expect(final.status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
   });

--- a/test/conformance/src/suites-execution/workflowexecution-child-approval.conformance.test.ts
+++ b/test/conformance/src/suites-execution/workflowexecution-child-approval.conformance.test.ts
@@ -69,7 +69,7 @@ import { ECHO_TOOL_NAME } from "../harness/mcp-server";
 import type { MockLlmProxy } from "../harness/mock-llm";
 import { anthropicText, anthropicToolUses } from "../harness/mock-llm";
 import { makeAgent } from "../support/agents";
-import { requireLlmProxy, requireMcpFixture } from "../support/agentexecutions";
+import { requireLlmProxy, requireMcpFixture, submitApprovalPerContract } from "../support/agentexecutions";
 import { makeHttpMcpServer } from "../support/mcpservers";
 import { uniqueName } from "../support/naming";
 import {
@@ -302,10 +302,23 @@ describe.skipIf(!forwarderEnabled)(
       expect(pending.approval?.toolName, "the parent gate names the gated tool").toBe(ECHO_TOOL_NAME);
 
       // Forward the decision through the parent; the handler routes it to the child.
-      await clients.workflowExecutionCommand.submitApproval({
-        executionId,
-        toolCallId: pending.approval!.toolCallId,
-        action: ApprovalAction.APPROVE,
+      // Through the seam: the forwarder's own response is the PARENT, loaded before
+      // the forward, so the contract is read off the child — whose gate the same
+      // agent-execution handler resolves synchronously — and a decision the Java
+      // race drops does not surface as the workflow never completing.
+      const childExecutionId = pending.childAgentExecutionId;
+      await submitApprovalPerContract(target, clients, {
+        executionId: childExecutionId,
+        expectedRemaining: 0,
+        label: "the forwarded approve clears the child's gate",
+        submit: async () => {
+          await clients.workflowExecutionCommand.submitApproval({
+            executionId,
+            toolCallId: pending.approval!.toolCallId,
+            action: ApprovalAction.APPROVE,
+          });
+          return clients.agentExecutionQuery.get({ value: childExecutionId });
+        },
       });
 
       // The child resumes and the workflow continues — the downstream task running

--- a/test/conformance/src/suites-execution/workflowexecution.conformance.test.ts
+++ b/test/conformance/src/suites-execution/workflowexecution.conformance.test.ts
@@ -29,6 +29,7 @@ import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/workflowexecu
 import { WorkflowEventType, type WorkflowExecutionEvent } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/event_pb";
 import { Code } from "@connectrpc/connect";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { assertContractOrKnownRace, SUBSCRIBE_TRAILING_TERMINAL_WRITE_RACE } from "../contract/deviations";
 import { expectGrpcCode } from "../contract/errors";
 import { assertResourceParity } from "../contract/parity";
 import type { ConformanceClients } from "../harness/clients";
@@ -546,8 +547,19 @@ describe("WorkflowExecution conformance — event log pagination & streaming (CW
         clients.workflowExecutionQuery.subscribe({ executionId: created.metadata!.id }, { signal }),
       { timeoutMs: 3_000 },
     );
-    expect(stream.outcome, "no server close — the bounded reader had to abort").toBe("timeout");
-    expect(stream.messages).toHaveLength(1);
+    // On the Java target a trailing duplicate terminal write can arrive as a
+    // broker update after the snapshot and trip the check — the tracked race
+    // (contract/deviations.ts); the observed reading is final, no remedy.
+    await assertContractOrKnownRace(target.name, SUBSCRIBE_TRAILING_TERMINAL_WRITE_RACE, {
+      contract: () => {
+        expect(stream.outcome, "no server close — the bounded reader had to abort").toBe("timeout");
+        expect(stream.messages).toHaveLength(1);
+      },
+      observed: () => {
+        expect(stream.outcome, "Java's trailing terminal write closed the stream").toBe("closed");
+        expect(stream.messages.length, "the snapshot, then the trailing update").toBeGreaterThanOrEqual(1);
+      },
+    });
     expect(stream.messages[0]?.status?.phase).toBe(ExecutionPhase.EXECUTION_COMPLETED);
   });
 

--- a/test/conformance/src/support/__tests__/agentexecutions.test.ts
+++ b/test/conformance/src/support/__tests__/agentexecutions.test.ts
@@ -1,0 +1,190 @@
+// Unit arms for the submit-approval seam and the race proof beneath it: the
+// proof finds exactly the tool calls decided in the approval-event stream and
+// undecided in the transcript (root and sub-agent); the seam is submit-and-
+// assert on a TS target and, on the registered Java target, prove-report-
+// re-submit-assert. Pure: hand-built executions, a stub reader, no target.
+// Domain: conformance support (execution engine).
+import { create } from "@bufbuild/protobuf";
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  ApprovalAction,
+  ApprovalEventType,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  decisionsLostFromTranscript,
+  expectDecisionLostFromTranscript,
+  submitApprovalPerContract,
+  type AgentExecutionReader,
+} from "../agentexecutions";
+
+interface ToolCallInit {
+  id: string;
+  action: ApprovalAction;
+  // Placed on a sub-agent's transcript instead of the root's.
+  nested?: boolean;
+}
+
+interface DecisionInit {
+  toolCallId: string;
+  type: ApprovalEventType;
+}
+
+function execution(opts: {
+  pending?: string[];
+  toolCalls?: ToolCallInit[];
+  events?: DecisionInit[];
+}): AgentExecution {
+  const root = (opts.toolCalls ?? []).filter((tc) => tc.nested !== true);
+  const nested = (opts.toolCalls ?? []).filter((tc) => tc.nested === true);
+  return create(AgentExecutionSchema, {
+    metadata: { id: "aex_unit" },
+    status: {
+      pendingApprovals: (opts.pending ?? []).map((toolCallId) => ({ toolCallId })),
+      messages: [{ toolCalls: root.map((tc) => ({ id: tc.id, approvalAction: tc.action })) }],
+      subAgentExecutions:
+        nested.length === 0
+          ? []
+          : [{ messages: [{ toolCalls: nested.map((tc) => ({ id: tc.id, approvalAction: tc.action })) }] }],
+      approvalEventStream: {
+        events: (opts.events ?? []).map((event) => ({
+          approvalRequestId: event.toolCallId,
+          eventType: event.type,
+        })),
+      },
+    },
+  });
+}
+
+describe("decisionsLostFromTranscript", () => {
+  it("names a tool call decided in the stream and undecided in the transcript — Java's only-in-scan divergence", () => {
+    const lost = decisionsLostFromTranscript(
+      execution({
+        toolCalls: [{ id: "call_reject", action: ApprovalAction.UNSPECIFIED }],
+        events: [
+          { toolCallId: "call_reject", type: ApprovalEventType.REQUESTED },
+          { toolCallId: "call_reject", type: ApprovalEventType.REJECTED },
+        ],
+      }),
+    );
+    expect(lost).toEqual(["call_reject"]);
+  });
+
+  it("is empty when the transcript carries the decision (the contract) or the stream has none (an undecided gate)", () => {
+    expect(
+      decisionsLostFromTranscript(
+        execution({
+          toolCalls: [{ id: "call_ok", action: ApprovalAction.APPROVE }],
+          events: [{ toolCallId: "call_ok", type: ApprovalEventType.APPROVED }],
+        }),
+      ),
+    ).toEqual([]);
+    expect(
+      decisionsLostFromTranscript(
+        execution({
+          toolCalls: [{ id: "call_waiting", action: ApprovalAction.UNSPECIFIED }],
+          events: [{ toolCallId: "call_waiting", type: ApprovalEventType.REQUESTED }],
+        }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("scans sub-agent transcripts too, and reports only the lost one of a co-pending pair", () => {
+    const lost = decisionsLostFromTranscript(
+      execution({
+        toolCalls: [
+          { id: "call_all_1", action: ApprovalAction.APPROVE_ALL },
+          { id: "call_all_2", action: ApprovalAction.UNSPECIFIED, nested: true },
+        ],
+        events: [
+          { toolCallId: "call_all_1", type: ApprovalEventType.APPROVED },
+          { toolCallId: "call_all_2", type: ApprovalEventType.APPROVED },
+        ],
+      }),
+    );
+    expect(lost).toEqual(["call_all_2"]);
+  });
+
+  it("expectDecisionLostFromTranscript throws with both sides named when nothing was lost", () => {
+    expect(() =>
+      expectDecisionLostFromTranscript(
+        execution({
+          toolCalls: [{ id: "call_x", action: ApprovalAction.UNSPECIFIED }],
+          events: [{ toolCallId: "call_x", type: ApprovalEventType.REQUESTED }],
+        }),
+      ),
+    ).toThrow(/decided in stream: \[\], undecided in transcript: \["call_x"\]/);
+  });
+});
+
+describe("submitApprovalPerContract", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const settled = execution({ pending: [], toolCalls: [{ id: "call_a", action: ApprovalAction.APPROVE }] });
+  const raced = execution({
+    pending: ["call_a"],
+    toolCalls: [{ id: "call_a", action: ApprovalAction.UNSPECIFIED }],
+    events: [{ toolCallId: "call_a", type: ApprovalEventType.APPROVED }],
+  });
+  const reader = (readBack: AgentExecution): AgentExecutionReader => ({
+    agentExecutionQuery: { get: async () => readBack },
+  });
+
+  it("on a TS target is submit-and-assert, returning the response", async () => {
+    const submit = vi.fn(async () => settled);
+    const response = await submitApprovalPerContract({ name: "local-execution" }, reader(settled), {
+      executionId: "aex_unit",
+      expectedRemaining: 0,
+      label: "approve clears the gate",
+      submit,
+    });
+    expect(response).toBe(settled);
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it("on a TS target a failed contract is red — the race path is not open there", async () => {
+    const read = vi.fn(async () => raced);
+    await expect(
+      submitApprovalPerContract({ name: "local-execution" }, { agentExecutionQuery: { get: read } }, {
+        executionId: "aex_unit",
+        expectedRemaining: 0,
+        label: "approve clears the gate",
+        submit: async () => raced,
+      }),
+    ).rejects.toThrow("approve clears the gate");
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("on the Java target proves the race from a fresh read, re-submits once, and returns the response that held", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const responses = [raced, settled];
+    const submit = vi.fn(async () => responses.shift()!);
+    const response = await submitApprovalPerContract({ name: "cloud-execution" }, reader(raced), {
+      executionId: "aex_unit",
+      expectedRemaining: 0,
+      label: "approve clears the gate",
+      submit,
+    });
+    expect(response).toBe(settled);
+    expect(submit).toHaveBeenCalledTimes(2);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("tracked race java.agentexecution.submit-approval.lost-update-race on cloud-execution"));
+  });
+
+  it("on the Java target a failure the fresh read cannot explain stays red", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const unexplained = execution({ pending: ["call_a"], toolCalls: [{ id: "call_a", action: ApprovalAction.UNSPECIFIED }] });
+    const submit = vi.fn(async () => unexplained);
+    await expect(
+      submitApprovalPerContract({ name: "cloud-execution" }, reader(unexplained), {
+        executionId: "aex_unit",
+        expectedRemaining: 0,
+        label: "approve clears the gate",
+        submit,
+      }),
+    ).rejects.toThrow("the known race: the approval-event stream carries a decision the transcript does not");
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/conformance/src/support/agentexecutions.ts
+++ b/test/conformance/src/support/agentexecutions.ts
@@ -8,14 +8,23 @@
 // agent, which the OSS single-tenant target does not seed, so suites always pass a
 // reference. Like WorkflowExecution this is a *running thing*, so this module also
 // exposes phase-await helpers, delegating the timing loop to the shared poll core
-// so both execution domains share one definition.
+// so both execution domains share one definition — and, since entry 20260908.01,
+// the submit-approval seam: the one place the approval contract is asserted and
+// the one Java race against it is handled (see the seam's own header below).
 import type { MessageInitShape } from "@bufbuild/protobuf";
 import type { InitShape } from "./init-shape";
 import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
-import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import {
+  ApprovalAction,
+  ApprovalEventType,
+  ExecutionPhase,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { ToolCall } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
 import type { AttachmentSchema, ExecutionConfigSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
 import type { SessionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
+import { expect } from "vitest";
+import { assertContractOrKnownRace, SUBMIT_APPROVAL_LOST_UPDATE_RACE } from "../contract/deviations";
 import type { ConformanceClients } from "../harness/clients";
 import type { McpToolFixture } from "../harness/mcp-server";
 import type { MockLlmProxy } from "../harness/mock-llm";
@@ -155,6 +164,115 @@ export function awaitTerminal(
     ...opts,
   });
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The submit-approval seam.
+//
+// Every approval submit in the execution suites is one gesture: submit the
+// decision right after the gate appears, assert the response's pending_approvals
+// reflects it (the contract the approval suite's header states — recomputed
+// SYNCHRONOUSLY), continue. Eight sites wrote that gesture by hand until entry
+// 20260908.01 found them all exposed to one Java race the OSS server is immune
+// to (contract/deviations.ts, SUBMIT_APPROVAL_LOST_UPDATE_RACE). The seam owns
+// the gesture once: on TS targets it is submit-and-assert; on the registered
+// Java target a failed assertion opens the race path — prove it is that race,
+// report it, re-submit once, assert again.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// The one read the seam needs from the clients — a structural slice so the
+// unit arms can hand in a stub instead of a Connect client.
+export interface AgentExecutionReader {
+  agentExecutionQuery: { get(request: { value: string }): Promise<AgentExecution> };
+}
+
+export interface SubmitApprovalPerContractOptions {
+  // The AgentExecution that owns the gated tool call.
+  executionId: string;
+  // Issues the decision. Resolves to the AgentExecution whose read model the
+  // contract is asserted on: the submit response for a direct submit; for the
+  // workflow forwarder — whose own response is the PARENT, loaded before the
+  // forward — a fresh get of the child.
+  submit: () => Promise<AgentExecution>;
+  // pending_approvals the response must carry after this decision: 0 for a
+  // single gate, 1 for the first approve of two co-pending calls.
+  expectedRemaining: number;
+  // Names the decision in the contract assertion's failure message.
+  label: string;
+}
+
+// Submits per the contract and returns the response the contract held on (the
+// second response when the registered race fired and the remedy re-submitted).
+export async function submitApprovalPerContract(
+  target: Pick<TargetProfile, "name">,
+  clients: AgentExecutionReader,
+  opts: SubmitApprovalPerContractOptions,
+): Promise<AgentExecution> {
+  let response = await opts.submit();
+  await assertContractOrKnownRace(target.name, SUBMIT_APPROVAL_LOST_UPDATE_RACE, {
+    contract: () =>
+      expect(response.status?.pendingApprovals.length, opts.label).toBe(opts.expectedRemaining),
+    observed: async () =>
+      expectDecisionLostFromTranscript(await clients.agentExecutionQuery.get({ value: opts.executionId })),
+    remedy: async () => {
+      response = await opts.submit();
+    },
+  });
+  return response;
+}
+
+// The race's proof, shared by the seam (the response face) and the REJECT arm's
+// audit assertions (the audit face): at least one tool call has a decision event
+// in the approval-event stream and no approval_action in the transcript — the
+// exact divergence Java's PendingApprovalProjector logs as
+// `only-in-scan:<tool_call_id>`. Anything else failing an approval assertion is
+// an unknown symptom, and this throws so the arm stays red.
+export function expectDecisionLostFromTranscript(execution: AgentExecution): void {
+  const lost = decisionsLostFromTranscript(execution);
+  expect(
+    lost,
+    "the known race: the approval-event stream carries a decision the transcript does not " +
+      `(execution ${execution.metadata?.id ?? "?"}; decided in stream: ` +
+      `${JSON.stringify(decidedToolCallIds(execution))}, undecided in transcript: ` +
+      `${JSON.stringify(undecidedToolCallIds(execution))})`,
+  ).not.toHaveLength(0);
+}
+
+// Tool call ids decided in the approval-event stream but undecided in the
+// transcript. Pure; the unit arms pin it.
+export function decisionsLostFromTranscript(execution: AgentExecution): string[] {
+  const undecided = new Set(undecidedToolCallIds(execution));
+  return decidedToolCallIds(execution).filter((id) => undecided.has(id));
+}
+
+// approval_request_id equals tool_call_id by the proto's documented decision
+// (approval.proto), so the stream is keyed by the same id the transcript uses.
+function decidedToolCallIds(execution: AgentExecution): string[] {
+  return (execution.status?.approvalEventStream?.events ?? [])
+    .filter((event) => DECISION_EVENT_TYPES.has(event.eventType))
+    .map((event) => event.approvalRequestId);
+}
+
+function undecidedToolCallIds(execution: AgentExecution): string[] {
+  return allToolCalls(execution)
+    .filter((toolCall) => toolCall.approvalAction === ApprovalAction.UNSPECIFIED)
+    .map((toolCall) => toolCall.id);
+}
+
+// Root and sub-agent transcripts, the same scan the projections run.
+export function allToolCalls(execution: AgentExecution): ToolCall[] {
+  const root = execution.status?.messages.flatMap((message) => message.toolCalls) ?? [];
+  const nested =
+    execution.status?.subAgentExecutions.flatMap((subAgent) =>
+      subAgent.messages.flatMap((message) => message.toolCalls),
+    ) ?? [];
+  return [...root, ...nested];
+}
+
+const DECISION_EVENT_TYPES: ReadonlySet<ApprovalEventType> = new Set([
+  ApprovalEventType.APPROVED,
+  ApprovalEventType.REJECTED,
+  ApprovalEventType.SKIPPED,
+]);
 
 // Obtain the mock LLM proxy from an execution target, failing loudly if the
 // active target does not provide one (e.g. a CRUD-only target). Agent

--- a/test/conformance/vitest.unit.config.ts
+++ b/test/conformance/vitest.unit.config.ts
@@ -1,15 +1,22 @@
 // Vitest configuration for the harness's PURE unit arms: the inventory
-// library and the cloud-capability fixtures.
+// library, the cloud-capability fixtures, the child-process discipline, the
+// deviation registry's helpers and the submit-approval seam.
 //
 // Deliberately separate from the suite configs: those boot a target in
 // globalSetup (the TS server build, or the hermetic cloud environment), and
 // these arms are pure — parsing a YAML, scanning sources, driving an in-process
-// fake over loopback. Running them under a target config would spend a server
-// build on a millisecond test.
+// fake over loopback, a stub reader. Running them under a target config would
+// spend a server build on a millisecond test. The suite configs include only
+// `src/suites*/**`, so nothing here is ever collected twice.
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["src/inventory/**/*.test.ts", "src/harness/__tests__/**/*.test.ts"],
+    include: [
+      "src/inventory/**/*.test.ts",
+      "src/harness/__tests__/**/*.test.ts",
+      "src/contract/__tests__/**/*.test.ts",
+      "src/support/__tests__/**/*.test.ts",
+    ],
   },
 });


### PR DESCRIPTION
## Summary
The cloud-execution (Class B) conformance lane was red on half its `main` runs while Class A was green on all of them. This PR fixes the one deterministic harness bug behind those reds, and gives the suite an honest way to carry the two Java-target races behind the rest — measured, proven per firing, and logged, never hidden.

## Context
Twenty-eight Class B failure artifacts (2026-08-25 → 09-07) fall into four symptoms and resolved history. Ten are the pinned S4-quirk subscribe twins closed by Java's trailing duplicate terminal write. Six are one Java lost-update race on approval: the workflow's second `WAITING_FOR_APPROVAL` persist (byte-pinned in both editions) is served by an `UpdateStatus` that reads the document and writes the whole `messages` list back with no lock across the two, so `SubmitApproval`'s targeted write landing in between is lost — five times as a decision vanished from the transcript after a passing response, once as a gate that stayed armed with no signal. Java's own `PendingApprovalProjector` logs the divergence. The TS server is structurally immune (store write lock, `preserveApprovalFields` inside it). Three are the harness itself: `runner-process.ts` ended its log tee and deleted its workspace the instant it sent SIGTERM, while the runner still wrote its shutdown lines — `ERR_STREAM_WRITE_AFTER_END` with all 160 arms green.

Java is not changed; the race is filed on the cloud side as stigmer/stigmer-cloud#683.

## Changes
- `harness/child-process.ts` (new): `stopChild` resolves only on exit with a bounded SIGKILL fallback and a caller-worded warning; `teeChildOutput` ends its file sink only after the child's stdio has closed. Adopted by all four spawn sites (runner, server, Temporal, launcher) with their signal choices preserved. Eight unit arms pin the ordering.
- `contract/deviations.ts`: `KnownDeviation` becomes `deterministic | race`. `assertContractOrKnownRace` asserts the contract on every target; only an assertion failure on a registered target opens the race path, where `observed` must prove the specific race (an unknown symptom stays red), one grep-able `[conformance] tracked race …` line is logged, and the contract is re-asserted exactly once after the arm's remedy. Race entries state `retires` because they cannot self-expire. Each helper refuses the other kind's ids. Two entries on `cloud-execution`.
- `support/agentexecutions.ts`: `submitApprovalPerContract`, the one place the approval contract is asserted; adopted by all nine gate-resolving submits (six in `agentexecution-approval`, `billing-gates`, the workflow child-approval forwarder read off the child, the idempotency arm's two live submits). The proof shared by both faces of the race is the divergence Java logs: a decision in `approval_event_stream` with no `approval_action` in the transcript. The REJECT arm's audit assertions and the two subscribe twins ride the registry directly.
- 27 new unit arms; `vitest.unit.config.ts` collects `contract/` and `support/` `__tests__`. README's spec-first section rewritten (it still described a helper that no longer existed).

## Implementation notes
- Not a retry budget, a sleep or a skip: the contract assertion runs on every target every time; nothing in the registry is reached unless the target is registered AND the contract just failed; the TS targets keep the synchronous contract the approval suite's header states.
- The seam reads the workflow forwarder's contract off the CHILD, because the forwarder's own response is the parent loaded before the forward.

## Test plan
- `tsc --noEmit` clean; unit arms 56/56; `inventory:check` 152 rows / 114 covered / 0 problems.
- Local Class A 507/0/95 (byte-identical to `main`); local Class B 160/0/6; hermetic Java Class B 160/0/1 three times — the subscribe race fired once and was absorbed as one tracked-race line; zero write-after-end events in any run.
- Not verified live: the approval race did not fire in three hermetic runs, so its remedy path is pinned by unit arms only. The five `main` runs after merge add to the sample.
- Surfaced by the new discipline, filed separately: the runner sometimes does not exit after `Worker stopped` (stigmer#1008); the harness now pays a 30 s grace and says so.

## Risks
- Adopting the discipline in `cloud-env.ts` is a call-site swap; the launcher's leak warning is verbatim.
- Rollback: revert the two commits; the lane returns to its coin-flip state.

## Checklist
- [x] Docs updated (README spec-first section, module headers)
- [x] Tests added/updated (27 unit arms)
- [x] Backward compatible (no contract, wire or proto change)

Closes #1007
Refs #919
