### PR TITLE
test(runner): hermetic ExecuteCursor regression net (S0 cursor-hermetic-instrument)

### DIFF
--- a/backend/services/runner/src/__test-utils__/hermetic-activity.ts
+++ b/backend/services/runner/src/__test-utils__/hermetic-activity.ts
@@ -75,8 +75,13 @@ import {
   type AgentExecution,
   type AgentExecutionStatus,
 } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
-import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import {
+  ApprovalAction,
+  ExecutionPhase,
+  ToolCallStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 import { UpdateStatusResponseSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import type { ToolCall } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
 import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
 import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
@@ -168,6 +173,32 @@ export class ExecutionRecord {
       if (out[out.length - 1] !== s.phase) out.push(s.phase);
     }
     return out;
+  }
+
+  /** Every tool call on the held transcript (top-level messages), in order. */
+  toolCalls(): ToolCall[] {
+    return this.execution.status?.messages.flatMap((m) => m.toolCalls) ?? [];
+  }
+
+  /** The tool calls currently paused for a decision. */
+  waitingToolCalls(): ToolCall[] {
+    return this.toolCalls().filter((tc) => tc.status === ToolCallStatus.TOOL_CALL_WAITING_APPROVAL);
+  }
+
+  /**
+   * What the server's `SubmitApproval` does to the row: record the decision on
+   * the tool call the runner wrote. The runner owns `status`; the server owns
+   * `approval_action` (field ownership, 005 mandate 2) — so this is the ONE
+   * place a test writes it, and the status stays WAITING_APPROVAL until the
+   * resumed turn runs the tool, exactly as in production.
+   */
+  decideWaitingToolCalls(action: ApprovalAction, decidedAt: string): number {
+    const waiting = this.waitingToolCalls();
+    for (const tc of waiting) {
+      tc.approvalAction = action;
+      tc.approvalDecidedAt = decidedAt;
+    }
+    return waiting.length;
   }
 
   applyStatusUpdate(status: AgentExecutionStatus): void {

--- a/backend/services/runner/src/__test-utils__/hermetic-activity.ts
+++ b/backend/services/runner/src/__test-utils__/hermetic-activity.ts
@@ -1,0 +1,440 @@
+/**
+ * Hermetic activity driver — run a REAL runner activity end to end with no
+ * network, no credentials, and no live Temporal worker, and read back every
+ * status it persisted.
+ *
+ * Why this exists: the runner's activities (`ExecuteCursor`, `ExecuteDeepAgent`)
+ * are the wire contract the control plane's workflow keys on — the phases they
+ * persist, the copy they write, whether they RETURN a slim status or THROW
+ * `CancelledFailure`. Refactoring them safely needs goldens recorded through the
+ * activity whole, not through its modules one at a time. The native harness
+ * tests already run their activity hermetically by mocking three modules at the
+ * boundary (`execute-deep-agent/__tests__/{index,hitl-*,sequential-gate-resume}.test.ts`);
+ * this module is that convention made reusable, harness-agnostic, and driven by
+ * the framework's own activity environment instead of a hand-written stand-in.
+ *
+ * What is generic here and what is not: everything an activity touches that is
+ * NOT the vendor SDK — the Temporal `Context`, the control-plane client, the
+ * runner-owned `~/.stigmer` tree, artifact storage, the model registry, the
+ * clock, the worker-shutdown signal — is set up here. The vendor SDK double
+ * belongs to the harness (`activities/execute-cursor/__test-utils__/scripted-*.ts`),
+ * the same split as `approval-contract/` (runner-wide kit) + each harness's
+ * `gateway-substrate.ts`.
+ *
+ * Three substitutions, and why each is shaped the way it is:
+ *
+ *  1. `Context.current()` — `MockActivityEnvironment` from `@temporalio/testing`,
+ *     ONE PER INVOCATION. It gives the activity a real `Context` (real
+ *     `cancellationSignal`, real `heartbeat()` surfaced as events, real
+ *     `CancelledFailure` on throw). The native tests' stand-in mints a fresh
+ *     `AbortController` on every `Context.current()` call and so cannot drive a
+ *     pause; production hands each attempt one `Context`, and so does this. The
+ *     environment's documented caveat — once cancelled it stays cancelled — is
+ *     why it is per invocation and never shared.
+ *
+ *  2. `StigmerClient` — the test file mocks the module (`vi.mock` is hoisted and
+ *     must live in the test file; see {@link hermeticStigmerClientModule}) and
+ *     the constructor hands back whatever client {@link bindHermeticClient} bound
+ *     for the current run. The client is `mockStigmerClient` over an
+ *     {@link ExecutionRecord}: `updateStatus` writes back into the record the way
+ *     the server would, so a REINVOCATION (`threadId` set) reads the transcript
+ *     the first invocation persisted — the resume path runs on real data, not on
+ *     a hand-built status.
+ *
+ *  3. The environment — a temp `HOME` (the runner-owned `~/.stigmer` tree,
+ *     `platform-dir.ts` reads `process.env.HOME`), a temp workspace root, local
+ *     artifact storage in a temp dir, and the HITL fingerprint secret pinned by
+ *     env var (`fingerprint-secret.ts` falls back to `randomBytes` — the ONE
+ *     source of randomness on the activity path — and memoizes on first call, so
+ *     the pin must precede the first invocation in the process).
+ *
+ * Determinism: the clock is faked for `Date` ONLY (`vi.useFakeTimers({ toFake:
+ * ["Date"] })`) and TICKS — the harness double advances it a fixed quantum per
+ * script step through {@link ScriptedClock}. Frozen time would make
+ * `delta-enricher.ts`'s persist debounce (`Date.now() - lastPersistTime`) never
+ * elapse and silently skip the mid-stream persist path production always runs;
+ * a ticking clock runs the same path and lands on the same instants every run.
+ * Timers stay real so the periodic heartbeat and the stall watchdog behave.
+ *
+ * Not in scope: this module never edits a production module and never
+ * normalizes output. If a golden is not byte-stable, the volatile source is
+ * controlled at its origin or the surprise is escalated — never redacted here.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { vi } from "vitest";
+import { MockActivityEnvironment } from "@temporalio/testing";
+import { CancelledFailure } from "@temporalio/activity";
+import { Code, ConnectError } from "@connectrpc/connect";
+import { clone, create } from "@bufbuild/protobuf";
+import {
+  AgentExecutionSchema,
+  AgentExecutionStatusSchema,
+  type AgentExecution,
+  type AgentExecutionStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { UpdateStatusResponseSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/io_pb";
+import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import type { Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import type { AgentInstance } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import type { StigmerClient } from "../client/stigmer-client.js";
+import {
+  registerWorkerShutdownSignal,
+  signalWorkerShutdown,
+  unregisterWorkerShutdownSignal,
+} from "../shared/worker-shutdown.js";
+import { mockStigmerClient } from "./mock-client.js";
+
+// ---------------------------------------------------------------------------
+// The execution record: what the control plane would hold for one execution
+// ---------------------------------------------------------------------------
+
+/**
+ * The four resources the activity's blueprint chain reads
+ * (`execution.spec.sessionId -> session.spec.agentInstanceId ->
+ * agentInstance.spec.agentId -> agent`) plus the status the server would hold.
+ */
+export interface ExecutionRecordInput {
+  readonly execution: AgentExecution;
+  readonly session: Session;
+  readonly agentInstance: AgentInstance;
+  readonly agent: Agent;
+}
+
+/**
+ * An in-memory stand-in for the server's execution row, with the TWO merge
+ * rules the activity depends on and no others:
+ *
+ *  - A status whose phase is UNSPECIFIED is a setup-progress report
+ *    (`reportSetupProgress`): the server keeps `setup_progress` and leaves the
+ *    phase and transcript alone. Modelled as: record the label, change nothing else.
+ *  - Any other status replaces the held status wholesale (the runner is the
+ *    writer of the transcript; the server's own field-ownership merge — approval
+ *    fields it owns — is exercised by the test SETTING `approvalAction` on the
+ *    record between invocations, exactly as `SubmitApproval` would).
+ *
+ * Every persisted status is also kept in order (`persisted`) so a test can
+ * assert the phase sequence the activity wrote, independent of the final state.
+ */
+export class ExecutionRecord {
+  readonly execution: AgentExecution;
+  readonly session: Session;
+  readonly agentInstance: AgentInstance;
+  readonly agent: Agent;
+  /** Every `updateStatus` payload, in order, snapshotted at write time. */
+  readonly persisted: AgentExecutionStatus[] = [];
+  /** Setup-progress labels reported before the stream started, in order. */
+  readonly setupProgress: string[] = [];
+  /** Every `updateSession` payload, in order (the `harness_state_id` write-back). */
+  readonly sessionUpdates: Session[] = [];
+
+  constructor(input: ExecutionRecordInput) {
+    this.execution = clone(AgentExecutionSchema, input.execution);
+    this.session = input.session;
+    this.agentInstance = input.agentInstance;
+    this.agent = input.agent;
+  }
+
+  get executionId(): string {
+    return this.execution.metadata?.id ?? "";
+  }
+
+  /** The status the server would currently hold (what `getExecution` returns). */
+  get status(): AgentExecutionStatus | undefined {
+    return this.execution.status;
+  }
+
+  /** The last FULL status written (phase set), or undefined if none yet. */
+  get lastFullStatus(): AgentExecutionStatus | undefined {
+    for (let i = this.persisted.length - 1; i >= 0; i--) {
+      const s = this.persisted[i];
+      if (s.phase !== ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED) return s;
+    }
+    return undefined;
+  }
+
+  /**
+   * The ORDERED, DISTINCT phases the activity persisted — the deterministic
+   * shape of the persist cadence. The COUNT of persists depends on the
+   * debounce timer and is deliberately not exposed as an assertion surface.
+   */
+  get persistedPhases(): ExecutionPhase[] {
+    const out: ExecutionPhase[] = [];
+    for (const s of this.persisted) {
+      if (s.phase === ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED) continue;
+      if (out[out.length - 1] !== s.phase) out.push(s.phase);
+    }
+    return out;
+  }
+
+  applyStatusUpdate(status: AgentExecutionStatus): void {
+    const snapshot = clone(AgentExecutionStatusSchema, status);
+    this.persisted.push(snapshot);
+    if (snapshot.phase === ExecutionPhase.EXECUTION_PHASE_UNSPECIFIED) {
+      if (snapshot.setupProgress?.currentPhase) {
+        this.setupProgress.push(snapshot.setupProgress.currentPhase);
+      }
+      return;
+    }
+    this.execution.status = clone(AgentExecutionStatusSchema, snapshot);
+  }
+
+  /**
+   * The control-plane client the activity sees: every read answers from this
+   * record; every write lands in it. Reads the activity makes for optional
+   * facets (execution context, channels, skills) answer the everyday shape —
+   * NOT_FOUND for the execution context (an execution with no env vars), no
+   * channels, no scoped token (the OSS/local posture) — so a scenario opts INTO
+   * a facet by overriding.
+   */
+  client(overrides: Partial<StigmerClient> = {}): StigmerClient {
+    return mockStigmerClient({
+      getExecution: vi.fn(async () => clone(AgentExecutionSchema, this.execution)),
+      getSession: vi.fn(async () => this.session),
+      getAgentInstance: vi.fn(async () => this.agentInstance),
+      getAgent: vi.fn(async () => this.agent),
+      updateStatus: vi.fn(async (_id: string, status: AgentExecutionStatus) => {
+        this.applyStatusUpdate(status);
+        // The activity reads only `.signal`; UNSPECIFIED means "keep going".
+        return create(UpdateStatusResponseSchema, {});
+      }),
+      updateSession: vi.fn(async (session: Session) => {
+        this.sessionUpdates.push(session);
+        return session;
+      }),
+      getExecutionContextByExecutionId: vi.fn(async () => {
+        throw new ConnectError("execution context not found", Code.NotFound);
+      }),
+      ...overrides,
+    } as Partial<StigmerClient>);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The module-boundary seam for StigmerClient
+// ---------------------------------------------------------------------------
+
+let boundClient: StigmerClient | undefined;
+
+/**
+ * Bind the client the mocked `StigmerClient` constructor hands out for the
+ * current run. Called by the harness driver immediately before invoking the
+ * activity factory (`createCursorActivities(config)` constructs its client
+ * inside the factory, so the bind must precede the factory call).
+ */
+export function bindHermeticClient(client: StigmerClient): void {
+  boundClient = client;
+}
+
+/**
+ * The factory a test passes to `vi.mock(".../client/stigmer-client.js", ...)`.
+ * `vi.mock` is hoisted and must appear in the test file itself; the factory can
+ * `await import()` this module. Usage:
+ *
+ * ```ts
+ * vi.mock("../../../../client/stigmer-client.js", async () =>
+ *   (await import("../../../../__test-utils__/hermetic-activity.js")).hermeticStigmerClientModule(),
+ * );
+ * ```
+ */
+export function hermeticStigmerClientModule(): { StigmerClient: new () => StigmerClient } {
+  return {
+    StigmerClient: class {
+      constructor() {
+        if (!boundClient) {
+          throw new Error(
+            "hermetic-activity: no StigmerClient bound — call bindHermeticClient(record.client()) " +
+              "before constructing the activities",
+          );
+        }
+        return boundClient;
+      }
+    } as unknown as new () => StigmerClient,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The environment: temp HOME, temp workspace root, local artifact storage
+// ---------------------------------------------------------------------------
+
+/**
+ * The env-var pins a hermetic run needs, and the reason for each:
+ *  - `HOME`: `platform-dir.ts` roots the runner-owned `~/.stigmer` tree (HITL
+ *    gate dir, session dirs, denial ledger) on it.
+ *  - `ARTIFACT_STORAGE_TYPE=local` + `LOCAL_ARTIFACT_PATH`: a writable local
+ *    store so capture mode and tool-output offload run the production path
+ *    (an absent store flips capture off — a different code path).
+ *  - `STIGMER_RUNNER_HITL_SECRET`: the one randomness source on the activity
+ *    path, pinned so grant tokens and fingerprints are byte-stable.
+ *  - `CURSOR_EVENT_RECORD_DIR` cleared: never write recordings from a test.
+ */
+const PINNED_ENV = {
+  ARTIFACT_STORAGE_TYPE: "local",
+  STIGMER_RUNNER_HITL_SECRET: "hermetic-fixture-secret-do-not-use-in-production",
+} as const;
+
+const CLEARED_ENV = ["CURSOR_EVENT_RECORD_DIR", "STIGMER_PROXY_ENDPOINT", "STIGMER_CLOUD_API_URL"] as const;
+
+export interface HermeticEnvironment {
+  /** The temp `HOME` (the runner's `~/.stigmer` lands under it). */
+  readonly home: string;
+  /** The temp workspace root (`config.workspaceRootDir`). */
+  readonly workspaceRootDir: string;
+  /** The temp local artifact store (`LOCAL_ARTIFACT_PATH`). */
+  readonly artifactPath: string;
+  /** Restore every env var and remove the temp tree. Idempotent. */
+  dispose(): void;
+}
+
+/**
+ * Create the temp tree and pin the env vars. Call once per test FILE (in
+ * `beforeAll`) — the fingerprint secret is memoized per process on first use,
+ * and vitest isolates files in forks, so per-file is the natural unit.
+ */
+export function createHermeticEnvironment(): HermeticEnvironment {
+  const root = mkdtempSync(join(tmpdir(), "stigmer-hermetic-"));
+  const home = join(root, "home");
+  const workspaceRootDir = join(root, "workspaces");
+  const artifactPath = join(root, "artifacts");
+
+  const saved = new Map<string, string | undefined>();
+  const set = (key: string, value: string | undefined): void => {
+    if (!saved.has(key)) saved.set(key, process.env[key]);
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  };
+  set("HOME", home);
+  set("LOCAL_ARTIFACT_PATH", artifactPath);
+  for (const [k, v] of Object.entries(PINNED_ENV)) set(k, v);
+  for (const k of CLEARED_ENV) set(k, undefined);
+
+  let disposed = false;
+  return {
+    home,
+    workspaceRootDir,
+    artifactPath,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      for (const [k, v] of saved) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The clock
+// ---------------------------------------------------------------------------
+
+/**
+ * A deterministic, TICKING `Date`. Only `Date` is faked; timers stay real (the
+ * periodic heartbeat, the stall watchdog, `withTimeout` all need them). The
+ * harness double calls {@link ScriptedClock.tick} once per script step, so
+ * every `Date.now()`-based decision on the activity path (status timestamps,
+ * the enricher's persist debounce, cache TTLs) sees the same instants run after
+ * run and runs the same branches production runs.
+ */
+export class ScriptedClock {
+  /** A fixed epoch: 2026-01-01T00:00:00.000Z. Chosen for readability in goldens. */
+  static readonly EPOCH_MS = Date.UTC(2026, 0, 1, 0, 0, 0, 0);
+  /** One second per step — well under any stall or cache horizon. */
+  static readonly STEP_MS = 1_000;
+
+  private nowMs = ScriptedClock.EPOCH_MS;
+
+  install(): void {
+    vi.useFakeTimers({ toFake: ["Date"], now: this.nowMs });
+  }
+
+  tick(ms: number = ScriptedClock.STEP_MS): void {
+    this.nowMs += ms;
+    vi.setSystemTime(this.nowMs);
+  }
+
+  uninstall(): void {
+    vi.useRealTimers();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Running one activity invocation
+// ---------------------------------------------------------------------------
+
+/** How an activity invocation ended: the return value or the error it threw. */
+export type ActivityOutcome =
+  | { readonly kind: "returned"; readonly value: unknown }
+  | { readonly kind: "threw"; readonly error: unknown };
+
+export interface ActivityInvocation {
+  readonly outcome: ActivityOutcome;
+  /** Heartbeat details the activity reported, in order. */
+  readonly heartbeats: unknown[];
+  /** The `taskQueue` the invocation ran on (the shutdown signal is keyed by it). */
+  readonly taskQueue: string;
+}
+
+/**
+ * Handles a scenario uses to interrupt the invocation FROM A SCRIPT STEP —
+ * never from a timer. `cancel()` aborts the activity's `cancellationSignal`
+ * (a user pause, as the workflow delivers it). `signalWorkerShutdown()` aborts
+ * the queue's shutdown signal first, which the activity reads to tell a worker
+ * drain from a user pause (`classifyTurnInterruption`).
+ */
+export interface InvocationControls {
+  cancel(): void;
+  signalWorkerShutdown(): void;
+}
+
+export interface RunActivityOptions {
+  readonly taskQueue?: string;
+  /**
+   * Receives the invocation's controls before the activity starts, so a
+   * scenario can hand them to the harness double's `effect` steps.
+   */
+  readonly onControls?: (controls: InvocationControls) => void;
+}
+
+/**
+ * Run one activity function under a fresh `MockActivityEnvironment` and
+ * capture how it ended. `CancelledFailure` is caught like any other throw and
+ * reported as `{ kind: "threw" }` — the throw-vs-return table is the thing
+ * under test, so the driver never interprets it.
+ */
+export async function runActivityHermetically<A extends unknown[]>(
+  activity: (...args: A) => Promise<unknown>,
+  args: A,
+  options: RunActivityOptions = {},
+): Promise<ActivityInvocation> {
+  const taskQueue = options.taskQueue ?? "hermetic-test-queue";
+  const env = new MockActivityEnvironment({ taskQueue });
+  const heartbeats: unknown[] = [];
+  env.on("heartbeat", (details: unknown) => heartbeats.push(details));
+
+  // The worker-shutdown signal is process-global per queue; register for this
+  // invocation and always unregister so no state leaks into the next one.
+  registerWorkerShutdownSignal(taskQueue);
+  options.onControls?.({
+    cancel: () => env.cancel(),
+    signalWorkerShutdown: () => signalWorkerShutdown(taskQueue),
+  });
+
+  try {
+    const value = await env.run(activity, ...args);
+    return { outcome: { kind: "returned", value }, heartbeats, taskQueue };
+  } catch (error) {
+    return { outcome: { kind: "threw", error }, heartbeats, taskQueue };
+  } finally {
+    unregisterWorkerShutdownSignal(taskQueue);
+  }
+}
+
+/** True when the outcome is a thrown Temporal `CancelledFailure`. */
+export function threwCancelledFailure(outcome: ActivityOutcome): outcome is { kind: "threw"; error: CancelledFailure } {
+  return outcome.kind === "threw" && outcome.error instanceof CancelledFailure;
+}

--- a/backend/services/runner/src/__test-utils__/hermetic-activity.ts
+++ b/backend/services/runner/src/__test-utils__/hermetic-activity.ts
@@ -388,6 +388,12 @@ export class ScriptedClock {
     vi.setSystemTime(this.nowMs);
   }
 
+  /** Back to the epoch — for a second scenario in the same file. */
+  reset(): void {
+    this.nowMs = ScriptedClock.EPOCH_MS;
+    vi.setSystemTime(this.nowMs);
+  }
+
   uninstall(): void {
     vi.useRealTimers();
   }

--- a/backend/services/runner/src/activities/execute-cursor/__test-utils__/hermetic-cursor.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__test-utils__/hermetic-cursor.ts
@@ -34,6 +34,9 @@
  * check — more of the production path under the golden.
  */
 
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { create } from "@bufbuild/protobuf";
 import type { ModelListItem } from "@cursor/sdk";
 import { vi } from "vitest";
@@ -47,7 +50,12 @@ import {
 } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
 import { SessionSchema, type Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
 import { SessionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
-import type { WorkspaceEntry } from "@stigmer/protos/ai/stigmer/agentic/session/v1/workspace_pb";
+import {
+  LocalPathSourceSchema,
+  WorkspaceEntrySchema,
+  WorkspaceSourceSchema,
+  type WorkspaceEntry,
+} from "@stigmer/protos/ai/stigmer/agentic/session/v1/workspace_pb";
 import { AgentSchema, type Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
 import { AgentSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/spec_pb";
 import {
@@ -252,6 +260,91 @@ export function hermeticCursorConfig(env: HermeticEnvironment): Config {
     agentResolveTimeoutMs: 120_000,
     workspaceLockTimeoutMs: 900_000,
   };
+}
+
+// ---------------------------------------------------------------------------
+// The side effects the real SDK performs, for `effect` steps
+// ---------------------------------------------------------------------------
+
+/**
+ * The primary workspace directory a session with NO workspace entries runs in
+ * (`session-root.ts`: `<workspaceRootDir>/sessions/<sessionId>`).
+ */
+export function sessionWorkspaceDir(env: HermeticEnvironment): string {
+  return join(env.workspaceRootDir, "sessions", FIXTURE.sessionId);
+}
+
+/**
+ * Run the workspace's installed preToolUse hook exactly as the Cursor SDK does:
+ * read `<workspaceRoot>/.cursor/hooks.json`, take the `preToolUse` command the
+ * gate installed (an absolute path to the runner's own stable bash script under
+ * `~/.stigmer/hitl-gate/<key>/`), and run it with the hook input on stdin. The
+ * script resolves the CURRENT turn's state file and denial ledger from the
+ * active-turn pointer, walks its parent PIDs to confirm this process is the
+ * runner, and prints `{"permission":"allow"|"deny"}`. A deny appends to the
+ * ledger the activity's stream loop reads.
+ *
+ * This is the out-of-process half of deny-and-retry, driven by the real script
+ * against the real gate the activity installed — not a simulation of either.
+ */
+export function runWorkspaceHook(
+  workspaceRoot: string,
+  hookInput: object,
+): { readonly permission: "allow" | "deny" | "?"; readonly raw: string } {
+  const hooksJsonPath = join(workspaceRoot, ".cursor", "hooks.json");
+  const parsed = JSON.parse(readFileSync(hooksJsonPath, "utf-8")) as {
+    hooks?: { preToolUse?: Array<{ command: string }> };
+  };
+  const command = parsed.hooks?.preToolUse?.[0]?.command;
+  if (!command) {
+    throw new Error(`runWorkspaceHook: no preToolUse hook installed in ${hooksJsonPath}`);
+  }
+  const raw = execFileSync("bash", [command], { input: JSON.stringify(hookInput) }).toString();
+  const permission = raw.includes('"permission":"deny"')
+    ? "deny"
+    : raw.includes('"permission":"allow"')
+      ? "allow"
+      : "?";
+  return { permission, raw };
+}
+
+/**
+ * A git work tree with one committed file, for the file-review capture
+ * scenario. Author, committer and both dates are pinned so the commit AND tree
+ * object ids are byte-stable — a file-review golden may carry them.
+ */
+export function initGitWorkspace(root: string, files: Record<string, string>): void {
+  mkdirSync(root, { recursive: true });
+  const gitEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: "hermetic",
+    GIT_AUTHOR_EMAIL: "hermetic@stigmer.test",
+    GIT_COMMITTER_NAME: "hermetic",
+    GIT_COMMITTER_EMAIL: "hermetic@stigmer.test",
+    GIT_AUTHOR_DATE: "2026-01-01T00:00:00Z",
+    GIT_COMMITTER_DATE: "2026-01-01T00:00:00Z",
+  };
+  const git = (args: string[]): void => {
+    execFileSync("git", args, { cwd: root, env: gitEnv, stdio: "ignore" });
+  };
+  git(["init", "-q", "-b", "main"]);
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = join(root, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content, "utf-8");
+  }
+  git(["add", "-A"]);
+  git(["commit", "-q", "-m", "initial"]);
+}
+
+/** A session workspace entry mounting an absolute local path (local mode only). */
+export function localPathEntry(name: string, path: string): WorkspaceEntry {
+  return create(WorkspaceEntrySchema, {
+    name,
+    source: create(WorkspaceSourceSchema, {
+      source: { case: "localPath", value: create(LocalPathSourceSchema, { path }) },
+    }),
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/backend/services/runner/src/activities/execute-cursor/__test-utils__/hermetic-cursor.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__test-utils__/hermetic-cursor.ts
@@ -1,0 +1,329 @@
+/**
+ * The Cursor slice of the hermetic activity driver: build the fixture record,
+ * the scripted SDK and the `Config`, run the REAL `ExecuteCursor` activity under
+ * `MockActivityEnvironment`, and hand back what it persisted.
+ *
+ * Layering (the `approval-contract/` + `gateway-substrate.ts` split): everything
+ * harness-agnostic lives in `src/__test-utils__/hermetic-activity.ts` (the
+ * activity environment, the execution record behind the client, the temp
+ * `~/.stigmer`, the ticking clock, the shutdown signal). This module adds only
+ * what is Cursor's: the `@cursor/sdk` double, the model catalog and pricing
+ * registry the harness reads at setup, the Cursor `Config` slice, and the
+ * per-scenario reset of the harness's module-level caches.
+ *
+ * What the two `vi.mock` calls a scenario file must carry look like — they are
+ * hoisted by vitest and so cannot live here:
+ *
+ * ```ts
+ * vi.mock("@cursor/sdk", async () =>
+ *   (await import("../../__test-utils__/scripted-sdk.js")).scriptedCursorSdkModule());
+ * vi.mock("../../../../client/stigmer-client.js", async () =>
+ *   (await import("../../../../__test-utils__/hermetic-activity.js")).hermeticStigmerClientModule());
+ * ```
+ *
+ * Network: the activity's only HTTP fetch is the model registry
+ * (`model-pricing-data.ts`, `shared/model-registry.ts`; both fail SOFT to
+ * defaults with a 60s failure cache, which would make the goldens depend on
+ * DEFAULT_PRICING and log warnings on every run). `fetch` is stubbed to answer
+ * one registry document — and to THROW for any other URL, so a new network
+ * dependency on the activity path fails the hermetic run instead of leaking.
+ *
+ * The fixture model is `composer-2.5`, pinned (not Auto) on purpose: Auto short-
+ * circuits `resolveServiceTierParams` before the catalog, and a pinned model runs
+ * the catalog path, the variant-param pinning, and the `run.wait()` model echo
+ * check — more of the production path under the golden.
+ */
+
+import { create } from "@bufbuild/protobuf";
+import type { ModelListItem } from "@cursor/sdk";
+import { vi } from "vitest";
+import {
+  AgentExecutionSchema,
+  type AgentExecution,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  AgentExecutionSpecSchema,
+  ExecutionConfigSchema,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/spec_pb";
+import { SessionSchema, type Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { SessionSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/spec_pb";
+import type { WorkspaceEntry } from "@stigmer/protos/ai/stigmer/agentic/session/v1/workspace_pb";
+import { AgentSchema, type Agent } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/spec_pb";
+import {
+  AgentInstanceSchema,
+  type AgentInstance,
+} from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/api_pb";
+import { AgentInstanceSpecSchema } from "@stigmer/protos/ai/stigmer/agentic/agentinstance/v1/spec_pb";
+import { ApiResourceMetadataSchema } from "@stigmer/protos/ai/stigmer/commons/apiresource/metadata_pb";
+import type { Config } from "../../../config.js";
+import type { ExecuteActivityInput } from "../../../shared/activity-input.js";
+import {
+  ExecutionRecord,
+  ScriptedClock,
+  bindHermeticClient,
+  runActivityHermetically,
+  type ActivityInvocation,
+  type HermeticEnvironment,
+  type InvocationControls,
+} from "../../../__test-utils__/hermetic-activity.js";
+import { _resetAgentSessionCacheForTests } from "../agent-session-cache.js";
+import { _resetPricingCache } from "../model-pricing-data.js";
+import { resetCatalogCacheForTests } from "../service-tier.js";
+import { _resetRegistryCache } from "../../../shared/model-registry.js";
+import { ScriptedCursorSdk, bindScriptedSdk, type ScriptedSdkOptions } from "./scripted-sdk.js";
+
+// ---------------------------------------------------------------------------
+// Fixture ids — fixed so goldens are readable and byte-stable
+// ---------------------------------------------------------------------------
+
+export const FIXTURE = {
+  org: "hermetic-org",
+  executionId: "aex_hermetic_0001",
+  sessionId: "ses_hermetic_0001",
+  agentInstanceId: "ain_hermetic_0001",
+  agentId: "agt_hermetic_0001",
+  agentName: "hermetic-agent",
+  /** The pinned model; in the registry stub AND the SDK catalog below. */
+  model: "composer-2.5",
+  cursorApiKey: "hermetic-cursor-api-key",
+} as const;
+
+// ---------------------------------------------------------------------------
+// The record
+// ---------------------------------------------------------------------------
+
+export interface CursorRecordOptions {
+  /** The user's message for this execution. */
+  readonly message: string;
+  /** The agent's instructions (system prompt body). */
+  readonly instructions?: string;
+  /** Session workspace entries (a `local_path` entry turns on capture mode). */
+  readonly workspaceEntries?: WorkspaceEntry[];
+  readonly modelName?: string;
+  readonly autoApproveAll?: boolean;
+}
+
+/** The four resources of one execution, wired by id into a chain. */
+export function cursorExecutionRecord(options: CursorRecordOptions): ExecutionRecord {
+  const execution: AgentExecution = create(AgentExecutionSchema, {
+    metadata: create(ApiResourceMetadataSchema, {
+      id: FIXTURE.executionId,
+      org: FIXTURE.org,
+      name: FIXTURE.executionId,
+    }),
+    spec: create(AgentExecutionSpecSchema, {
+      sessionId: FIXTURE.sessionId,
+      message: options.message,
+      autoApproveAll: options.autoApproveAll ?? false,
+      executionConfig: create(ExecutionConfigSchema, {
+        modelName: options.modelName ?? FIXTURE.model,
+      }),
+    }),
+  });
+  const session: Session = create(SessionSchema, {
+    metadata: create(ApiResourceMetadataSchema, {
+      id: FIXTURE.sessionId,
+      org: FIXTURE.org,
+      name: FIXTURE.sessionId,
+    }),
+    spec: create(SessionSpecSchema, {
+      agentInstanceId: FIXTURE.agentInstanceId,
+      workspaceEntries: options.workspaceEntries ?? [],
+    }),
+  });
+  const agentInstance: AgentInstance = create(AgentInstanceSchema, {
+    metadata: create(ApiResourceMetadataSchema, {
+      id: FIXTURE.agentInstanceId,
+      org: FIXTURE.org,
+      name: FIXTURE.agentInstanceId,
+    }),
+    spec: create(AgentInstanceSpecSchema, { agentId: FIXTURE.agentId }),
+  });
+  const agent: Agent = create(AgentSchema, {
+    metadata: create(ApiResourceMetadataSchema, {
+      id: FIXTURE.agentId,
+      org: FIXTURE.org,
+      name: FIXTURE.agentName,
+    }),
+    spec: create(AgentSpecSchema, {
+      description: "Hermetic fixture agent",
+      instructions: options.instructions ?? "You are the hermetic fixture agent. Answer briefly.",
+    }),
+  });
+  return new ExecutionRecord({ execution, session, agentInstance, agent });
+}
+
+// ---------------------------------------------------------------------------
+// The registry document and the SDK catalog
+// ---------------------------------------------------------------------------
+
+/**
+ * The model registry document both readers parse (`parsePricingTable` wants
+ * `harness: "cursor"` + `pricing`; `parseRegistry` wants `id` + `provider` and
+ * reads `capabilities.vision`). One entry, the fixture model, priced at round
+ * numbers so the golden's `estimatedCostUsd` is legible.
+ */
+export const REGISTRY_DOCUMENT = {
+  models: [
+    {
+      id: FIXTURE.model,
+      displayName: "Composer 2.5 (hermetic fixture)",
+      provider: "cursor",
+      harness: "cursor",
+      costTier: "standard",
+      featured: true,
+      capabilities: { vision: true },
+      pricing: {
+        inputPricePerMillion: 1.0,
+        outputPricePerMillion: 4.0,
+        cacheWritePricePerMillion: 1.0,
+        cacheReadPricePerMillion: 0.1,
+      },
+      pricingVariants: {
+        fast: {
+          inputPricePerMillion: 3.0,
+          outputPricePerMillion: 12.0,
+          cacheWritePricePerMillion: 3.0,
+          cacheReadPricePerMillion: 0.3,
+        },
+      },
+    },
+  ],
+} as const;
+
+/** The SDK catalog entry for the fixture model: both pinnable params declared. */
+export const SDK_CATALOG: readonly ModelListItem[] = [
+  {
+    id: FIXTURE.model,
+    displayName: "Composer 2.5",
+    parameters: [
+      { id: "fast", values: [{ value: "true" }, { value: "false" }] },
+      { id: "thinking", values: [{ value: "true" }, { value: "false" }] },
+    ],
+  },
+];
+
+/**
+ * Stub `fetch` to answer the registry document and refuse everything else.
+ * Returns the URLs fetched, for the "no other network" assertion.
+ */
+export function stubRegistryFetch(): { readonly urls: string[]; restore(): void } {
+  const urls: string[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      urls.push(url);
+      if (!url.includes("/model-registry")) {
+        throw new Error(`hermetic run attempted a non-registry network call: ${url}`);
+      }
+      return { ok: true, status: 200, json: async () => REGISTRY_DOCUMENT } as unknown as Response;
+    }),
+  );
+  return { urls, restore: () => vi.unstubAllGlobals() };
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/** The OSS/local runner posture: direct Cursor API key, no proxy, local mode. */
+export function hermeticCursorConfig(env: HermeticEnvironment): Config {
+  return {
+    taskQueue: "hermetic-test-queue",
+    temporalAddress: "localhost:7233",
+    temporalNamespace: "default",
+    stigmerBackendEndpoint: "http://localhost:7234",
+    mcpBridgeEndpoint: null,
+    stigmerToken: null,
+    cursorApiKey: FIXTURE.cursorApiKey,
+    workspaceRootDir: env.workspaceRootDir,
+    mode: "local",
+    proxyEndpoint: null,
+    maxConcurrentActivities: 1,
+    idleTimeoutSeconds: null,
+    cloudModeEnabled: false,
+    checkpointerType: "memory",
+    checkpointerProxyEndpoint: null,
+    artifactProxyEndpoint: null,
+    primaryModel: FIXTURE.model,
+    cursorStreamStallTimeoutMs: 180_000,
+    agentResolveTimeoutMs: 120_000,
+    workspaceLockTimeoutMs: 900_000,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Running a scenario
+// ---------------------------------------------------------------------------
+
+/**
+ * Drop every module-level cache the harness keeps across invocations. Called
+ * at the START of a scenario, never between its invocations: a deny-and-retry
+ * scenario relies on the parked agent surviving from turn 1 into turn 2 exactly
+ * as it does in a live worker.
+ */
+export function resetCursorModuleState(): void {
+  _resetAgentSessionCacheForTests();
+  resetCatalogCacheForTests();
+  _resetPricingCache();
+  _resetRegistryCache();
+}
+
+export interface CursorScenario {
+  readonly env: HermeticEnvironment;
+  readonly clock: ScriptedClock;
+  readonly record: ExecutionRecord;
+  readonly sdk: ScriptedCursorSdk;
+}
+
+export interface CursorScenarioOptions {
+  readonly env: HermeticEnvironment;
+  readonly clock: ScriptedClock;
+  readonly record: ExecutionRecord;
+  readonly sdk: ScriptedSdkOptions;
+}
+
+/** Bind the record and the SDK for a scenario; resets the harness caches first. */
+export function beginCursorScenario(options: CursorScenarioOptions): CursorScenario {
+  resetCursorModuleState();
+  const sdk = new ScriptedCursorSdk(options.sdk);
+  bindScriptedSdk(sdk);
+  bindHermeticClient(options.record.client());
+  return { env: options.env, clock: options.clock, record: options.record, sdk };
+}
+
+export interface CursorTurnOptions {
+  /** Empty for a first invocation; the agent id for a HITL reinvocation. */
+  readonly threadId?: string;
+  /** The HITL cycle index (0 on the first turn); mints the change-set id. */
+  readonly turnSeq?: number;
+  readonly onControls?: (controls: InvocationControls) => void;
+}
+
+/**
+ * Run ONE `ExecuteCursor` invocation for the scenario. The activities are
+ * constructed per invocation (the factory constructs its client, which is the
+ * one bound at `beginCursorScenario`).
+ */
+export async function runCursorTurn(
+  scenario: CursorScenario,
+  options: CursorTurnOptions = {},
+): Promise<ActivityInvocation> {
+  // Imported lazily so the scenario file's `vi.mock` declarations are in
+  // force before the activity module (and, through it, `@cursor/sdk` and the
+  // client) is loaded.
+  const { createCursorActivities } = await import("../index.js");
+  const activities = createCursorActivities(hermeticCursorConfig(scenario.env));
+  // The typed wire shape the control plane's workflow sends (activity-input.ts).
+  const input: ExecuteActivityInput = {
+    execution_id: scenario.record.executionId,
+    thread_id: options.threadId ?? "",
+    turn_seq: options.turnSeq ?? 0,
+  };
+  return runActivityHermetically(activities.ExecuteCursor, [input], {
+    taskQueue: "hermetic-test-queue",
+    onControls: options.onControls,
+  });
+}

--- a/backend/services/runner/src/activities/execute-cursor/__test-utils__/scripted-agent.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__test-utils__/scripted-agent.ts
@@ -111,6 +111,39 @@ export const step = {
   },
 } as const;
 
+/**
+ * `SDKMessage` builders bound to one (agent_id, run_id) pair, so a scenario
+ * reads as the conversation it scripts. Shapes are the SDK's `messages.d.ts`;
+ * tool names are the STREAM taxonomy (`edit`, `shell`, `read` — lowercase; the
+ * hook sees `Write`, `Shell`, `Read`; see `approval-gate.test.ts`).
+ */
+export function sdkEvents(agentId: string, runId: string) {
+  const base = { agent_id: agentId, run_id: runId } as const;
+  return {
+    init(): SDKMessage {
+      return { type: "system", subtype: "init", ...base };
+    },
+    assistant(text: string): SDKMessage {
+      return { type: "assistant", ...base, message: { role: "assistant", content: [{ type: "text", text }] } };
+    },
+    thinking(text: string): SDKMessage {
+      return { type: "thinking", ...base, text };
+    },
+    toolCall(
+      callId: string,
+      name: string,
+      status: "running" | "completed" | "error",
+      args?: unknown,
+      result?: unknown,
+    ): SDKMessage {
+      return { type: "tool_call", ...base, call_id: callId, name, status, args, result };
+    },
+    status(status: "CREATING" | "RUNNING" | "FINISHED" | "ERROR" | "CANCELLED" | "EXPIRED", message?: string): SDKMessage {
+      return { type: "status", ...base, status, message };
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // The run
 // ---------------------------------------------------------------------------

--- a/backend/services/runner/src/activities/execute-cursor/__test-utils__/scripted-agent.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__test-utils__/scripted-agent.ts
@@ -1,0 +1,309 @@
+/**
+ * Scripted `@cursor/sdk` agent — the double the hermetic `ExecuteCursor` runs
+ * drive instead of a live Cursor agent.
+ *
+ * The Cursor harness delegates the agent loop to the SDK: `agent.send()`
+ * returns a `Run` whose `stream()` yields `SDKMessage`s, whose `onDelta`
+ * callback carries usage, and whose `wait()` resolves the `RunResult`. Between
+ * those events the REAL SDK also performs side effects the harness observes
+ * only indirectly — it executes the tool (writing a file into the workspace) and
+ * it spawns the workspace's `.cursor/hooks.json` hook before a gated tool (the
+ * runner's own bash script, which appends to the denial ledger). A double that
+ * replays events alone would leave those effects out and the harness's
+ * deny-and-retry and file-review paths untested.
+ *
+ * So a turn is a SCRIPT of ordered steps, one of four kinds:
+ *
+ *  - `event(SDKMessage)`     — yielded from `stream()`
+ *  - `delta(update)`         — fired through `onDelta` (usage, `turn-ended`)
+ *  - `effect(fn)`            — the side effect the SDK would have performed
+ *                              (run the real hook, write a workspace file,
+ *                              cancel the activity from the outside)
+ *  - `result(RunResult)`     — what `wait()` resolves; ends the run
+ *
+ * The same shape as the native harness's `__test-utils__/scripted-model.ts`
+ * (`ScriptStep`, driven in order), applied to the SDK's event surface.
+ *
+ * Typing: `SDKMessage`, `Run`, `RunResult` and `SDKAgent` are the SDK's own
+ * types (`@cursor/sdk` 1.0.13, concrete in `messages.d.ts` / `run.d.ts` /
+ * `agent.d.ts`), so a script that drifts from the real event shape fails
+ * `tsc`. The delta channel is the exception: `InteractionUpdate` re-exports
+ * from `@anysphere/cursor-sdk-shared`, a workspace package the published SDK
+ * does not ship, so under `skipLibCheck` it resolves to `any` — in production
+ * code too (`turn-stream.ts`, `delta-enricher.ts` read it untyped). The one
+ * delta this double emits, the `turn-ended` usage, is therefore typed HERE
+ * ({@link TurnEndedUsageDelta}) against what `turn-stream.ts` reads from it,
+ * and that gap is recorded in the entry's findings rather than papered over.
+ *
+ * Cancellation: `run.cancel()` is how the harness stops a turn (first denial,
+ * cost cap, stall). The double honours it the way the SDK does — the stream
+ * ends at the next step, `wait()` resolves `{ status: "cancelled" }` — because
+ * the deny-and-retry path depends on exactly that ordering.
+ *
+ * Every `send()` consumes the NEXT script in the agent's queue: turn 1, then
+ * the resumed turn 2 on the same parked agent. A `send()` with no script left
+ * is a test bug and throws.
+ */
+
+import type {
+  ModelSelection,
+  Run,
+  RunOperation,
+  RunResult,
+  RunStatus,
+  SDKAgent,
+  SDKMessage,
+  SDKUserMessage,
+  SendOptions,
+} from "@cursor/sdk";
+import type { ConversationTurn } from "@cursor/sdk";
+
+// ---------------------------------------------------------------------------
+// Script steps
+// ---------------------------------------------------------------------------
+
+/**
+ * The `turn-ended` delta as `turn-stream.ts` reads it (`update.type ===
+ * "turn-ended" && update.usage` -> `usageAccumulator.addTurn(update.usage)`).
+ * See the module header for why this is typed locally.
+ */
+export interface TurnEndedUsageDelta {
+  readonly type: "turn-ended";
+  readonly usage: {
+    readonly inputTokens?: number;
+    readonly outputTokens?: number;
+    readonly cacheWriteTokens?: number;
+    readonly cacheReadTokens?: number;
+  };
+}
+
+/** What an `effect` step can reach: the run it is part of. */
+export interface EffectContext {
+  readonly run: ScriptedRun;
+  readonly agent: ScriptedCursorAgent;
+}
+
+export type ScriptStep =
+  | { readonly kind: "event"; readonly event: SDKMessage }
+  | { readonly kind: "delta"; readonly update: TurnEndedUsageDelta }
+  | { readonly kind: "effect"; readonly label: string; readonly run: (ctx: EffectContext) => void | Promise<void> }
+  | { readonly kind: "result"; readonly result: Omit<RunResult, "id"> };
+
+/** One `send()`'s worth of behaviour. */
+export type TurnScript = readonly ScriptStep[];
+
+/** Step builders — the vocabulary a scenario file reads as. */
+export const step = {
+  event(event: SDKMessage): ScriptStep {
+    return { kind: "event", event };
+  },
+  turnEnded(usage: TurnEndedUsageDelta["usage"]): ScriptStep {
+    return { kind: "delta", update: { type: "turn-ended", usage } };
+  },
+  effect(label: string, run: (ctx: EffectContext) => void | Promise<void>): ScriptStep {
+    return { kind: "effect", label, run };
+  },
+  finished(result?: Partial<Omit<RunResult, "id" | "status">>): ScriptStep {
+    return { kind: "result", result: { status: "finished", ...result } };
+  },
+  errored(result?: Partial<Omit<RunResult, "id" | "status">>): ScriptStep {
+    return { kind: "result", result: { status: "error", ...result } };
+  },
+} as const;
+
+// ---------------------------------------------------------------------------
+// The run
+// ---------------------------------------------------------------------------
+
+/** Called once per step so the driver's clock can tick. */
+export type StepObserver = (step: ScriptStep, index: number) => void;
+
+export class ScriptedRun implements Run {
+  readonly id: string;
+  readonly agentId: string;
+  private _status: RunStatus = "running";
+  private cancelled = false;
+  private scriptedResult: Omit<RunResult, "id"> | undefined;
+  private streamed = false;
+  private readonly statusListeners = new Set<(status: RunStatus) => void>();
+  /** `run.cancel()` calls, for assertions. */
+  readonly cancelCalls: number[] = [];
+
+  constructor(
+    readonly agent: ScriptedCursorAgent,
+    id: string,
+    private readonly script: TurnScript,
+    private readonly onDelta: SendOptions["onDelta"],
+    private readonly observeStep: StepObserver | undefined,
+    /** What `conversation()` answers; the error classifier reads it on a failed run. */
+    private readonly conversationTurns: ConversationTurn[] = [],
+  ) {
+    this.id = id;
+    this.agentId = agent.agentId;
+  }
+
+  get status(): RunStatus {
+    return this._status;
+  }
+
+  get result(): string | undefined {
+    return this.scriptedResult?.result;
+  }
+
+  get model(): ModelSelection | undefined {
+    return this.scriptedResult?.model ?? this.agent.model;
+  }
+
+  supports(_operation: RunOperation): boolean {
+    return true;
+  }
+
+  unsupportedReason(_operation: RunOperation): string | undefined {
+    return undefined;
+  }
+
+  onDidChangeStatus(listener: (status: RunStatus) => void): () => void {
+    this.statusListeners.add(listener);
+    return () => this.statusListeners.delete(listener);
+  }
+
+  async conversation(): Promise<ConversationTurn[]> {
+    return this.conversationTurns;
+  }
+
+  async *stream(): AsyncGenerator<SDKMessage, void> {
+    if (this.streamed) {
+      throw new Error(`ScriptedRun ${this.id}: stream() consumed twice`);
+    }
+    this.streamed = true;
+    for (let i = 0; i < this.script.length; i++) {
+      // A cancel lands between steps, exactly where the SDK's own stream would
+      // stop delivering.
+      if (this.cancelled) break;
+      const s = this.script[i];
+      this.observeStep?.(s, i);
+      switch (s.kind) {
+        case "event":
+          yield s.event;
+          break;
+        case "delta":
+          await this.onDelta?.({ update: s.update as never });
+          break;
+        case "effect":
+          await s.run({ run: this, agent: this.agent });
+          break;
+        case "result":
+          this.scriptedResult = s.result;
+          break;
+        default: {
+          const exhaustive: never = s;
+          throw new Error(`ScriptedRun: unknown step ${String(exhaustive)}`);
+        }
+      }
+    }
+    if (!this.cancelled) this.setStatus(this.scriptedResult?.status ?? "finished");
+  }
+
+  async wait(): Promise<RunResult> {
+    if (this.cancelled) {
+      return { id: this.id, status: "cancelled" };
+    }
+    if (!this.scriptedResult) {
+      // A script that never declared its result is a test bug — surface it
+      // instead of inventing a "finished" the golden would then pin.
+      throw new Error(
+        `ScriptedRun ${this.id}: wait() called but the script has no result step ` +
+          `(add step.finished() or step.errored())`,
+      );
+    }
+    return { id: this.id, ...this.scriptedResult };
+  }
+
+  async cancel(): Promise<void> {
+    this.cancelCalls.push(Date.now());
+    this.cancelled = true;
+    this.setStatus("cancelled");
+  }
+
+  private setStatus(status: RunStatus): void {
+    this._status = status;
+    for (const l of this.statusListeners) l(status);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The agent
+// ---------------------------------------------------------------------------
+
+export interface ScriptedAgentOptions {
+  readonly agentId: string;
+  /** One script per `send()`, consumed in order. */
+  readonly turns: readonly TurnScript[];
+  /** Run ids, one per turn, so goldens carry stable `run_id`s. */
+  readonly runIds?: readonly string[];
+  readonly observeStep?: StepObserver;
+  readonly conversationTurns?: ConversationTurn[];
+}
+
+/** What the harness passed to `send()`, kept for assertions on the prompt. */
+export interface RecordedSend {
+  readonly message: string | SDKUserMessage;
+  readonly hasOnDelta: boolean;
+}
+
+export class ScriptedCursorAgent implements SDKAgent {
+  readonly agentId: string;
+  model: ModelSelection | undefined = undefined;
+  readonly sends: RecordedSend[] = [];
+  readonly runs: ScriptedRun[] = [];
+  closeCalls = 0;
+  private nextTurn = 0;
+
+  constructor(private readonly options: ScriptedAgentOptions) {
+    this.agentId = options.agentId;
+  }
+
+  async send(message: string | SDKUserMessage, options?: SendOptions): Promise<Run> {
+    const script = this.options.turns[this.nextTurn];
+    if (!script) {
+      throw new Error(
+        `ScriptedCursorAgent ${this.agentId}: send() #${this.nextTurn + 1} has no script ` +
+          `(the scenario declared ${this.options.turns.length})`,
+      );
+    }
+    const runId = this.options.runIds?.[this.nextTurn] ?? `run-${this.agentId}-${this.nextTurn + 1}`;
+    this.nextTurn++;
+    this.sends.push({ message, hasOnDelta: !!options?.onDelta });
+    if (options?.model) this.model = options.model;
+    const run = new ScriptedRun(
+      this,
+      runId,
+      script,
+      options?.onDelta,
+      this.options.observeStep,
+      this.options.conversationTurns,
+    );
+    this.runs.push(run);
+    return run;
+  }
+
+  close(): void {
+    this.closeCalls++;
+  }
+
+  async reload(): Promise<void> {
+    // No persisted state to reload in the double.
+  }
+
+  async [Symbol.asyncDispose](): Promise<void> {
+    this.close();
+  }
+
+  async listArtifacts(): Promise<never[]> {
+    return [];
+  }
+
+  async downloadArtifact(_path: string): Promise<Buffer> {
+    throw new Error("ScriptedCursorAgent: artifacts are not part of the scripted surface");
+  }
+}

--- a/backend/services/runner/src/activities/execute-cursor/__test-utils__/scripted-sdk.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__test-utils__/scripted-sdk.ts
@@ -1,0 +1,163 @@
+/**
+ * The `@cursor/sdk` module a hermetic `ExecuteCursor` run imports — every
+ * runtime surface the activity path touches, backed by scripted agents.
+ *
+ * The activity reaches the SDK at three runtime sites and nowhere else:
+ *
+ *  - `session-lifecycle.ts`: `Agent.create(options)`, `Agent.resume(id, options)`,
+ *    `Agent.archive(id, ...)` — the agent handle.
+ *  - `service-tier.ts`: `Cursor.models.list({ apiKey })` — the catalog the
+ *    variant params (`fast`, `thinking`) are pinned from.
+ *  - `index.ts` outer catch: `import("@cursor/sdk")` for `CursorSdkError`, the
+ *    `instanceof` the error classifier keys on.
+ *
+ * Neither the SDK nor the client is injectable into the activity (the real
+ * seam arrives with the harness contract; parent Q1/Q2), so — exactly as the
+ * native activity tests already do for their boundary modules — the module is
+ * substituted with `vi.mock`. Three existing tests each mock ONE of these
+ * surfaces (`session-lifecycle.test.ts`, `service-tier.test.ts`,
+ * `sdk-warmup.test.ts`); a whole-activity run needs all three at once, which is
+ * what this module is.
+ *
+ * `vi.mock` is hoisted and must appear in the test file; the factory can
+ * `await import()` this module and return {@link scriptedCursorSdkModule}. The
+ * module's statics read the {@link ScriptedCursorSdk} bound for the current
+ * scenario ({@link bindScriptedSdk}), so one test file can run several
+ * scenarios with different agents against the same mocked module.
+ *
+ * Resolution rules a scenario declares, mirroring what the real SDK does:
+ *  - `Agent.create` hands out the NEXT unclaimed agent in `agents` (turn 1 of a
+ *    fresh session; the fresh agent of a poisoned-handle recovery).
+ *  - `Agent.resume(id)` hands back the agent with that id if the scenario
+ *    declared it resumable, else throws — `resolveAgent` then falls back to
+ *    `create`, which is the production shape of a stale handle.
+ *  - `Cursor.models.list` answers the scenario's catalog.
+ */
+
+import type { AgentOptions, ModelListItem, SDKAgent } from "@cursor/sdk";
+import type { ScriptedCursorAgent } from "./scripted-agent.js";
+
+export interface ScriptedSdkOptions {
+  /** Agents handed out by `Agent.create`, in order. */
+  readonly agents: readonly ScriptedCursorAgent[];
+  /** Agent ids `Agent.resume` succeeds for (defaults to every declared agent). */
+  readonly resumable?: readonly string[];
+  /** What `Cursor.models.list` answers. */
+  readonly catalog: readonly ModelListItem[];
+}
+
+/** One `Agent.create` / `Agent.resume` call as the activity made it. */
+export interface RecordedResolution {
+  readonly kind: "create" | "resume";
+  readonly agentId: string | undefined;
+  readonly options: Partial<AgentOptions> | undefined;
+}
+
+export class ScriptedCursorSdk {
+  readonly resolutions: RecordedResolution[] = [];
+  readonly archived: string[] = [];
+  private nextCreate = 0;
+  private readonly byId = new Map<string, ScriptedCursorAgent>();
+  private readonly resumable: ReadonlySet<string>;
+
+  constructor(private readonly options: ScriptedSdkOptions) {
+    for (const a of options.agents) this.byId.set(a.agentId, a);
+    this.resumable = new Set(options.resumable ?? options.agents.map((a) => a.agentId));
+  }
+
+  create(options: AgentOptions): SDKAgent {
+    const agent = this.options.agents[this.nextCreate];
+    if (!agent) {
+      throw new Error(
+        `ScriptedCursorSdk: Agent.create() #${this.nextCreate + 1} has no agent ` +
+          `(the scenario declared ${this.options.agents.length})`,
+      );
+    }
+    this.nextCreate++;
+    agent.model = options.model;
+    this.resolutions.push({ kind: "create", agentId: agent.agentId, options });
+    return agent;
+  }
+
+  resume(agentId: string, options: Partial<AgentOptions> | undefined): SDKAgent {
+    this.resolutions.push({ kind: "resume", agentId, options });
+    const agent = this.byId.get(agentId);
+    if (!agent || !this.resumable.has(agentId)) {
+      throw new ScriptedCursorSdkError(`agent ${agentId} not found`, { code: "agent_not_found" });
+    }
+    if (options?.model) agent.model = options.model;
+    return agent;
+  }
+
+  archive(agentId: string): void {
+    this.archived.push(agentId);
+  }
+
+  listModels(): readonly ModelListItem[] {
+    return this.options.catalog;
+  }
+}
+
+/**
+ * The `CursorSdkError` the mocked module exports. A real `Error` subclass with
+ * the two fields the classifier reads (`isRetryable`, `code`), under the SDK's
+ * class name so `err.constructor.name` and `instanceof` (against THIS module's
+ * export, which is what the activity's dynamic import resolves to) both hold.
+ */
+export class ScriptedCursorSdkError extends Error {
+  readonly isRetryable: boolean;
+  readonly code: string | undefined;
+  constructor(message: string, opts: { isRetryable?: boolean; code?: string } = {}) {
+    super(message);
+    this.name = "CursorSdkError";
+    this.isRetryable = opts.isRetryable ?? false;
+    this.code = opts.code;
+  }
+}
+
+let bound: ScriptedCursorSdk | undefined;
+
+/** Bind the SDK the mocked module serves for the current scenario. */
+export function bindScriptedSdk(sdk: ScriptedCursorSdk): void {
+  bound = sdk;
+}
+
+function current(): ScriptedCursorSdk {
+  if (!bound) {
+    throw new Error(
+      "scripted-sdk: no ScriptedCursorSdk bound — call bindScriptedSdk(sdk) before running the activity",
+    );
+  }
+  return bound;
+}
+
+/**
+ * The factory a test passes to `vi.mock("@cursor/sdk", ...)`:
+ *
+ * ```ts
+ * vi.mock("@cursor/sdk", async () =>
+ *   (await import("../../__test-utils__/scripted-sdk.js")).scriptedCursorSdkModule(),
+ * );
+ * ```
+ *
+ * Only the runtime surface the activity path uses is provided. Any other
+ * import from the mocked module is `undefined` and fails loudly at the call
+ * site — deliberately, so a new SDK dependency in production code is noticed
+ * here rather than silently stubbed.
+ */
+export function scriptedCursorSdkModule(): Record<string, unknown> {
+  return {
+    Agent: {
+      create: async (options: AgentOptions): Promise<SDKAgent> => current().create(options),
+      resume: async (agentId: string, options?: Partial<AgentOptions>): Promise<SDKAgent> =>
+        current().resume(agentId, options),
+      archive: async (agentId: string): Promise<void> => current().archive(agentId),
+    },
+    Cursor: {
+      models: {
+        list: async (): Promise<readonly ModelListItem[]> => current().listModels(),
+      },
+    },
+    CursorSdkError: ScriptedCursorSdkError,
+  };
+}

--- a/backend/services/runner/src/activities/execute-cursor/__test-utils__/scripted-sdk.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__test-utils__/scripted-sdk.ts
@@ -29,8 +29,8 @@
  *  - `Agent.create` hands out the NEXT unclaimed agent in `agents` (turn 1 of a
  *    fresh session; the fresh agent of a poisoned-handle recovery).
  *  - `Agent.resume(id)` hands back the agent with that id if the scenario
- *    declared it resumable, else throws — `resolveAgent` then falls back to
- *    `create`, which is the production shape of a stale handle.
+ *    declared it (in `agents` or `resumableAgents`), else throws — `resolveAgent`
+ *    then falls back to `create`, which is the production shape of a lost handle.
  *  - `Cursor.models.list` answers the scenario's catalog.
  */
 
@@ -38,10 +38,13 @@ import type { AgentOptions, ModelListItem, SDKAgent } from "@cursor/sdk";
 import type { ScriptedCursorAgent } from "./scripted-agent.js";
 
 export interface ScriptedSdkOptions {
-  /** Agents handed out by `Agent.create`, in order. */
+  /** Agents handed out by `Agent.create`, in order. Also resumable by id. */
   readonly agents: readonly ScriptedCursorAgent[];
-  /** Agent ids `Agent.resume` succeeds for (defaults to every declared agent). */
-  readonly resumable?: readonly string[];
+  /**
+   * Agents `Agent.resume` finds by id but `Agent.create` never hands out — a
+   * previous turn's agent the session knows only by `harness_state_id`.
+   */
+  readonly resumableAgents?: readonly ScriptedCursorAgent[];
   /** What `Cursor.models.list` answers. */
   readonly catalog: readonly ModelListItem[];
 }
@@ -58,11 +61,11 @@ export class ScriptedCursorSdk {
   readonly archived: string[] = [];
   private nextCreate = 0;
   private readonly byId = new Map<string, ScriptedCursorAgent>();
-  private readonly resumable: ReadonlySet<string>;
 
   constructor(private readonly options: ScriptedSdkOptions) {
-    for (const a of options.agents) this.byId.set(a.agentId, a);
-    this.resumable = new Set(options.resumable ?? options.agents.map((a) => a.agentId));
+    for (const a of [...options.agents, ...(options.resumableAgents ?? [])]) {
+      this.byId.set(a.agentId, a);
+    }
   }
 
   create(options: AgentOptions): SDKAgent {
@@ -82,7 +85,7 @@ export class ScriptedCursorSdk {
   resume(agentId: string, options: Partial<AgentOptions> | undefined): SDKAgent {
     this.resolutions.push({ kind: "resume", agentId, options });
     const agent = this.byId.get(agentId);
-    if (!agent || !this.resumable.has(agentId)) {
+    if (!agent) {
       throw new ScriptedCursorSdkError(`agent ${agentId} not found`, { code: "agent_not_found" });
     }
     if (options?.model) agent.model = options.model;

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/deny-and-retry.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/deny-and-retry.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Hermetic golden: the DENY-AND-RETRY approval round trip through two real
+ * `ExecuteCursor` invocations, with the REAL bash hook as the out-of-process
+ * half.
+ *
+ * Invariant pinned (the Cursor pause primitive, parent §4a `pausePrimitive:
+ * "deny-and-retry"`): the model proposes a gated built-in (`shell`); the
+ * workspace hook the activity installed DENIES it and appends to the denial
+ * ledger; the stream loop reads the ledger on the next `tool_call` event, cancels
+ * the run, and the turn boundary overlays the row as WAITING_APPROVAL; the
+ * activity persists WAITING_FOR_APPROVAL, parks the agent, and RETURNS a slim
+ * status. The user approves (the server writes `approval_action` on the row —
+ * here the record does, per field ownership). The reinvocation (`thread_id` set,
+ * `turn_seq` 1) seeds its transcript from the persisted execution, derives a
+ * grant from the approved row, reinstalls the gate, and the SAME hook now ALLOWS
+ * the re-issued call — which the model emits under a FRESH `call_id`, and which
+ * the transcript reconciles onto the committed row by canonical identity (a
+ * superset, never a duplicate, never a second gate). The turn ends COMPLETED.
+ *
+ * Two goldens, one per invocation: `goldens/deny-and-retry.turn1.status.json`
+ * (the paused transcript) and `goldens/deny-and-retry.turn2.status.json` (the
+ * resumed, completed transcript). S2 must reproduce both byte for byte.
+ *
+ * Parent phase rows exercised beyond `tool-call`: reinvocation detection and
+ * transcript seeding (Phase 3); reading approval decisions from the persisted
+ * transcript (`reconstructAdjudicatedApprovals`); grants → approval state →
+ * the gate (Phase 5c); the first-denial early stop in the stream loop; the
+ * turn boundary's denial overlay; `enterApprovalPause` (WAITING_FOR_APPROVAL,
+ * park, return); the parked-agent checkout on the resume (#215, no `Agent.resume`
+ * call); the resume prompt.
+ *
+ * The hook is the runner's own generated bash script, found the way the SDK
+ * finds it (`.cursor/hooks.json` in the workspace) and run with the SDK's real
+ * preToolUse input shape (`cursor-hook-harness.ts` builders). Skipped where
+ * `bash` is unavailable — reported as SKIPPED, never a silent pass.
+ *
+ * Regenerate ONLY after a deliberate behavior change:
+ *   npx vitest run src/activities/execute-cursor/__tests__/hermetic -u
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { toJson } from "@bufbuild/protobuf";
+import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import {
+  ApprovalAction,
+  ExecutionPhase,
+  ToolCallStatus,
+} from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+vi.mock("@cursor/sdk", async () =>
+  (await import("../../__test-utils__/scripted-sdk.js")).scriptedCursorSdkModule(),
+);
+vi.mock("../../../../client/stigmer-client.js", async () =>
+  (await import("../../../../__test-utils__/hermetic-activity.js")).hermeticStigmerClientModule(),
+);
+
+import {
+  ScriptedClock,
+  createHermeticEnvironment,
+  type HermeticEnvironment,
+} from "../../../../__test-utils__/hermetic-activity.js";
+import { hasBash, hookShell } from "../../__test-utils__/cursor-hook-harness.js";
+import { ScriptedCursorAgent, sdkEvents, step } from "../../__test-utils__/scripted-agent.js";
+import {
+  FIXTURE,
+  SDK_CATALOG,
+  beginCursorScenario,
+  cursorExecutionRecord,
+  runCursorTurn,
+  runWorkspaceHook,
+  sessionWorkspaceDir,
+  stubRegistryFetch,
+} from "../../__test-utils__/hermetic-cursor.js";
+
+const AGENT_ID = "agent-hermetic-deny-0001";
+const RUN_1 = "run-hermetic-deny-0001";
+const RUN_2 = "run-hermetic-deny-0002";
+const CALL_TURN_1 = "call-hermetic-shell-0001";
+const CALL_TURN_2 = "call-hermetic-shell-0002";
+const USER_MESSAGE = "Run the build and tell me if it passes.";
+const COMMAND = "npm run build";
+const SHELL_ARGS = { command: COMMAND };
+const BUILD_OUTPUT = "build ok (hermetic)\n";
+const FINAL_TEXT = "The build passes.";
+
+describe.skipIf(!hasBash)("ExecuteCursor hermetic — deny-and-retry approval round trip", () => {
+  let env: HermeticEnvironment;
+  let registry: ReturnType<typeof stubRegistryFetch>;
+  const clock = new ScriptedClock();
+
+  beforeAll(() => {
+    env = createHermeticEnvironment();
+    registry = stubRegistryFetch();
+    clock.install();
+  });
+
+  afterAll(() => {
+    clock.uninstall();
+    registry.restore();
+    env.dispose();
+  });
+
+  it("pauses on the hook's deny, then completes on the approved re-issue", async () => {
+    // ── Arrange ──────────────────────────────────────────────────────────────
+    const workspaceRoot = sessionWorkspaceDir(env);
+    const hookDecisions: string[] = [];
+    const runHook = (label: string) =>
+      step.effect(label, () => {
+        hookDecisions.push(runWorkspaceHook(workspaceRoot, hookShell(COMMAND)).permission);
+      });
+
+    const ev1 = sdkEvents(AGENT_ID, RUN_1);
+    const ev2 = sdkEvents(AGENT_ID, RUN_2);
+    const agent = new ScriptedCursorAgent({
+      agentId: AGENT_ID,
+      runIds: [RUN_1, RUN_2],
+      observeStep: () => clock.tick(),
+      turns: [
+        // Turn 1: the SDK runs the hook before executing the gated tool; the
+        // hook denies and writes the ledger; the SDK reports the call blocked.
+        [
+          step.event(ev1.init()),
+          step.event(ev1.assistant("I'll run the build now.")),
+          step.event(ev1.toolCall(CALL_TURN_1, "shell", "running", SHELL_ARGS)),
+          runHook("hook: turn 1 (expect deny)"),
+          step.event(ev1.toolCall(CALL_TURN_1, "shell", "error", SHELL_ARGS, "Blocked by hook")),
+          // Never reached: the loop detects the denial on the event above and
+          // cancels the run. Present so a regression that does NOT cancel is
+          // caught by the golden, not by a missing-result throw.
+          step.event(ev1.assistant("The build was blocked.")),
+          step.finished({ result: "The build was blocked." }),
+        ],
+        // Turn 2 (resumed): the hook runs again for the re-issued call and now
+        // allows it (the grant); the tool runs under a FRESH call id.
+        [
+          runHook("hook: turn 2 (expect allow)"),
+          step.event(ev2.toolCall(CALL_TURN_2, "shell", "running", SHELL_ARGS)),
+          step.event(ev2.toolCall(CALL_TURN_2, "shell", "completed", SHELL_ARGS, BUILD_OUTPUT)),
+          step.event(ev2.assistant(FINAL_TEXT)),
+          step.turnEnded({ inputTokens: 3_100, outputTokens: 60 }),
+          step.finished({ result: FINAL_TEXT, model: { id: FIXTURE.model, params: [] } }),
+        ],
+      ],
+    });
+    const record = cursorExecutionRecord({ message: USER_MESSAGE });
+    const scenario = beginCursorScenario({
+      env,
+      clock,
+      record,
+      sdk: { agents: [agent], catalog: SDK_CATALOG },
+    });
+
+    // ── Act 1: the first invocation ──────────────────────────────────────────
+    const turn1 = await runCursorTurn(scenario, { threadId: "", turnSeq: 0 });
+
+    // ── Assert 1: paused for approval, returned, agent parked ────────────────
+    expect(hookDecisions, "the real hook denied the gated shell call").toEqual(["deny"]);
+    expect(turn1.outcome.kind, "an approval pause RETURNS to the workflow").toBe("returned");
+    expect((turn1.outcome as { value: Record<string, unknown> }).value.phase).toBe(
+      "EXECUTION_WAITING_FOR_APPROVAL",
+    );
+    expect(record.persistedPhases).toEqual([
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+    ]);
+    expect(agent.runs[0].cancelCalls, "the first denial cancels the run exactly once").toHaveLength(1);
+    expect(agent.closeCalls, "the agent is parked for the resume, not closed").toBe(0);
+
+    const waiting = record.waitingToolCalls();
+    expect(waiting, "exactly one gate row").toHaveLength(1);
+    expect(waiting[0].id).toBe(CALL_TURN_1);
+    expect(waiting[0].name).toBe("shell");
+    expect(waiting[0].requiresApproval).toBe(true);
+    // The gate row carries what the HOOK saw (the ledger's captured tool_input:
+    // command, cwd, timeout), overlaid on the stream's args — the golden pins
+    // the full shape; here only the shared salient field is asserted.
+    expect(waiting[0].args).toMatchObject(SHELL_ARGS);
+    // The model's post-denial narration never reaches the user as fact.
+    expect(record.status?.messages.some((m) => m.content === "The build was blocked.")).toBe(false);
+
+    const turn1Json = JSON.stringify(toJson(AgentExecutionStatusSchema, record.lastFullStatus!), null, 2) + "\n";
+    await expect(turn1Json).toMatchFileSnapshot("./goldens/deny-and-retry.turn1.status.json");
+
+    // ── The user approves (the server's SubmitApproval effect on the row) ────
+    clock.tick();
+    expect(record.decideWaitingToolCalls(ApprovalAction.APPROVE, new Date().toISOString())).toBe(1);
+
+    // ── Act 2: the reinvocation ──────────────────────────────────────────────
+    const turn2 = await runCursorTurn(scenario, { threadId: AGENT_ID, turnSeq: 1 });
+
+    // ── Assert 2: allowed, reconciled, completed ─────────────────────────────
+    expect(hookDecisions, "the SAME hook allows the approved re-issue").toEqual(["deny", "allow"]);
+    expect(turn2.outcome.kind).toBe("returned");
+    const slim2 = (turn2.outcome as { value: Record<string, unknown> }).value;
+    expect(slim2.phase).toBe("EXECUTION_COMPLETED");
+    expect(slim2.final_text).toBe(FINAL_TEXT);
+    expect(record.persistedPhases).toEqual([
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_COMPLETED,
+    ]);
+
+    // #215: the resume checks the parked agent out of the session cache; the
+    // SDK is asked to create once for the whole round trip and never to resume.
+    expect(scenario.sdk.resolutions.map((r) => r.kind)).toEqual(["create"]);
+    expect(agent.sends).toHaveLength(2);
+
+    // Each tool gates exactly once: the committed row survives under its
+    // ORIGINAL id, now COMPLETED with the tool's result; the fresh call id the
+    // model emitted is reconciled onto it, never a second row.
+    const rows = record.toolCalls();
+    expect(rows.filter((tc) => tc.name === "shell")).toHaveLength(1);
+    const shell = rows.find((tc) => tc.name === "shell")!;
+    expect(shell.id).toBe(CALL_TURN_1);
+    expect(shell.status).toBe(ToolCallStatus.TOOL_CALL_COMPLETED);
+    expect(shell.result).toBe(BUILD_OUTPUT);
+    expect(shell.approvalAction, "the decision survives on the row").toBe(ApprovalAction.APPROVE);
+    expect(rows.some((tc) => tc.id === CALL_TURN_2)).toBe(false);
+    expect(record.waitingToolCalls()).toHaveLength(0);
+
+    // ── Assert: hermeticity ──────────────────────────────────────────────────
+    expect(registry.urls.every((u) => u.includes("/model-registry"))).toBe(true);
+
+    const turn2Json = JSON.stringify(toJson(AgentExecutionStatusSchema, record.lastFullStatus!), null, 2) + "\n";
+    await expect(turn2Json).toMatchFileSnapshot("./goldens/deny-and-retry.turn2.status.json");
+  });
+});

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/file-review-capture.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/file-review-capture.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Hermetic golden: a FILE-REVIEW CAPTURE turn on a git workspace through the
+ * whole `ExecuteCursor` activity.
+ *
+ * Invariant pinned (apply-then-review, the universal file-review model): on a
+ * git work tree the file edit FLOWS — the hook the activity installed ALLOWS
+ * the write (capture mode gates only gitignored paths, shell and MCP) — and the
+ * turn boundary captures the net change from the git diff against the baseline
+ * tree pinned before the agent ran, authors CANDIDATE_CAPTURED to the
+ * file_review ledger with one card for the edited file, stamps the flowed edit
+ * row with the change-set id, and the activity persists WAITING_FOR_APPROVAL
+ * and RETURNS without consulting `run.wait()`. The change-set id is the
+ * deterministic `executionId:turnSeq`. The golden
+ * (`goldens/file-review-capture.status.json`) pins the ledger shape S2 must
+ * reproduce.
+ *
+ * Parent phase rows exercised beyond `deny-and-retry`: provision a `local_path`
+ * workspace entry (mounted as-is in local mode); capture-mode derivation on a
+ * git tree; the baseline pin (`captureBaselineToLedger`, git snapshot); the
+ * turn boundary's candidate capture (`captureTurnToLedger`) and row stamping;
+ * the pause for review with file cards.
+ *
+ * Determinism: the fixture repo's commit and tree ids are byte-stable because
+ * `initGitWorkspace` pins author, committer and both dates. The stream's edit
+ * args use the REPO-RELATIVE path so no temp directory can reach the golden;
+ * the hook input carries the absolute path the SDK would pass (the hook's
+ * `git check-ignore` resolves it against the baked workspace root).
+ *
+ * Skipped where `bash` is unavailable — reported as SKIPPED, never a silent pass.
+ *
+ * Regenerate ONLY after a deliberate behavior change:
+ *   npx vitest run src/activities/execute-cursor/__tests__/hermetic -u
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { toJson } from "@bufbuild/protobuf";
+import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase, ToolCallStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+vi.mock("@cursor/sdk", async () =>
+  (await import("../../__test-utils__/scripted-sdk.js")).scriptedCursorSdkModule(),
+);
+vi.mock("../../../../client/stigmer-client.js", async () =>
+  (await import("../../../../__test-utils__/hermetic-activity.js")).hermeticStigmerClientModule(),
+);
+
+import {
+  ScriptedClock,
+  createHermeticEnvironment,
+  type HermeticEnvironment,
+} from "../../../../__test-utils__/hermetic-activity.js";
+import { hasBash, hookWrite } from "../../__test-utils__/cursor-hook-harness.js";
+import { ScriptedCursorAgent, sdkEvents, step } from "../../__test-utils__/scripted-agent.js";
+import {
+  FIXTURE,
+  SDK_CATALOG,
+  beginCursorScenario,
+  cursorExecutionRecord,
+  initGitWorkspace,
+  localPathEntry,
+  runCursorTurn,
+  runWorkspaceHook,
+  stubRegistryFetch,
+} from "../../__test-utils__/hermetic-cursor.js";
+
+const AGENT_ID = "agent-hermetic-capture-0001";
+const RUN_ID = "run-hermetic-capture-0001";
+const CALL_ID = "call-hermetic-edit-0001";
+const USER_MESSAGE = "Add a line to notes.md saying the fixture was reviewed.";
+const FILE = "notes.md";
+const BEFORE = "# Notes\n\nA fixture file.\n";
+const AFTER = "# Notes\n\nA fixture file.\n\nReviewed by the hermetic run.\n";
+const CHANGE_SET_ID = `${FIXTURE.executionId}:0`;
+
+describe.skipIf(!hasBash)("ExecuteCursor hermetic — file-review capture on a git workspace", () => {
+  let env: HermeticEnvironment;
+  let registry: ReturnType<typeof stubRegistryFetch>;
+  const clock = new ScriptedClock();
+
+  beforeAll(() => {
+    env = createHermeticEnvironment();
+    registry = stubRegistryFetch();
+    clock.install();
+  });
+
+  afterAll(() => {
+    clock.uninstall();
+    registry.restore();
+    env.dispose();
+  });
+
+  it("lets the edit flow, captures it at the boundary, and pauses for review", async () => {
+    // ── Arrange ──────────────────────────────────────────────────────────────
+    const repo = join(env.workspaceRootDir, "repos", "notes");
+    initGitWorkspace(repo, { [FILE]: BEFORE });
+    const absFile = join(repo, FILE);
+    const hookDecisions: string[] = [];
+
+    const ev = sdkEvents(AGENT_ID, RUN_ID);
+    const agent = new ScriptedCursorAgent({
+      agentId: AGENT_ID,
+      runIds: [RUN_ID],
+      observeStep: () => clock.tick(),
+      turns: [
+        [
+          step.event(ev.init()),
+          step.event(ev.assistant("Appending the review line.")),
+          // The SDK runs the hook before the write tool executes...
+          step.effect("hook: Write (expect allow in capture mode)", () => {
+            hookDecisions.push(runWorkspaceHook(repo, hookWrite(absFile, AFTER)).permission);
+          }),
+          // ...then performs the write itself...
+          step.effect("write notes.md", () => writeFileSync(absFile, AFTER, "utf-8")),
+          // ...and streams the tool call.
+          step.event(ev.toolCall(CALL_ID, "edit", "running", { path: FILE, content: AFTER })),
+          step.event(ev.toolCall(CALL_ID, "edit", "completed", { path: FILE, content: AFTER }, "ok")),
+          step.event(ev.assistant("Done — notes.md now records the review.")),
+          step.turnEnded({ inputTokens: 2_400, outputTokens: 70 }),
+          step.finished({ result: "Done", model: { id: FIXTURE.model, params: [] } }),
+        ],
+      ],
+    });
+    const record = cursorExecutionRecord({
+      message: USER_MESSAGE,
+      workspaceEntries: [localPathEntry("notes", repo)],
+    });
+    const scenario = beginCursorScenario({
+      env,
+      clock,
+      record,
+      sdk: { agents: [agent], catalog: SDK_CATALOG },
+    });
+
+    // ── Act ──────────────────────────────────────────────────────────────────
+    const invocation = await runCursorTurn(scenario);
+
+    // ── Assert: the edit flowed and the turn paused for review ───────────────
+    expect(hookDecisions, "capture mode lets the write flow").toEqual(["allow"]);
+    expect(readFileSync(absFile, "utf-8"), "the working tree holds the candidate").toBe(AFTER);
+    expect(invocation.outcome.kind, "a review pause RETURNS to the workflow").toBe("returned");
+    expect((invocation.outcome as { value: Record<string, unknown> }).value.phase).toBe(
+      "EXECUTION_WAITING_FOR_APPROVAL",
+    );
+    expect(record.persistedPhases).toEqual([
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_WAITING_FOR_APPROVAL,
+    ]);
+    expect(agent.runs[0].cancelCalls, "a flowed edit is not a denial; nothing is cancelled").toHaveLength(0);
+
+    // ── Assert: the file_review ledger ───────────────────────────────────────
+    const events = record.status?.fileReviewEventStream?.events ?? [];
+    const types = events.map((e) => e.payload.case);
+    expect(types).toEqual(["baselineCaptured", "candidateCaptured"]);
+    const candidate = events[1].payload;
+    if (candidate.case !== "candidateCaptured") throw new Error("unreachable");
+    expect(candidate.value.changeSetId).toBe(CHANGE_SET_ID);
+    expect(candidate.value.changes.map((c) => c.pathAfter)).toEqual([FILE]);
+
+    // The flowed edit row: the built-in policy still classifies `edit` as a
+    // gated category (`requiresApproval: true` is the policy's verdict, stamped
+    // at fold time), but capture mode let it FLOW — so the row is COMPLETED,
+    // never WAITING_APPROVAL, and the review happens on the file card instead.
+    const rows = record.toolCalls();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].name).toBe("edit");
+    expect(rows[0].status).toBe(ToolCallStatus.TOOL_CALL_COMPLETED);
+    expect(rows[0].requiresApproval, "policy verdict, not the gate outcome").toBe(true);
+    expect(record.waitingToolCalls(), "no gate row — the review is on the file card").toHaveLength(0);
+
+    // ── Assert: hermeticity ──────────────────────────────────────────────────
+    expect(registry.urls.every((u) => u.includes("/model-registry"))).toBe(true);
+
+    // ── Assert: the golden ───────────────────────────────────────────────────
+    const json = JSON.stringify(toJson(AgentExecutionStatusSchema, record.lastFullStatus!), null, 2) + "\n";
+    expect(json, "no temp path may reach the golden").not.toContain(env.workspaceRootDir);
+    await expect(json).toMatchFileSnapshot("./goldens/file-review-capture.status.json");
+  });
+});

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/deny-and-retry.turn1.status.json
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/deny-and-retry.turn1.status.json
@@ -1,0 +1,55 @@
+{
+  "messages": [
+    {
+      "type": "MESSAGE_AI",
+      "content": "I'll run the build now.",
+      "timestamp": "2026-01-01T00:00:02.000Z",
+      "toolCalls": [
+        {
+          "id": "call-hermetic-shell-0001",
+          "name": "shell",
+          "args": {
+            "command": "npm run build",
+            "cwd": "/x",
+            "timeout": 30000
+          },
+          "status": "TOOL_CALL_WAITING_APPROVAL",
+          "startedAt": "2026-01-01T00:00:03.000Z",
+          "requiresApproval": true,
+          "approvalMessage": "Run command: npm run build",
+          "approvalRequestedAt": "2026-01-01T00:00:05.000Z",
+          "argsPreview": "{\"command\":\"npm run build\",\"cwd\":\"/x\",\"timeout\":30000}",
+          "toolKind": "TOOL_KIND_SHELL",
+          "approvalPolicySource": "APPROVAL_POLICY_SOURCE_BUILTIN_CATEGORY",
+          "policyEngineVersion": "phase-7"
+        }
+      ]
+    }
+  ],
+  "phase": "EXECUTION_WAITING_FOR_APPROVAL",
+  "startedAt": "2026-01-01T00:00:00.000Z",
+  "fileReviewEventStream": {
+    "executionId": "aex_hermetic_0001",
+    "events": [
+      {
+        "eventId": "aex_hermetic_0001:0:aex_hermetic_0001:0:FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "changeSetId": "aex_hermetic_0001:0",
+        "eventType": "FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "actor": "runner",
+        "baselineCaptured": {
+          "changeSetId": "aex_hermetic_0001:0",
+          "turnId": "aex_hermetic_0001:0",
+          "harnessId": "cursor",
+          "baselineSnapshot": {
+            "kind": "SNAPSHOT_KIND_CAS_MANIFEST"
+          }
+        }
+      }
+    ]
+  },
+  "fileChangeProgress": {
+    "changeSetId": "aex_hermetic_0001:0",
+    "capturedAt": "2026-01-01T00:00:01.000Z"
+  }
+}

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/deny-and-retry.turn2.status.json
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/deny-and-retry.turn2.status.json
@@ -1,0 +1,77 @@
+{
+  "messages": [
+    {
+      "type": "MESSAGE_AI",
+      "content": "I'll run the build now.",
+      "timestamp": "2026-01-01T00:00:02.000Z",
+      "toolCalls": [
+        {
+          "id": "call-hermetic-shell-0001",
+          "name": "shell",
+          "args": {
+            "command": "npm run build",
+            "cwd": "/x",
+            "timeout": 30000
+          },
+          "result": "build ok (hermetic)\n",
+          "status": "TOOL_CALL_COMPLETED",
+          "startedAt": "2026-01-01T00:00:03.000Z",
+          "completedAt": "2026-01-01T00:00:09.000Z",
+          "requiresApproval": true,
+          "approvalMessage": "Run command: npm run build",
+          "approvalRequestedAt": "2026-01-01T00:00:05.000Z",
+          "approvalDecidedAt": "2026-01-01T00:00:06.000Z",
+          "approvalAction": "APPROVAL_ACTION_APPROVE",
+          "argsPreview": "{\"command\":\"npm run build\",\"cwd\":\"/x\",\"timeout\":30000}",
+          "toolKind": "TOOL_KIND_SHELL",
+          "approvalPolicySource": "APPROVAL_POLICY_SOURCE_BUILTIN_CATEGORY",
+          "policyEngineVersion": "phase-7"
+        }
+      ]
+    },
+    {
+      "type": "MESSAGE_AI",
+      "content": "The build passes.",
+      "timestamp": "2026-01-01T00:00:10.000Z"
+    }
+  ],
+  "phase": "EXECUTION_COMPLETED",
+  "startedAt": "2026-01-01T00:00:06.000Z",
+  "completedAt": "2026-01-01T00:00:12.000Z",
+  "streamingUsage": {
+    "inputTokens": "3100",
+    "outputTokens": "60",
+    "totalTokens": "3160",
+    "turnCount": 1,
+    "estimatedCostUsd": 0.00334,
+    "model": "composer-2.5",
+    "observedAt": "2026-01-01T00:00:11.000Z",
+    "requestedServiceTier": "SERVICE_TIER_STANDARD",
+    "requestedModelParams": "[{\"id\":\"fast\",\"value\":\"false\"},{\"id\":\"thinking\",\"value\":\"false\"}]",
+    "requestedThinkingMode": "THINKING_MODE_DISABLED"
+  },
+  "fileReviewEventStream": {
+    "executionId": "aex_hermetic_0001",
+    "events": [
+      {
+        "eventId": "aex_hermetic_0001:1:aex_hermetic_0001:1:FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "changeSetId": "aex_hermetic_0001:1",
+        "eventType": "FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "timestamp": "2026-01-01T00:00:06.000Z",
+        "actor": "runner",
+        "baselineCaptured": {
+          "changeSetId": "aex_hermetic_0001:1",
+          "turnId": "aex_hermetic_0001:1",
+          "harnessId": "cursor",
+          "baselineSnapshot": {
+            "kind": "SNAPSHOT_KIND_CAS_MANIFEST"
+          }
+        }
+      }
+    ]
+  },
+  "fileChangeProgress": {
+    "changeSetId": "aex_hermetic_0001:1",
+    "capturedAt": "2026-01-01T00:00:08.000Z"
+  }
+}

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/file-review-capture.status.json
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/file-review-capture.status.json
@@ -1,0 +1,126 @@
+{
+  "messages": [
+    {
+      "type": "MESSAGE_AI",
+      "content": "Appending the review line.",
+      "timestamp": "2026-01-01T00:00:02.000Z",
+      "toolCalls": [
+        {
+          "id": "call-hermetic-edit-0001",
+          "name": "edit",
+          "args": {
+            "path": "notes.md",
+            "content": "# Notes\n\nA fixture file.\n\nReviewed by the hermetic run.\n"
+          },
+          "result": "ok",
+          "status": "TOOL_CALL_COMPLETED",
+          "startedAt": "2026-01-01T00:00:05.000Z",
+          "completedAt": "2026-01-01T00:00:06.000Z",
+          "requiresApproval": true,
+          "approvalMessage": "Write file: notes.md",
+          "argsPreview": "{\"path\":\"notes.md\",\"content\":\"# Notes\\n\\nA fixture file.\\n\\nReviewed by the hermetic run.\\n\"}",
+          "toolKind": "TOOL_KIND_FILE_EDIT",
+          "approvalPolicySource": "APPROVAL_POLICY_SOURCE_BUILTIN_CATEGORY",
+          "policyEngineVersion": "phase-7",
+          "fileChangeSetId": "aex_hermetic_0001:0"
+        }
+      ]
+    },
+    {
+      "type": "MESSAGE_AI",
+      "content": "Done — notes.md now records the review.",
+      "timestamp": "2026-01-01T00:00:07.000Z"
+    }
+  ],
+  "phase": "EXECUTION_WAITING_FOR_APPROVAL",
+  "startedAt": "2026-01-01T00:00:00.000Z",
+  "streamingUsage": {
+    "inputTokens": "2400",
+    "outputTokens": "70",
+    "totalTokens": "2470",
+    "turnCount": 1,
+    "estimatedCostUsd": 0.00268,
+    "model": "composer-2.5",
+    "observedAt": "2026-01-01T00:00:08.000Z",
+    "requestedServiceTier": "SERVICE_TIER_STANDARD",
+    "requestedModelParams": "[{\"id\":\"fast\",\"value\":\"false\"},{\"id\":\"thinking\",\"value\":\"false\"}]",
+    "requestedThinkingMode": "THINKING_MODE_DISABLED"
+  },
+  "fileReviewEventStream": {
+    "executionId": "aex_hermetic_0001",
+    "events": [
+      {
+        "eventId": "aex_hermetic_0001:0:aex_hermetic_0001:0:FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "changeSetId": "aex_hermetic_0001:0",
+        "eventType": "FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "actor": "runner",
+        "baselineCaptured": {
+          "changeSetId": "aex_hermetic_0001:0",
+          "turnId": "aex_hermetic_0001:0",
+          "harnessId": "cursor",
+          "baselineSnapshot": {
+            "kind": "SNAPSHOT_KIND_GIT_TREE_REF",
+            "git": {
+              "treeOid": "06669a7bfb7a3e46bda2c295d6851e52e8f778c6",
+              "ref": "refs/stigmer/baseline/aex_hermetic_0001"
+            }
+          }
+        }
+      },
+      {
+        "eventId": "aex_hermetic_0001:0:aex_hermetic_0001:0:FILE_REVIEW_EVENT_TYPE_CANDIDATE_CAPTURED",
+        "changeSetId": "aex_hermetic_0001:0",
+        "eventType": "FILE_REVIEW_EVENT_TYPE_CANDIDATE_CAPTURED",
+        "timestamp": "2026-01-01T00:00:09.000Z",
+        "actor": "runner",
+        "candidateCaptured": {
+          "changeSetId": "aex_hermetic_0001:0",
+          "candidateSnapshot": {
+            "kind": "SNAPSHOT_KIND_GIT_TREE_REF",
+            "git": {
+              "treeOid": "2bb46c28a7498d578d76b52fa1cd9c941032e787",
+              "ref": "refs/stigmer/capture/aex_hermetic_0001"
+            }
+          },
+          "changes": [
+            {
+              "id": "aex_hermetic_0001:0:notes.md",
+              "pathBefore": "notes.md",
+              "pathAfter": "notes.md",
+              "kind": "FILE_CHANGE_KIND_MODIFY",
+              "captureClass": "FILE_CAPTURE_CLASS_GIT_TRACKED",
+              "before": {
+                "inline": "# Notes\n\nA fixture file.\n"
+              },
+              "after": {
+                "inline": "# Notes\n\nA fixture file.\n\nReviewed by the hermetic run.\n"
+              },
+              "beforeSha256": "0db28d643539d6a16370a30971d73a2ee0f9509dec6cbb5a143373d5ad52b83f",
+              "afterSha256": "96e76ecee9e8af5ef051ad2edaeeed6fbc989a50850a3ef1bcf518115fd1c097",
+              "diffComplete": true,
+              "fileDigest": "10056ad414223572125b6f8a148e79dbed10b58e18957d213992e79f475bedef",
+              "linesAdded": 2
+            }
+          ],
+          "aggregateDigest": "0a2af1c9c6e6f36e81beb770fdeea30860686096a409eb6df47d34d8e46737b9",
+          "diffCompleteness": "DIFF_COMPLETENESS_COMPLETE"
+        }
+      }
+    ]
+  },
+  "fileChangeProgress": {
+    "changeSetId": "aex_hermetic_0001:0",
+    "filesChanged": 1,
+    "linesAdded": 2,
+    "entries": [
+      {
+        "pathBefore": "notes.md",
+        "pathAfter": "notes.md",
+        "kind": "FILE_CHANGE_KIND_MODIFY",
+        "linesAdded": 2
+      }
+    ],
+    "capturedAt": "2026-01-01T00:00:05.000Z"
+  }
+}

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/pause.status.json
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/pause.status.json
@@ -1,0 +1,45 @@
+{
+  "messages": [
+    {
+      "type": "MESSAGE_AI",
+      "content": "Starting on the parser.",
+      "timestamp": "2026-01-01T00:00:02.000Z"
+    },
+    {
+      "type": "MESSAGE_SYSTEM",
+      "content": "Execution paused by user. Use resume to continue.",
+      "timestamp": "2026-01-01T00:00:04.000Z"
+    },
+    {
+      "type": "MESSAGE_SYSTEM",
+      "content": "Execution paused by user. Use resume to continue.",
+      "timestamp": "2026-01-01T00:00:04.000Z"
+    }
+  ],
+  "phase": "EXECUTION_PAUSED",
+  "startedAt": "2026-01-01T00:00:00.000Z",
+  "fileReviewEventStream": {
+    "executionId": "aex_hermetic_0001",
+    "events": [
+      {
+        "eventId": "aex_hermetic_0001:0:aex_hermetic_0001:0:FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "changeSetId": "aex_hermetic_0001:0",
+        "eventType": "FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "actor": "runner",
+        "baselineCaptured": {
+          "changeSetId": "aex_hermetic_0001:0",
+          "turnId": "aex_hermetic_0001:0",
+          "harnessId": "cursor",
+          "baselineSnapshot": {
+            "kind": "SNAPSHOT_KIND_CAS_MANIFEST"
+          }
+        }
+      }
+    ]
+  },
+  "fileChangeProgress": {
+    "changeSetId": "aex_hermetic_0001:0",
+    "capturedAt": "2026-01-01T00:00:01.000Z"
+  }
+}

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/plain-turn.status.json
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/plain-turn.status.json
@@ -1,0 +1,48 @@
+{
+  "messages": [
+    {
+      "type": "MESSAGE_AI",
+      "content": "Hello there, hermetic world.",
+      "timestamp": "2026-01-01T00:00:02.000Z"
+    }
+  ],
+  "phase": "EXECUTION_COMPLETED",
+  "startedAt": "2026-01-01T00:00:00.000Z",
+  "completedAt": "2026-01-01T00:00:04.000Z",
+  "streamingUsage": {
+    "inputTokens": "1200",
+    "outputTokens": "40",
+    "totalTokens": "1240",
+    "turnCount": 1,
+    "estimatedCostUsd": 0.00136,
+    "model": "composer-2.5",
+    "observedAt": "2026-01-01T00:00:03.000Z",
+    "requestedServiceTier": "SERVICE_TIER_STANDARD",
+    "requestedModelParams": "[{\"id\":\"fast\",\"value\":\"false\"},{\"id\":\"thinking\",\"value\":\"false\"}]",
+    "requestedThinkingMode": "THINKING_MODE_DISABLED"
+  },
+  "fileReviewEventStream": {
+    "executionId": "aex_hermetic_0001",
+    "events": [
+      {
+        "eventId": "aex_hermetic_0001:0:aex_hermetic_0001:0:FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "changeSetId": "aex_hermetic_0001:0",
+        "eventType": "FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "actor": "runner",
+        "baselineCaptured": {
+          "changeSetId": "aex_hermetic_0001:0",
+          "turnId": "aex_hermetic_0001:0",
+          "harnessId": "cursor",
+          "baselineSnapshot": {
+            "kind": "SNAPSHOT_KIND_CAS_MANIFEST"
+          }
+        }
+      }
+    ]
+  },
+  "fileChangeProgress": {
+    "changeSetId": "aex_hermetic_0001:0",
+    "capturedAt": "2026-01-01T00:00:01.000Z"
+  }
+}

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/recovery-fresh-agent.status.json
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/recovery-fresh-agent.status.json
@@ -1,0 +1,53 @@
+{
+  "messages": [
+    {
+      "type": "MESSAGE_AI",
+      "content": "Let me look at the recent changes.",
+      "timestamp": "2026-01-01T00:00:02.000Z"
+    },
+    {
+      "type": "MESSAGE_AI",
+      "content": "Two files changed since yesterday: notes.md and README.md.",
+      "timestamp": "2026-01-01T00:00:06.000Z"
+    }
+  ],
+  "phase": "EXECUTION_COMPLETED",
+  "startedAt": "2026-01-01T00:00:00.000Z",
+  "completedAt": "2026-01-01T00:00:08.000Z",
+  "streamingUsage": {
+    "inputTokens": "2800",
+    "outputTokens": "55",
+    "totalTokens": "2855",
+    "turnCount": 1,
+    "estimatedCostUsd": 0.00302,
+    "model": "composer-2.5",
+    "observedAt": "2026-01-01T00:00:07.000Z",
+    "requestedServiceTier": "SERVICE_TIER_STANDARD",
+    "requestedModelParams": "[{\"id\":\"fast\",\"value\":\"false\"},{\"id\":\"thinking\",\"value\":\"false\"}]",
+    "requestedThinkingMode": "THINKING_MODE_DISABLED"
+  },
+  "fileReviewEventStream": {
+    "executionId": "aex_hermetic_0001",
+    "events": [
+      {
+        "eventId": "aex_hermetic_0001:0:aex_hermetic_0001:0:FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "changeSetId": "aex_hermetic_0001:0",
+        "eventType": "FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "actor": "runner",
+        "baselineCaptured": {
+          "changeSetId": "aex_hermetic_0001:0",
+          "turnId": "aex_hermetic_0001:0",
+          "harnessId": "cursor",
+          "baselineSnapshot": {
+            "kind": "SNAPSHOT_KIND_CAS_MANIFEST"
+          }
+        }
+      }
+    ]
+  },
+  "fileChangeProgress": {
+    "changeSetId": "aex_hermetic_0001:0",
+    "capturedAt": "2026-01-01T00:00:01.000Z"
+  }
+}

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/tool-call.status.json
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/tool-call.status.json
@@ -1,0 +1,68 @@
+{
+  "messages": [
+    {
+      "type": "MESSAGE_AI",
+      "content": "Let me read it.",
+      "timestamp": "2026-01-01T00:00:02.000Z",
+      "toolCalls": [
+        {
+          "id": "call-hermetic-read-0001",
+          "name": "read",
+          "args": {
+            "path": "README.md"
+          },
+          "result": "# Hermetic\n\nA fixture readme.\n",
+          "status": "TOOL_CALL_COMPLETED",
+          "startedAt": "2026-01-01T00:00:03.000Z",
+          "completedAt": "2026-01-01T00:00:04.000Z",
+          "argsPreview": "{\"path\":\"README.md\"}",
+          "toolKind": "TOOL_KIND_FILE_READ"
+        }
+      ]
+    },
+    {
+      "type": "MESSAGE_AI",
+      "content": "README.md holds a one-line fixture description.",
+      "timestamp": "2026-01-01T00:00:05.000Z"
+    }
+  ],
+  "phase": "EXECUTION_COMPLETED",
+  "startedAt": "2026-01-01T00:00:00.000Z",
+  "completedAt": "2026-01-01T00:00:07.000Z",
+  "streamingUsage": {
+    "inputTokens": "2000",
+    "outputTokens": "90",
+    "totalTokens": "2090",
+    "turnCount": 1,
+    "estimatedCostUsd": 0.00236,
+    "model": "composer-2.5",
+    "observedAt": "2026-01-01T00:00:06.000Z",
+    "requestedServiceTier": "SERVICE_TIER_STANDARD",
+    "requestedModelParams": "[{\"id\":\"fast\",\"value\":\"false\"},{\"id\":\"thinking\",\"value\":\"false\"}]",
+    "requestedThinkingMode": "THINKING_MODE_DISABLED"
+  },
+  "fileReviewEventStream": {
+    "executionId": "aex_hermetic_0001",
+    "events": [
+      {
+        "eventId": "aex_hermetic_0001:0:aex_hermetic_0001:0:FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "changeSetId": "aex_hermetic_0001:0",
+        "eventType": "FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "actor": "runner",
+        "baselineCaptured": {
+          "changeSetId": "aex_hermetic_0001:0",
+          "turnId": "aex_hermetic_0001:0",
+          "harnessId": "cursor",
+          "baselineSnapshot": {
+            "kind": "SNAPSHOT_KIND_CAS_MANIFEST"
+          }
+        }
+      }
+    ]
+  },
+  "fileChangeProgress": {
+    "changeSetId": "aex_hermetic_0001:0",
+    "capturedAt": "2026-01-01T00:00:01.000Z"
+  }
+}

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/worker-shutdown.status.json
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/worker-shutdown.status.json
@@ -1,0 +1,47 @@
+{
+  "messages": [
+    {
+      "type": "MESSAGE_AI",
+      "content": "Starting on the parser.",
+      "timestamp": "2026-01-01T00:00:02.000Z"
+    },
+    {
+      "type": "MESSAGE_SYSTEM",
+      "content": "Execution interrupted: the runner worker was shut down while the agent was still running. You can retry or resume.",
+      "timestamp": "2026-01-01T00:00:04.000Z"
+    },
+    {
+      "type": "MESSAGE_SYSTEM",
+      "content": "Execution interrupted: the runner worker was shut down while the agent was still running. You can retry or resume.",
+      "timestamp": "2026-01-01T00:00:04.000Z"
+    }
+  ],
+  "phase": "EXECUTION_FAILED",
+  "error": "Execution interrupted: runner worker was shut down. Retry or resume.",
+  "startedAt": "2026-01-01T00:00:00.000Z",
+  "completedAt": "2026-01-01T00:00:04.000Z",
+  "fileReviewEventStream": {
+    "executionId": "aex_hermetic_0001",
+    "events": [
+      {
+        "eventId": "aex_hermetic_0001:0:aex_hermetic_0001:0:FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "changeSetId": "aex_hermetic_0001:0",
+        "eventType": "FILE_REVIEW_EVENT_TYPE_BASELINE_CAPTURED",
+        "timestamp": "2026-01-01T00:00:00.000Z",
+        "actor": "runner",
+        "baselineCaptured": {
+          "changeSetId": "aex_hermetic_0001:0",
+          "turnId": "aex_hermetic_0001:0",
+          "harnessId": "cursor",
+          "baselineSnapshot": {
+            "kind": "SNAPSHOT_KIND_CAS_MANIFEST"
+          }
+        }
+      }
+    ]
+  },
+  "fileChangeProgress": {
+    "changeSetId": "aex_hermetic_0001:0",
+    "capturedAt": "2026-01-01T00:00:01.000Z"
+  }
+}

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/pause-vs-shutdown.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/pause-vs-shutdown.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Hermetic goldens: USER PAUSE versus WORKER SHUTDOWN — the two interruptions
+ * that THROW, and the byte-pinned copy that tells them apart.
+ *
+ * Invariant pinned (the throw-vs-return table the runtime will own in S2; parent
+ * §5c): both interruptions end the activity with a thrown Temporal
+ * `CancelledFailure` (never a return), but they persist DIFFERENT terminal
+ * states the control plane keys on:
+ *
+ *  - a user pause (Temporal delivers cancellation, no shutdown signal) persists
+ *    EXECUTION_PAUSED with "Execution paused by user. Use resume to continue."
+ *    and throws "Activity paused by orchestrator";
+ *  - a worker shutdown (the runner's per-queue shutdown signal is aborted AND
+ *    cancellation is delivered) persists EXECUTION_FAILED with the error copy
+ *    "Execution interrupted: runner worker was shut down. Retry or resume." and
+ *    throws "Activity cancelled (worker shutdown, not user pause)".
+ *
+ * The cloud channel decision table matches on that copy, so the goldens
+ * (`goldens/pause.status.json`, `goldens/worker-shutdown.status.json`) are the
+ * wire contract, character for character. Both interruptions are triggered from
+ * a script `effect` step — never a timer — so the instant is deterministic: the
+ * stream loop sees `isCancelled()` on its next iteration and never processes
+ * the event that follows.
+ *
+ * What the goldens ALSO pin, on purpose: both paths append their system message
+ * TWICE — once in `resolvePreBoundaryTerminal` before the throw, once again in
+ * the outer `catch (CancelledFailure)`, which re-stamps and re-persists. That is
+ * today's production behavior on the wire. S2 must reproduce it byte for byte;
+ * whether it is later collapsed to one message is a separate, deliberate change
+ * (recorded in the entry's execution log for the owner).
+ *
+ * Parent phase rows exercised: the stream loop's cancellation check; the
+ * post-stream `classifyTurnInterruption`; `resolvePreBoundaryTerminal`'s
+ * pause and worker-shutdown arms; the outer `CancelledFailure` catch; the
+ * `finally` teardown under a thrown exit.
+ *
+ * Regenerate ONLY after a deliberate behavior change:
+ *   npx vitest run src/activities/execute-cursor/__tests__/hermetic -u
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { toJson } from "@bufbuild/protobuf";
+import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase, MessageType } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+vi.mock("@cursor/sdk", async () =>
+  (await import("../../__test-utils__/scripted-sdk.js")).scriptedCursorSdkModule(),
+);
+vi.mock("../../../../client/stigmer-client.js", async () =>
+  (await import("../../../../__test-utils__/hermetic-activity.js")).hermeticStigmerClientModule(),
+);
+
+import {
+  ScriptedClock,
+  createHermeticEnvironment,
+  threwCancelledFailure,
+  type HermeticEnvironment,
+  type InvocationControls,
+} from "../../../../__test-utils__/hermetic-activity.js";
+import { ScriptedCursorAgent, sdkEvents, step } from "../../__test-utils__/scripted-agent.js";
+import {
+  SDK_CATALOG,
+  beginCursorScenario,
+  cursorExecutionRecord,
+  runCursorTurn,
+  stubRegistryFetch,
+} from "../../__test-utils__/hermetic-cursor.js";
+
+const USER_MESSAGE = "Refactor the parser module.";
+const NEVER_SEEN = "This text must never reach the transcript.";
+
+/**
+ * A turn that is interrupted mid-stream by `interrupt(controls)`: one assistant
+ * message lands, then the interruption, then an event the loop must NOT process.
+ */
+function interruptedTurn(
+  agentId: string,
+  runId: string,
+  clock: ScriptedClock,
+  getControls: () => InvocationControls,
+  interrupt: (controls: InvocationControls) => void,
+): ScriptedCursorAgent {
+  const ev = sdkEvents(agentId, runId);
+  return new ScriptedCursorAgent({
+    agentId,
+    runIds: [runId],
+    observeStep: () => clock.tick(),
+    turns: [
+      [
+        step.event(ev.init()),
+        step.event(ev.assistant("Starting on the parser.")),
+        step.effect("interrupt the activity from outside", () => interrupt(getControls())),
+        step.event(ev.assistant(NEVER_SEEN)),
+        step.finished({ result: NEVER_SEEN }),
+      ],
+    ],
+  });
+}
+
+describe("ExecuteCursor hermetic — user pause vs worker shutdown", () => {
+  let env: HermeticEnvironment;
+  let registry: ReturnType<typeof stubRegistryFetch>;
+  const clock = new ScriptedClock();
+
+  beforeAll(() => {
+    env = createHermeticEnvironment();
+    registry = stubRegistryFetch();
+    clock.install();
+  });
+
+  afterAll(() => {
+    clock.uninstall();
+    registry.restore();
+    env.dispose();
+  });
+
+  it("a user pause persists PAUSED and throws CancelledFailure", async () => {
+    // ── Arrange ──────────────────────────────────────────────────────────────
+    clock.reset(); // both goldens read from :00
+    let controls: InvocationControls | undefined;
+    const agent = interruptedTurn(
+      "agent-hermetic-pause-0001",
+      "run-hermetic-pause-0001",
+      clock,
+      () => controls!,
+      (c) => c.cancel(),
+    );
+    const record = cursorExecutionRecord({ message: USER_MESSAGE });
+    const scenario = beginCursorScenario({ env, clock, record, sdk: { agents: [agent], catalog: SDK_CATALOG } });
+
+    // ── Act ──────────────────────────────────────────────────────────────────
+    const invocation = await runCursorTurn(scenario, { onControls: (c) => (controls = c) });
+
+    // ── Assert: the throw and the persisted state ────────────────────────────
+    expect(threwCancelledFailure(invocation.outcome), "a pause THROWS CancelledFailure").toBe(true);
+    if (!threwCancelledFailure(invocation.outcome)) throw new Error("unreachable");
+    expect(invocation.outcome.error.message).toBe("Activity paused by orchestrator");
+    expect(record.persistedPhases).toEqual([
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_PAUSED,
+    ]);
+    const final = record.lastFullStatus!;
+    expect(final.error, "a pause is not an error").toBe("");
+    expect(final.completedAt, "a paused turn is not complete").toBe("");
+    expect(
+      final.messages.filter((m) => m.type === MessageType.MESSAGE_SYSTEM).map((m) => m.content),
+    ).toEqual([
+      "Execution paused by user. Use resume to continue.",
+      "Execution paused by user. Use resume to continue.",
+    ]);
+    expect(final.messages.some((m) => m.content === NEVER_SEEN), "nothing after the cancel is processed").toBe(false);
+
+    const json = JSON.stringify(toJson(AgentExecutionStatusSchema, final), null, 2) + "\n";
+    await expect(json).toMatchFileSnapshot("./goldens/pause.status.json");
+  });
+
+  it("a worker shutdown persists FAILED with the shutdown copy and throws CancelledFailure", async () => {
+    // ── Arrange ──────────────────────────────────────────────────────────────
+    clock.reset();
+    let controls: InvocationControls | undefined;
+    const agent = interruptedTurn(
+      "agent-hermetic-shutdown-0001",
+      "run-hermetic-shutdown-0001",
+      clock,
+      () => controls!,
+      (c) => {
+        // The runner-manager drains: the queue's shutdown signal aborts, then
+        // Temporal delivers the cancellation.
+        c.signalWorkerShutdown();
+        c.cancel();
+      },
+    );
+    const record = cursorExecutionRecord({ message: USER_MESSAGE });
+    const scenario = beginCursorScenario({ env, clock, record, sdk: { agents: [agent], catalog: SDK_CATALOG } });
+
+    // ── Act ──────────────────────────────────────────────────────────────────
+    const invocation = await runCursorTurn(scenario, { onControls: (c) => (controls = c) });
+
+    // ── Assert: the throw and the persisted state ────────────────────────────
+    expect(threwCancelledFailure(invocation.outcome), "a shutdown THROWS CancelledFailure").toBe(true);
+    if (!threwCancelledFailure(invocation.outcome)) throw new Error("unreachable");
+    expect(invocation.outcome.error.message).toBe("Activity cancelled (worker shutdown, not user pause)");
+    expect(record.persistedPhases).toEqual([
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_FAILED,
+    ]);
+    const final = record.lastFullStatus!;
+    expect(final.error).toBe("Execution interrupted: runner worker was shut down. Retry or resume.");
+    expect(final.completedAt).not.toBe("");
+    expect(
+      final.messages.filter((m) => m.type === MessageType.MESSAGE_SYSTEM).map((m) => m.content),
+    ).toEqual([
+      "Execution interrupted: the runner worker was shut down while the agent was still running. You can retry or resume.",
+      "Execution interrupted: the runner worker was shut down while the agent was still running. You can retry or resume.",
+    ]);
+    expect(final.messages.some((m) => m.content === NEVER_SEEN)).toBe(false);
+
+    const json = JSON.stringify(toJson(AgentExecutionStatusSchema, final), null, 2) + "\n";
+    await expect(json).toMatchFileSnapshot("./goldens/worker-shutdown.status.json");
+  });
+});

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/plain-turn.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/plain-turn.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Hermetic golden: a PLAIN TURN through the whole `ExecuteCursor` activity.
+ *
+ * Invariant pinned: an execution with no tools, no workspace entries, no MCP
+ * servers and no skills — the user asks, the agent answers — runs the full
+ * setup pipeline and ends COMPLETED with exactly the transcript, usage and
+ * timestamps recorded in `goldens/plain-turn.status.json`, RETURNING a slim
+ * status to the workflow (never throwing). This is the baseline every other
+ * scenario is a delta from, and the first proof that the activity is byte-
+ * stable under the hermetic driver.
+ *
+ * Parent phase rows exercised (20260908.02 `T01_0_plan.md` §3a): normalize
+ * input / heartbeat; artifact storage + the `persist` chokepoint; fetch
+ * execution, session, agent, blueprint; resolve environment (NOT_FOUND ->
+ * empty); provision workspace (per-session dir); workspace turn lock; MCP
+ * resolve (none); skills (none); attachments (none); HITL gate install;
+ * pricing + model id + variant params; create the engine session; write
+ * `harness_state_id` back; prompt composition; usage accumulation; run the
+ * turn; terminal mapping COMPLETED -> return; cleanup.
+ *
+ * Nothing here is a live Cursor agent: `@cursor/sdk` is the scripted double
+ * (`__test-utils__/scripted-sdk.ts`) and the control plane is the in-memory
+ * execution record (`__test-utils__/hermetic-activity.ts`). No network, no
+ * `CURSOR_API_KEY`, no Temporal worker.
+ *
+ * Regenerate the golden ONLY after a deliberate behavior change:
+ *   npx vitest run src/activities/execute-cursor/__tests__/hermetic -u
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { toJson } from "@bufbuild/protobuf";
+import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+// Both mocks are hoisted by vitest; they must live in this file. Each factory
+// imports the reusable module and returns its mock surface.
+vi.mock("@cursor/sdk", async () =>
+  (await import("../../__test-utils__/scripted-sdk.js")).scriptedCursorSdkModule(),
+);
+vi.mock("../../../../client/stigmer-client.js", async () =>
+  (await import("../../../../__test-utils__/hermetic-activity.js")).hermeticStigmerClientModule(),
+);
+
+import {
+  ScriptedClock,
+  createHermeticEnvironment,
+  type HermeticEnvironment,
+} from "../../../../__test-utils__/hermetic-activity.js";
+import { ScriptedCursorAgent, step } from "../../__test-utils__/scripted-agent.js";
+import {
+  FIXTURE,
+  SDK_CATALOG,
+  beginCursorScenario,
+  cursorExecutionRecord,
+  runCursorTurn,
+  stubRegistryFetch,
+} from "../../__test-utils__/hermetic-cursor.js";
+
+const AGENT_ID = "agent-hermetic-plain-0001";
+const RUN_ID = "run-hermetic-plain-0001";
+const USER_MESSAGE = "Say hello in five words or fewer.";
+const ASSISTANT_TEXT = "Hello there, hermetic world.";
+
+describe("ExecuteCursor hermetic — plain turn", () => {
+  let env: HermeticEnvironment;
+  let registry: ReturnType<typeof stubRegistryFetch>;
+  const clock = new ScriptedClock();
+
+  beforeAll(() => {
+    env = createHermeticEnvironment();
+    registry = stubRegistryFetch();
+    clock.install();
+  });
+
+  afterAll(() => {
+    clock.uninstall();
+    registry.restore();
+    env.dispose();
+  });
+
+  it("completes with the golden transcript and returns a slim COMPLETED status", async () => {
+    // ── Arrange ──────────────────────────────────────────────────────────────
+    const agent = new ScriptedCursorAgent({
+      agentId: AGENT_ID,
+      runIds: [RUN_ID],
+      observeStep: () => clock.tick(),
+      turns: [
+        [
+          step.event({ type: "system", subtype: "init", agent_id: AGENT_ID, run_id: RUN_ID }),
+          step.event({
+            type: "assistant",
+            agent_id: AGENT_ID,
+            run_id: RUN_ID,
+            message: { role: "assistant", content: [{ type: "text", text: ASSISTANT_TEXT }] },
+          }),
+          step.turnEnded({ inputTokens: 1_200, outputTokens: 40 }),
+          step.finished({
+            result: ASSISTANT_TEXT,
+            model: {
+              id: FIXTURE.model,
+              params: [
+                { id: "fast", value: "false" },
+                { id: "thinking", value: "false" },
+              ],
+            },
+          }),
+        ],
+      ],
+    });
+    const record = cursorExecutionRecord({ message: USER_MESSAGE });
+    const scenario = beginCursorScenario({
+      env,
+      clock,
+      record,
+      sdk: { agents: [agent], catalog: SDK_CATALOG },
+    });
+
+    // ── Act ──────────────────────────────────────────────────────────────────
+    const invocation = await runCursorTurn(scenario);
+
+    // ── Assert: the outcome the workflow sees ────────────────────────────────
+    expect(invocation.outcome.kind, "a completed turn RETURNS, never throws").toBe("returned");
+    const slim = (invocation.outcome as { value: Record<string, unknown> }).value;
+    expect(slim.phase).toBe("EXECUTION_COMPLETED");
+    expect(slim.final_text).toBe(ASSISTANT_TEXT);
+    expect(slim, "the slim return carries no transcript").not.toHaveProperty("messages");
+
+    // ── Assert: what the control plane received, in order ────────────────────
+    expect(record.persistedPhases).toEqual([
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_COMPLETED,
+    ]);
+    expect(record.setupProgress, "the setup pipeline's phase labels, in order").toEqual([
+      "Fetching execution",
+      "Resolving agent blueprint",
+      "Resolving environment",
+      "Provisioning workspace",
+      "Resolving MCP servers",
+      "Resolving skills",
+      "Initializing Cursor agent",
+    ]);
+
+    // ── Assert: what the SDK was asked ───────────────────────────────────────
+    expect(scenario.sdk.resolutions).toHaveLength(1);
+    expect(scenario.sdk.resolutions[0].kind, "a fresh session creates, never resumes").toBe("create");
+    expect(scenario.sdk.resolutions[0].options?.model).toEqual({
+      id: FIXTURE.model,
+      params: [
+        { id: "fast", value: "false" },
+        { id: "thinking", value: "false" },
+      ],
+    });
+    expect(agent.sends).toHaveLength(1);
+    expect(String(agent.sends[0].message), "the prompt carries the user's message").toContain(USER_MESSAGE);
+    expect(agent.sends[0].hasOnDelta).toBe(true);
+
+    // ── Assert: the harness_state_id write-back ─────────────────────────────
+    expect(record.sessionUpdates).toHaveLength(1);
+    expect(record.sessionUpdates[0].spec?.harnessStateId).toBe(AGENT_ID);
+
+    // ── Assert: hermeticity ──────────────────────────────────────────────────
+    expect(invocation.heartbeats.length, "the whole-activity heartbeat ran").toBeGreaterThan(0);
+    expect(registry.urls.every((u) => u.includes("/model-registry")), "no network beyond the registry").toBe(true);
+
+    // ── Assert: the golden ───────────────────────────────────────────────────
+    const finalStatus = record.lastFullStatus;
+    expect(finalStatus).toBeDefined();
+    const json = JSON.stringify(toJson(AgentExecutionStatusSchema, finalStatus!), null, 2) + "\n";
+    await expect(json).toMatchFileSnapshot("./goldens/plain-turn.status.json");
+  });
+});

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/recovery-fresh-agent.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/recovery-fresh-agent.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Hermetic golden: POISONED-HANDLE RECOVERY — a resumed agent whose run fails
+ * with a transport error is replaced by a fresh agent, once, and the turn
+ * completes on the replacement.
+ *
+ * Invariant pinned: when `run.wait()` reports `error` on an agent that was
+ * RESUMED (`resolution.reason === "resumed_successfully"`) and the classifier
+ * files the error as `network` or `agent-stale`, the activity closes the stale
+ * handle, calls `Agent.create` for a fresh one, writes the fresh id to the
+ * session's `harness_state_id`, re-runs the turn on the fresh agent through the
+ * IDENTICAL stream loop and boundary, and ends COMPLETED. The retry happens at
+ * most once (`alreadyRetriedWithFreshAgent`). The golden
+ * (`goldens/recovery-fresh-agent.status.json`) pins what the user sees after a
+ * recovered turn.
+ *
+ * Parent phase rows exercised beyond the earlier scenarios: `Agent.resume`
+ * through `resolveAgentWithTransportRecovery` (a second execution in a session:
+ * `thread_id` set, no parked agent); the `status: ERROR` stream event feeding
+ * `streamErrorMessage`; `run.wait()` error mapping; the error classifier
+ * (`error-classifier.ts` NETWORK_PATTERNS, the same shapes its own tests pin);
+ * the fresh-agent recovery spine (`runRecoveryStream`); the second
+ * `harness_state_id` write-back.
+ *
+ * Regenerate ONLY after a deliberate behavior change:
+ *   npx vitest run src/activities/execute-cursor/__tests__/hermetic -u
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { toJson } from "@bufbuild/protobuf";
+import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+vi.mock("@cursor/sdk", async () =>
+  (await import("../../__test-utils__/scripted-sdk.js")).scriptedCursorSdkModule(),
+);
+vi.mock("../../../../client/stigmer-client.js", async () =>
+  (await import("../../../../__test-utils__/hermetic-activity.js")).hermeticStigmerClientModule(),
+);
+
+import {
+  ScriptedClock,
+  createHermeticEnvironment,
+  type HermeticEnvironment,
+} from "../../../../__test-utils__/hermetic-activity.js";
+import { ScriptedCursorAgent, sdkEvents, step } from "../../__test-utils__/scripted-agent.js";
+import {
+  FIXTURE,
+  SDK_CATALOG,
+  beginCursorScenario,
+  cursorExecutionRecord,
+  runCursorTurn,
+  stubRegistryFetch,
+} from "../../__test-utils__/hermetic-cursor.js";
+
+const STALE_AGENT_ID = "agent-hermetic-stale-0001";
+const FRESH_AGENT_ID = "agent-hermetic-fresh-0002";
+const RUN_STALE = "run-hermetic-stale-0001";
+const RUN_FRESH = "run-hermetic-fresh-0001";
+const USER_MESSAGE = "Summarize what changed since yesterday.";
+// A real network-class failure shape (error-classifier NETWORK_PATTERNS:
+// "unavailable", "econnreset", "fetch failed").
+const TRANSPORT_ERROR = "UNAVAILABLE: fetch failed (ECONNRESET) while streaming the run";
+const FINAL_TEXT = "Two files changed since yesterday: notes.md and README.md.";
+
+describe("ExecuteCursor hermetic — poisoned-handle recovery on a fresh agent", () => {
+  let env: HermeticEnvironment;
+  let registry: ReturnType<typeof stubRegistryFetch>;
+  const clock = new ScriptedClock();
+
+  beforeAll(() => {
+    env = createHermeticEnvironment();
+    registry = stubRegistryFetch();
+    clock.install();
+  });
+
+  afterAll(() => {
+    clock.uninstall();
+    registry.restore();
+    env.dispose();
+  });
+
+  it("replaces the stale resumed agent once and completes on the fresh one", async () => {
+    // ── Arrange ──────────────────────────────────────────────────────────────
+    const evStale = sdkEvents(STALE_AGENT_ID, RUN_STALE);
+    const evFresh = sdkEvents(FRESH_AGENT_ID, RUN_FRESH);
+    const stale = new ScriptedCursorAgent({
+      agentId: STALE_AGENT_ID,
+      runIds: [RUN_STALE],
+      observeStep: () => clock.tick(),
+      turns: [
+        [
+          step.event(evStale.init()),
+          step.event(evStale.assistant("Let me look at the recent changes.")),
+          step.event(evStale.status("ERROR", TRANSPORT_ERROR)),
+          step.errored({ result: TRANSPORT_ERROR }),
+        ],
+      ],
+    });
+    const fresh = new ScriptedCursorAgent({
+      agentId: FRESH_AGENT_ID,
+      runIds: [RUN_FRESH],
+      observeStep: () => clock.tick(),
+      turns: [
+        [
+          step.event(evFresh.init()),
+          step.event(evFresh.assistant(FINAL_TEXT)),
+          step.turnEnded({ inputTokens: 2_800, outputTokens: 55 }),
+          step.finished({ result: FINAL_TEXT, model: { id: FIXTURE.model, params: [] } }),
+        ],
+      ],
+    });
+    const record = cursorExecutionRecord({ message: USER_MESSAGE });
+    const scenario = beginCursorScenario({
+      env,
+      clock,
+      record,
+      // `Agent.create` hands out `fresh`; `Agent.resume(STALE)` finds `stale`,
+      // the previous turn's agent the session knows only by harness_state_id.
+      sdk: { agents: [fresh], resumableAgents: [stale], catalog: SDK_CATALOG },
+    });
+
+    // ── Act: the second execution in the session resumes the stale handle ────
+    const invocation = await runCursorTurn(scenario, { threadId: STALE_AGENT_ID, turnSeq: 0 });
+
+    // ── Assert: outcome ──────────────────────────────────────────────────────
+    expect(invocation.outcome.kind, "a recovered turn RETURNS like any completion").toBe("returned");
+    const slim = (invocation.outcome as { value: Record<string, unknown> }).value;
+    expect(slim.phase).toBe("EXECUTION_COMPLETED");
+    expect(slim.final_text).toBe(FINAL_TEXT);
+    expect(record.persistedPhases).toEqual([
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_COMPLETED,
+    ]);
+
+    // ── Assert: the recovery spine ───────────────────────────────────────────
+    expect(scenario.sdk.resolutions.map((r) => [r.kind, r.agentId])).toEqual([
+      ["resume", STALE_AGENT_ID],
+      ["create", FRESH_AGENT_ID],
+    ]);
+    expect(stale.sends, "the stale handle ran exactly once").toHaveLength(1);
+    expect(stale.closeCalls, "the poisoned handle is disposed").toBe(1);
+    expect(fresh.sends, "the fresh agent ran the turn exactly once — no second retry").toHaveLength(1);
+    expect(String(fresh.sends[0].message), "the rebuilt prompt carries the user's message").toContain(USER_MESSAGE);
+
+    // The session now points at the fresh agent (the stale id is superseded).
+    const lastSessionWrite = record.sessionUpdates.at(-1);
+    expect(lastSessionWrite?.spec?.harnessStateId).toBe(FRESH_AGENT_ID);
+
+    // ── Assert: hermeticity ──────────────────────────────────────────────────
+    expect(registry.urls.every((u) => u.includes("/model-registry"))).toBe(true);
+
+    // ── Assert: the golden ───────────────────────────────────────────────────
+    const json = JSON.stringify(toJson(AgentExecutionStatusSchema, record.lastFullStatus!), null, 2) + "\n";
+    await expect(json).toMatchFileSnapshot("./goldens/recovery-fresh-agent.status.json");
+  });
+});

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/tool-call.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/tool-call.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Hermetic golden: a turn with an UNGATED TOOL CALL through the whole
+ * `ExecuteCursor` activity.
+ *
+ * Invariant pinned: a `tool_call` the SDK streams as `running` and then
+ * `completed` folds into exactly one `ToolCall` row on the AI message — id from
+ * `call_id`, name from the stream taxonomy, `args` + `argsPreview` from the
+ * event's args, `result` from the completed event, `startedAt`/`completedAt`
+ * from the two events' instants, `toolKind` classified, no approval fields set
+ * (a read-only built-in is not gated) — and the turn ends COMPLETED. The golden
+ * (`goldens/tool-call.status.json`) is the row shape S4's canonical transcript
+ * builder must reproduce byte for byte.
+ *
+ * Parent phase rows exercised beyond `plain-turn`: run the turn and consume
+ * the engine stream (tool-call folding in `message-translator.ts`); the turn
+ * boundary with nothing to gate or capture (a read tool writes no file; the
+ * per-session workspace is unchanged, so the capture finds no candidate).
+ *
+ * Regenerate ONLY after a deliberate behavior change:
+ *   npx vitest run src/activities/execute-cursor/__tests__/hermetic -u
+ */
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { toJson } from "@bufbuild/protobuf";
+import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ExecutionPhase, ToolCallStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+vi.mock("@cursor/sdk", async () =>
+  (await import("../../__test-utils__/scripted-sdk.js")).scriptedCursorSdkModule(),
+);
+vi.mock("../../../../client/stigmer-client.js", async () =>
+  (await import("../../../../__test-utils__/hermetic-activity.js")).hermeticStigmerClientModule(),
+);
+
+import {
+  ScriptedClock,
+  createHermeticEnvironment,
+  type HermeticEnvironment,
+} from "../../../../__test-utils__/hermetic-activity.js";
+import { ScriptedCursorAgent, sdkEvents, step } from "../../__test-utils__/scripted-agent.js";
+import {
+  FIXTURE,
+  SDK_CATALOG,
+  beginCursorScenario,
+  cursorExecutionRecord,
+  runCursorTurn,
+  stubRegistryFetch,
+} from "../../__test-utils__/hermetic-cursor.js";
+
+const AGENT_ID = "agent-hermetic-tool-0001";
+const RUN_ID = "run-hermetic-tool-0001";
+const CALL_ID = "call-hermetic-read-0001";
+const USER_MESSAGE = "What is in README.md?";
+const READ_ARGS = { path: "README.md" };
+const READ_RESULT = "# Hermetic\n\nA fixture readme.\n";
+const ASSISTANT_TEXT = "README.md holds a one-line fixture description.";
+
+describe("ExecuteCursor hermetic — ungated tool call", () => {
+  let env: HermeticEnvironment;
+  let registry: ReturnType<typeof stubRegistryFetch>;
+  const clock = new ScriptedClock();
+
+  beforeAll(() => {
+    env = createHermeticEnvironment();
+    registry = stubRegistryFetch();
+    clock.install();
+  });
+
+  afterAll(() => {
+    clock.uninstall();
+    registry.restore();
+    env.dispose();
+  });
+
+  it("folds running -> completed into one COMPLETED tool-call row and completes", async () => {
+    // ── Arrange ──────────────────────────────────────────────────────────────
+    const ev = sdkEvents(AGENT_ID, RUN_ID);
+    const agent = new ScriptedCursorAgent({
+      agentId: AGENT_ID,
+      runIds: [RUN_ID],
+      observeStep: () => clock.tick(),
+      turns: [
+        [
+          step.event(ev.init()),
+          step.event(ev.assistant("Let me read it.")),
+          step.event(ev.toolCall(CALL_ID, "read", "running", READ_ARGS)),
+          step.event(ev.toolCall(CALL_ID, "read", "completed", READ_ARGS, READ_RESULT)),
+          step.event(ev.assistant(ASSISTANT_TEXT)),
+          step.turnEnded({ inputTokens: 2_000, outputTokens: 90 }),
+          step.finished({ result: ASSISTANT_TEXT, model: { id: FIXTURE.model, params: [] } }),
+        ],
+      ],
+    });
+    const record = cursorExecutionRecord({ message: USER_MESSAGE });
+    const scenario = beginCursorScenario({
+      env,
+      clock,
+      record,
+      sdk: { agents: [agent], catalog: SDK_CATALOG },
+    });
+
+    // ── Act ──────────────────────────────────────────────────────────────────
+    const invocation = await runCursorTurn(scenario);
+
+    // ── Assert: outcome and phases ───────────────────────────────────────────
+    expect(invocation.outcome.kind).toBe("returned");
+    const slim = (invocation.outcome as { value: Record<string, unknown> }).value;
+    expect(slim.phase).toBe("EXECUTION_COMPLETED");
+    expect(slim.final_text).toBe(ASSISTANT_TEXT);
+    expect(record.persistedPhases).toEqual([
+      ExecutionPhase.EXECUTION_IN_PROGRESS,
+      ExecutionPhase.EXECUTION_COMPLETED,
+    ]);
+
+    // ── Assert: the one tool-call row ────────────────────────────────────────
+    const rows = record.toolCalls();
+    expect(rows, "running + completed fold into ONE row, never two").toHaveLength(1);
+    const row = rows[0];
+    expect(row.id).toBe(CALL_ID);
+    expect(row.name).toBe("read");
+    expect(row.status).toBe(ToolCallStatus.TOOL_CALL_COMPLETED);
+    expect(row.args).toEqual(READ_ARGS);
+    expect(row.result).toBe(READ_RESULT);
+    expect(row.requiresApproval, "a read-only built-in is not gated").toBe(false);
+    expect(row.startedAt < row.completedAt, "started before completed on the scripted clock").toBe(true);
+
+    // ── Assert: hermeticity ──────────────────────────────────────────────────
+    expect(registry.urls.every((u) => u.includes("/model-registry"))).toBe(true);
+    expect(agent.runs[0].cancelCalls, "an ungated turn is never cancelled").toHaveLength(0);
+
+    // ── Assert: the golden ───────────────────────────────────────────────────
+    const finalStatus = record.lastFullStatus;
+    expect(finalStatus).toBeDefined();
+    const json = JSON.stringify(toJson(AgentExecutionStatusSchema, finalStatus!), null, 2) + "\n";
+    await expect(json).toMatchFileSnapshot("./goldens/tool-call.status.json");
+  });
+});


### PR DESCRIPTION
## Summary
A hermetic (no network, no `CURSOR_API_KEY`, no Temporal worker) end-to-end regression net for the `ExecuteCursor` activity: a scripted `@cursor/sdk` double, a runner-wide activity driver on `MockActivityEnvironment`, and eight byte-stable goldens of the final `AgentExecutionStatus` across six scenarios, recorded on today's code before any refactor. No production module is changed.

## Context
S0 of the harness runtime program (stigmer-cloud `_projects/2026-09/20260908.02.harness-runtime-and-adapter-contract`, entry `20260911.01.sp.cursor-hermetic-instrument`). The Cursor harness had no offline end-to-end coverage (every `cursor_*_test.go` needs a live key); the program's S2 extraction of the 2,876-line orchestrator must prove it left the wire byte-identical, and these goldens are that proof. The native harness already runs its activity hermetically by mocking the boundary modules (`execute-deep-agent/__tests__/{index,hitl-*,sequential-gate-resume}.test.ts`); this gives Cursor the same, made reusable.

## Changes
- `src/__test-utils__/hermetic-activity.ts` (runner-wide, harness-agnostic): `ExecutionRecord` (the in-memory execution row behind `mockStigmerClient`; `updateStatus` writes back so a reinvocation reads the persisted transcript; `decideWaitingToolCalls` is the server's `SubmitApproval` effect, per field ownership), the `vi.mock` seam for `StigmerClient`, temp `HOME` / workspace root / local artifact store, pinned HITL fingerprint secret, a ticking fake `Date` (timers real), one `MockActivityEnvironment` per invocation, `InvocationControls` (cancel, worker shutdown).
- `execute-cursor/__test-utils__/scripted-agent.ts`: `ScriptedCursorAgent implements SDKAgent`, `ScriptedRun implements Run`; a `TurnScript` of `event` / `turnEnded` / `effect` / `result` steps, one per `send()`; `sdkEvents` builders.
- `execute-cursor/__test-utils__/scripted-sdk.ts`: the `@cursor/sdk` runtime surface the activity uses (`Agent.create/resume/archive`, `Cursor.models.list`, `CursorSdkError`), bound per scenario; a create queue plus resume-only agents.
- `execute-cursor/__test-utils__/hermetic-cursor.ts`: fixture record, registry document + SDK catalog for the pinned model, a `fetch` stub that refuses any non-registry URL, the OSS/local `Config`, `runWorkspaceHook` (finds the hook through `.cursor/hooks.json` exactly as the SDK does and runs the real bash script), `initGitWorkspace` (pinned author/committer/dates), `runCursorTurn`.
- `execute-cursor/__tests__/hermetic/`: six scenario files, eight goldens:
  - `plain-turn` — COMPLETED, returns a slim status; setup-progress labels in order; `Agent.create` model selection with pinned variant params; `harness_state_id` write-back.
  - `tool-call` — an ungated `read` folds `running` → `completed` into one row.
  - `deny-and-retry` (two invocations, two goldens) — the REAL bash hook denies the gated `shell`; first-denial stop; WAITING_FOR_APPROVAL returned; approval written on the row; the resume checks the parked agent out of the cache (no `Agent.resume`), the same hook allows, the fresh `call_id` reconciles onto the committed row; COMPLETED.
  - `file-review-capture` — `local_path` git workspace; capture mode lets the write flow (hook allows); the boundary captures the diff against the baseline tree, authors `CANDIDATE_CAPTURED` with one card, pauses for review.
  - `recovery-fresh-agent` — a resumed handle fails with a network-class error; the classifier files it `network`; the stale handle is closed, `Agent.create` hands out a fresh agent, `harness_state_id` is rewritten, the turn re-runs once; COMPLETED.
  - `pause-vs-shutdown` (two goldens) — both THROW `CancelledFailure`; a user pause persists PAUSED, a worker shutdown persists FAILED with the byte-pinned copy; both triggered from a script step, never a timer.

## Implementation notes
- **No production module is changed.** Substitution is at the module boundary with `vi.mock`, the existing convention.
- **Zero redacted fields** across all eight goldens. Every volatile source is controlled at its origin: fake `Date`, pinned secret (the ONE randomness source on the activity path, `fingerprint-secret.ts`), fixture ids, pinned git identity and dates (tree and commit ids are content-derived), repo-relative paths in stream args so no temp directory reaches a golden (asserted).
- **Ticking, not frozen, clock**: `delta-enricher.ts`'s persist debounce reads `Date.now()`; a frozen clock would skip the mid-stream persist path production always runs. The tick also made `fileChangeProgress` land mid-run in the capture golden.
- **Findings recorded, not worked around** (the entry's `T01_3_execution.md`):
  1. `InteractionUpdate` and every SDK delta type resolve to `any` in the runner (`@cursor/sdk`'s `delta-types.d.ts` re-exports a `workspace:*` package the published SDK does not ship; `skipLibCheck` swallows it). Production reads the delta channel untyped. The double types the one delta it emits locally.
  2. Both interruption paths append their system message TWICE (`resolvePreBoundaryTerminal`, then the outer `catch (CancelledFailure)` re-stamps and re-persists). The goldens pin today's wire on purpose; collapsing it is a separate, deliberate change after S2.
  3. A WAITING gate row's `args` carry the hook's full `tool_input` (`command`, `cwd`, `timeout`) overlaid from the ledger; a flowed edit row in capture mode keeps `requiresApproval: true` (the policy's verdict) while COMPLETED. Both pinned with a comment.
- **Measured size of the double** (S5's first data point): 508 lines for the whole SDK runtime surface (`scripted-agent.ts` 342 + `scripted-sdk.ts` 166), plus 422 lines of Cursor driver glue and 477 lines of runner-wide driver every harness shares.

## Breaking changes
- None.

## Test plan
- `cd backend/services/runner && npm run typecheck` — green.
- `env -u CURSOR_API_KEY npx vitest run src/activities/execute-cursor/__tests__/hermetic` — 6 files / 7 tests / 8 goldens green in ~8s; the only `fetch` is the model registry (asserted).
- Byte stability: a second full run leaves every golden byte-identical (`shasum` before/after); `git status` on the goldens dir clean.
- Full runner suite in the CI posture, `CI=1 npm test` — **283 files / 4,743 tests pass, 0 failures**. One `[vitest-worker]: Timeout calling "onTaskUpdate"` unhandled error remains; it is the reporter-RPC timeout `vitest.config.ts` documents as spurious under subprocess load, and it reproduces identically with the hermetic tests excluded (verified at M1).
- Without the CI fork cap (20 forks on this machine), several pre-existing bash/git-spawning tests and the capture scenario hit the 30s timeout under CPU saturation — the exact class the config's `testTimeout` comment describes; none is an assertion failure.

## Risks
- Test-only change; rollback is a revert. The goldens pin today's behavior deliberately: a future change to `ExecuteCursor`'s wire shape must regenerate them on purpose (`vitest -u`) and say why in the PR.

## Checklist
- [x] Tests added (six scenarios, eight goldens)
- [x] Backward compatible (no production change)
- [x] Full runner suite green in the CI posture
- [x] Findings recorded in the project entry for the owner's disposition
