### PR TITLE
test(test/conformance): inventory gains Java's four Postgres capacity gauges as ported platform rows the SigNoz Postgres rules read

### DIFF
--- a/test/conformance/inventory/cloud-capabilities.yaml
+++ b/test/conformance/inventory/cloud-capabilities.yaml
@@ -2583,6 +2583,34 @@ metrics:
     alerts: [grpc-latency-regression-p95]
     note: >-
       The count's sibling, same labels, fractional milliseconds from interception to the RPC's end — for a server stream, the end of the stream (Java measured to ServerCall.close). Never pre-registered: a record(0) would be a real sample in the p95. SDK default histogram buckets in both editions.
+  - name: stigmer.db.postgres.connections.used
+    surface: platform
+    java_source: config/observability/PostgresCapacityMetrics.java
+    disposition: ported
+    alerts: [postgres-connections-above-80-of-max]
+    note: >-
+      Backends connected to the composition's database (pg_stat_activity, datname = current_database()), polled every 60 s by the composition's observability/postgres-capacity.ts (convergence entry 20260909.03) and observed as a gauge with db.cluster = app-postgres only: Java's second cluster label, checkpointer-postgres, probed the separate stigmer_checkpoints database, whose tables C6 moved into the one database — that series retires with Java. The connections rule divides this by connections.max, so both rows name it. Nothing is observed before the first successful poll; a failed poll keeps the last values (Java's atomics).
+  - name: stigmer.db.postgres.connections.max
+    surface: platform
+    java_source: config/observability/PostgresCapacityMetrics.java
+    disposition: ported
+    alerts: [postgres-connections-above-80-of-max]
+    note: >-
+      The server's max_connections setting (current_setting), the denominator of the connections rule; same poll, same label as connections.used.
+  - name: stigmer.db.postgres.database.size
+    surface: platform
+    java_source: config/observability/PostgresCapacityMetrics.java
+    disposition: ported
+    alerts: [postgres-database-above-70-of-disk]
+    note: >-
+      pg_database_size(current_database()) in bytes; the disk rule's threshold is 70 % of the 30 G volume, a production fact the rule carries, not a metric.
+  - name: stigmer.db.postgres.wal.size
+    surface: platform
+    java_source: config/observability/PostgresCapacityMetrics.java
+    disposition: ported
+    alerts: [postgres-wal-above-80-of-max-wal-size]
+    note: >-
+      The WAL directory's size in bytes (sum over pg_ls_waldir()), which needs the pg_monitor role — granted to stigmer_app by hand on 2026-07-29 and carried by the composition's connections as the same role. Probed inside the same poll but on its own terms, as Java does: a failure sits out the next 15 polls and warns once with the GRANT to run, the last good value stays observed through the window, and only a probe that has never succeeded is absent. The rule's threshold is 80 % of max_wal_size (1024 MB), a production fact the rule carries.
   - name: stigmer.proxy.cursor.execution_authority_lookups
     surface: proxy
     java_source: proxy/cursor/keyselection/CompositionAuthorityExecutionContextSource.java


### PR DESCRIPTION
## Summary

The conformance inventory's `metrics:` section gains four `platform` rows for Java's Postgres capacity gauges — `stigmer.db.postgres.connections.used`, `.connections.max`, `.database.size`, `.wal.size` — each `ported`, each naming the SigNoz alert that reads it. Records only; no runtime code changes.

## Context

stigmer-cloud entry `20260909.03.sp.postgres-capacity-metrics` (the Q4 move-up of the X1 alert-roster reconciliation) ports Java's `PostgresCapacityMetrics` onto the TS composition so the three Postgres alert rules — connections vs `max_connections`, database size vs the disk, WAL vs `max_wal_size` — keep watching the one production database after the flip instead of going dark with Java. The cloud guard (`check-x1-parity-dispositions.sh`) reads THIS inventory at the submodule pin and refuses a `repoint` whose cited row is not `ported` or does not name the alert back — the inventory declares, the cloud guard proves. The composition emits nothing under these names today (read-only census 2026-09-09: all four series under `stigmer-service` only).

## Changes

- `inventory/cloud-capabilities.yaml`: four new rows after the gRPC RED pair. Both `connections.*` rows name `postgres-connections-above-80-of-max` (the rule divides one by the other, so the cloud guard learns to prove a rule that reads two metrics). The notes carry the two facts a reader needs: the composition observes `db.cluster = app-postgres` only (Java's `checkpointer-postgres` probed the separate `stigmer_checkpoints` database, whose tables C6 moved into the one database — that series retires with Java), and `wal.size` rides `pg_ls_waldir()` behind the `pg_monitor` grant with Java's 15-poll suppression on failure.

## Test plan

- `npm run inventory:check`: 152 rows, 0 problems; metrics 44 (41 ported, 3 dropped) — was 40 (37, 3)
- The consuming guard (stigmer-cloud, same entry) proves each row three ways on this pin; that PR bumps the submodule to this squash

## Risks

None at runtime. A `ported` row the composition does not actually emit would be caught by the cloud guard's instrument-literal check, not here.

Made with [Cursor](https://cursor.com)
