### PR TITLE
test(test/conformance): inventory gains the platform metric surface and the alert links the SigNoz roster reads

### DIFF
--- a/test/conformance/inventory/cloud-capabilities.yaml
+++ b/test/conformance/inventory/cloud-capabilities.yaml
@@ -2542,19 +2542,29 @@ metrics:
     surface: proxy
     java_source: proxy/llm/PlatformProviderErrorMetrics.java
     disposition: ported
-    alerts: [platform-provider-errors-log]
+    alerts: [platform-provider-errors, platform-provider-errors-log]
     note: >-
-      The alert is log-based on the phrase "platform provider key rejected upstream"; the composition logs the same phrase at ERROR on the same event.
+      Two rules read this event: the metric rule on the counter and a logs rule on the phrase "platform provider key rejected upstream"; the composition logs the same phrase at ERROR on the same event.
   - name: stigmer.http.request.duration
-    surface: proxy
+    surface: platform
     java_source: config/observability/HttpRequestMetricsFilter.java
     disposition: ported
     note: >-
-      Recorded once by the composition's cloud ingress listener for every route it serves (proxy, webhooks), with the same labels: http.request.method, http.route (first two path segments), http.response.status_code.
+      Java's servlet filter saw every HTTP route. The contract for the composition is the same: the pair recorded once per request by each HTTP lane's dispatcher — the cloud ingress (proxy and webhook mounts) and the public lane — with the same labels: http.request.method, http.route (first two path segments), http.response.status_code. stigmer-cloud entry 20260909.01 lands that; before it only the proxy dispatcher recorded (this row's earlier note claimed the ingress did — the 2026-09-09 census found the /webhook series absent).
   - name: stigmer.http.request.count
-    surface: proxy
+    surface: platform
     java_source: config/observability/HttpRequestMetricsFilter.java
     disposition: ported
+    alerts: [webhook-silence-24h]
+    note: >-
+      The webhook silence rule is a threshold on this counter's rate under http_route contains /webhook, so the /webhook route series must exist from boot (born at zero) or the rule never fires — a money-path watch (Stripe rides /webhook/stripe).
+  - name: stigmer.encryption.cleanup.failures
+    surface: platform
+    java_source: domain/commons/secrets/SecretValueCleanup.java
+    disposition: ported
+    alerts: [encryption-cleanup-failures]
+    note: >-
+      Secret backing-state destructions that failed after the DB write succeeded (orphaned KV entries); pre-registered at zero on boot in both editions so the first orphan after a pod start is visible to the alert.
   - name: stigmer.proxy.cursor.execution_authority_lookups
     surface: proxy
     java_source: proxy/cursor/keyselection/CompositionAuthorityExecutionContextSource.java

--- a/test/conformance/src/inventory/inventory.ts
+++ b/test/conformance/src/inventory/inventory.ts
@@ -103,10 +103,18 @@ export type InventoryRow = z.infer<typeof rowSchema>;
 // mechanism retires with Java — the note says which). `alerts` names the
 // SigNoz alert files that read the series, so "re-pointed before X1" is a
 // list, not a sentence. One inventory mechanism for the program, not two.
+//
+// `platform` (2026-09-09, the alert-roster reconciliation, stigmer-cloud
+// entry 20260909.01) is the surface for Java metrics that belong to no lane
+// — the HTTP edge filter, the secret-cleanup counter — whose alert rules
+// read them all the same. stigmer-cloud's `check-x1-parity-dispositions.sh`
+// reads this list at the submodule pin and refuses an alert re-point that
+// cites a row which is not `ported` or does not name the alert back, so a
+// metric the roster watches needs a row here whatever its lane.
 const metricRowSchema = z
   .object({
     name: z.string().regex(/^stigmer\.[a-z0-9_.]+$/, "a Java stigmer.* metric name, byte-exact"),
-    surface: z.enum(["billing", "proxy"]),
+    surface: z.enum(["billing", "proxy", "platform"]),
     java_source: z.string().min(1),
     disposition: z.enum(["ported", "dropped"]),
     alerts: z.array(z.string().min(1)).optional(),


### PR DESCRIPTION
## Summary

The conformance inventory's `metrics:` section gains a `platform` surface and the alert links the SigNoz roster actually reads. Test-only; no runtime code changes.

## Context

stigmer-cloud entry `20260909.01.sp.alert-roster-reconciliation` (the X1 alert-roster reconciliation, checklist line 81) gives every SigNoz rule a lint-checked disposition. Its guard reads THIS inventory at the submodule pin and refuses a `repoint` whose cited row is not `ported` or does not name the alert back — the inventory declares, the cloud guard proves. Reading the 55-rule roster against the inventory found:

- `stigmer.http.request.duration`'s note claimed the composition's ingress recorded the pair for proxy and webhooks. In code only the proxy dispatcher did; the 2026-09-09 read-only census found no `/webhook` series under `stigmer-server`. `webhook-silence-24h` (the Stripe lane's silence watch) had no series to watch and no row naming it.
- `stigmer.encryption.cleanup.failures` had no row although `encryption-cleanup-failures` reads it.
- `stigmer.proxy.llm.platform_provider_errors` listed the logs rule but not the metric rule `platform-provider-errors`.

## Changes

- `src/inventory/inventory.ts`: `metricRowSchema.surface` gains `platform` — Java metrics that belong to no lane (the HTTP edge filter, the secret-cleanup counter) whose alert rules read them all the same. Header comment says why and who reads the list.
- `inventory/cloud-capabilities.yaml`: the two `stigmer.http.request.*` rows move to `platform`; the duration note states the contract and that stigmer-cloud `20260909.01` lands it (the earlier claim is corrected in place); the count row gains `alerts: [webhook-silence-24h]`; a new `stigmer.encryption.cleanup.failures` row on `platform`; `platform-provider-errors` added to the llm platform-provider-errors row's `alerts:`.

## Test plan

- `npm run inventory:check`: 152 rows, 0 problems; metrics 38 (35 ported, 3 dropped)
- `tsc --noEmit` clean; `src/inventory` unit suite 15/15
- The consuming guard (stigmer-cloud, same entry) goes from two reds to green on this pin — that PR bumps the submodule to this squash

## Risks

None at runtime. A `platform` row that a future entry cites must still be `ported` and name its alerts; the cloud guard enforces both directions.

Made with [Cursor](https://cursor.com)