### PR TITLE
feat(stigmer-server): add a structured sink seam to the logger for log export

### DIFF
--- a/backend/services/stigmer-server/src/boot/__tests__/logger.test.ts
+++ b/backend/services/stigmer-server/src/boot/__tests__/logger.test.ts
@@ -1,12 +1,14 @@
 /**
  * Pins the logger mechanism: threshold filtering, structured fields in the
- * NDJSON shape, pretty output for ENV=local, and the unknown-level → info
- * fallback. The per-RPC level TIERING contract is asserted in the logging
- * interceptor's tests, not here.
+ * NDJSON shape, pretty output for ENV=local, the unknown-level → info
+ * fallback, and the sink seam — the structured entry a deployable's
+ * exporter receives after the line is written, only for lines that passed
+ * the threshold, with the written output untouched. The per-RPC level
+ * TIERING contract is asserted in the logging interceptor's tests, not here.
  */
 import { describe, expect, it } from "vitest";
 
-import { createLogger } from "../logger.js";
+import { createLogger, type LogEntry } from "../logger.js";
 
 function capture(): { lines: string[]; write: (line: string) => void } {
   const lines: string[] = [];
@@ -64,5 +66,82 @@ describe("createLogger", () => {
     logger.info("visible");
 
     expect(lines).toHaveLength(1);
+  });
+
+  describe("sink", () => {
+    it("receives the structured entry for every line that passed the threshold, and nothing below it", () => {
+      const { write } = capture();
+      const entries: LogEntry[] = [];
+      const logger = createLogger({
+        level: "warn",
+        pretty: false,
+        write,
+        sink: (entry) => entries.push(entry),
+      });
+
+      logger.info("below");
+      logger.warn("at", { code: 7 });
+      logger.error("above");
+
+      expect(entries.map((entry) => entry.level)).toEqual(["warn", "error"]);
+      expect(entries[0]).toMatchObject({ message: "at", fields: { code: 7 } });
+      expect(entries[0]!.time).toBeInstanceOf(Date);
+      expect(entries[1]!.fields).toBeUndefined();
+    });
+
+    it("hands the sink the same instant the written line carries", () => {
+      const { lines, write } = capture();
+      const entries: LogEntry[] = [];
+      const logger = createLogger({
+        level: "info",
+        pretty: false,
+        write,
+        sink: (entry) => entries.push(entry),
+      });
+
+      logger.info("stamped");
+
+      const written = JSON.parse(lines[0]!) as { time: string };
+      expect(entries[0]!.time.toISOString()).toBe(written.time);
+    });
+
+    it("leaves the written output unchanged in both shapes when a sink is present", () => {
+      const ndjson = capture();
+      const pretty = capture();
+      const sink = (): void => {};
+      createLogger({
+        level: "info",
+        pretty: false,
+        write: ndjson.write,
+        sink,
+      }).info("rpc completed", { code: "ok" });
+      createLogger({
+        level: "info",
+        pretty: true,
+        write: pretty.write,
+        sink,
+      }).warn("something odd", { detail: 7 });
+
+      expect(JSON.parse(ndjson.lines[0]!)).toMatchObject({
+        level: "info",
+        message: "rpc completed",
+        code: "ok",
+      });
+      expect(pretty.lines[0]).toMatch(/WARN {2}something odd \{"detail":7\}$/);
+    });
+
+    it("writes the line before it calls the sink", () => {
+      const order: string[] = [];
+      const logger = createLogger({
+        level: "info",
+        pretty: false,
+        write: () => order.push("write"),
+        sink: () => order.push("sink"),
+      });
+
+      logger.info("ordered");
+
+      expect(order).toEqual(["write", "sink"]);
+    });
   });
 });

--- a/backend/services/stigmer-server/src/boot/logger.ts
+++ b/backend/services/stigmer-server/src/boot/logger.ts
@@ -9,6 +9,18 @@
  * human-readable console output when ENV=local (server.go:939), stdout
  * untouched.
  *
+ * The sink is the one seam for a structured export. A deployable that
+ * ships records to a collector (the cloud composition's OTLP log export,
+ * convergence entry 20260909.05; a self-hosting team's own exporter next)
+ * needs the entry — level, instant, message, fields — not the formatted
+ * line, and it needs it exactly for the lines the threshold let through,
+ * so LOG_LEVEL governs every output from one place. The written line stays
+ * the operator's `kubectl logs` view, unchanged whether a sink is present
+ * or not; the sink is called after the write, so a stderr fault skips the
+ * export of that line rather than the reverse. This module stays free of
+ * runtime dependencies on purpose: the SDK that turns an entry into a
+ * record belongs to the deployable that chose a collector.
+ *
  * The level tiering CONTRACT lives in the logging interceptor
  * (pipeline/interceptors/logging.ts) — this module only provides the
  * mechanism.
@@ -25,6 +37,26 @@ export interface Logger {
   error(message: string, fields?: LogFields): void;
 }
 
+/**
+ * One log line, structured, as a sink receives it: computed once per
+ * emission, so the written line and the exported record carry the same
+ * instant and the same fields.
+ */
+export interface LogEntry {
+  readonly level: LogLevel;
+  readonly time: Date;
+  readonly message: string;
+  readonly fields: LogFields | undefined;
+}
+
+/**
+ * Receives every entry that passed the threshold, after the line is
+ * written. A sink owns its own failure handling — the logger is called
+ * from every hot path in the process and never wraps the sink in a
+ * try/catch it would then have to log through itself.
+ */
+export type LogSink = (entry: LogEntry) => void;
+
 const LEVEL_RANK: Record<LogLevel, number> = {
   debug: 10,
   info: 20,
@@ -39,27 +71,35 @@ export interface LoggerOptions {
   pretty: boolean;
   /** Test seam; defaults to stderr so stdout stays clean for tooling. */
   write?: (line: string) => void;
+  /** Structured export seam; absent means the written line is the only output. */
+  sink?: LogSink;
 }
 
 export function createLogger(options: LoggerOptions): Logger {
   const threshold = LEVEL_RANK[options.level as LogLevel] ?? LEVEL_RANK.info;
   const write =
     options.write ?? ((line: string) => process.stderr.write(line + "\n"));
+  const sink = options.sink;
 
   const emit = (level: LogLevel, message: string, fields?: LogFields): void => {
     if (LEVEL_RANK[level] < threshold) {
       return;
     }
-    const time = new Date().toISOString();
+    const time = new Date();
     if (options.pretty) {
       const suffix =
         fields === undefined || Object.keys(fields).length === 0
           ? ""
           : " " + JSON.stringify(fields);
-      write(`${time} ${level.toUpperCase().padEnd(5)} ${message}${suffix}`);
-      return;
+      write(
+        `${time.toISOString()} ${level.toUpperCase().padEnd(5)} ${message}${suffix}`,
+      );
+    } else {
+      write(
+        JSON.stringify({ level, time: time.toISOString(), message, ...fields }),
+      );
     }
-    write(JSON.stringify({ level, time, message, ...fields }));
+    sink?.({ level, time, message, fields });
   };
 
   return {

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -40,10 +40,12 @@ export { loadConfig } from "./boot/config.js";
 export type { ServerConfig } from "./boot/config.js";
 export { createLogger } from "./boot/logger.js";
 export type {
+  LogEntry,
   LogFields,
   Logger,
   LoggerOptions,
   LogLevel,
+  LogSink,
 } from "./boot/logger.js";
 
 // The extension-point types (DD-006 — the seven-point registry).


### PR DESCRIPTION
## Summary
`createLogger` gains an optional structured `sink`: a deployable's log exporter receives the entry (level, instant, message, fields) for exactly the lines the threshold let through, after the line is written. The written output is unchanged; the seam carries no runtime dependency.

## Context
The cloud composition ships every log line through this logger and today exports metrics only — its logs never reach Stigmer's SigNoz, while the Java service's do over OTLP from its logback bridge (stigmer-cloud entry `20260909.05.sp.composition-log-export`, X1 checklist line 82). The bridge point is the logger's threshold-filtered `emit`: a decorator around `Logger` would have to re-implement the level ranks. By DD-001 the seam is OSS — a self-hosting team's own exporter is the next consumer — and by stigmer#1017's reasoning the SDK is not: the code that turns an entry into a record belongs to the deployable that chose a collector.

## Changes
- `boot/logger.ts`: `LogEntry`, `LogSink`, `LoggerOptions.sink`; `emit` computes the instant once as a `Date`, prints its ISO form as before, and calls the sink after `write`. Header states the seam's reason, the write-before-sink order, the no-dependency rule and that a sink owns its own failure handling.
- `index.ts`: `LogEntry` and `LogSink` exported.
- `boot/__tests__/logger.test.ts`: four sink arms — threshold-filtered delivery, the same instant on the line and in the entry, both output shapes unchanged with a sink present, write-before-sink ordering.

## Implementation notes
- The logger does not wrap the sink in a try/catch: it runs on every hot path and has nothing to log a sink fault through except itself. The contract (the sink never throws) is stated at the type; the first consumer's sink catches.
- No behavior change without a sink — `time` is still the ISO string on the wire, computed from one `Date` instead of `toISOString()` inline.

## Breaking changes
- None. `LoggerOptions.sink` is optional; every existing call site is unchanged.

## Test plan
- `npm run typecheck` clean; `npm test` 2215 passed / 62 skipped on Node 22.22.1 (the CI version; Node 23.4's `node:sqlite` lacks FTS5 locally, the known environment issue).
- Prettier clean on the touched files.

## Risks
- None beyond a one-line `sink?.()` call on the emit path. Rollback: revert; no consumer depends on the seam until the cloud PR lands.

## Checklist
- [x] Tests added/updated
- [x] Backward compatible
- [ ] Docs — none needed (the self-hosting how-to arrives with #1017's bootstrap)

Refs stigmer#1017.
