### PR TITLE
scratch: S6 test concurrency measurement (do not merge)

### DIFF
--- a/.github/workflows/ci.ts-workspace.yaml
+++ b/.github/workflows/ci.ts-workspace.yaml
@@ -171,7 +171,7 @@ jobs:
         run: node scripts/verify-esm-node.mjs --only="$AFFECTED"
 
       - name: Tests
-        run: node scripts/turbo-set.mjs libs test --only="$AFFECTED"
+        run: node scripts/turbo-set.mjs libs test --only="$AFFECTED" --concurrency=2
 
   # Every affected package's tsconfig.json pass (the one config that includes
   # its test files) and eslint where a package has one, then the gates that

--- a/.github/workflows/ci.ts-workspace.yaml
+++ b/.github/workflows/ci.ts-workspace.yaml
@@ -171,7 +171,7 @@ jobs:
         run: node scripts/verify-esm-node.mjs --only="$AFFECTED"
 
       - name: Tests
-        run: node scripts/turbo-set.mjs libs test --only="$AFFECTED" --concurrency=2
+        run: node scripts/turbo-set.mjs libs test --only="$AFFECTED" --concurrency=4
 
   # Every affected package's tsconfig.json pass (the one config that includes
   # its test files) and eslint where a package has one, then the gates that


### PR DESCRIPTION
Scratch PR against the S6 branch: the lane file changes, so the gate runs everything and the libs Tests step runs the full set at the concurrency under test. Reruns give the samples. Closed after the numbers are recorded in T01_6.

Made with [Cursor](https://cursor.com)