### PR TITLE
feat(stigmer-server): emit Java's gRPC RED metrics from the serving chain

### DIFF
--- a/backend/services/stigmer-server/package-lock.json
+++ b/backend/services/stigmer-server/package-lock.json
@@ -16,6 +16,7 @@
         "@connectrpc/connect": "^2.0.0",
         "@connectrpc/connect-node": "^2.0.0",
         "@kubernetes/client-node": "2.0.0",
+        "@opentelemetry/api": "^1.9.0",
         "@stigmer/protos": "file:../../../apis/stubs/ts",
         "@stigmer/temporal-codecs": "file:../../libs/ts/temporal-codecs",
         "@stigmer/zip-structure": "file:../../libs/ts/zip-structure",
@@ -33,6 +34,7 @@
       },
       "devDependencies": {
         "@connectrpc/connect-web": "^2.0.0",
+        "@opentelemetry/sdk-metrics": "^2.0.0",
         "@temporalio/testing": "1.16.2",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "22.20.1",
@@ -1525,6 +1527,75 @@
       ],
       "engines": {
         "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.11.0.tgz",
+      "integrity": "sha512-7YP44XH0tV6+Mb54x2YGf84i7yi+31MBZlE8JwvozkxyTvXbSp10X7cI7YE49ChJ3shMJoBmCJF3+1QFBJctGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.11.0.tgz",
+      "integrity": "sha512-Ie7+8q8MDF4FAEQCKVMTx3ReUvxiIAgIiiW3c9JdmP8+HMcDy20puT+AHjexnExgnbvBxjQ9fjkFDWrikJ2jQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.11.0.tgz",
+      "integrity": "sha512-7GXXcObyHyDUUSG+L+kJoquty01bzm7ivE7+SSgXXJcHuPzGviptxwARmI2c+bnnxjexGQbJnyNlN8HxBP/Y7A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.11.0",
+        "@opentelemetry/resources": "2.11.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@protobufjs/aspromise": {

--- a/backend/services/stigmer-server/package.json
+++ b/backend/services/stigmer-server/package.json
@@ -40,6 +40,7 @@
     "@connectrpc/connect": "^2.0.0",
     "@connectrpc/connect-node": "^2.0.0",
     "@kubernetes/client-node": "2.0.0",
+    "@opentelemetry/api": "^1.9.0",
     "@stigmer/protos": "file:../../../apis/stubs/ts",
     "@stigmer/temporal-codecs": "file:../../libs/ts/temporal-codecs",
     "@stigmer/zip-structure": "file:../../libs/ts/zip-structure",
@@ -57,6 +58,7 @@
   },
   "devDependencies": {
     "@connectrpc/connect-web": "^2.0.0",
+    "@opentelemetry/sdk-metrics": "^2.0.0",
     "@temporalio/testing": "1.16.2",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "22.20.1",

--- a/backend/services/stigmer-server/src/boot/compose.ts
+++ b/backend/services/stigmer-server/src/boot/compose.ts
@@ -111,9 +111,14 @@ import { registerSearchServices } from "../query/search/controller.js";
 import { SearchHandler } from "../query/search/handler.js";
 import { SqliteSearchQueryStore } from "../query/search/query-store.js";
 import { newSearchableResourceRegistry } from "../query/search/registry.js";
+import {
+  initRpcMetrics,
+  metricsExportPosture,
+} from "../observability/rpc-metrics.js";
 import { buildInterceptorChain } from "../pipeline/chain.js";
 import { createVerifierChainInterceptor } from "../pipeline/interceptors/auth.js";
 import { createErrorBoundaryInterceptor } from "../pipeline/interceptors/error-boundary.js";
+import { createRequestMetricsInterceptor } from "../pipeline/interceptors/request-metrics.js";
 import { newPermissiveSingleTeamAuthorizer } from "../pipeline/steps/authorize.js";
 import { newExecutionScopedRunnerCredentialProvider } from "../runnerauth/runner-credential-provider.js";
 import { RunnerAuthService } from "../runnerauth/runnerauth.js";
@@ -1160,10 +1165,12 @@ export async function composeServer(
     // transport above carries its own
     // position-1 source — the internal caller class only it can mint
     // (ruling Q4), and NO guards: the in-process exemption is structural
-    // (caller-guards.ts). Position 0 is the error boundary (20260830.03):
-    // the raw-error conversion net plus the composed visitor sanitizer —
-    // SERVING chain only, so in-process hops keep full diagnostics by
-    // construction.
+    // (caller-guards.ts). The serving-only pair: position 0 is the error
+    // boundary (20260830.03) — the raw-error conversion net plus the
+    // composed visitor sanitizer — and the request-metrics emitter sits
+    // just inside the identity source (20260909.02, Java's position). Both
+    // are SERVING chain only, so in-process hops keep full diagnostics
+    // and are never counted as requests, by construction.
     interceptors: buildInterceptorChain(
       logger,
       createVerifierChainInterceptor(
@@ -1172,10 +1179,13 @@ export async function composeServer(
         logger,
         requireAuthentication,
       ),
-      createErrorBoundaryInterceptor(
-        logger,
-        extensions.drivers.visitorErrorPolicy,
-      ),
+      {
+        errorBoundary: createErrorBoundaryInterceptor(
+          logger,
+          extensions.drivers.visitorErrorPolicy,
+        ),
+        requestMetrics: createRequestMetricsInterceptor(),
+      },
     ),
     taskKindRegistryLane: registryLanes.taskKindRegistryLane,
     modelRegistryLane: registryLanes.modelRegistryLane,
@@ -1227,6 +1237,19 @@ export async function composeServer(
           error: error instanceof Error ? error.message : String(error),
         });
       }
+      // The request counter is born at zero before the port binds (Java's
+      // constructor add(0); the heartbeat's premise), and the boot says
+      // whether anything will export it: the emitter is library
+      // instrumentation on @opentelemetry/api, so "exporting" is the
+      // host's meter provider (the cloud composition's bootstrap) and
+      // "inert" is the OSS default until an export bootstrap exists —
+      // two states an operator must be able to tell apart in the log.
+      await initRpcMetrics();
+      logger.info("request metrics", {
+        posture: await metricsExportPosture(),
+        instruments:
+          "stigmer.grpc.request.count, stigmer.grpc.request.duration",
+      });
       // Wiring complete → SERVING → background refresh → bind. The port
       // must be the LAST observable effect (serverGate contract).
       healthState.setOverall(ServingStatus.SERVING);

--- a/backend/services/stigmer-server/src/observability/__tests__/in-memory-meter.ts
+++ b/backend/services/stigmer-server/src/observability/__tests__/in-memory-meter.ts
@@ -1,0 +1,101 @@
+/**
+ * A REAL OTel MeterProvider backed by an in-memory exporter, for suites
+ * that pin an instrument registry's names, label vocabulary and zero
+ * baselines — what the SigNoz rules key on. The registries are lazy and
+ * memoized on the GLOBAL meter provider (rpc-metrics.ts), so the helper
+ * installs the provider globally and takes the registry's reset seam to
+ * clear the memo before and after; a registry created against an earlier
+ * provider would otherwise keep recording into it.
+ *
+ * Collection is manual (`collect()` forces a flush) and the export interval
+ * is set far out so nothing races the test. Recorders are fire-and-forget
+ * over a dynamic import; callers poll `collect()` with a deadline (`until`)
+ * rather than sleeping — the determinism rule.
+ *
+ * The cloud composition's `src/observability/__tests__/in-memory-meter.ts`
+ * (stigmer-cloud `694b6a57e`) is this file's source; the two registries it
+ * serves there and the one here share the idiom on purpose.
+ */
+
+export interface CollectedPoint {
+  readonly value: unknown;
+  readonly attributes: Record<string, unknown>;
+}
+
+/** Metric name → its data points at the last collection. */
+export type CollectedMetrics = Map<string, CollectedPoint[]>;
+
+export interface InMemoryMeter {
+  /** Flushes the provider and returns every exported metric by name. */
+  collect(): Promise<CollectedMetrics>;
+  /** Shuts the provider down, disables the global API and clears the registry memo. */
+  dispose(): Promise<void>;
+}
+
+/**
+ * @param resetInstruments the registry's test seam (`resetRpcInstruments`),
+ *   invoked after the provider is installed and again on dispose so no
+ *   memoized meter outlives this provider.
+ */
+export async function inMemoryMeter(
+  resetInstruments: () => void,
+): Promise<InMemoryMeter> {
+  const {
+    AggregationTemporality,
+    InMemoryMetricExporter,
+    MeterProvider,
+    PeriodicExportingMetricReader,
+  } = await import("@opentelemetry/sdk-metrics");
+  const api = await import("@opentelemetry/api");
+  const exporter = new InMemoryMetricExporter(
+    AggregationTemporality.CUMULATIVE,
+  );
+  const reader = new PeriodicExportingMetricReader({
+    exporter,
+    // Effectively manual: collection happens on forceFlush in collect().
+    exportIntervalMillis: 3_600_000,
+  });
+  const provider = new MeterProvider({ readers: [reader] });
+  api.metrics.setGlobalMeterProvider(provider);
+  resetInstruments();
+  return {
+    async collect() {
+      await provider.forceFlush();
+      const byName: CollectedMetrics = new Map();
+      for (const resource of exporter.getMetrics()) {
+        for (const scope of resource.scopeMetrics) {
+          for (const metric of scope.metrics) {
+            byName.set(
+              metric.descriptor.name,
+              metric.dataPoints.map((point) => ({
+                value: point.value,
+                attributes: point.attributes,
+              })),
+            );
+          }
+        }
+      }
+      return byName;
+    },
+    async dispose() {
+      await provider.shutdown();
+      api.metrics.disable();
+      resetInstruments();
+    },
+  };
+}
+
+/** Polls collect() until the predicate holds or the deadline (5 s) passes; returns the last collection either way. */
+export async function until<T>(
+  collect: () => Promise<T>,
+  ready: (collected: T) => boolean,
+): Promise<T> {
+  const deadline = Date.now() + 5_000;
+  for (;;) {
+    const collected = await collect();
+    if (ready(collected) || Date.now() > deadline) {
+      return collected;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}

--- a/backend/services/stigmer-server/src/observability/rpc-metrics.ts
+++ b/backend/services/stigmer-server/src/observability/rpc-metrics.ts
@@ -1,0 +1,203 @@
+/**
+ * The gRPC request metrics the serving chain records — Java's
+ * `stigmer.grpc.request.count` and `stigmer.grpc.request.duration`
+ * (`GrpcRequestMetricsInterceptor`, cloud `backend/libs/java/grpc/
+ * grpc-request`), names and labels verbatim: `rpc.service` (the
+ * fully-qualified service name), `rpc.method` (the bare method name) and
+ * `rpc.grpc.status_code` (the gRPC status NAME — `OK`, `NOT_FOUND`,
+ * `CANCELLED` with two Ls — never Connect's PascalCase enum key, which the
+ * SigNoz rules would not match). Three consumers read the pair under the
+ * dotted-to-underscored spelling: `telemetry-heartbeat-lost` (the absence
+ * of the count series for ten minutes), `grpc-error-rate-spike` (the
+ * share of `status_code != OK`) and `grpc-latency-regression-p95` (the
+ * duration histogram's buckets), plus the `gRPC RED` dashboard grouped by
+ * every label. Convergence entry 20260909.02.
+ *
+ * This module is library instrumentation, on `@opentelemetry/api` alone:
+ * instruments are created lazily on first use against the GLOBAL meter
+ * provider and are no-ops until a host registers one, so every call site
+ * records unconditionally (the OSS runner's otel-metrics.ts shape; the
+ * cloud composition's registries are its siblings). Lazy creation is what
+ * makes the host's boot order irrelevant — the API has no proxy meter
+ * provider, so an instrument created before registration would stay a
+ * no-op forever. Two facts a host must know:
+ *
+ *   - The counter is BORN AT ZERO by `initRpcMetrics` (Java's constructor
+ *     `add(0)`, the heartbeat's premise, cloud#255): an attribute-less
+ *     series exists from the first post-boot export, so the absence rule's
+ *     ten-minute window measures the export pipeline, not an RPC-free lull
+ *     after a restart. The histogram is deliberately NOT pre-registered —
+ *     a `record(0)` is a real sample that would pollute the percentiles,
+ *     and no rule watches its absence.
+ *   - A host that installs this package from its own `node_modules` runs a
+ *     second copy of `@opentelemetry/api`. The two share one global only
+ *     while this copy's minor version does not exceed the registering
+ *     copy's (`isCompatible`, `internal/semver.ts`); a lockfile bump here
+ *     ahead of the host's makes these instruments silently inert. The
+ *     cloud composition pins the same `^1.9.0` and proves the sharing with
+ *     a composed test on every pin.
+ *
+ * `metricsExportPosture` lets the boot say which of the two states it is
+ * in, so "nothing exported" and "nothing instrumented" stay
+ * distinguishable in the log (the guidelines' explicit-optional-
+ * infrastructure rule).
+ */
+import { Code } from "@connectrpc/connect";
+import type { Counter, Histogram } from "@opentelemetry/api";
+
+const METER_NAME = "stigmer-server";
+
+/** `rpc.grpc.status_code` values: the gRPC status names, Java's `Status.Code.name()`. */
+export type GrpcStatusName =
+  | "OK"
+  | "CANCELLED"
+  | "UNKNOWN"
+  | "INVALID_ARGUMENT"
+  | "DEADLINE_EXCEEDED"
+  | "NOT_FOUND"
+  | "ALREADY_EXISTS"
+  | "PERMISSION_DENIED"
+  | "RESOURCE_EXHAUSTED"
+  | "FAILED_PRECONDITION"
+  | "ABORTED"
+  | "OUT_OF_RANGE"
+  | "UNIMPLEMENTED"
+  | "INTERNAL"
+  | "UNAVAILABLE"
+  | "DATA_LOSS"
+  | "UNAUTHENTICATED";
+
+export const GRPC_STATUS_OK: GrpcStatusName = "OK";
+
+/**
+ * Connect's error code → the gRPC status name. Connect's `Code` enum has no
+ * OK member (success is the absence of an error), so the table covers the
+ * sixteen error codes and `GRPC_STATUS_OK` names success. Byte-exact
+ * against grpc-java's `Status.Code`; the one spelling trap is CANCELLED.
+ */
+export function grpcStatusName(code: Code): GrpcStatusName {
+  switch (code) {
+    case Code.Canceled:
+      return "CANCELLED";
+    case Code.Unknown:
+      return "UNKNOWN";
+    case Code.InvalidArgument:
+      return "INVALID_ARGUMENT";
+    case Code.DeadlineExceeded:
+      return "DEADLINE_EXCEEDED";
+    case Code.NotFound:
+      return "NOT_FOUND";
+    case Code.AlreadyExists:
+      return "ALREADY_EXISTS";
+    case Code.PermissionDenied:
+      return "PERMISSION_DENIED";
+    case Code.ResourceExhausted:
+      return "RESOURCE_EXHAUSTED";
+    case Code.FailedPrecondition:
+      return "FAILED_PRECONDITION";
+    case Code.Aborted:
+      return "ABORTED";
+    case Code.OutOfRange:
+      return "OUT_OF_RANGE";
+    case Code.Unimplemented:
+      return "UNIMPLEMENTED";
+    case Code.Internal:
+      return "INTERNAL";
+    case Code.Unavailable:
+      return "UNAVAILABLE";
+    case Code.DataLoss:
+      return "DATA_LOSS";
+    case Code.Unauthenticated:
+      return "UNAUTHENTICATED";
+    default: {
+      const exhaustive: never = code;
+      throw new Error(`unknown Connect code ${String(exhaustive)}`);
+    }
+  }
+}
+
+export interface RpcInstruments {
+  /** stigmer.grpc.request.duration {rpc.service, rpc.method, rpc.grpc.status_code} — ms, fractional. */
+  readonly requestDuration: Histogram;
+  /** stigmer.grpc.request.count — same labels; the heartbeat and error-rate series. */
+  readonly requestCount: Counter;
+}
+
+// The PROMISE is memoized (not the result) so concurrent first callers
+// share one creation — two racing registries would double-create every
+// instrument.
+let instrumentsPromise: Promise<RpcInstruments> | null = null;
+
+export function getRpcInstruments(): Promise<RpcInstruments> {
+  instrumentsPromise ??= createInstruments();
+  return instrumentsPromise;
+}
+
+async function createInstruments(): Promise<RpcInstruments> {
+  const api = await import("@opentelemetry/api");
+  const meter = api.metrics.getMeter(METER_NAME);
+  return {
+    requestDuration: meter.createHistogram("stigmer.grpc.request.duration", {
+      unit: "ms",
+      description: "Duration of gRPC server requests in milliseconds",
+    }),
+    requestCount: meter.createCounter("stigmer.grpc.request.count", {
+      description: "Total number of gRPC server requests",
+    }),
+  };
+}
+
+/**
+ * Fire-and-forget record of one finished RPC — sync so the interceptor
+ * never awaits instrument resolution on the request path. Both
+ * instruments take the same attribute set, Java's single `close` record.
+ */
+export function recordRpc(
+  service: string,
+  method: string,
+  status: GrpcStatusName,
+  durationMs: number,
+): void {
+  void getRpcInstruments().then((registry) => {
+    const attributes = {
+      "rpc.service": service,
+      "rpc.method": method,
+      "rpc.grpc.status_code": status,
+    };
+    registry.requestDuration.record(durationMs, attributes);
+    registry.requestCount.add(1, attributes);
+  });
+}
+
+/**
+ * Births the count series at zero, attribute-less (Java's constructor
+ * posture — no fake `rpc.*` labels on a point that counts nothing).
+ * Awaited by the boot before the port binds so a boot-time provider
+ * exports the series before any traffic.
+ */
+export async function initRpcMetrics(): Promise<void> {
+  const registry = await getRpcInstruments();
+  registry.requestCount.add(0);
+}
+
+/**
+ * Whether a meter provider is registered for these instruments to record
+ * into. `exporting` is the host's doing (the cloud composition's
+ * bootstrap, or any `setGlobalMeterProvider` before the first record);
+ * `inert` is the OSS default until an export bootstrap exists. Read
+ * through the public API only: the no-op meter is a singleton the API
+ * exposes, so identity against it is the supported check.
+ */
+export type MetricsExportPosture = "exporting" | "inert";
+
+export async function metricsExportPosture(): Promise<MetricsExportPosture> {
+  const api = await import("@opentelemetry/api");
+  return api.metrics.getMeter(METER_NAME) === api.createNoopMeter()
+    ? "inert"
+    : "exporting";
+}
+
+/** Test seam: clears the memoized registry. */
+export function resetRpcInstruments(): void {
+  instrumentsPromise = null;
+}

--- a/backend/services/stigmer-server/src/pipeline/chain.ts
+++ b/backend/services/stigmer-server/src/pipeline/chain.ts
@@ -1,11 +1,17 @@
 /**
  * The server's interceptor chain, in the ratified order (D2 §2; position
- * 0 added by 20260830.03, gate ruling Q1):
+ * 0 added by 20260830.03, gate ruling Q1; the request-metrics position
+ * added by 20260909.02, gate ruling Q1):
  *
- *   0. error boundary   — SERVING chain only, optional parameter
+ *   0. error boundary   — SERVING chain only
  *                         (interceptors/error-boundary.ts: the raw-error
  *                         conversion net + the visitor sanitizer seam)
  *   1. identity source  — REQUIRED parameter (DD-004; O2)
+ *      request metrics  — SERVING chain only, immediately inside the
+ *                         identity source (interceptors/request-metrics.ts:
+ *                         Java's RED emitter at Java's position — an
+ *                         identity refusal is position 1's own record,
+ *                         never a counted error)
  *   2. logging          — level-tiered per outcome
  *   3. protovalidate    — boundary validation before any handler
  *   4. apiresource      — kind context from the service option
@@ -19,10 +25,14 @@
  * own interceptor mints (interceptors/auth.ts owns both sources and the
  * spoofing-impossible invariant). The parameter is required — a chain
  * without an identity source is a compile error, never a silently
- * unauthenticated transport. Position 0 deliberately exists ONLY on the
- * serving chain: in-process hops are exempt from sanitization by
- * construction — the outer handler needs the full inner diagnostic (the
- * Java InProcessCallContextHolder exemption, structurally).
+ * unauthenticated transport.
+ *
+ * The two serving-only interceptors travel as ONE optional parameter so
+ * a chain cannot half-inherit them: in-process hops are exempt from
+ * sanitization by construction — the outer handler needs the full inner
+ * diagnostic (the Java InProcessCallContextHolder exemption,
+ * structurally) — and an in-process hop is not a request, so it is not
+ * counted as one.
  */
 import type { Interceptor } from "@connectrpc/connect";
 
@@ -31,14 +41,21 @@ import { createApiResourceInterceptor } from "./interceptors/apiresource.js";
 import { createLoggingInterceptor } from "./interceptors/logging.js";
 import { createProtovalidateInterceptor } from "./interceptors/protovalidate.js";
 
+/** The interceptors only the serving chain composes; the in-process chain passes none. */
+export interface ServingChainInterceptors {
+  readonly errorBoundary: Interceptor;
+  readonly requestMetrics: Interceptor;
+}
+
 export function buildInterceptorChain(
   logger: Logger,
   identitySource: Interceptor,
-  errorBoundary?: Interceptor,
+  serving?: ServingChainInterceptors,
 ): Interceptor[] {
   return [
-    ...(errorBoundary === undefined ? [] : [errorBoundary]),
+    ...(serving === undefined ? [] : [serving.errorBoundary]),
     identitySource,
+    ...(serving === undefined ? [] : [serving.requestMetrics]),
     createLoggingInterceptor(logger),
     createProtovalidateInterceptor(),
     createApiResourceInterceptor(),

--- a/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/request-metrics.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/__tests__/request-metrics.test.ts
@@ -1,0 +1,573 @@
+/**
+ * Pins the request-metrics interceptor (20260909.02, gate rulings Q1–Q5)
+ * against a REAL MeterProvider (in-memory exporter) through the REAL
+ * serving chain over the router transport — Java's
+ * GrpcRequestMetricsInterceptor contract, label for label:
+ *
+ *   - one record per RPC with `rpc.service`, `rpc.method` and the gRPC
+ *     status NAME (`OK`, `NOT_FOUND`, `UNKNOWN` for a raw throw — the
+ *     logging interceptor's derivation, INTERNAL on the wire);
+ *   - the health service is never measured; an identity refusal at
+ *     position 1 is never counted (the paging property ruling Q1 protects);
+ *     the in-process chain records nothing;
+ *   - a server stream is measured to its END — OK on completion, the
+ *     error's code on a mid-stream throw, CANCELLED when the consumer
+ *     stops early — never to the handler's return;
+ *   - the count series is born attribute-less at zero and the histogram
+ *     is not (the heartbeat's premise);
+ *   - instruments resolve lazily, so a provider registered after the
+ *     module loaded still receives every record;
+ *   - the sixteen Connect codes map to grpc-java's names byte-exact
+ *     (CANCELLED, two Ls).
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  Code,
+  ConnectError,
+  createClient,
+  createRouterTransport,
+} from "@connectrpc/connect";
+import type { Interceptor } from "@connectrpc/connect";
+import { create } from "@bufbuild/protobuf";
+
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { AgentExecutionQueryController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/query_pb";
+import {
+  Health,
+  HealthCheckResponse_ServingStatus as ServingStatus,
+} from "@stigmer/protos/grpc/health/v1/health_pb";
+
+import { createLogger } from "../../../boot/logger.js";
+import {
+  inMemoryMeter as inMemoryMeterFor,
+  until,
+  type CollectedMetrics,
+  type CollectedPoint,
+} from "../../../observability/__tests__/in-memory-meter.js";
+import {
+  GRPC_STATUS_OK,
+  grpcStatusName,
+  initRpcMetrics,
+  resetRpcInstruments,
+} from "../../../observability/rpc-metrics.js";
+import { buildInterceptorChain } from "../../chain.js";
+import { createVerifierChainInterceptor } from "../auth.js";
+import { createErrorBoundaryInterceptor } from "../error-boundary.js";
+import { createRequestMetricsInterceptor } from "../request-metrics.js";
+
+const logger = createLogger({ level: "error", pretty: false });
+const inMemoryMeter = () => inMemoryMeterFor(resetRpcInstruments);
+
+const COUNT = "stigmer.grpc.request.count";
+const DURATION = "stigmer.grpc.request.duration";
+const AGENT_SERVICE = "ai.stigmer.agentic.agent.v1.AgentCommandController";
+const EXECUTION_SERVICE =
+  "ai.stigmer.agentic.agentexecution.v1.AgentExecutionQueryController";
+
+const VALID_AGENT = {
+  apiVersion: "agentic.stigmer.ai/v1",
+  kind: "Agent",
+  metadata: { name: "request metrics test agent" },
+  spec: {
+    instructions: "You are a helpful test agent used by interceptor tests.",
+  },
+} as const;
+
+afterEach(() => {
+  resetRpcInstruments();
+});
+
+/** A clock the test advances by hand, so durations are exact, never timing-dependent. */
+function fakeClock(): { now: () => number; advance: (ms: number) => void } {
+  let current = 1_000;
+  return {
+    now: () => current,
+    advance: (ms) => {
+      current += ms;
+    },
+  };
+}
+
+/** The count points that carry a status — real requests, not the zero birth. */
+function requestPoints(collected: CollectedMetrics): CollectedPoint[] {
+  return (collected.get(COUNT) ?? []).filter(
+    (point) => "rpc.grpc.status_code" in point.attributes,
+  );
+}
+
+function durationPoints(collected: CollectedMetrics): CollectedPoint[] {
+  return collected.get(DURATION) ?? [];
+}
+
+/** A histogram point's recorded sum — one record per RPC makes sum = the duration. */
+function sumOf(point: CollectedPoint): number {
+  return (point.value as { sum: number }).sum;
+}
+
+interface Handlers {
+  create?: () => unknown;
+  subscribe?: () => AsyncIterable<unknown>;
+}
+
+/**
+ * The serving chain as compose.ts builds it — boundary, identity source
+ * (zero verifiers unless `requireAuthentication`), the metrics emitter
+ * under test with a hand-advanced clock, then the ratified inner three.
+ */
+function servingTransport(
+  handlers: Handlers,
+  now: () => number,
+  options: { requireAuthentication?: boolean } = {},
+) {
+  return createRouterTransport(
+    (router) => {
+      router.service(AgentCommandController, {
+        create: () =>
+          (handlers.create?.() as never) ?? create(AgentSchema, VALID_AGENT),
+        apply: (request) => request,
+        update: (request) => request,
+        updateVisibility: () => create(AgentSchema, VALID_AGENT),
+        delete: () => create(AgentSchema, VALID_AGENT),
+      });
+      router.service(AgentExecutionQueryController, {
+        subscribe: () => (handlers.subscribe?.() ?? emptyStream()) as never,
+      });
+      router.service(Health, {
+        check: () => ({ status: ServingStatus.SERVING }),
+        list: () => ({ statuses: {} }),
+        watch: async function* () {},
+      });
+    },
+    {
+      router: {
+        interceptors: buildInterceptorChain(
+          logger,
+          createVerifierChainInterceptor(
+            [],
+            [],
+            logger,
+            options.requireAuthentication ?? false,
+          ),
+          {
+            errorBoundary: createErrorBoundaryInterceptor(logger),
+            requestMetrics: createRequestMetricsInterceptor(now),
+          },
+        ),
+      },
+    },
+  );
+}
+
+async function* emptyStream(): AsyncIterable<unknown> {}
+
+function execution(id: string) {
+  return create(AgentExecutionSchema, { metadata: { id } });
+}
+
+describe("the request-metrics interceptor on the serving chain", () => {
+  it("records one OK count and one duration per unary RPC, labelled with the service and the bare method", async () => {
+    const meter = await inMemoryMeter();
+    const clock = fakeClock();
+    try {
+      const transport = servingTransport(
+        {
+          create: () => {
+            clock.advance(12.5);
+            return create(AgentSchema, VALID_AGENT);
+          },
+        },
+        clock.now,
+      );
+
+      await createClient(AgentCommandController, transport).create(VALID_AGENT);
+
+      const collected = await until(
+        meter.collect,
+        (m) => requestPoints(m).length >= 1,
+      );
+      expect(requestPoints(collected)).toHaveLength(1);
+      expect(requestPoints(collected)[0]).toMatchObject({
+        value: 1,
+        attributes: {
+          "rpc.service": AGENT_SERVICE,
+          "rpc.method": "create",
+          "rpc.grpc.status_code": "OK",
+        },
+      });
+      const durations = durationPoints(collected);
+      expect(durations).toHaveLength(1);
+      expect(durations[0]!.attributes).toEqual(
+        requestPoints(collected)[0]!.attributes,
+      );
+      // Fractional milliseconds, Java's nanoTime / 1e6 — never rounded.
+      expect(sumOf(durations[0]!)).toBe(12.5);
+    } finally {
+      await meter.dispose();
+    }
+  });
+
+  it("labels a ConnectError failure with the gRPC status name", async () => {
+    const meter = await inMemoryMeter();
+    try {
+      const transport = servingTransport(
+        {
+          create: () => {
+            throw new ConnectError('agent "ghost" not found', Code.NotFound);
+          },
+        },
+        fakeClock().now,
+      );
+
+      const failure = await createClient(AgentCommandController, transport)
+        .create(VALID_AGENT)
+        .then(() => null)
+        .catch((error: unknown) => ConnectError.from(error));
+      expect(failure?.code).toBe(Code.NotFound);
+
+      const collected = await until(
+        meter.collect,
+        (m) => requestPoints(m).length >= 1,
+      );
+      expect(requestPoints(collected)[0]!.attributes).toMatchObject({
+        "rpc.method": "create",
+        "rpc.grpc.status_code": "NOT_FOUND",
+      });
+    } finally {
+      await meter.dispose();
+    }
+  });
+
+  it("labels a raw throw UNKNOWN — the code before the boundary's INTERNAL rewrite, the logging interceptor's derivation", async () => {
+    const meter = await inMemoryMeter();
+    try {
+      const transport = servingTransport(
+        {
+          create: () => {
+            throw new Error("sqlite exploded");
+          },
+        },
+        fakeClock().now,
+      );
+
+      const failure = await createClient(AgentCommandController, transport)
+        .create(VALID_AGENT)
+        .then(() => null)
+        .catch((error: unknown) => ConnectError.from(error));
+      // The wire sees the boundary's conversion …
+      expect(failure?.code).toBe(Code.Internal);
+
+      // … the metric sees the raw error's Connect mapping, as the log does.
+      const collected = await until(
+        meter.collect,
+        (m) => requestPoints(m).length >= 1,
+      );
+      expect(requestPoints(collected)[0]!.attributes).toMatchObject({
+        "rpc.grpc.status_code": "UNKNOWN",
+      });
+    } finally {
+      await meter.dispose();
+    }
+  });
+
+  it("never measures the health service (probe chatter would own the request-rate signal)", async () => {
+    const meter = await inMemoryMeter();
+    try {
+      const transport = servingTransport({}, fakeClock().now);
+
+      await createClient(Health, transport).check({});
+      // A measured RPC afterwards proves the pipeline is live, so the
+      // absence above is the interceptor's choice, not a collection race.
+      await createClient(AgentCommandController, transport).create(VALID_AGENT);
+
+      const collected = await until(
+        meter.collect,
+        (m) => requestPoints(m).length >= 1,
+      );
+      expect(
+        requestPoints(collected).map((p) => p.attributes["rpc.service"]),
+      ).toEqual([AGENT_SERVICE]);
+    } finally {
+      await meter.dispose();
+    }
+  });
+
+  it("does not count an identity refusal — position 1's own record, Java's position (ruling Q1)", async () => {
+    const meter = await inMemoryMeter();
+    try {
+      const transport = servingTransport({}, fakeClock().now, {
+        requireAuthentication: true,
+      });
+      const client = createClient(AgentCommandController, transport);
+
+      const refused = await client
+        .create(VALID_AGENT)
+        .then(() => null)
+        .catch((error: unknown) => ConnectError.from(error));
+      expect(refused?.code).toBe(Code.Unauthenticated);
+      // A credentialed call passes position 1 (zero verifiers claim it →
+      // trusted-local) and IS measured; waiting for it makes the refusal's
+      // absence a fact, not a collection race. An emitter placed outside
+      // the identity source would show two points here.
+      await client.create(VALID_AGENT, {
+        headers: { authorization: "Bearer any-token" },
+      });
+
+      const collected = await until(
+        meter.collect,
+        (m) => requestPoints(m).length >= 1,
+      );
+      expect(
+        requestPoints(collected).map(
+          (p) => p.attributes["rpc.grpc.status_code"],
+        ),
+      ).toEqual(["OK"]);
+      expect(durationPoints(collected)).toHaveLength(1);
+    } finally {
+      await meter.dispose();
+    }
+  });
+
+  it("measures a server stream to its END, not to the handler's return", async () => {
+    const meter = await inMemoryMeter();
+    const clock = fakeClock();
+    try {
+      const transport = servingTransport(
+        {
+          subscribe: async function* () {
+            clock.advance(5);
+            yield execution("e1");
+            clock.advance(40);
+            yield execution("e2");
+            clock.advance(55);
+          },
+        },
+        clock.now,
+      );
+
+      const seen: string[] = [];
+      for await (const message of createClient(
+        AgentExecutionQueryController,
+        transport,
+      ).subscribe({ value: "exec-1" })) {
+        seen.push(message.metadata?.id ?? "");
+      }
+      expect(seen).toEqual(["e1", "e2"]);
+
+      const collected = await until(
+        meter.collect,
+        (m) => requestPoints(m).length >= 1,
+      );
+      expect(requestPoints(collected)).toHaveLength(1);
+      expect(requestPoints(collected)[0]!.attributes).toEqual({
+        "rpc.service": EXECUTION_SERVICE,
+        "rpc.method": "subscribe",
+        "rpc.grpc.status_code": "OK",
+      });
+      expect(sumOf(durationPoints(collected)[0]!)).toBe(100);
+    } finally {
+      await meter.dispose();
+    }
+  });
+
+  it("labels a mid-stream throw with the error's code, once", async () => {
+    const meter = await inMemoryMeter();
+    try {
+      const transport = servingTransport(
+        {
+          subscribe: async function* () {
+            yield execution("e1");
+            throw new ConnectError("engine went away", Code.Unavailable);
+          },
+        },
+        fakeClock().now,
+      );
+
+      const failure = await (async () => {
+        try {
+          for await (const _ of createClient(
+            AgentExecutionQueryController,
+            transport,
+          ).subscribe({ value: "exec-1" })) {
+            // drain
+          }
+          return null;
+        } catch (error) {
+          return ConnectError.from(error);
+        }
+      })();
+      expect(failure?.code).toBe(Code.Unavailable);
+
+      const collected = await until(
+        meter.collect,
+        (m) => requestPoints(m).length >= 1,
+      );
+      expect(requestPoints(collected)).toHaveLength(1);
+      expect(requestPoints(collected)[0]!.attributes).toMatchObject({
+        "rpc.method": "subscribe",
+        "rpc.grpc.status_code": "UNAVAILABLE",
+      });
+    } finally {
+      await meter.dispose();
+    }
+  });
+
+  it("labels a stream the consumer abandoned CANCELLED, once — Java's client-cancel status", async () => {
+    // Exercised on the interceptor directly: the transport's own abort
+    // plumbing is not under test here, the interceptor's `finally` arm is.
+    const meter = await inMemoryMeter();
+    const clock = fakeClock();
+    try {
+      const interceptor = createRequestMetricsInterceptor(clock.now);
+      const next = async () =>
+        ({
+          stream: true,
+          message: (async function* () {
+            yield "m1";
+            clock.advance(7);
+            yield "m2";
+            yield "never-pulled";
+          })(),
+        }) as never;
+      const request = {
+        service: { typeName: EXECUTION_SERVICE },
+        method: { name: "subscribe" },
+      } as never;
+
+      const response = (await interceptor(next)(request)) as {
+        message: AsyncIterable<string>;
+      };
+      for await (const message of response.message) {
+        if (message === "m2") break; // the consumer goes away
+      }
+
+      const collected = await until(
+        meter.collect,
+        (m) => requestPoints(m).length >= 1,
+      );
+      expect(requestPoints(collected)).toHaveLength(1);
+      expect(requestPoints(collected)[0]!.attributes).toMatchObject({
+        "rpc.grpc.status_code": "CANCELLED",
+      });
+      expect(sumOf(durationPoints(collected)[0]!)).toBe(7);
+    } finally {
+      await meter.dispose();
+    }
+  });
+
+  it("is absent from the in-process chain — a hop is not a request", async () => {
+    const meter = await inMemoryMeter();
+    try {
+      const inProcess = createRouterTransport(
+        (router) => {
+          router.service(AgentCommandController, {
+            create: () => create(AgentSchema, VALID_AGENT),
+            apply: (request) => request,
+            update: (request) => request,
+            updateVisibility: () => create(AgentSchema, VALID_AGENT),
+            delete: () => create(AgentSchema, VALID_AGENT),
+          });
+        },
+        {
+          router: {
+            // inprocess.ts's shape: no serving extras.
+            interceptors: buildInterceptorChain(
+              logger,
+              createVerifierChainInterceptor([], [], logger),
+            ),
+          },
+        },
+      );
+
+      await createClient(AgentCommandController, inProcess).create(VALID_AGENT);
+      // One measured call through a serving chain afterwards, on a
+      // DIFFERENT method: records resolve in call order, so once `delete`
+      // is exported any record `create` made is already there — the
+      // absence is a fact, not a race.
+      await createClient(
+        AgentCommandController,
+        servingTransport({}, fakeClock().now),
+      ).delete({ value: "agent-1" });
+
+      const collected = await until(meter.collect, (m) =>
+        requestPoints(m).some((p) => p.attributes["rpc.method"] === "delete"),
+      );
+      expect(
+        requestPoints(collected).map((p) => p.attributes["rpc.method"]),
+      ).toEqual(["delete"]);
+      expect(durationPoints(collected)).toHaveLength(1);
+    } finally {
+      await meter.dispose();
+    }
+  });
+});
+
+describe("the rpc-metrics registry", () => {
+  it("births the count series attribute-less at zero and leaves the histogram untouched", async () => {
+    const meter = await inMemoryMeter();
+    try {
+      await initRpcMetrics();
+
+      const collected = await until(meter.collect, (m) => m.has(COUNT));
+      expect(collected.get(COUNT)).toEqual([{ value: 0, attributes: {} }]);
+      expect(collected.has(DURATION)).toBe(false);
+    } finally {
+      await meter.dispose();
+    }
+  });
+
+  it("resolves instruments lazily — a provider registered after the module loaded receives the records", async () => {
+    // The module was imported at the top of this file, long before any
+    // provider existed; the API has no proxy meter, so eager instruments
+    // would be permanent no-ops. The registry must defer to first use.
+    const meter = await inMemoryMeter();
+    try {
+      const transport = servingTransport({}, fakeClock().now);
+      await createClient(AgentCommandController, transport).create(VALID_AGENT);
+
+      const collected = await until(
+        meter.collect,
+        (m) => requestPoints(m).length >= 1,
+      );
+      expect(requestPoints(collected)).toHaveLength(1);
+    } finally {
+      await meter.dispose();
+    }
+  });
+
+  it("maps every Connect code to grpc-java's status name, byte-exact", () => {
+    const expected: Record<Code, string> = {
+      [Code.Canceled]: "CANCELLED",
+      [Code.Unknown]: "UNKNOWN",
+      [Code.InvalidArgument]: "INVALID_ARGUMENT",
+      [Code.DeadlineExceeded]: "DEADLINE_EXCEEDED",
+      [Code.NotFound]: "NOT_FOUND",
+      [Code.AlreadyExists]: "ALREADY_EXISTS",
+      [Code.PermissionDenied]: "PERMISSION_DENIED",
+      [Code.ResourceExhausted]: "RESOURCE_EXHAUSTED",
+      [Code.FailedPrecondition]: "FAILED_PRECONDITION",
+      [Code.Aborted]: "ABORTED",
+      [Code.OutOfRange]: "OUT_OF_RANGE",
+      [Code.Unimplemented]: "UNIMPLEMENTED",
+      [Code.Internal]: "INTERNAL",
+      [Code.Unavailable]: "UNAVAILABLE",
+      [Code.DataLoss]: "DATA_LOSS",
+      [Code.Unauthenticated]: "UNAUTHENTICATED",
+    };
+    for (const [code, name] of Object.entries(expected)) {
+      expect(grpcStatusName(Number(code) as Code)).toBe(name);
+    }
+    expect(Object.keys(expected)).toHaveLength(16);
+    expect(GRPC_STATUS_OK).toBe("OK");
+    // The naive port — Connect's enum key upper-cased — would say CANCELED.
+    expect(Code[Code.Canceled].toUpperCase()).not.toBe(
+      grpcStatusName(Code.Canceled),
+    );
+  });
+});
+
+// Type-level pin: the interceptor is a plain Connect Interceptor, so
+// chain.ts can hold it where the ruling placed it.
+const _typed: Interceptor = createRequestMetricsInterceptor();
+void _typed;

--- a/backend/services/stigmer-server/src/pipeline/interceptors/request-metrics.ts
+++ b/backend/services/stigmer-server/src/pipeline/interceptors/request-metrics.ts
@@ -1,0 +1,114 @@
+/**
+ * Request-metrics interceptor — the serving chain's RED emitter, the TS
+ * port of the cloud Java `GrpcRequestMetricsInterceptor` (convergence
+ * entry 20260909.02, gate rulings Q1–Q5 as recommended). One record per
+ * RPC into `observability/rpc-metrics.ts`: the count and the duration,
+ * labelled with the service, the method and the gRPC status name.
+ *
+ * Placement contract: SERVING chain only, immediately INSIDE the identity
+ * source (chain.ts). That is Java's real position —
+ * `@Order(ORDER_SECURITY_AUTHENTICATION + 2)`, after the authentication
+ * interceptor that closes tokenless and invalid-token calls — and the
+ * position the logging interceptor already holds, so metrics and logs
+ * observe the same set of requests: an identity refusal is position 1's
+ * own record (auth.ts logs it), never a counted error. The choice has a
+ * paging consequence and was ruled, not assumed: `grpc-error-rate-spike`
+ * counts every non-OK code with no exclusions, and an outermost emitter
+ * would page on an expired console tab's retries or an internet scanner
+ * at a quiet hour. The disclosed deviation from Java: the caller guards
+ * run inside position 1 here (Java's platform-client enforcement sat
+ * inside its metrics), so a guard refusal is not counted either — fewer
+ * errors counted, never more. The in-process chain never composes this
+ * interceptor: an in-process hop is not a request.
+ *
+ * Status of a failure is `ConnectError.from(error).code`, exactly the
+ * logging interceptor's derivation: a raw non-ConnectError is UNKNOWN
+ * here and INTERNAL on the wire after the error boundary outside converts
+ * it — the boundary's error-level line names each such conversion, and
+ * grpc-java produced UNKNOWN for the same class. Health is not measured
+ * (the by-name authentication-exempt services — Kubernetes probes every
+ * few seconds would own the request-rate signal; Java's auth and metrics
+ * skip lists are the same names by construction); `is_public` methods
+ * ARE measured — they are API.
+ *
+ * Duration is fractional milliseconds from interception to the RPC's
+ * end. For a server stream that is the END OF THE STREAM (Java measured
+ * to `ServerCall.close`): the response iterable is re-wrapped, the error
+ * boundary's idiom, and the one record fires in `finally` — OK when the
+ * stream ran to completion, the error's code when it threw, CANCELLED
+ * when the consumer stopped early (the client went away, or the
+ * transport stopped pulling). The logging interceptor measures a stream
+ * only to the handler's return; the difference is deliberate here and
+ * disclosed there.
+ */
+import { ConnectError } from "@connectrpc/connect";
+import type { Interceptor } from "@connectrpc/connect";
+
+import {
+  GRPC_STATUS_OK,
+  grpcStatusName,
+  recordRpc,
+} from "../../observability/rpc-metrics.js";
+import type { GrpcStatusName } from "../../observability/rpc-metrics.js";
+import { AUTHENTICATION_EXEMPT_SERVICES } from "./auth.js";
+
+/** Test seam: a fake clock; production reads `performance.now()`. */
+export type Clock = () => number;
+
+export function createRequestMetricsInterceptor(
+  now: Clock = () => performance.now(),
+): Interceptor {
+  return (next) => async (request) => {
+    if (AUTHENTICATION_EXEMPT_SERVICES.has(request.service.typeName)) {
+      return next(request);
+    }
+    const service = request.service.typeName;
+    const method = request.method.name;
+    const startedAt = now();
+    const record = (status: GrpcStatusName): void => {
+      recordRpc(service, method, status, now() - startedAt);
+    };
+
+    let response;
+    try {
+      response = await next(request);
+    } catch (error) {
+      record(statusOf(error));
+      throw error;
+    }
+    if (!response.stream) {
+      record(GRPC_STATUS_OK);
+      return response;
+    }
+    return {
+      ...response,
+      message: measureStream(response.message, record),
+    };
+  };
+}
+
+function statusOf(error: unknown): GrpcStatusName {
+  return grpcStatusName(ConnectError.from(error).code);
+}
+
+/**
+ * Records once when the stream ends, however it ends. `finally` runs on
+ * completion, on a throw, and when the consumer returns early — the
+ * three ways a server stream closes; `outcome` distinguishes the first two
+ * and its absence is the third.
+ */
+async function* measureStream<T>(
+  messages: AsyncIterable<T>,
+  record: (status: GrpcStatusName) => void,
+): AsyncIterable<T> {
+  let outcome: GrpcStatusName | undefined;
+  try {
+    yield* messages;
+    outcome = GRPC_STATUS_OK;
+  } catch (error) {
+    outcome = statusOf(error);
+    throw error;
+  } finally {
+    record(outcome ?? "CANCELLED");
+  }
+}

--- a/test/conformance/inventory/cloud-capabilities.yaml
+++ b/test/conformance/inventory/cloud-capabilities.yaml
@@ -2463,9 +2463,13 @@ rows:
 # discipline, same file — one inventory mechanism for the program.
 #
 #   name         the Java metric name, byte-exact (the composition emits the
-#                same name when `disposition: ported`)
-#   surface      billing | proxy
-#   java_source  where Java emits it
+#                same name when `disposition: ported` — from its own code or
+#                from the OSS server it pins, the row's note says which)
+#   surface      billing | proxy | platform (a metric no lane owns: the HTTP
+#                edge, the gRPC edge, the secret cleanup — 20260909.01)
+#   java_source  where Java emits it: a path under
+#                backend/services/stigmer-service/src/main/java/ai/stigmer, or
+#                `libs/<lib>/…` for backend/libs/java
 #   disposition  ported | dropped
 #   alerts       SigNoz alert files under tools/ops/signoz/alerts/ that read
 #                the series (re-pointed at stigmer-server before X1)
@@ -2565,6 +2569,20 @@ metrics:
     alerts: [encryption-cleanup-failures]
     note: >-
       Secret backing-state destructions that failed after the DB write succeeded (orphaned KV entries); pre-registered at zero on boot in both editions so the first orphan after a pod start is visible to the alert.
+  - name: stigmer.grpc.request.count
+    surface: platform
+    java_source: libs/grpc/grpc-request/interceptor/GrpcRequestMetricsInterceptor.java
+    disposition: ported
+    alerts: [telemetry-heartbeat-lost, grpc-error-rate-spike]
+    note: >-
+      Emitted by the OSS server itself (pipeline/interceptors/request-metrics.ts, convergence entry 20260909.02), not by the composition: one record per RPC on the serving chain, labels rpc.service, rpc.method and rpc.grpc.status_code as the gRPC status NAME (OK, NOT_FOUND, CANCELLED). Born attribute-less at zero before the port binds, Java's constructor add(0), so the heartbeat's ten-minute absence window measures the export pipeline rather than a post-restart lull; the error-rate rule is the share of status_code != OK. Recorded inside the identity source — Java's @Order position — so an identity refusal is never a counted error (a paging-effect ruling, 20260909.02 gate Q1). Health is not measured; is_public methods are.
+  - name: stigmer.grpc.request.duration
+    surface: platform
+    java_source: libs/grpc/grpc-request/interceptor/GrpcRequestMetricsInterceptor.java
+    disposition: ported
+    alerts: [grpc-latency-regression-p95]
+    note: >-
+      The count's sibling, same labels, fractional milliseconds from interception to the RPC's end — for a server stream, the end of the stream (Java measured to ServerCall.close). Never pre-registered: a record(0) would be a real sample in the p95. SDK default histogram buckets in both editions.
   - name: stigmer.proxy.cursor.execution_authority_lookups
     surface: proxy
     java_source: proxy/cursor/keyselection/CompositionAuthorityExecutionContextSource.java


### PR DESCRIPTION
## Summary
The OSS server emits Java's gRPC RED metrics itself — `stigmer.grpc.request.count` and `stigmer.grpc.request.duration`, labels `rpc.service`, `rpc.method` and `rpc.grpc.status_code` (the gRPC status name) — from a serving-chain Connect interceptor on `@opentelemetry/api` alone. The cloud composition's SigNoz heartbeat, error-rate and latency rules get their series through the library it pins; a self-hosting team gets the same instrumentation the moment a `MeterProvider` is registered.

## Context
Convergence entry `20260909.02.sp.rpc-edge-red-metrics`. After the X1 flip the composition would have had no request-rate, error-rate, latency or heartbeat signal on the API that was just flipped — the Connect edge emitted nothing (`stigmer-server/src` had zero `@opentelemetry` imports). The alert-roster reconciliation (stigmer-cloud#693) left exactly four rows `pending` on this entry. DD-001 puts the emitter on the OSS side: RED metrics on a server are something every self-hosting team needs.

## Changes
- `src/observability/rpc-metrics.ts` (new): the lazy, memoized instrument registry (the runner's `otel-metrics.ts` idiom); `grpcStatusName` — the byte-exact Connect-code → gRPC-name table (`CANCELLED`, two Ls), a `switch` closed with `never`; `recordRpc` (sync fire-and-forget); `initRpcMetrics` (the counter born attribute-less at zero, the histogram never pre-registered); `metricsExportPosture`.
- `src/pipeline/interceptors/request-metrics.ts` (new): one record per RPC; skips the by-name authentication-exempt services (health); a server stream is measured to its END — `OK` on completion, the error's code on a mid-stream throw, `CANCELLED` when the consumer stops early; fractional milliseconds.
- `src/pipeline/chain.ts`: the two serving-only interceptors travel as one `ServingChainInterceptors` object; the request-metrics emitter sits immediately INSIDE the identity source. The in-process chain composes neither.
- `src/boot/compose.ts`: wires the pair; `start()` births the counter before the port binds and logs the telemetry posture (`exporting` | `inert`) once.
- `package.json`: `@opentelemetry/api ^1.9.0` (runtime); `@opentelemetry/sdk-metrics ^2.0.0` (dev, the in-memory reader).
- `test/conformance/inventory/cloud-capabilities.yaml`: two `platform` rows with their `alerts:` links; the metrics header names the `platform` surface and the libs `java_source` form.

## Implementation notes
- **Position is Java's, not "outermost".** Java's `GrpcRequestMetricsInterceptor` is `@Order(ORDER_SECURITY_AUTHENTICATION + 2)` — inside authentication, so it never counted identity refusals. The `gRPC error rate spike` rule counts every non-OK code with no exclusions; an outermost emitter would page on an expired console tab's retries. Placing it inside the identity source keeps the alert's semantics without touching the rule, and matches where the logging interceptor already observes. Disclosed deviation: caller-guard refusals (inside position 1 here) go uncounted — fewer errors counted, never more.
- **Failure code is the logging interceptor's derivation**: `ConnectError.from(error).code` — a raw throw is `UNKNOWN` here and `INTERNAL` on the wire after the error boundary; the boundary's error-level line names each conversion; grpc-java produced `UNKNOWN` for the same class.
- **Library instrumentation, not a bootstrap.** The OSS server still has no export bootstrap (the only TS service where `OTEL_EXPORTER_OTLP_ENDPOINT` does nothing); that is filed separately. Until then the boot says `posture: inert`.
- Two `@opentelemetry/api` copies (the composition's and this package's) share one global while this copy's minor does not exceed the registering copy's — the registry header states the rule; the composition proves the sharing with a composed test on every pin.

## Breaking changes
- `buildInterceptorChain`'s optional third parameter is now `ServingChainInterceptors` (`{ errorBoundary, requestMetrics }`) instead of a bare `Interceptor`. Internal — not on the `@stigmer/server` exports map.

## Test plan
- `src/pipeline/interceptors/__tests__/request-metrics.test.ts` (12 arms over the real router transport with real descriptors and a real in-memory `MeterProvider`): unary OK / `NOT_FOUND` / raw → `UNKNOWN` with `INTERNAL` on the wire; health never measured; an identity refusal NOT counted while a credentialed call is; stream measured to its end (100 ms across three yields, not the handler's return); mid-stream `UNAVAILABLE` once; abandoned stream `CANCELLED` once; the in-process chain records nothing; zero birth attribute-less with the histogram absent; provider registered after import still receives records; the 16-name table byte-exact and the naive `CANCELED` port refused.
- Nine mutations proven red, then green after each: drop the interceptor from the chain; move it outside the identity source; add it to the in-process chain; misspell `CANCELLED`; record an abandoned stream as `OK`; round durations; pre-register the histogram; measure health; measure a stream to the handler's return.
- Full server suite on Node 22.22.1 (`.nvmrc`): 167 files / 2211 tests passed; `tsc --noEmit` clean; Prettier clean on touched files; `npm run build` + `verify:dist` boots, serves and shuts down, the boot log showing `request metrics {"posture":"inert",…}` before `listening`; `bundle-slim` step 3/6 bundles the API (the console-staging step needs the web export, CI's job); `test/conformance` `inventory:check` 40 metrics / 0 problems and `test:unit` 75/75.

## Risks
- A hot-path cost of one closure and one fire-and-forget promise per RPC; health excluded. Rollback: revert; the chain's inner three are untouched.

Made with [Cursor](https://cursor.com)