### PR TITLE
fix(sdk/react): declare @base-ui/react and @lezer/highlight as devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4589,14 +4589,14 @@
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
       "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@lezer/highlight": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
       "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lezer/common": "^1.3.0"
@@ -23736,6 +23736,7 @@
         "yaml": "^2.8.2"
       },
       "devDependencies": {
+        "@base-ui/react": "^1.3.0",
         "@codemirror/autocomplete": "^6.18.6",
         "@codemirror/commands": "^6.8.0",
         "@codemirror/lang-yaml": "^6.1.2",
@@ -23743,6 +23744,7 @@
         "@codemirror/lint": "^6.8.5",
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.36.5",
+        "@lezer/highlight": "^1.2.3",
         "@tailwindcss/postcss": "^4",
         "@tanstack/react-table": "^8.21.3",
         "@testing-library/react": "^16.3.2",

--- a/sdk/react/package.json
+++ b/sdk/react/package.json
@@ -150,6 +150,7 @@
     }
   },
   "devDependencies": {
+    "@base-ui/react": "^1.3.0",
     "@codemirror/autocomplete": "^6.18.6",
     "@codemirror/commands": "^6.8.0",
     "@codemirror/lang-yaml": "^6.1.2",
@@ -157,6 +158,7 @@
     "@codemirror/lint": "^6.8.5",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.36.5",
+    "@lezer/highlight": "^1.2.3",
     "@tailwindcss/postcss": "^4",
     "@tanstack/react-table": "^8.21.3",
     "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
## Summary
Adds `@base-ui/react` and `@lezer/highlight` to `@stigmer/react`'s `devDependencies`, the pattern its other thirteen optional peers already follow. Two lines; no resolved version changes.

## Context
`ci.ts-sdk`'s `typecheck (clean-room resolution)` job has been red on `main` since run 34444426519 with `TS2307: Cannot find module '@base-ui/react/popover'` (and `/menu`, `/tooltip`). Not an upstream break: `@base-ui/react@1.8.0` still exports every subpath. `sdk/react` imports the package in nine modules (and `@lezer/highlight` in `manifest/YamlEditor.tsx`) and declares both as optional peers, but listed neither in its own `devDependencies`. They resolved for `sdk/react` only because sibling workspaces happen to hoist them to the root `node_modules`; yarn's lockfile-free install did not, and the typecheck told the truth. The clean-room job caught a real declaration gap.

Found while preparing Stage B of stigmer-cloud project `20260904.04` (Turborepo adoption), which moves that job from yarn to npm. Under npm's hoisting the job would have gone green for the wrong reason, so this lands on its own first.

## Changes
- `sdk/react/package.json`: `@base-ui/react` `^1.3.0` and `@lezer/highlight` `^1.2.3` added to `devDependencies` (ranges as the file does it: at or above the peer floor, caret on a recent minor).
- `package-lock.json`: `@lezer/highlight` and `@lezer/common` flip from `devOptional` to `dev`; nothing else moves.

## Implementation notes
- Both packages were already resolved at exactly these versions in the lockfile, so `npm ci` trees are byte-identical before and after.
- The optional-peer *design* question (nine top-level imports of a peer documented as optional) is separate and not touched here.

## Breaking changes
- None.

## Test plan
- Locally (Node 22.22.1, npm 10.9.4): `npm install` → only the two declarations and two lock flags change; `npm ls @base-ui/react @lezer/highlight -w @stigmer/react` shows both declared; `npm run build -w @stigmer/protos && npx tsc -p sdk/react/tsconfig.build.json --noEmit` green.
- On this PR: `ci.ts-sdk` `typecheck (clean-room resolution)` is the proof; it is the job that has been red on `main`.

## Risks
- None beyond a lockfile flag flip. Rollback is a revert.

## Checklist
- [x] Docs updated (not needed)
- [x] Tests added/updated (the clean-room CI job is the test)
- [x] Backward compatible

Closes #1044
