### PR TITLE
refactor(test/conformance): derive the billing-denial and direct-handler-authz contracts from the target's implementation

### DIFF
--- a/test/conformance/src/suites-execution/billing-denial.conformance.test.ts
+++ b/test/conformance/src/suites-execution/billing-denial.conformance.test.ts
@@ -17,13 +17,14 @@
 //   engine's denial_reason verbatim (blueprint §7 "strictly earlier than the
 //   Java refusal"; the C1 NOT_FOUND-arm disposition precedent).
 //
-// Because both editions serve behind the same `cloud` target type, the suite
-// cannot tell them apart by target name. The arm is declared explicitly via
-// STIGMER_CONFORMANCE_BILLING_DENIAL_CONTRACT ("async" | "sync", default
-// "async" — the Java baseline, so the nightly hermetic lane runs unchanged;
-// composition readouts set "sync"). Each arm is enforced strictly: a
-// composition regressing to the async shape, or Java changing its failure
-// bytes, turns this suite red.
+// Which arm applies is a fact about the IMPLEMENTATION behind the target
+// (TargetProfile.implementation — the Java stigmer-service answers async, the
+// TypeScript stigmer-server sync), so the suite derives it from the target
+// the environment declared rather than from a knob of its own (stigmer#1012;
+// the knob this replaced, STIGMER_CONFORMANCE_BILLING_DENIAL_CONTRACT, was
+// the second copy of "which server is behind `cloud`"). Each arm is enforced
+// strictly: a composition regressing to the async shape, or Java changing its
+// failure bytes, turns this suite red.
 //
 // Precondition: an org whose billing account exists AT THE ZERO BALANCE an
 // org create provisions (GetOrCreateBillingAccountHandler creates accounts
@@ -51,6 +52,7 @@ import {
 } from "../support/agentexecutions";
 import { uniqueName } from "../support/naming";
 import { createTarget, type TargetProfile, type TenancyContext } from "../targets";
+import type { ServerImplementation } from "../targets/target";
 
 // Collection-time capability read (the schedule-firing/forwarder pattern).
 const billingEnabled = createTarget().capabilities.billingGates;
@@ -61,17 +63,20 @@ const ENGINE_DENIAL_REASON = "Insufficient credits to start execution";
 const ASYNC_FAILURE_ERROR = `Insufficient credits: ${ENGINE_DENIAL_REASON}`;
 const ASYNC_FAILURE_MESSAGE = `Execution could not start: ${ENGINE_DENIAL_REASON}`;
 
-const DENIAL_CONTRACT_ENV = "STIGMER_CONFORMANCE_BILLING_DENIAL_CONTRACT";
 type DenialContract = "async" | "sync";
 
-function resolveDenialContract(): DenialContract {
-  const raw = process.env[DENIAL_CONTRACT_ENV] ?? "async";
-  if (raw !== "async" && raw !== "sync") {
-    throw new Error(
-      `${DENIAL_CONTRACT_ENV} must be "async" or "sync" when set; got "${raw}"`,
-    );
+// The ruled denial shape per implementation — see the header.
+function denialContractOf(implementation: ServerImplementation): DenialContract {
+  switch (implementation) {
+    case "stigmer-service":
+      return "async";
+    case "stigmer-server":
+      return "sync";
+    default: {
+      const exhaustive: never = implementation;
+      throw new Error(`unhandled server implementation ${String(exhaustive)}`);
+    }
   }
-  return raw;
 }
 
 let target: TargetProfile;
@@ -122,7 +127,7 @@ describe.skipIf(!billingEnabled)(
     it("[billing.gate.reserve.unfunded-execution-denied-with-ruled-contract] a zero-credit org's execution lands the ruled denial for this edition", async () => {
       const { org } = await provisionUnfunded();
       const agentId = await provisionAgent(org);
-      const contract = resolveDenialContract();
+      const contract = denialContractOf(target.implementation);
 
       if (contract === "sync") {
         // The composition's create-time reserve gate: the RPC itself refuses,

--- a/test/conformance/src/suites/direct-handler-authorization.conformance.test.ts
+++ b/test/conformance/src/suites/direct-handler-authorization.conformance.test.ts
@@ -17,10 +17,9 @@
 //     connect trio) keeps its handler-owned NotFound copy for unknown
 //     ids, outsider or not — the load fires before the check (#224).
 //
-// Both cloud editions serve behind the same `cloud` target type, so the
-// suite cannot tell them apart by target name — and three arms below pin
-// behavior on which the editions DIVERGE by ruling, not by drift (the
-// per-method dispositions in docs/authorization-coverage.md):
+// Three arms below pin behavior on which the two cloud implementations
+// DIVERGE by ruling, not by drift (the per-method dispositions in
+// docs/authorization-coverage.md):
 //
 //   - workflow getVersion: this server evaluates the annotation; the Java
 //     edition declares it but never evaluates it (stigmer-cloud#562,
@@ -33,13 +32,15 @@
 //     NOT_FOUND vs the Java edition's PERMISSION_DENIED — an artifact of
 //     its missing load steps, ruled at the Stage-4 gate.
 //
-// The contract under test is declared explicitly via
-// STIGMER_CONFORMANCE_DIRECT_HANDLER_AUTHZ_CONTRACT ("java-baseline" |
-// "annotation-enforced", default "java-baseline" — the nightly hermetic
-// Java lane runs unchanged; composition readouts set "annotation-enforced").
-// The STIGMER_CONFORMANCE_BILLING_DENIAL_CONTRACT precedent: each arm is
-// enforced strictly, so a composition regressing to a Java gap, or Java
-// changing its bytes, turns this suite red.
+// The contract under test is a fact about the IMPLEMENTATION behind the
+// target (TargetProfile.implementation: the Java stigmer-service is the
+// java-baseline, the TypeScript stigmer-server is annotation-enforced), so the
+// suite derives it from the target the environment declared rather than from
+// a knob of its own (stigmer#1012; the knob this replaced,
+// STIGMER_CONFORMANCE_DIRECT_HANDLER_AUTHZ_CONTRACT, was another copy of
+// "which server is behind `cloud`"). Each arm is enforced strictly, so a
+// composition regressing to a Java gap, or Java changing its bytes, turns
+// this suite red.
 //
 // Single-user targets skip: one implicit caller, isolation untestable by
 // construction (the organization suite's outsider precedent).
@@ -57,21 +58,28 @@ import { makeMcpServer } from "../support/mcpservers";
 import { makeSession } from "../support/sessions";
 import { makeWorkflow } from "../support/workflows";
 import { uniqueName } from "../support/naming";
+import type { ServerImplementation } from "../targets/target";
 
-const AUTHZ_CONTRACT_ENV = "STIGMER_CONFORMANCE_DIRECT_HANDLER_AUTHZ_CONTRACT";
 type AuthzContract = "java-baseline" | "annotation-enforced";
 
-function resolveAuthzContract(): AuthzContract {
-  const raw = process.env[AUTHZ_CONTRACT_ENV] ?? "java-baseline";
-  if (raw !== "java-baseline" && raw !== "annotation-enforced") {
-    throw new Error(
-      `${AUTHZ_CONTRACT_ENV} must be "java-baseline" or "annotation-enforced" when set; got "${raw}"`,
-    );
+// The ruled authorization posture per implementation — see the header.
+function authzContractOf(implementation: ServerImplementation): AuthzContract {
+  switch (implementation) {
+    case "stigmer-service":
+      return "java-baseline";
+    case "stigmer-server":
+      return "annotation-enforced";
+    default: {
+      const exhaustive: never = implementation;
+      throw new Error(`unhandled server implementation ${String(exhaustive)}`);
+    }
   }
-  return raw;
 }
 
-const authzContract = resolveAuthzContract();
+// Valid inside an arm: the target is set up in beforeAll.
+function authzContract(): AuthzContract {
+  return authzContractOf(target.implementation);
+}
 
 let target: TargetProfile;
 let clients: ConformanceClients;
@@ -152,7 +160,7 @@ describe("direct-handler authorization — outsider denials (multi-tenant only)"
     // recorded gap, not a contract — so under the Java baseline there is
     // nothing to pin, and asserting the permissive answer would turn the
     // gap into one. The arm resumes for Java the day #562 closes at the flip.
-    if (authzContract === "java-baseline") return ctx.skip();
+    if (authzContract() === "java-baseline") return ctx.skip();
     const { org } = await target.provisionTenancy();
     const outsider = await outsiderClients();
 
@@ -228,7 +236,7 @@ describe("direct-handler authorization — outsider denials (multi-tenant only)"
     // precondition — its copy pinned so a reorder on either side shows.
     const initiate = () =>
       outsider.mcpServerCommand.initiateOAuthConnect({ mcpServerId: id, org });
-    if (authzContract === "annotation-enforced") {
+    if (authzContract() === "annotation-enforced") {
       const denied = await expectGrpcCode(
         initiate,
         Code.PermissionDenied,
@@ -363,7 +371,7 @@ describe("direct-handler authorization — outsider denials (multi-tenant only)"
     for (const [lane, op] of lanes) {
       observed[lane] = Code[await grpcCodeOf(op, `outsider ${lane} on an unknown execution`)];
     }
-    const expectedCode = authzContract === "annotation-enforced" ? "NotFound" : "PermissionDenied";
+    const expectedCode = authzContract() === "annotation-enforced" ? "NotFound" : "PermissionDenied";
     expect(observed).toEqual(
       Object.fromEntries(lanes.map(([lane]) => [lane, expectedCode])),
     );

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -200,8 +200,8 @@ export interface CapabilityFlags {
   // authorized inside InvokeAgentExecutionWorkflow), and the TS composition
   // through the C5 billing facade (the create-time reserve gate, ruling Q5 of
   // 20260830.02.sp.billing-facade). WHERE the denial lands differs by ruled
-  // design — see STIGMER_CONFORMANCE_BILLING_DENIAL_CONTRACT in the
-  // billing-denial suite.
+  // design per implementation — see denialContractOf in the billing-denial
+  // suite, keyed on TargetProfile.implementation.
   //
   // False for the local OSS targets — BY DD-001 BOUNDARY, not a gap: OSS has
   // no billing engine, no credit accounting, and no billing gates; every


### PR DESCRIPTION
## Summary

Stacked on #1013 (retarget to `main` after its squash). Two suites carried their own env knob for the fact #1013 puts on the target — `STIGMER_CONFORMANCE_BILLING_DENIAL_CONTRACT` (`async|sync`) and `STIGMER_CONFORMANCE_DIRECT_HANDLER_AUTHZ_CONTRACT` (`java-baseline|annotation-enforced`) — each a suite-local `process.env` read with its own validator and a Java-shaped default, each existing, in its own words, because "the suite cannot tell the editions apart by target name". It can now.

- Each suite maps `target.implementation` to its ruled contract with an exhaustive `switch` (`stigmer-service` → `async` / `java-baseline`; `stigmer-server` → `sync` / `annotation-enforced`) and reads it inside the arm, after `setup()`.
- The two knobs and their validators are deleted; the headers describe the axis instead of the knob; `target.ts`'s `billingGates` comment points at the derivation.
- The stigmer-cloud readout recipe loses two `export` lines (its follow-up PR).

No behavior change on either implementation: the nightly hermetic-Java lane reads exactly what the defaults gave it; the composition readout reads exactly what the two exports gave it.

## Test plan

- [x] `tsc --noEmit` clean; unit arms 75/75.
- [x] Composition on the spike (readout recipe, **no** contract exports set): `direct-handler-authorization` 5 / 0 / 0, `billing-denial` 2 / 0 / 0 — the same numbers the S5 readout read with the exports.
- [ ] `ci.conformance-cloud` on this PR: hermetic Java Class A 568 / 0 / 38 and Class B 160 / 0 / 1, unchanged.

Refs #1012

Made with [Cursor](https://cursor.com)