### PR TITLE
fix(test/conformance): make the runner's SIGKILL-fallback line say whether the worker had stopped

### DIFF
--- a/test/conformance/src/harness/__tests__/runner-process.test.ts
+++ b/test/conformance/src/harness/__tests__/runner-process.test.ts
@@ -1,0 +1,143 @@
+// Unit arms for the runner harness's SIGKILL-fallback line: when a runner
+// outlives its SIGTERM grace, the line the job log keeps must say on its own
+// whether the Temporal worker had stopped (the stigmer#1008 shape) or never
+// finished draining (a hang of a new shape), and quote the runner's last output
+// so the verdict can be checked without the log file CI discards on a green run
+// (stigmer#1010; entry 20260908.01's wrong-assumption of 2026-09-08).
+// Pure: a string in, a string out. No target, no spawn.
+// Domain: conformance harness (execution engine).
+import { describe, expect, it } from "vitest";
+import { describeRunnerForceKill } from "../runner-process";
+
+// The Temporal SDK prints each worker state change as a five-line object.
+function workerStateChanged(state: string): string[] {
+  return [
+    `2026-09-07T23:06:47.287Z [INFO] Worker state changed {`,
+    "  sdkComponent: 'worker',",
+    "  taskQueue: 'stigmer_runner',",
+    `  state: '${state}'`,
+    "}",
+  ];
+}
+
+// The tail of a #1008 hang, as the runner's log records it: the graceful path
+// completes and the process then stays alive with nothing more logged.
+const HANG_AFTER_WORKER_STOPPED = [
+  "[ExecuteDeepAgent] Completed execution aex_01m1z1zhtfgkk9jmn0rka2kg73: events=73, messages=1, artifacts=0, writebacks=0, hasStructuredOutput=false",
+  "Received SIGTERM, stopping worker gracefully...",
+  ...workerStateChanged("STOPPING"),
+  ...workerStateChanged("DRAINING"),
+  ...workerStateChanged("DRAINED"),
+  ...workerStateChanged("STOPPED"),
+  "Worker stopped",
+  "",
+].join("\n");
+
+const FALLBACK_HEADER = /^\[runner\] did not exit within \d+ms of SIGTERM — SIGKILL fallback; /;
+
+function quotedLines(message: string): string[] {
+  return message
+    .split("\n")
+    .filter((line) => line.startsWith("    | "))
+    .map((line) => line.slice("    | ".length));
+}
+
+describe("describeRunnerForceKill", () => {
+  it("reads a tail that reached `Worker stopped` as the #1008 shape and quotes up to the marker", () => {
+    const message = describeRunnerForceKill(HANG_AFTER_WORKER_STOPPED);
+
+    expect(message, "the recipe's grep token must survive").toMatch(FALLBACK_HEADER);
+    expect(message).toContain('worker="stopped"');
+    expect(message, "the verdict names the issue it stands for").toContain("stigmer#1008");
+    expect(message).not.toContain('worker="not stopped"');
+    const quoted = quotedLines(message);
+    expect(quoted.at(-1), "the excerpt ends where the runner went silent").toBe("Worker stopped");
+    expect(quoted[0], "the whole shutdown sequence fits: 23 non-blank lines under the bound").toMatch(
+      /^\[ExecuteDeepAgent\]/,
+    );
+    expect(quoted, "the sequence is readable from SIGTERM to the marker").toContain(
+      "Received SIGTERM, stopping worker gracefully...",
+    );
+  });
+
+  it("reads a tail that never reached the marker as NOT the #1008 shape", () => {
+    // Cut mid-drain: through the DRAINING state change, before DRAINED.
+    const tail = HANG_AFTER_WORKER_STOPPED.split("\n").slice(0, 12).join("\n");
+    expect(tail, "the arm's premise: the drain is still in flight").toMatch(/state: 'DRAINING'\n}$/);
+
+    const message = describeRunnerForceKill(tail);
+
+    expect(message).toMatch(FALLBACK_HEADER);
+    expect(message).toContain('worker="not stopped"');
+    expect(message, "a reader is told this is not the known shape").toContain("NOT the #1008 shape");
+    expect(message).not.toContain('worker="stopped"');
+    const quoted = quotedLines(message);
+    expect(quoted, "the excerpt shows how far the drain got").toContain("  state: 'DRAINING'");
+    expect(quoted.join("\n")).not.toMatch(/DRAINED|STOPPED/);
+  });
+
+  it("keeps the `stopped` verdict when the runner printed after the marker, and shows what it printed", () => {
+    const tail =
+      HANG_AFTER_WORKER_STOPPED +
+      "agent-session-cache: closed parked agent for session=ses_01 (shutdown)\n" +
+      "Error: something the harness has never seen\n";
+
+    const message = describeRunnerForceKill(tail);
+
+    expect(message, "a post-drain line is evidence, not a different verdict").toContain('worker="stopped"');
+    const quoted = quotedLines(message);
+    expect(quoted).toContain("Worker stopped");
+    expect(quoted.at(-2)).toBe("agent-session-cache: closed parked agent for session=ses_01 (shutdown)");
+    expect(quoted.at(-1), "the surprise is in the job log, where a reader sees it").toBe(
+      "Error: something the harness has never seen",
+    );
+  });
+
+  it("does not throw on an empty tail and says nothing was captured", () => {
+    const message = describeRunnerForceKill("");
+
+    expect(message).toMatch(FALLBACK_HEADER);
+    expect(message, "no output cannot prove the worker stopped").toContain('worker="not stopped"');
+    expect(quotedLines(message)).toEqual(["(no runner output captured)"]);
+  });
+
+  it("quotes only the last 24 non-blank lines and clips a long line", () => {
+    const longLine = "x".repeat(5_000);
+    const lines = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`);
+    const tail = [...lines.slice(0, 20), "", "   ", ...lines.slice(20), longLine, "Worker stopped"].join("\n");
+
+    const message = describeRunnerForceKill(tail);
+
+    const quoted = quotedLines(message);
+    expect(quoted, "exactly the bound, blanks not counted").toHaveLength(24);
+    expect(quoted[0]).toBe("line 29");
+    expect(quoted.at(-1)).toBe("Worker stopped");
+    const clipped = quoted.at(-2)!;
+    expect(clipped.endsWith("…"), "a clipped line says so").toBe(true);
+    expect(clipped.length, "240 kept characters plus the ellipsis").toBe(241);
+    expect(message.length, "the whole message stays a job-log-sized paragraph").toBeLessThan(2_500);
+  });
+
+  it("matches the marker as a whole line only, tolerating surrounding whitespace and CRLF", () => {
+    for (const notTheMarker of ["Worker stopped?", "Worker stopped early", "xWorker stopped", "Worker  stopped"]) {
+      expect(
+        describeRunnerForceKill(`Received SIGTERM, stopping worker gracefully...\n${notTheMarker}\n`),
+        `"${notTheMarker}" merely contains the words`,
+      ).toContain('worker="not stopped"');
+    }
+    for (const theMarker of ["  Worker stopped  ", "Worker stopped\r", "\tWorker stopped"]) {
+      expect(
+        describeRunnerForceKill(`Received SIGTERM, stopping worker gracefully...\r\n${theMarker}\r\n`),
+        `${JSON.stringify(theMarker)} is the marker with whitespace around it`,
+      ).toContain('worker="stopped"');
+    }
+  });
+
+  it("ignores a marker that is only a fragment at the tail's cut-off edge", () => {
+    // The in-memory tail is a character slice, so its first line may be partial.
+    // A fragment must not read as the marker in either direction.
+    const message = describeRunnerForceKill("rker stopped\nsomething else\n");
+
+    expect(message).toContain('worker="not stopped"');
+  });
+});

--- a/test/conformance/src/harness/runner-process.ts
+++ b/test/conformance/src/harness/runner-process.ts
@@ -43,8 +43,21 @@ const LOG_TAIL_BYTES = 8_000;
 // prompt; the bound only exists so a wedged drain cannot hang the vitest run.
 const SHUTDOWN_GRACE_MS = 30_000;
 
-// Printed by the runner immediately before it begins polling (runner/src/runner.ts).
+// Two lines the runner prints that this harness reads back (runner/src/runner.ts,
+// `start()`): the first immediately before the worker begins polling, the
+// second once `worker.run()` has returned — the Temporal worker has drained and
+// stopped, and whatever the process does next is no longer the worker's.
 const READY_MARKER = "Worker ready, polling for tasks";
+const WORKER_STOPPED_MARKER = "Worker stopped";
+
+// How much of the runner's output the SIGKILL-fallback line quotes. Enough to
+// show the whole shutdown sequence as the runner actually prints it: the
+// Temporal SDK logs each `Worker state changed` as a five-line object, so
+// `Received SIGTERM`, the four state changes and the marker are ~22 lines —
+// short ones, so the excerpt stays around a kilobyte. The per-line clip is for
+// the odd long line (an activity's completion summary, say), not the norm.
+const FORCE_KILL_EXCERPT_LINES = 24;
+const FORCE_KILL_EXCERPT_LINE_CHARS = 240;
 
 // Hermetic LLM wiring for agent executions. Omit it entirely for the data-only
 // WorkflowExecution path, which must stay LLM-free.
@@ -222,11 +235,7 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
     await stopChild(child, {
       signal: "SIGTERM",
       graceMs: SHUTDOWN_GRACE_MS,
-      onForceKill: () =>
-        console.error(
-          `[runner] did not exit within ${SHUTDOWN_GRACE_MS}ms of SIGTERM — SIGKILL fallback; ` +
-            "its Temporal worker may have left an in-flight activity to time out",
-        ),
+      onForceKill: () => console.error(describeRunnerForceKill(output.tail())),
     });
     await output.close();
     await rm(workspaceDir, { recursive: true, force: true });
@@ -251,6 +260,48 @@ export async function spawnRunner(opts: RunnerOptions): Promise<RunningRunner> {
     logTail: () => output.tail(),
     stop,
   };
+}
+
+// The line stop() prints when the runner outlives its grace and is SIGKILLed.
+// It has to carry its own evidence: on a green CI run the runner's log file is
+// not retained (the workflow uploads logs on failure only), so the job log is
+// the only surface a reader has, and "the harness had to kill a runner" alone
+// cannot say whether that is stigmer#1008 — the worker drained and stopped,
+// then the process idled instead of exiting — or a hang of a new shape where
+// the drain itself never finished (stigmer#1010).
+//
+// The verdict is decided on the one axis #1008 is defined by: did the runner
+// print WORKER_STOPPED_MARKER? A line-exact match anywhere in the tail — not
+// "the last line", because the runner may legitimately print after the worker
+// stops (a parked Cursor agent being closed, say), and such a line must not
+// turn a #1008 hang into a false alarm. Whatever followed the marker is in the
+// quoted excerpt, where a reader can see it, not folded into the verdict.
+// Pure, so the unit arms drive it directly; it never throws, because it runs
+// inside stopChild's grace timer during teardown.
+export function describeRunnerForceKill(tail: string): string {
+  const lines = tail.split(/\r?\n/);
+  const workerStopped = lines.some((line) => line.trim() === WORKER_STOPPED_MARKER);
+  const verdict = workerStopped
+    ? 'worker="stopped" — the process idled after its worker drained (stigmer#1008)'
+    : 'worker="not stopped" — the drain itself did not finish; NOT the #1008 shape, read the runner log';
+  return (
+    `[runner] did not exit within ${SHUTDOWN_GRACE_MS}ms of SIGTERM — SIGKILL fallback; ${verdict}\n` +
+    `[runner] last output:\n${quoteLastLines(lines)}`
+  );
+}
+
+// The tail's last non-blank lines as an indented quotation, each clipped so one
+// long line (an activity's completion summary, say) cannot swallow the log.
+function quoteLastLines(lines: string[]): string {
+  const kept = lines.filter((line) => line.trim() !== "").slice(-FORCE_KILL_EXCERPT_LINES);
+  if (kept.length === 0) return "    | (no runner output captured)";
+  return kept
+    .map((line) =>
+      line.length > FORCE_KILL_EXCERPT_LINE_CHARS
+        ? `    | ${line.slice(0, FORCE_KILL_EXCERPT_LINE_CHARS)}…`
+        : `    | ${line}`,
+    )
+    .join("\n");
 }
 
 async function waitForReady(


### PR DESCRIPTION
## Summary
When a conformance runner outlives its 30 s SIGTERM grace and the harness SIGKILLs it, the line it prints now states whether the runner's Temporal worker had stopped — `worker="stopped"` (the stigmer#1008 shape) or `worker="not stopped"` (a hang of a new shape) — and quotes the runner's last lines of output, so the verdict can be checked from the CI job log alone.

## Context
On a green `ci.conformance-cloud` run the runner's own log — the only place `Worker stopped` is written — is discarded (logs upload `if: failure()` only). The fallback has fired in 3 of the 4 CI runs the awaiting harness (#1009) has had, every time on a green run and every time in `agentexecution-recover`, and each time the Class B acceptance table had to say *unclassified, presumed #1008* because the job log could not back the claim. A different hang — a worker whose drain never finished — would have printed the identical line and been read as #1008. Issue: #1010.

## Changes
- `test/conformance/src/harness/runner-process.ts`
  - `WORKER_STOPPED_MARKER` beside `READY_MARKER`, both pinned to the runner's `start()` log lines.
  - `describeRunnerForceKill(tail)` — pure, exported — builds the fallback message: the unchanged `did not exit within … SIGKILL fallback` tokens, the verdict in the harness's `key="value"` grammar, then the runner's last 24 non-blank lines (each clipped to 240 chars) quoted under `[runner] last output:`.
  - `onForceKill` calls it with `output.tail()`, which the tee already holds in memory.
- `test/conformance/src/harness/__tests__/runner-process.test.ts` (new) — seven unit arms: the #1008 tail verbatim, marker absent (cut mid-`DRAINING`), marker followed by more output, empty tail, the line/char bounds, line-exact negatives (`Worker stopped?`, `xWorker stopped`, …) and whitespace/CRLF tolerance, a partial first line at the tail's cut-off edge.

## Implementation notes
- The verdict is a **line-exact match anywhere in the tail**, not "the last line". The runner may legitimately print after the worker stops (`closeAllCachedAgents()` logs one line per parked Cursor agent); a last-line rule would turn any such line into a false "not stopped" alarm. "Worker stopped, process did not exit" is #1008's literal title whatever else was printed — the excerpt shows the rest.
- The excerpt bound is 24 lines because the Temporal SDK prints each `Worker state changed` as a five-line object; `Received SIGTERM` + four state changes + the marker is ~22 short lines, so the whole shutdown sequence is readable and the footprint stays around a kilobyte.
- If the runner ever renames `Worker stopped`, every fallback reads `worker="not stopped"` — loud, not silent.
- Nothing else parses the fallback line; the existing grep token is preserved verbatim.

## Breaking changes
- None. The harness sends the same signal, waits the same grace, kills the same way — only what it says changes.

## Test plan
- `npm run typecheck -w @stigmer/conformance` — clean.
- `npm run test:unit -w @stigmer/conformance` (also under `make check-conformance-inventory`) — 63/63, the 7 new arms included. A mutation check (`trim() ===` → `includes()`) is caught by the line-exact negative arm.
- Local `make test-conformance-execution` (Node 22.22.1 per `.nvmrc`) — 160 passed / 6 skipped, byte-identical to the entry's S4 run.
- Seen live: looping `agent.harness.smoke` + `agentexecution-recover` locally caught a firing on the first attempt — `worker="stopped" — the process idled after its worker drained (stigmer#1008)` with the excerpt ending at `Worker stopped`. The `worker="not stopped"` path is unit-pinned only, by design (no known way to provoke it).

## Risks
- Log-only change; cannot alter pass/fail. Rollback is a revert.

## Checklist
- [x] Docs updated (if needed) — the entry's reading recipe in stigmer-cloud gains the `worker=` token; the package README does not document the line
- [x] Tests added/updated
- [x] Backward compatible

Closes #1010
Refs #1008

Origin: stigmer-cloud entry `20260908.01.sp.class-b-lane-integrity`, Q3.

Made with [Cursor](https://cursor.com)