### PR TITLE
fix(test/conformance): key the known-deviation ledger on the implementation that deviates, not the target name

### DIFF
--- a/.github/workflows/ci.conformance.yaml
+++ b/.github/workflows/ci.conformance.yaml
@@ -63,6 +63,13 @@ jobs:
       - name: Check the cloud-capability inventory
         run: npm run inventory:check -w @stigmer/conformance
 
+      # The harness's PURE unit arms (the deviation registry, the submit seam,
+      # the child-process discipline, the targets' implementation declaration):
+      # `make check-conformance-inventory` runs them locally; this is the same
+      # gate in CI, before any target boots.
+      - name: Run the harness unit arms
+        run: npm run test:unit -w @stigmer/conformance
+
       # The server is standalone (own lockfile, file-linked protos); its
       # global-setup compiles it, but the install must happen here where
       # network access is expected.

--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -219,6 +219,18 @@ CRUD suites:
   contract; the addresses state where the environment serves it — a cloud
   target whose flag is true and whose lane is missing FAILS, never skips.
   That red is the implementing entry's acceptance.
+- **The environment declares which server answers.**
+  `STIGMER_CONFORMANCE_CLOUD_IMPLEMENTATION` is `stigmer-service` (the Java
+  service the hermetic launcher boots) or `stigmer-server` (the TypeScript
+  composition the readout recipe boots), REQUIRED on the cloud targets and
+  published by the provisioner — the global setup for the launcher, the
+  composition's `readout-bootstrap` for the readout. The cloud targets are
+  connect-only and cannot tell from the wire (`getServerInfo` rightly answers
+  `cloud` for both), yet the known-deviation registry keys Java's bugs on
+  exactly this fact; an environment that forgets it is refused by name rather
+  than inheriting the other implementation's quirks (stigmer#1012). It is a
+  different axis from the target NAME: a name is a deployment shape, the
+  implementation is whose code is behind it (`TargetProfile.implementation`).
 
 **Launcher posture vs production.** The launcher boots Java the way production
 runs it wherever the harness can (stigmer-cloud entry `20260907.02`, closing
@@ -302,35 +314,45 @@ codebase writes anyway.
 ### Spec-first contract (`src/contract/`)
 
 Tests assert the **intended** contract, not whatever an implementation happens
-to do today. When a target legitimately deviates because of a known bug, it gets
-a tracked entry in the **known-deviation registry** (`deviations.ts`) instead of
-the test quietly asserting the wrong behavior. An entry records both readings as
-prose — `contract` and `observed` — and the arm supplies the two assertions.
-There are two kinds, because there are two kinds of bug:
+to do today. When an implementation legitimately deviates because of a known
+bug, it gets a tracked entry in the **known-deviation registry**
+(`deviations.ts`) instead of the test quietly asserting the wrong behavior. An
+entry records both readings as prose — `contract` and `observed` — and the arm
+supplies the two assertions, handing over the target's identity
+(`TargetIdentity`: its name and its implementation). Entries key on the
+**implementation** that deviates (`stigmer-service`, the Java service; every
+entry today), never on a target's name — the `cloud` targets serve whichever
+implementation the environment declares, and the TypeScript composition behind
+the same name asserts the contract (stigmer#1012). There are two kinds, because
+there are two kinds of bug:
 
-- **Deterministic** (`assertContractOrDeviation`): the target ALWAYS answers the
-  observed reading. The arm runs only the `observed` assertion there, so the day
-  the target is fixed that assertion fails and the entry must be deleted. Three
-  entries today, all Java's, from the launcher entry that first ran Java in
-  production security mode (stigmer-cloud `20260907.02`).
-- **Race** (`assertContractOrKnownRace`): the target SOMETIMES answers the
-  observed reading, on a timing it does not control. The arm asserts the
+- **Deterministic** (`assertContractOrDeviation`): the implementation ALWAYS
+  answers the observed reading. The arm runs only the `observed` assertion
+  there, so the day the implementation is fixed that assertion fails and the
+  entry must be deleted. Three entries today, all Java's, from the launcher
+  entry that first ran Java in production security mode (stigmer-cloud
+  `20260907.02`).
+- **Race** (`assertContractOrKnownRace`): the implementation SOMETIMES answers
+  the observed reading, on a timing it does not control. The arm asserts the
   contract first, on every target; only an assertion failure on a registered
-  target opens the race path, where `observed` must PROVE the specific race (a
-  failure there is an unknown symptom and stays red), the firing is reported on
-  one grep-able `[conformance] tracked race …` line, and — where the entry names
-  a remedy — the arm applies it and asserts the contract exactly once more. A
-  race entry cannot self-expire, so it states when it is deleted. Two entries
-  today, both Java's execution target, from the Class B lane-integrity entry
-  (stigmer-cloud `20260908.01`): the approval write lost to the workflow's
-  WAITING heartbeat, applied at the submit seam
+  implementation opens the race path, where `observed` must PROVE the specific
+  race (a failure there is an unknown symptom and stays red), the firing is
+  reported on one grep-able `[conformance] tracked race … on <target>
+  (<implementation>)` line, and — where the entry names a remedy — the arm
+  applies it and asserts the contract exactly once more. A race entry cannot
+  self-expire, so it states when it is deleted. Two entries today, both Java's
+  and reachable only under a runner (the execution suites), from the Class B
+  lane-integrity entry (stigmer-cloud `20260908.01`): the approval write lost
+  to the workflow's WAITING heartbeat, applied at the submit seam
   (`support/agentexecutions.ts` → `submitApprovalPerContract`), and the trailing
   terminal write that closes a subscription the pinned S4 quirk says stays open.
 
 Neither kind is a retry budget, a sleep or a skip: the contract assertion runs
 on every target every time, and nothing in the registry is reached unless the
-target is registered AND (for a race) the contract just failed. The registry
-can never hide a regression or bless a bug permanently. The local targets carry
+target's implementation is registered AND (for a race) the contract just
+failed. The registry can never hide a regression or bless a bug permanently.
+At R1 the Java service retires and, with it, every entry naming it and the
+`stigmer-service` member of `ServerImplementation`. The local targets carry
 no entries: the previous ones — duplicate-create / missing-name / missing-spec
 returning `Unknown`, and `getVersion` with a malformed hash returning `NotFound`
 — were resolved (stigmer/stigmer#192) by enforcing protovalidate at the gRPC

--- a/test/conformance/src/contract/__tests__/deviations.test.ts
+++ b/test/conformance/src/contract/__tests__/deviations.test.ts
@@ -1,8 +1,11 @@
 // Unit arms for the known-deviation registry's two helpers: the deterministic
 // one runs exactly one reading; the race one runs the contract everywhere and
-// opens its path only for a registered target, only on an assertion failure,
-// only when the observed reading PROVES the race — and re-tries the contract
-// exactly once when the arm brings a remedy. Pure: no target.
+// opens its path only for a registered IMPLEMENTATION, only on an assertion
+// failure, only when the observed reading PROVES the race — and re-tries the
+// contract exactly once when the arm brings a remedy. The registry keys on the
+// implementation behind a target, never its name (stigmer#1012): the arms
+// below drive the same "cloud" / "cloud-execution" names served by both.
+// Pure: no live target — a two-field identity literal is the whole input.
 // Domain: conformance contract.
 import { ConnectError, Code } from "@connectrpc/connect";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -12,11 +15,18 @@ import {
   KNOWN_DEVIATIONS,
   SUBMIT_APPROVAL_LOST_UPDATE_RACE,
 } from "../deviations";
+import { SERVER_IMPLEMENTATIONS, type TargetIdentity } from "../../targets/target";
 
 const DETERMINISTIC_ID = "java.direct-login.stranger-signature-copy";
 const RACE_ID = SUBMIT_APPROVAL_LOST_UPDATE_RACE;
-const RACE_TARGET = "cloud-execution";
-const TS_TARGET = "local-execution";
+// The Java service behind the cloud targets — the hermetic launcher's shape.
+const JAVA_CLOUD: TargetIdentity = { name: "cloud", implementation: "stigmer-service" };
+const JAVA_CLOUD_EXECUTION: TargetIdentity = { name: "cloud-execution", implementation: "stigmer-service" };
+// The TypeScript composition behind the SAME target names — the readout's shape.
+const COMPOSITION_CLOUD: TargetIdentity = { name: "cloud", implementation: "stigmer-server" };
+const COMPOSITION_CLOUD_EXECUTION: TargetIdentity = { name: "cloud-execution", implementation: "stigmer-server" };
+// The spawned TypeScript server on a local target.
+const LOCAL_EXECUTION: TargetIdentity = { name: "local-execution", implementation: "stigmer-server" };
 
 // A failure the way vitest's expect produces one — the only kind that opens
 // the race path.
@@ -34,15 +44,35 @@ describe("the registry", () => {
     }
   });
 
+  it("keys every entry on at least one known implementation and never on a target name", () => {
+    for (const entry of KNOWN_DEVIATIONS) {
+      expect(entry.implementations.length, `${entry.id} names an implementation`).toBeGreaterThan(0);
+      for (const implementation of entry.implementations) {
+        expect(SERVER_IMPLEMENTATIONS, `${entry.id}: "${implementation}" is a server implementation`).toContain(
+          implementation,
+        );
+      }
+    }
+  });
+
+  it("holds only the Java service's bugs today — an entry naming the TypeScript server would be a contract question, not a deviation", () => {
+    // The TS server is the reference implementation the contract is written
+    // against; if it ever deviates, the fix is the server's or the contract's,
+    // and this arm is where that decision surfaces first.
+    for (const entry of KNOWN_DEVIATIONS) {
+      expect(entry.implementations, entry.id).toEqual(["stigmer-service"]);
+    }
+  });
+
   it("refuses an unknown id and refuses an entry handed to the wrong helper", async () => {
     await expect(
-      assertContractOrDeviation(TS_TARGET, "no.such.id", { contract: () => {}, observed: () => {} }),
+      assertContractOrDeviation(LOCAL_EXECUTION, "no.such.id", { contract: () => {}, observed: () => {} }),
     ).rejects.toThrow("unknown deviation id: no.such.id");
     await expect(
-      assertContractOrDeviation(TS_TARGET, RACE_ID, { contract: () => {}, observed: () => {} }),
+      assertContractOrDeviation(LOCAL_EXECUTION, RACE_ID, { contract: () => {}, observed: () => {} }),
     ).rejects.toThrow(`deviation ${RACE_ID} is race, not deterministic; use assertContractOrKnownRace`);
     await expect(
-      assertContractOrKnownRace(TS_TARGET, DETERMINISTIC_ID, { contract: () => {}, observed: () => {} }),
+      assertContractOrKnownRace(LOCAL_EXECUTION, DETERMINISTIC_ID, { contract: () => {}, observed: () => {} }),
     ).rejects.toThrow(`deviation ${DETERMINISTIC_ID} is deterministic, not race; use assertContractOrDeviation`);
   });
 });
@@ -52,22 +82,45 @@ describe("assertContractOrDeviation", () => {
     vi.restoreAllMocks();
   });
 
-  it("runs only the contract on an unregistered target", async () => {
+  it("runs only the contract on a local TypeScript target", async () => {
     const contract = vi.fn();
     const observed = vi.fn();
-    await assertContractOrDeviation(TS_TARGET, DETERMINISTIC_ID, { contract, observed });
+    await assertContractOrDeviation(LOCAL_EXECUTION, DETERMINISTIC_ID, { contract, observed });
     expect(contract).toHaveBeenCalledTimes(1);
     expect(observed).not.toHaveBeenCalled();
   });
 
-  it("runs only the observed reading on a registered target and reports it", async () => {
+  it("runs only the contract on the composition behind the `cloud` NAME — the name registers nothing", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const contract = vi.fn();
     const observed = vi.fn();
-    await assertContractOrDeviation("cloud", DETERMINISTIC_ID, { contract, observed });
+    await assertContractOrDeviation(COMPOSITION_CLOUD, DETERMINISTIC_ID, { contract, observed });
+    expect(contract).toHaveBeenCalledTimes(1);
+    expect(observed).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("runs only the observed reading on the Java service and reports the target with its implementation", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const contract = vi.fn();
+    const observed = vi.fn();
+    await assertContractOrDeviation(JAVA_CLOUD, DETERMINISTIC_ID, { contract, observed });
     expect(contract).not.toHaveBeenCalled();
     expect(observed).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`tracked deviation ${DETERMINISTIC_ID} on cloud`));
+    // The grep-able prefix readouts key on, then the implementation.
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(`tracked deviation ${DETERMINISTIC_ID} on cloud (stigmer-service)`),
+    );
+  });
+
+  it("a Java service that starts meeting the contract fails the observed reading — the entry cannot outlive the bug", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(
+      assertContractOrDeviation(JAVA_CLOUD, DETERMINISTIC_ID, {
+        contract: () => {},
+        observed: () => failAssertion("Java now answers the contract; delete the entry"),
+      }),
+    ).rejects.toThrow("delete the entry");
   });
 });
 
@@ -76,10 +129,10 @@ describe("assertContractOrKnownRace", () => {
     vi.restoreAllMocks();
   });
 
-  it("is the contract alone on an unregistered target — a failure there is red, never a race", async () => {
+  it("is the contract alone on a local TypeScript target — a failure there is red, never a race", async () => {
     const observed = vi.fn();
     await expect(
-      assertContractOrKnownRace(TS_TARGET, RACE_ID, {
+      assertContractOrKnownRace(LOCAL_EXECUTION, RACE_ID, {
         contract: () => failAssertion("the TS server met the contract"),
         observed,
       }),
@@ -87,10 +140,26 @@ describe("assertContractOrKnownRace", () => {
     expect(observed).not.toHaveBeenCalled();
   });
 
+  it("is the contract alone on the composition behind the `cloud-execution` NAME — the race is Java's, not the name's", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const observed = vi.fn();
+    const remedy = vi.fn();
+    await expect(
+      assertContractOrKnownRace(COMPOSITION_CLOUD_EXECUTION, RACE_ID, {
+        contract: () => failAssertion("pending still 1"),
+        observed,
+        remedy,
+      }),
+    ).rejects.toThrow("pending still 1");
+    expect(observed).not.toHaveBeenCalled();
+    expect(remedy).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it("is silent on a registered target whose contract holds", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const observed = vi.fn();
-    await assertContractOrKnownRace(RACE_TARGET, RACE_ID, { contract: () => {}, observed });
+    await assertContractOrKnownRace(JAVA_CLOUD_EXECUTION, RACE_ID, { contract: () => {}, observed });
     expect(observed).not.toHaveBeenCalled();
     expect(warn).not.toHaveBeenCalled();
   });
@@ -100,7 +169,7 @@ describe("assertContractOrKnownRace", () => {
     let attempts = 0;
     const observed = vi.fn();
     const remedy = vi.fn();
-    await assertContractOrKnownRace(RACE_TARGET, RACE_ID, {
+    await assertContractOrKnownRace(JAVA_CLOUD_EXECUTION, RACE_ID, {
       contract: () => {
         attempts++;
         if (attempts === 1) failAssertion("pending still 1");
@@ -112,7 +181,7 @@ describe("assertContractOrKnownRace", () => {
     expect(observed).toHaveBeenCalledTimes(1);
     expect(remedy).toHaveBeenCalledTimes(1);
     expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`tracked race ${RACE_ID} on ${RACE_TARGET}`));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(`tracked race ${RACE_ID} on cloud-execution (stigmer-service)`));
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("remedy="));
   });
 
@@ -120,7 +189,7 @@ describe("assertContractOrKnownRace", () => {
     vi.spyOn(console, "warn").mockImplementation(() => {});
     let attempts = 0;
     await expect(
-      assertContractOrKnownRace(RACE_TARGET, RACE_ID, {
+      assertContractOrKnownRace(JAVA_CLOUD_EXECUTION, RACE_ID, {
         contract: () => {
           attempts++;
           failAssertion(`attempt ${attempts} failed`);
@@ -135,7 +204,7 @@ describe("assertContractOrKnownRace", () => {
   it("without a remedy, the observed reading is the whole story", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     let attempts = 0;
-    await assertContractOrKnownRace(RACE_TARGET, RACE_ID, {
+    await assertContractOrKnownRace(JAVA_CLOUD_EXECUTION, RACE_ID, {
       contract: () => {
         attempts++;
         failAssertion("closed, not timeout");
@@ -150,7 +219,7 @@ describe("assertContractOrKnownRace", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const remedy = vi.fn();
     await expect(
-      assertContractOrKnownRace(RACE_TARGET, RACE_ID, {
+      assertContractOrKnownRace(JAVA_CLOUD_EXECUTION, RACE_ID, {
         contract: () => failAssertion("pending still 1"),
         observed: () => failAssertion("no decision in the stream either"),
         remedy,
@@ -163,7 +232,7 @@ describe("assertContractOrKnownRace", () => {
   it("lets a non-assertion error through untouched — a ConnectError is not a race", async () => {
     const observed = vi.fn();
     await expect(
-      assertContractOrKnownRace(RACE_TARGET, RACE_ID, {
+      assertContractOrKnownRace(JAVA_CLOUD_EXECUTION, RACE_ID, {
         contract: () => {
           throw new ConnectError("unauthorized", Code.PermissionDenied);
         },

--- a/test/conformance/src/contract/deviations.ts
+++ b/test/conformance/src/contract/deviations.ts
@@ -30,16 +30,28 @@
 //
 // What neither kind is: a retry budget, a sleep, or a skip. The contract
 // assertion runs on every target every time; nothing here is reached unless
-// the target is registered AND (for a race) the contract just failed.
+// the target's implementation is registered AND (for a race) the contract
+// just failed.
+//
+// Entries key on the IMPLEMENTATION that deviates (TargetProfile
+// .implementation), never on a target's name. A bug lives in a server binary;
+// a target name describes a deployment shape, and the connect-only `cloud`
+// targets serve whichever implementation the environment booted — the Java
+// service under the hermetic launcher, the TypeScript composition under the
+// readout recipe. Keyed on names, Java's quirks were asserted against the
+// composition (stigmer#1012). This module imports the identity type from
+// targets/ — the registry classifies targets, so it names what it classifies;
+// the reverse edge would put the harness's fault list upstream of the harness.
+import type { ServerImplementation, TargetIdentity } from "../targets/target";
 
 interface DeviationRecord {
   // Stable identifier used by tests to opt a case into the registry.
   id: string;
-  // Target names that currently exhibit the deviation (TargetProfile.name).
-  targets: string[];
+  // The implementations that currently exhibit the deviation.
+  implementations: ServerImplementation[];
   // What the contract requires, in one sentence.
   contract: string;
-  // What the listed targets do instead, in one sentence.
+  // What the listed implementations do instead, in one sentence.
   observed: string;
   // Why the deviation exists.
   rationale: string;
@@ -63,12 +75,9 @@ export interface RaceDeviation extends DeviationRecord {
 
 export type KnownDeviation = DeterministicDeviation | RaceDeviation;
 
-// The hermetic Java targets. The Java service retires at R1; every entry
-// naming them is deleted with it.
-const JAVA_TARGETS = ["cloud", "cloud-execution"];
-// The Java execution target alone: races between the runner's status writes
-// and a caller's RPC need a runner, so Class A never reaches them.
-const JAVA_EXECUTION_TARGET = ["cloud-execution"];
+// The Java service. It retires at R1; every entry naming it is deleted with
+// it, together with the "stigmer-service" member of ServerImplementation.
+const JAVA: ServerImplementation[] = ["stigmer-service"];
 
 // Race ids, exported so the one seam that applies each (support/agentexecutions.ts
 // for the first; the two subscribe arms for the second) cannot drift from the
@@ -80,7 +89,7 @@ export const KNOWN_DEVIATIONS: KnownDeviation[] = [
   {
     kind: "deterministic",
     id: "java.stripe-webhook.missing-signature-header-401",
-    targets: JAVA_TARGETS,
+    implementations: JAVA,
     contract: "POST /webhook/stripe without a Stripe-Signature header answers 400 and grants nothing.",
     observed: "Java answers 401 (and still grants nothing).",
     rationale:
@@ -96,7 +105,7 @@ export const KNOWN_DEVIATIONS: KnownDeviation[] = [
   {
     kind: "deterministic",
     id: "java.direct-login.personal-org-owner-is-raw-subject",
-    targets: JAVA_TARGETS,
+    implementations: JAVA,
     contract:
       "A first login's provisionMyAccount creates a personal organization OWNED BY the new identity " +
       "account, visible to it on findMyOrganizations.",
@@ -115,7 +124,7 @@ export const KNOWN_DEVIATIONS: KnownDeviation[] = [
   {
     kind: "deterministic",
     id: "java.direct-login.stranger-signature-copy",
-    targets: JAVA_TARGETS,
+    implementations: JAVA,
     contract:
       "A tenant-issuer token signed by a key the tenant's JWKS does not carry is refused " +
       'UNAUTHENTICATED "token signature verification failed".',
@@ -132,7 +141,9 @@ export const KNOWN_DEVIATIONS: KnownDeviation[] = [
   {
     kind: "race",
     id: SUBMIT_APPROVAL_LOST_UPDATE_RACE,
-    targets: JAVA_EXECUTION_TARGET,
+    // Reachable only where a runner drives the gate (the execution suites);
+    // Class A never submits an approval, so the entry is never consulted there.
+    implementations: JAVA,
     contract:
       "submitApproval's response reflects the decision synchronously — pending_approvals recomputed — " +
       "and the decided tool call carries its approval_action in the transcript for the rest of the run.",
@@ -156,12 +167,14 @@ export const KNOWN_DEVIATIONS: KnownDeviation[] = [
     tracking:
       "stigmer-cloud#683 (a Java finding, retires with Java, an X1 input); the evidence table and Java " +
       "timelines in stigmer-cloud entry 20260908.01's tasks/T01_2_execution.md.",
-    retires: "R1 — deleted with the Java targets; the OSS store lock makes the entry unreachable elsewhere.",
+    retires: "R1 — deleted with the Java implementation; the OSS store lock makes the entry unreachable elsewhere.",
   },
   {
     kind: "race",
     id: SUBSCRIBE_TRAILING_TERMINAL_WRITE_RACE,
-    targets: JAVA_EXECUTION_TARGET,
+    // Reachable only where a run reaches a terminal status under a runner
+    // (the execution suites' subscribe arms).
+    implementations: JAVA,
     contract:
       "A subscription opened on an already-terminal run receives the snapshot and is never closed by " +
       "the server (the pinned wave-2 S4 quirk: the terminal-close check fires only on broker updates).",
@@ -177,16 +190,18 @@ export const KNOWN_DEVIATIONS: KnownDeviation[] = [
     tracking:
       "stigmer-cloud entry 20260908.01 — ten of the twenty-eight Class B reds in its evidence table; " +
       "stigmer#919.",
-    retires: "R1 — deleted with the Java targets.",
+    retires: "R1 — deleted with the Java implementation.",
   },
 ];
 
-// Runs the contract assertion, or — for a target registered as deterministically
-// deviating — the observed assertion, reporting the deviation (never silently).
-// If a registered target starts meeting the contract, `observed` fails,
-// signaling the entry is stale and should be deleted.
+// Runs the contract assertion, or — for a target whose implementation is
+// registered as deterministically deviating — the observed assertion,
+// reporting the deviation (never silently). If a registered implementation
+// starts meeting the contract, `observed` fails, signaling the entry is stale
+// and should be deleted. The report line keeps its `tracked deviation <id> on
+// <target>` prefix (readouts grep it) and names the implementation after it.
 export async function assertContractOrDeviation(
-  targetName: string,
+  target: TargetIdentity,
   deviationId: string,
   assertions: {
     contract: () => Promise<void> | void;
@@ -194,24 +209,25 @@ export async function assertContractOrDeviation(
   },
 ): Promise<void> {
   const deviation = lookupDeviation(deviationId, "deterministic");
-  if (!deviation.targets.includes(targetName)) {
+  if (!deviation.implementations.includes(target.implementation)) {
     await assertions.contract();
     return;
   }
   await assertions.observed();
   console.warn(
-    `[conformance] tracked deviation ${deviation.id} on ${targetName}: ` +
+    `[conformance] tracked deviation ${deviation.id} on ${target.name} (${target.implementation}): ` +
       `contract="${deviation.contract}" observed="${deviation.observed}" (${deviation.tracking})`,
   );
 }
 
-// Runs the contract assertion on every target. On a target registered for the
-// named race, an ASSERTION failure (and only that — any other error propagates)
-// opens the race path: `observed` must hold, proving this is the known race and
-// not a new symptom; the firing is reported on one line; if the arm supplies a
-// remedy, it runs and the contract is asserted once more, this time for real.
+// Runs the contract assertion on every target. On a target whose implementation
+// is registered for the named race, an ASSERTION failure (and only that — any
+// other error propagates) opens the race path: `observed` must hold, proving
+// this is the known race and not a new symptom; the firing is reported on one
+// line; if the arm supplies a remedy, it runs and the contract is asserted once
+// more, this time for real.
 export async function assertContractOrKnownRace(
-  targetName: string,
+  target: TargetIdentity,
   deviationId: string,
   assertions: {
     contract: () => Promise<void> | void;
@@ -224,11 +240,11 @@ export async function assertContractOrKnownRace(
     await assertions.contract();
     return;
   } catch (err) {
-    if (!race.targets.includes(targetName) || !isAssertionFailure(err)) throw err;
+    if (!race.implementations.includes(target.implementation) || !isAssertionFailure(err)) throw err;
   }
   await assertions.observed();
   console.warn(
-    `[conformance] tracked race ${race.id} on ${targetName}: ` +
+    `[conformance] tracked race ${race.id} on ${target.name} (${target.implementation}): ` +
       `contract="${race.contract}" observed="${race.observed}"` +
       (race.remedy !== undefined ? ` remedy="${race.remedy}"` : "") +
       ` (${race.tracking})`,

--- a/test/conformance/src/harness/cloud-env.ts
+++ b/test/conformance/src/harness/cloud-env.ts
@@ -34,7 +34,18 @@ import { uniqueName } from "../support/naming";
 
 // Contract between global-setup-cloud.ts (writer) and CloudTarget (reader).
 export const CLOUD_ENV = {
-  // gRPC base URL of the stigmer-service under test, e.g. http://127.0.0.1:52341.
+  // Which server binary the environment booted behind the cloud targets —
+  // "stigmer-service" (the Java service the hermetic launcher runs) or
+  // "stigmer-server" (the TypeScript composition the readout recipe boots).
+  // REQUIRED: the cloud targets are connect-only and cannot tell from the
+  // wire (getServerInfo answers `cloud` for both, correctly — the product
+  // edition is the same), yet the known-deviation registry keys Java's bugs
+  // on exactly this fact. Declared by the provisioner that knows what it
+  // built (global-setup-cloud.ts; the composition's readout-bootstrap), never
+  // defaulted — an environment that forgets it fails setup by name rather
+  // than inheriting the other implementation's quirks (stigmer#1012).
+  implementation: "STIGMER_CONFORMANCE_CLOUD_IMPLEMENTATION",
+  // gRPC base URL of the service under test, e.g. http://127.0.0.1:52341.
   address: "STIGMER_CONFORMANCE_CLOUD_ADDRESS",
   // HTTP (Spring) base URL of the same service — the routes the gRPC port
   // does not serve, notably the artifact presign endpoints

--- a/test/conformance/src/harness/global-setup-cloud.ts
+++ b/test/conformance/src/harness/global-setup-cloud.ts
@@ -31,6 +31,11 @@ import {
   type CloudEnvironment,
 } from "./cloud-env";
 import { launcherEnvFor, startCloudFixtures, type CloudFixtures } from "./cloud-fixtures";
+import type { ServerImplementation } from "../targets/target";
+
+// What this setup boots. Typed so the published value can only ever be one of
+// the two the cloud target accepts.
+const BOOTED_IMPLEMENTATION: ServerImplementation = "stigmer-service";
 
 export default async function setup(): Promise<() => Promise<void>> {
   if (process.env[CLOUD_ENV.address] !== undefined && process.env[CLOUD_ENV.token] !== undefined) {
@@ -58,6 +63,9 @@ export default async function setup(): Promise<() => Promise<void>> {
       environment.grpcBaseUrl,
       mintBootstrapOperatorToken(tenant),
     );
+    // This setup booted the Java fat JAR: say so, because the cloud targets
+    // cannot tell from the wire and the deviation registry keys on it.
+    process.env[CLOUD_ENV.implementation] = BOOTED_IMPLEMENTATION;
     process.env[CLOUD_ENV.address] = environment.grpcBaseUrl;
     process.env[CLOUD_ENV.httpAddress] = environment.httpBaseUrl;
     // The cloud-capability lanes: on Java every HTTP lane but bidi is the

--- a/test/conformance/src/suites-execution/agentexecution-approval.conformance.test.ts
+++ b/test/conformance/src/suites-execution/agentexecution-approval.conformance.test.ts
@@ -249,7 +249,7 @@ describe("AgentExecution submitApproval — gate resolution", () => {
     // approval-event stream — there is no remedy, the observed reading is final.
     const rejectedTc = allToolCalls(final).find((tc) => tc.id === toolCallId);
     expect(rejectedTc, "the rejected echo tool call is present in the transcript").toBeDefined();
-    await assertContractOrKnownRace(target.name, SUBMIT_APPROVAL_LOST_UPDATE_RACE, {
+    await assertContractOrKnownRace(target, SUBMIT_APPROVAL_LOST_UPDATE_RACE, {
       contract: () => {
         expect(rejectedTc!.status, "rejected tool call resolves to SKIPPED, not WAITING").toBe(
           ToolCallStatus.TOOL_CALL_SKIPPED,

--- a/test/conformance/src/suites-execution/agentexecution.conformance.test.ts
+++ b/test/conformance/src/suites-execution/agentexecution.conformance.test.ts
@@ -958,7 +958,7 @@ describe("AgentExecution conformance — subscribe & populated read surfaces (CW
     // On the Java target a trailing duplicate terminal write can arrive as a
     // broker update after the snapshot and trip the check — the tracked race
     // (contract/deviations.ts); the observed reading is final, no remedy.
-    await assertContractOrKnownRace(target.name, SUBSCRIBE_TRAILING_TERMINAL_WRITE_RACE, {
+    await assertContractOrKnownRace(target, SUBSCRIBE_TRAILING_TERMINAL_WRITE_RACE, {
       contract: () => {
         expect(stream.outcome, "no server close — the bounded reader had to abort").toBe("timeout");
         expect(stream.messages).toHaveLength(1);

--- a/test/conformance/src/suites-execution/workflowexecution.conformance.test.ts
+++ b/test/conformance/src/suites-execution/workflowexecution.conformance.test.ts
@@ -550,7 +550,7 @@ describe("WorkflowExecution conformance — event log pagination & streaming (CW
     // On the Java target a trailing duplicate terminal write can arrive as a
     // broker update after the snapshot and trip the check — the tracked race
     // (contract/deviations.ts); the observed reading is final, no remedy.
-    await assertContractOrKnownRace(target.name, SUBSCRIBE_TRAILING_TERMINAL_WRITE_RACE, {
+    await assertContractOrKnownRace(target, SUBSCRIBE_TRAILING_TERMINAL_WRITE_RACE, {
       contract: () => {
         expect(stream.outcome, "no server close — the bounded reader had to abort").toBe("timeout");
         expect(stream.messages).toHaveLength(1);

--- a/test/conformance/src/suites/billing.conformance.test.ts
+++ b/test/conformance/src/suites/billing.conformance.test.ts
@@ -812,7 +812,7 @@ describe.skipIf(!ledgerServed)("Billing ledger conformance — the purchase mone
     expect(stale.status).toBe(400);
 
     const missing = await fetch(`${lane.baseUrl}/webhook/stripe`, { method: "POST", headers: { "content-type": "application/json" }, body: signStripePayload(JSON.stringify(event), lane.signingSecret).payload });
-    await assertContractOrDeviation(target.name, "java.stripe-webhook.missing-signature-header-401", {
+    await assertContractOrDeviation(target, "java.stripe-webhook.missing-signature-header-401", {
       contract: () => expect(missing.status, "no Stripe-Signature header is a bad request").toBe(400),
       observed: () => expect(missing.status, "Java: the framework 400 re-dispatches to /error, which denyAll turns into 401").toBe(401),
     });

--- a/test/conformance/src/suites/direct-login.conformance.test.ts
+++ b/test/conformance/src/suites/direct-login.conformance.test.ts
@@ -149,7 +149,7 @@ describe.skipIf(!directLoginEnabled)(
         const mine = await asUser.organizationQuery.findMyOrganizations({});
         const personalVisible = mine.entries.some((org) => org.spec?.isPersonal === true);
         await assertContractOrDeviation(
-          target.name,
+          target,
           "java.direct-login.personal-org-owner-is-raw-subject",
           {
             contract: () => {
@@ -260,7 +260,7 @@ describe.skipIf(!directLoginEnabled)(
         "a token claiming the tenant's issuer but signed by a key its JWKS does not carry",
       );
       await assertContractOrDeviation(
-        target.name,
+        target,
         "java.direct-login.stranger-signature-copy",
         {
           contract: () => {

--- a/test/conformance/src/support/__tests__/agentexecutions.test.ts
+++ b/test/conformance/src/support/__tests__/agentexecutions.test.ts
@@ -18,6 +18,7 @@ import {
   submitApprovalPerContract,
   type AgentExecutionReader,
 } from "../agentexecutions";
+import type { TargetIdentity } from "../../targets/target";
 
 interface ToolCallInit {
   id: string;
@@ -123,6 +124,13 @@ describe("submitApprovalPerContract", () => {
     vi.restoreAllMocks();
   });
 
+  // The two identities the seam distinguishes: the same "cloud-execution"
+  // deployment shape served by either implementation. The race is Java's; the
+  // composition behind the same target name asserts the contract, full stop.
+  const tsTarget: TargetIdentity = { name: "local-execution", implementation: "stigmer-server" };
+  const compositionTarget: TargetIdentity = { name: "cloud-execution", implementation: "stigmer-server" };
+  const javaTarget: TargetIdentity = { name: "cloud-execution", implementation: "stigmer-service" };
+
   const settled = execution({ pending: [], toolCalls: [{ id: "call_a", action: ApprovalAction.APPROVE }] });
   const raced = execution({
     pending: ["call_a"],
@@ -135,7 +143,7 @@ describe("submitApprovalPerContract", () => {
 
   it("on a TS target is submit-and-assert, returning the response", async () => {
     const submit = vi.fn(async () => settled);
-    const response = await submitApprovalPerContract({ name: "local-execution" }, reader(settled), {
+    const response = await submitApprovalPerContract(tsTarget, reader(settled), {
       executionId: "aex_unit",
       expectedRemaining: 0,
       label: "approve clears the gate",
@@ -148,7 +156,20 @@ describe("submitApprovalPerContract", () => {
   it("on a TS target a failed contract is red — the race path is not open there", async () => {
     const read = vi.fn(async () => raced);
     await expect(
-      submitApprovalPerContract({ name: "local-execution" }, { agentExecutionQuery: { get: read } }, {
+      submitApprovalPerContract(tsTarget, { agentExecutionQuery: { get: read } }, {
+        executionId: "aex_unit",
+        expectedRemaining: 0,
+        label: "approve clears the gate",
+        submit: async () => raced,
+      }),
+    ).rejects.toThrow("approve clears the gate");
+    expect(read).not.toHaveBeenCalled();
+  });
+
+  it("on the composition behind the cloud-execution NAME a failed contract is red too — the race is keyed on the implementation, not the name", async () => {
+    const read = vi.fn(async () => raced);
+    await expect(
+      submitApprovalPerContract(compositionTarget, { agentExecutionQuery: { get: read } }, {
         executionId: "aex_unit",
         expectedRemaining: 0,
         label: "approve clears the gate",
@@ -162,7 +183,7 @@ describe("submitApprovalPerContract", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const responses = [raced, settled];
     const submit = vi.fn(async () => responses.shift()!);
-    const response = await submitApprovalPerContract({ name: "cloud-execution" }, reader(raced), {
+    const response = await submitApprovalPerContract(javaTarget, reader(raced), {
       executionId: "aex_unit",
       expectedRemaining: 0,
       label: "approve clears the gate",
@@ -170,7 +191,7 @@ describe("submitApprovalPerContract", () => {
     });
     expect(response).toBe(settled);
     expect(submit).toHaveBeenCalledTimes(2);
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining("tracked race java.agentexecution.submit-approval.lost-update-race on cloud-execution"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("tracked race java.agentexecution.submit-approval.lost-update-race on cloud-execution (stigmer-service)"));
   });
 
   it("on the Java target a failure the fresh read cannot explain stays red", async () => {
@@ -178,7 +199,7 @@ describe("submitApprovalPerContract", () => {
     const unexplained = execution({ pending: ["call_a"], toolCalls: [{ id: "call_a", action: ApprovalAction.UNSPECIFIED }] });
     const submit = vi.fn(async () => unexplained);
     await expect(
-      submitApprovalPerContract({ name: "cloud-execution" }, reader(unexplained), {
+      submitApprovalPerContract(javaTarget, reader(unexplained), {
         executionId: "aex_unit",
         expectedRemaining: 0,
         label: "approve clears the gate",

--- a/test/conformance/src/support/agentexecutions.ts
+++ b/test/conformance/src/support/agentexecutions.ts
@@ -28,7 +28,7 @@ import { assertContractOrKnownRace, SUBMIT_APPROVAL_LOST_UPDATE_RACE } from "../
 import type { ConformanceClients } from "../harness/clients";
 import type { McpToolFixture } from "../harness/mcp-server";
 import type { MockLlmProxy } from "../harness/mock-llm";
-import type { TargetProfile } from "../targets/target";
+import type { TargetIdentity, TargetProfile } from "../targets/target";
 import { type ExecutionValueInit, makeExecutionValues } from "./executioncontexts";
 import { type PollCoreOptions, pollUntil } from "./execution-poll";
 
@@ -203,12 +203,12 @@ export interface SubmitApprovalPerContractOptions {
 // Submits per the contract and returns the response the contract held on (the
 // second response when the registered race fired and the remedy re-submitted).
 export async function submitApprovalPerContract(
-  target: Pick<TargetProfile, "name">,
+  target: TargetIdentity,
   clients: AgentExecutionReader,
   opts: SubmitApprovalPerContractOptions,
 ): Promise<AgentExecution> {
   let response = await opts.submit();
-  await assertContractOrKnownRace(target.name, SUBMIT_APPROVAL_LOST_UPDATE_RACE, {
+  await assertContractOrKnownRace(target, SUBMIT_APPROVAL_LOST_UPDATE_RACE, {
     contract: () =>
       expect(response.status?.pendingApprovals.length, opts.label).toBe(opts.expectedRemaining),
     observed: async () =>

--- a/test/conformance/src/targets/__tests__/cloud-implementation.test.ts
+++ b/test/conformance/src/targets/__tests__/cloud-implementation.test.ts
@@ -1,0 +1,70 @@
+// Unit arms for the cloud target's implementation declaration
+// (CLOUD_ENV.implementation, stigmer#1012): REQUIRED and CLOSED. A connect-only
+// target cannot learn from the wire whether Java or the TypeScript composition
+// answers it, so the provisioner says — and a provisioner that forgot, or
+// typed something else, is refused by name rather than inheriting the other
+// implementation's registered quirks. Pure: the reader takes its env.
+// Domain: conformance targets.
+import { describe, expect, it } from "vitest";
+import { CLOUD_ENV } from "../../harness/cloud-env";
+import { CloudTarget, readCloudImplementation } from "../cloud";
+import { CloudExecutionTarget } from "../cloud-execution";
+import { LocalTarget } from "../local";
+import { LocalExecutionTarget } from "../local-execution";
+import { LocalPostgresExecutionTarget, LocalPostgresTarget } from "../local-postgres";
+import { SERVER_IMPLEMENTATIONS, isServerImplementation } from "../target";
+
+describe("readCloudImplementation", () => {
+  it("accepts each server implementation as declared", () => {
+    for (const implementation of SERVER_IMPLEMENTATIONS) {
+      expect(readCloudImplementation({ [CLOUD_ENV.implementation]: implementation })).toBe(implementation);
+    }
+  });
+
+  it("refuses an unset declaration by name — there is no default to inherit", () => {
+    expect(() => readCloudImplementation({})).toThrow(
+      `${CLOUD_ENV.implementation} is not set: the cloud target is connect-only and cannot tell which server answers it`,
+    );
+    expect(() => readCloudImplementation({ [CLOUD_ENV.implementation]: "" })).toThrow(
+      `${CLOUD_ENV.implementation} is not set`,
+    );
+  });
+
+  it("refuses a value outside the union, naming the offender — a typo cannot pass as either side", () => {
+    expect(() => readCloudImplementation({ [CLOUD_ENV.implementation]: "java" })).toThrow(
+      `${CLOUD_ENV.implementation} must be "stigmer-server" or "stigmer-service"; got "java"`,
+    );
+    expect(() => readCloudImplementation({ [CLOUD_ENV.implementation]: "Stigmer-Server" })).toThrow('got "Stigmer-Server"');
+  });
+});
+
+describe("isServerImplementation", () => {
+  it("is exactly the two-member union", () => {
+    expect(SERVER_IMPLEMENTATIONS).toEqual(["stigmer-server", "stigmer-service"]);
+    expect(isServerImplementation("stigmer-server")).toBe(true);
+    expect(isServerImplementation("stigmer-service")).toBe(true);
+    expect(isServerImplementation("cloud")).toBe(false);
+    expect(isServerImplementation("")).toBe(false);
+  });
+});
+
+describe("TargetProfile.implementation", () => {
+  it("is the TypeScript server on every local target, by construction", () => {
+    for (const target of [
+      new LocalTarget(),
+      new LocalExecutionTarget(),
+      new LocalPostgresTarget(),
+      new LocalPostgresExecutionTarget(),
+    ]) {
+      expect(target.implementation, target.name).toBe("stigmer-server");
+    }
+  });
+
+  it("on the cloud targets is unknown until setup() has read the declaration, and says so", () => {
+    expect(() => new CloudTarget().implementation).toThrow("CloudTarget.setup() must run before implementation is read");
+    // The execution target delegates to the inner cloud target verbatim.
+    expect(() => new CloudExecutionTarget().implementation).toThrow(
+      "CloudTarget.setup() must run before implementation is read",
+    );
+  });
+});

--- a/test/conformance/src/targets/cloud-execution.ts
+++ b/test/conformance/src/targets/cloud-execution.ts
@@ -34,7 +34,13 @@ import { MockLlmProxy } from "../harness/mock-llm";
 import { ensureRunnerBuilt } from "../harness/runner-build";
 import { spawnRunner, type RunningRunner } from "../harness/runner-process";
 import { CloudTarget } from "./cloud";
-import type { CapabilityFlags, StripeWebhookLane, TargetProfile, TenancyContext } from "./target";
+import type {
+  CapabilityFlags,
+  ServerImplementation,
+  StripeWebhookLane,
+  TargetProfile,
+  TenancyContext,
+} from "./target";
 
 // The integration module's log dir — where the hermetic launcher already
 // writes stigmer-service.log, and what the CI lane uploads on failure. Each
@@ -57,6 +63,12 @@ export class CloudExecutionTarget implements TargetProfile {
   // (DD-012); since D4 #23 the TS server's HITL loop emits the same signal,
   // so local-execution runs the identical forwarding round-trip.
   private readonly cloud = new CloudTarget();
+
+  // Whose code answers: the same declaration the inner target read from the
+  // environment (valid after setup(), like everything else it delegates).
+  get implementation(): ServerImplementation {
+    return this.cloud.implementation;
+  }
 
   private runner: RunningRunner | undefined;
   private mockLlm: MockLlmProxy | undefined;

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -19,13 +19,16 @@ import {
 } from "../harness/direct-login-tenant";
 import { awaitGrpcReady } from "../harness/grpc-ready";
 import { uniqueName, uniqueOrg } from "../support/naming";
-import type {
-  CapabilityFlags,
-  DirectLoginTenant,
-  PrivilegedScope,
-  StripeWebhookLane,
-  TargetProfile,
-  TenancyContext,
+import {
+  isServerImplementation,
+  SERVER_IMPLEMENTATIONS,
+  type CapabilityFlags,
+  type DirectLoginTenant,
+  type PrivilegedScope,
+  type ServerImplementation,
+  type StripeWebhookLane,
+  type TargetProfile,
+  type TenancyContext,
 } from "./target";
 
 const ORG_API_VERSION = "tenancy.stigmer.ai/v1";
@@ -51,8 +54,41 @@ function requireEnv(name: string): string {
   return value;
 }
 
+// The implementation the environment declares behind this target. Required
+// and closed: an unset variable is the same failure as a missing address (a
+// provisioner that forgot to say what it built), and a value outside the
+// union names itself in the refusal so a typo cannot pass as either side.
+export function readCloudImplementation(env: NodeJS.ProcessEnv = process.env): ServerImplementation {
+  const raw = env[CLOUD_ENV.implementation];
+  if (raw === undefined || raw === "") {
+    throw new Error(
+      `${CLOUD_ENV.implementation} is not set: the cloud target is connect-only and cannot tell ` +
+        "which server answers it. The provisioner declares it — " +
+        `${SERVER_IMPLEMENTATIONS.map((value) => `"${value}"`).join(" or ")} (stigmer#1012).`,
+    );
+  }
+  if (!isServerImplementation(raw)) {
+    throw new Error(
+      `${CLOUD_ENV.implementation} must be ${SERVER_IMPLEMENTATIONS.map((value) => `"${value}"`).join(" or ")}; got "${raw}"`,
+    );
+  }
+  return raw;
+}
+
 export class CloudTarget implements TargetProfile {
   readonly name = "cloud";
+
+  // Declared by the environment, read at setup() with the address and token —
+  // the same moment the other connect-only facts arrive. Before setup() the
+  // target has no implementation to report, and says so.
+  private declaredImplementation: ServerImplementation | undefined;
+
+  get implementation(): ServerImplementation {
+    if (this.declaredImplementation === undefined) {
+      throw new Error("CloudTarget.setup() must run before implementation is read");
+    }
+    return this.declaredImplementation;
+  }
   readonly capabilities: CapabilityFlags = {
     multiTenant: true,
     externalOrgLookup: true,
@@ -135,6 +171,7 @@ export class CloudTarget implements TargetProfile {
   directLoginTenant?: () => DirectLoginTenant;
 
   async setup(): Promise<void> {
+    this.declaredImplementation = readCloudImplementation();
     this.grpcBaseUrl = requireEnv(CLOUD_ENV.address);
     const token = requireEnv(CLOUD_ENV.token);
     this.conformanceClients = makeClients(createTransport(this.grpcBaseUrl, { bearerToken: token }));

--- a/test/conformance/src/targets/index.ts
+++ b/test/conformance/src/targets/index.ts
@@ -1,9 +1,12 @@
 // Target selection from the environment.
 // Domain: conformance targets.
 //
-// CONFORMANCE_TARGET selects which implementation the suite runs against,
-// defaulting to the local OSS server. The same suite runs unchanged against
-// any registered target.
+// CONFORMANCE_TARGET selects the TARGET the suite runs against — a deployment
+// shape (spawned locally, with or without an engine; an external cloud
+// endpoint) — defaulting to the local OSS server. The same suite runs
+// unchanged against any registered target. Which server IMPLEMENTATION
+// answers a target is a separate axis (TargetProfile.implementation): fixed
+// for the local targets, declared by the environment for the cloud ones.
 import { CloudTarget } from "./cloud";
 import { CloudExecutionTarget } from "./cloud-execution";
 import { LocalTarget } from "./local";

--- a/test/conformance/src/targets/local-execution.ts
+++ b/test/conformance/src/targets/local-execution.ts
@@ -18,10 +18,18 @@ import { spawnServer, type RunningServer } from "../harness/server-process";
 import { spawnTemporal, type RunningTemporal } from "../harness/temporal";
 import { ensureTsServerEntry } from "../harness/ts-build";
 import { uniqueOrg } from "../support/naming";
-import type { CapabilityFlags, PrivilegedScope, TargetProfile, TenancyContext } from "./target";
+import type {
+  CapabilityFlags,
+  PrivilegedScope,
+  ServerImplementation,
+  TargetProfile,
+  TenancyContext,
+} from "./target";
 
 export class LocalExecutionTarget implements TargetProfile {
   readonly name: string = "local-execution";
+  // The spawned TypeScript server (see LocalTarget).
+  readonly implementation: ServerImplementation = "stigmer-server";
   // The retired local-go-execution matrix plus exactly ONE deliberate
   // difference: workflowChildApprovalForwarding is true here (the D4
   // ratified parity-plus delta, #23) where the Go server never sent it.

--- a/test/conformance/src/targets/local.ts
+++ b/test/conformance/src/targets/local.ts
@@ -12,10 +12,19 @@ import { createTransport, makeClients, type ConformanceClients } from "../harnes
 import { awaitGrpcReady } from "../harness/grpc-ready";
 import { spawnServer, type RunningServer } from "../harness/server-process";
 import { uniqueOrg } from "../support/naming";
-import type { CapabilityFlags, PrivilegedScope, TargetProfile, TenancyContext } from "./target";
+import type {
+  CapabilityFlags,
+  PrivilegedScope,
+  ServerImplementation,
+  TargetProfile,
+  TenancyContext,
+} from "./target";
 
 export class LocalTarget implements TargetProfile {
   readonly name: string = "local";
+  // The spawned TypeScript server — every local target, Postgres or SQLite,
+  // engine or not, is this implementation by construction.
+  readonly implementation: ServerImplementation = "stigmer-server";
   // The retired Go server's exact matrix — the parity promise the TS port
   // was gated on (D4). The one deliberate divergence, workflowChild-
   // ApprovalForwarding, lives on local-execution (#23).

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -361,8 +361,36 @@ export interface PrivilegedScope {
   cleanup(): Promise<void>;
 }
 
+// The server binary answering a target — a different axis from the target's
+// NAME. A name describes a deployment shape (spawned locally, an external
+// cloud endpoint, with or without an engine); the implementation says whose
+// code is on the other end. The two are not one-to-one: every local target is
+// the TypeScript server, but the `cloud` targets are connect-only and serve
+// whichever implementation the environment's provisioner booted — the Java
+// stigmer-service under the hermetic launcher, the TypeScript stigmer-server
+// under the composition readout. A known bug belongs to an implementation, so
+// the deviation registry (contract/deviations.ts) keys on this and never on
+// the name. "stigmer-service" retires with the Java service at R1, together
+// with every registry entry naming it.
+export type ServerImplementation = "stigmer-server" | "stigmer-service";
+
+export const SERVER_IMPLEMENTATIONS: readonly ServerImplementation[] = ["stigmer-server", "stigmer-service"];
+
+export function isServerImplementation(value: string): value is ServerImplementation {
+  return (SERVER_IMPLEMENTATIONS as readonly string[]).includes(value);
+}
+
+// What a helper needs to classify a target: its name (for the human-readable
+// report line) and its implementation (for the decision). Narrow on purpose so
+// pure unit arms can hand over a two-field literal instead of a live target.
+export type TargetIdentity = Pick<TargetProfile, "name" | "implementation">;
+
 export interface TargetProfile {
   readonly name: string;
+  // Whose code answers this target — see ServerImplementation. Fixed on the
+  // local targets; on the cloud targets declared by the environment
+  // (CLOUD_ENV.implementation, REQUIRED) and valid only after setup().
+  readonly implementation: ServerImplementation;
   readonly capabilities: CapabilityFlags;
 
   // Bring the target to a state where clients() can be used. For managed

--- a/test/conformance/vitest.unit.config.ts
+++ b/test/conformance/vitest.unit.config.ts
@@ -1,6 +1,7 @@
 // Vitest configuration for the harness's PURE unit arms: the inventory
 // library, the cloud-capability fixtures, the child-process discipline, the
-// deviation registry's helpers and the submit-approval seam.
+// deviation registry's helpers, the submit-approval seam and the targets'
+// implementation declaration.
 //
 // Deliberately separate from the suite configs: those boot a target in
 // globalSetup (the TS server build, or the hermetic cloud environment), and
@@ -17,6 +18,7 @@ export default defineConfig({
       "src/harness/__tests__/**/*.test.ts",
       "src/contract/__tests__/**/*.test.ts",
       "src/support/__tests__/**/*.test.ts",
+      "src/targets/__tests__/**/*.test.ts",
     ],
   },
 });


### PR DESCRIPTION
## Summary

The known-deviation registry (`src/contract/deviations.ts`, stigmer#1001) named **targets** — `cloud`, `cloud-execution`. The cloud targets are connect-only and serve whichever implementation the environment booted: the Java `stigmer-service` under the hermetic launcher, the TypeScript composition under the readout recipe. Keyed on names, Java's three deterministic quirks were asserted against the composition, whose contract-correct answers then failed — the three Class A reds of the C5 close readout (566/3/37). The authz suite already said the quiet part: "both cloud editions serve behind the same `cloud` target type, so the suite cannot tell them apart by target name."

- **`TargetProfile.implementation: "stigmer-server" | "stigmer-service"`** (`targets/target.ts`, with `TargetIdentity = Pick<TargetProfile, "name" | "implementation">`). A target NAME is a deployment shape; the implementation is whose code answers. The local targets are `stigmer-server` by construction; `CloudExecutionTarget` delegates to its inner `CloudTarget`.
- **`STIGMER_CONFORMANCE_CLOUD_IMPLEMENTATION`** joins `CLOUD_ENV`, **required and closed** on the cloud targets (read at `setup()` beside the address and token) — the "never false-greens" rule `cloud-env.ts` already states for every lane address. No default: an environment that forgets it is refused by name; a value outside the union names the offender. The hermetic global setup publishes `stigmer-service` (it boots the JAR — it knows). The composition's `readout-bootstrap.ts` publishes `stigmer-server` in the stigmer-cloud follow-up.
- **The ledger keys on `implementations`**; the five entries name `stigmer-service`; the execution-only reachability of the two race entries stays in their `rationale`. Both helpers take the `TargetIdentity` instead of a bare string (a caller cannot pass the wrong thing); the seven call sites hand over `target`. Report lines keep their grep-able `tracked deviation <id> on <target>` / `tracked race …` prefix and append `(<implementation>)`.
- `targets/index.ts`'s header stops calling a target "an implementation" — one meaning for the word in the package. `contract/` gains its first (type-only) import from `targets/`; the header says why that direction and not the reverse.
- README: the CLOUD_ENV block and the spec-first section describe the axis.
- **CI**: `ci.conformance.yaml` now runs `npm run test:unit -w @stigmer/conformance` beside `inventory:check` — the harness's pure unit arms ran only under `make check-conformance-inventory` locally, never in CI (pre-existing; the arms below would otherwise gate nothing).

No server code changes. `ci.conformance-cloud` (hermetic Java) must read the same numbers and the same tracked-deviation lines as `main`.

## Test plan

- [x] Unit arms (`npm run test:unit`): 75/75 — the composition behind the `cloud` / `cloud-execution` NAME runs the contract and never opens a race path; Java still takes the observed path and reports `on cloud (stigmer-service)`; a Java that meets the contract fails `observed` (the entry cannot outlive the bug); the reader refuses unset and out-of-union values by name; every registry entry names a known implementation; the local targets report `stigmer-server`; the cloud targets refuse to report before `setup()`.
- [x] `tsc --noEmit` clean — the compiler is what found every call site.
- [x] `inventory:check`: 152 rows, 0 problems.
- [x] Local Class A: **507 / 0 / 95 on 602**, byte-identical to `main`.
- [ ] `ci.conformance-cloud` on this PR: hermetic Java Class A and Class B at `main`'s numbers, with the tracked-deviation lines now reading `on cloud (stigmer-service)`.
- [ ] Composition (stigmer-cloud follow-up, the readout recipe with the submodule at this squash): the three arms green; with this change reverted, exactly the three S5 reds reproduce.

Closes #1012

Made with [Cursor](https://cursor.com)