### PR TITLE
feat(backend/runner): harness adapter contract, scripted fake, contract kit and registry (S1)

### DIFF
--- a/backend/services/runner/src/__test-utils__/__tests__/harness-contract-self-check.test.ts
+++ b/backend/services/runner/src/__test-utils__/__tests__/harness-contract-self-check.test.ts
@@ -1,0 +1,229 @@
+/**
+ * The harness contract kit's self-check: proof that every invariant in
+ * `harness-contract/contract.ts` can FAIL.
+ *
+ * A contract kit that only ever passes proves nothing about the adapters it
+ * runs against — it might be asserting the wrong thing, or nothing. So each
+ * invariant is run here against an adapter deliberately broken in exactly the
+ * way that invariant exists to catch, and the kit must reject with a message
+ * that names the subject and the violation. The tester role's rule: a test
+ * that cannot fail is not a test.
+ *
+ * Every broken adapter wraps the honest scripted fake and breaks ONE thing,
+ * so a rejection here is attributable to the kit's assertion and not to some
+ * other defect of the double. Where an invariant races a hang against the
+ * interrupt bound, the bound is shortened through the assertion's parameter;
+ * the production bound stays what `contract.ts` declares.
+ */
+
+import { describe, it, expect } from "vitest";
+import { CancelledFailure } from "@temporalio/activity";
+import { ApprovalAction, ToolCallStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+import type { HarnessAdapter, TurnInput, TurnOutcome, TurnSink } from "../../harness/types.js";
+import {
+  assertConcurrentTurnsAreIndependent,
+  assertDecisionsExecuteExactlyOnce,
+  assertEveryExitIsAnOutcome,
+  assertLifetimesResolve,
+  assertProposalIsWaitingAndUnexecuted,
+  assertStateIdCapabilityAgrees,
+  assertStopSignalInterrupts,
+  assertUsageReachesSinkAsDeltas,
+} from "../harness-contract/contract.js";
+import { scriptedSubject } from "../harness-contract/scripted-adapter.js";
+import type { ScriptedSubject } from "../harness-contract/scripted-adapter.js";
+import type { HarnessContractSubject, TurnScenario } from "../harness-contract/types.js";
+
+/** Short enough to keep this file fast; long enough that an honest microtask settle never trips it. */
+const SHORT_BOUND_MS = 100;
+
+// ── Wrapping helpers ────────────────────────────────────────────────────────
+
+/** The honest fake's adapter with the named members replaced. */
+function adapterOver(inner: HarnessAdapter, name: string, patch: Partial<HarnessAdapter>): HarnessAdapter {
+  return {
+    name,
+    capabilities: inner.capabilities,
+    boot: (config) => inner.boot(config),
+    shutdown: () => inner.shutdown(),
+    releaseSession: (sessionId) => inner.releaseSession(sessionId),
+    runTurn: (input, sink) => inner.runTurn(input, sink),
+    ...patch,
+  };
+}
+
+/** A sink that delegates to the real one except for the named members. */
+function sinkOver(inner: TurnSink, patch: Partial<TurnSink>): TurnSink {
+  return {
+    status: inner.status,
+    stopSignal: inner.stopSignal,
+    requestPersist: () => inner.requestPersist(),
+    recordActivity: () => inner.recordActivity(),
+    reportUsage: (delta) => inner.reportUsage(delta),
+    bindHarnessState: (id) => inner.bindHarnessState(id),
+    ...patch,
+  };
+}
+
+/** A subject over a broken adapter that still arranges and observes through the honest fake. */
+function subjectOver(inner: ScriptedSubject, adapter: HarnessAdapter): HarnessContractSubject {
+  return {
+    name: adapter.name,
+    adapter,
+    config: inner.config,
+    arrange: (turn) => inner.arrange(turn),
+    executionCount: (toolCallId) => inner.executionCount(toolCallId),
+  };
+}
+
+function honest(): ScriptedSubject {
+  return scriptedSubject({ pausePrimitive: "interrupt", stateIdSource: "engine-minted" });
+}
+
+// ── The broken adapters, one violation each ─────────────────────────────────
+
+/** Throws the one thing an adapter must never throw. */
+function throwsCancelledFailure(): HarnessContractSubject {
+  const inner = honest();
+  return subjectOver(inner, adapterOver(inner.adapter, "broken:throws-CancelledFailure", {
+    runTurn: async () => {
+      throw new CancelledFailure("adapter decided this was a pause");
+    },
+  }));
+}
+
+/** Treats every proposal as approved: executes what was never decided. */
+function executesUndecidedProposals(): HarnessContractSubject {
+  const inner = honest();
+  let proposedIds: string[] = [];
+  const adapter = adapterOver(inner.adapter, "broken:executes-undecided", {
+    runTurn: (input, sink) => {
+      const approvalDecisions = new Map(input.approvalDecisions);
+      for (const id of proposedIds) if (!approvalDecisions.has(id)) approvalDecisions.set(id, ApprovalAction.APPROVE);
+      return inner.adapter.runTurn({ ...input, approvalDecisions }, sink);
+    },
+  });
+  return {
+    ...subjectOver(inner, adapter),
+    arrange: (turn: TurnScenario) => {
+      proposedIds = turn.flatMap((step) => (step.kind === "propose" ? [step.toolCallId] : []));
+      inner.arrange(turn);
+    },
+  };
+}
+
+/** Re-gates a row an earlier invocation already settled — the second-ledger drift. */
+function reGatesSettledRows(): HarnessContractSubject {
+  const inner = honest();
+  return subjectOver(inner, adapterOver(inner.adapter, "broken:re-gates-settled", {
+    runTurn: (input, sink) => {
+      for (const message of sink.status.messages) {
+        for (const row of message.toolCalls) {
+          if (row.status === ToolCallStatus.TOOL_CALL_COMPLETED) row.status = ToolCallStatus.TOOL_CALL_WAITING_APPROVAL;
+        }
+      }
+      return inner.adapter.runTurn(input, sink);
+    },
+  }));
+}
+
+/** Hands the engine a signal nobody will ever abort. */
+function ignoresStopSignal(): HarnessContractSubject {
+  const inner = honest();
+  return subjectOver(inner, adapterOver(inner.adapter, "broken:ignores-stopSignal", {
+    runTurn: (input, sink) => inner.adapter.runTurn(input, sinkOver(sink, { stopSignal: new AbortController().signal })),
+  }));
+}
+
+/** Reports running totals where the contract asks for deltas. */
+function reportsCumulativeUsage(): HarnessContractSubject {
+  const inner = honest();
+  return subjectOver(inner, adapterOver(inner.adapter, "broken:cumulative-usage", {
+    runTurn: (input, sink) => {
+      const total = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+      return inner.adapter.runTurn(input, sinkOver(sink, {
+        reportUsage: (delta) => {
+          total.inputTokens += delta.inputTokens ?? 0;
+          total.outputTokens += delta.outputTokens ?? 0;
+          total.cacheReadTokens += delta.cacheReadTokens ?? 0;
+          total.cacheWriteTokens += delta.cacheWriteTokens ?? 0;
+          sink.reportUsage({ ...total });
+        },
+      }));
+    },
+  }));
+}
+
+/** Declares an engine-minted id and never binds one. */
+function claimsEngineMintedNeverBinds(): HarnessContractSubject {
+  const inner = scriptedSubject({ pausePrimitive: "interrupt", stateIdSource: "deterministic" });
+  return subjectOver(inner, adapterOver(inner.adapter, "broken:claims-engine-minted", {
+    capabilities: { ...inner.adapter.capabilities, stateIdSource: "engine-minted" },
+  }));
+}
+
+/** Refuses to release a session it does not know. */
+function refusesUnknownRelease(): HarnessContractSubject {
+  const inner = honest();
+  const served = new Set<string>();
+  return subjectOver(inner, adapterOver(inner.adapter, "broken:refuses-unknown-release", {
+    runTurn: (input, sink) => {
+      served.add(input.sessionId);
+      return inner.adapter.runTurn(input, sink);
+    },
+    releaseSession: async (sessionId) => {
+      if (!served.has(sessionId)) throw new Error(`unknown session ${sessionId}`);
+      await inner.adapter.releaseSession(sessionId);
+    },
+  }));
+}
+
+/** Runs turns one at a time through a single slot: per-turn state on the adapter object. */
+function serializesTurns(): HarnessContractSubject {
+  const inner = honest();
+  let slot: Promise<unknown> = Promise.resolve();
+  return subjectOver(inner, adapterOver(inner.adapter, "broken:serializes-turns", {
+    runTurn: (input: TurnInput, sink: TurnSink): Promise<TurnOutcome> => {
+      const next = slot.then(() => inner.adapter.runTurn(input, sink));
+      slot = next.catch(() => undefined);
+      return next;
+    },
+  }));
+}
+
+// ── The proof ───────────────────────────────────────────────────────────────
+
+describe("harness contract kit self-check — every invariant can fail", () => {
+  it("invariant 1 fires when runTurn throws a CancelledFailure", async () => {
+    await expect(assertEveryExitIsAnOutcome(throwsCancelledFailure(), SHORT_BOUND_MS)).rejects.toThrow(/broken:throws-CancelledFailure: runTurn rejected with a CancelledFailure/);
+  });
+
+  it("invariant 2 fires when an undecided proposal executes", async () => {
+    await expect(assertProposalIsWaitingAndUnexecuted(executesUndecidedProposals())).rejects.toThrow(/broken:executes-undecided: .*awaiting_approval/);
+  });
+
+  it("invariant 3 fires when a settled row is re-gated on a later invocation", async () => {
+    await expect(assertDecisionsExecuteExactlyOnce(reGatesSettledRows())).rejects.toThrow(/broken:re-gates-settled: .*must not re-gate/);
+  });
+
+  it("invariant 4 fires when the adapter ignores stopSignal", async () => {
+    await expect(assertStopSignalInterrupts(ignoresStopSignal(), SHORT_BOUND_MS)).rejects.toThrow(/broken:ignores-stopSignal: runTurn did not settle within 100ms/);
+  });
+
+  it("invariant 5 fires when usage is reported as running totals", async () => {
+    await expect(assertUsageReachesSinkAsDeltas(reportsCumulativeUsage())).rejects.toThrow(/broken:cumulative-usage: .*must sum to what the engine emitted/);
+  });
+
+  it("invariant 6 fires when an adapter claims engine-minted and never binds", async () => {
+    await expect(assertStateIdCapabilityAgrees(claimsEngineMintedNeverBinds())).rejects.toThrow(/broken:claims-engine-minted: .*must bind its state id/);
+  });
+
+  it("invariant 7 fires when releaseSession rejects an unknown session", async () => {
+    await expect(assertLifetimesResolve(refusesUnknownRelease())).rejects.toThrow(/broken:refuses-unknown-release: releaseSession for an unknown session rejected/);
+  });
+
+  it("invariant 8 fires when the adapter serializes turns through shared state", async () => {
+    await expect(assertConcurrentTurnsAreIndependent(serializesTurns(), SHORT_BOUND_MS)).rejects.toThrow(/broken:serializes-turns: runTurn did not settle within 100ms/);
+  });
+});

--- a/backend/services/runner/src/__test-utils__/config-fixture.ts
+++ b/backend/services/runner/src/__test-utils__/config-fixture.ts
@@ -1,0 +1,63 @@
+/**
+ * A complete, inert runner `Config` for tests.
+ *
+ * `Config` has twenty required fields (plus two optional token refs), so
+ * every test that needs one has had to spell all of them out; eight test
+ * files carry their own literal today. This is the one place a test-only `Config` is
+ * built from now on: {@link testConfig} returns the whole record with values
+ * that dial nothing (loopback endpoints on a port nothing listens on, no
+ * proxy, no token, the in-memory checkpointer, a temp workspace root) and
+ * takes a `Partial<Config>` for the fields a test cares about.
+ *
+ * Inert means: a component handed this config may READ every field, but a
+ * component that tries to ACT on one (connect, authenticate, spawn) fails
+ * loudly and immediately rather than reaching a real service. That is the
+ * posture the harness contract kit needs for `HarnessAdapter.boot(config)`,
+ * and the one the existing inline literals were reaching for one at a time.
+ *
+ * Not a `vi.mock`: `Config` is plain data, and a fixture that is plain data
+ * stays type-checked against the real interface, so a field added to `Config`
+ * fails here at `tsc` time instead of at the first test that needed it.
+ */
+
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { Config } from "../config.js";
+import {
+  DEFAULT_CURSOR_AGENT_RESOLVE_TIMEOUT_MS,
+  DEFAULT_CURSOR_STREAM_STALL_TIMEOUT_MS,
+  DEFAULT_WORKSPACE_LOCK_TIMEOUT_MS,
+} from "../config.js";
+
+/**
+ * Loopback on a port nothing listens on, so a component that dials it fails
+ * fast with ECONNREFUSED instead of hanging on a route to nowhere.
+ */
+const INERT_ENDPOINT = "http://127.0.0.1:1";
+
+export function testConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    taskQueue: "test-task-queue",
+    temporalAddress: "127.0.0.1:1",
+    temporalNamespace: "default",
+    stigmerBackendEndpoint: INERT_ENDPOINT,
+    stigmerToken: null,
+    mcpBridgeEndpoint: null,
+    cursorApiKey: "",
+    workspaceRootDir: join(tmpdir(), "stigmer-runner-test-workspaces"),
+    mode: "local",
+    proxyEndpoint: null,
+    maxConcurrentActivities: 1,
+    idleTimeoutSeconds: null,
+    cloudModeEnabled: false,
+    checkpointerType: "memory",
+    checkpointerProxyEndpoint: null,
+    artifactProxyEndpoint: null,
+    primaryModel: "test-model",
+    cursorStreamStallTimeoutMs: DEFAULT_CURSOR_STREAM_STALL_TIMEOUT_MS,
+    agentResolveTimeoutMs: DEFAULT_CURSOR_AGENT_RESOLVE_TIMEOUT_MS,
+    workspaceLockTimeoutMs: DEFAULT_WORKSPACE_LOCK_TIMEOUT_MS,
+    ...overrides,
+  };
+}

--- a/backend/services/runner/src/__test-utils__/harness-contract/contract.ts
+++ b/backend/services/runner/src/__test-utils__/harness-contract/contract.ts
@@ -11,29 +11,32 @@
  * it exists, through the hermetic activity driver.
  *
  * The kit IS the runtime stand-in. {@link ExecutionDriver} does what the
- * runtime does around a turn: builds the `TurnInput`, threads the engine's
- * state id (empty on an engine-minted harness's first turn, then the id the
- * adapter bound; one fixed id for a deterministic harness), advances
- * `turnSeq`, hands each reinvocation a CLONE of the previous status (the
- * runtime persists and reads back; nothing survives by object identity), and
- * owns the sink. The subject owns the engine.
+ * runtime and the server do around a turn: builds the `TurnInput`, threads
+ * the engine's state id (empty on an engine-minted harness's first turn, then
+ * the id the adapter bound; one fixed id for a deterministic harness),
+ * advances `turnSeq`, records a user's decision the way `SubmitApproval` does
+ * (on the persisted row's `approvalAction`, the one copy) and derives the
+ * decisions map from those rows on the next invocation, hands each
+ * reinvocation a CLONE of the previous status (the runtime persists and reads
+ * back; nothing survives by object identity), and owns the sink. The subject
+ * owns the engine.
  *
  * ── Invariant catalog ───────────────────────────────────────────────────────
  *  1. Every exit is a `TurnOutcome`. `runTurn` resolves, never rejects, under
  *     every scenario kind and under a pre-aborted signal; a `CancelledFailure`
  *     never escapes (the runtime, not the adapter, throws it).
- *  2. A proposal is a WAITING_APPROVAL row on `sink.status` before
+ *  2. A proposal is a WAITING_APPROVAL row on `sink.status` when
  *     `awaiting_approval` resolves, and never executes in that turn.
  *  3. Reinvoked with APPROVE for that id → executes exactly once; with REJECT
- *     or SKIP → never; reinvoked twice with the same decision → still once.
+ *     or SKIP → never; reinvoked again after the approval → still once.
  *  4. Aborting `stopSignal` mid-turn settles `runTurn` as `interrupted` within
- *     {@link INTERRUPT_SETTLE_BOUND_MS}; a signal aborted BEFORE `runTurn`
- *     yields `interrupted` with nothing executed.
+ *     {@link INTERRUPT_SETTLE_BOUND_MS} and nothing after the stop executes; a
+ *     signal aborted BEFORE `runTurn` yields `interrupted` with nothing done.
  *  5. Usage reaches the sink as non-negative deltas summing to what the engine
  *     emitted.
  *  6. Capability and behaviour agree on the state id: an `engine-minted`
  *     adapter binds before its first persist and resumes by the bound id, and
- *     surfaces a rejected bind as `failed` with nothing executed after it; a
+ *     surfaces a rejected bind as `failed` with nothing done after it; a
  *     `deterministic` adapter never binds.
  *  7. Lifetimes: `boot` then `shutdown` resolve; `releaseSession` for a served
  *     session and for an unknown one both resolve; `shutdown` after a release
@@ -58,11 +61,11 @@ import { CancelledFailure } from "@temporalio/activity";
 import { clone } from "@bufbuild/protobuf";
 import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
-import type { ApprovalAction } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import { ApprovalAction, ToolCallStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
 
-import type { TurnInput, TurnOutcome } from "../../harness/types.js";
+import type { TurnInput, TurnOutcome, UsageDelta } from "../../harness/types.js";
 import type { ProposedAction } from "../approval-contract/types.js";
-import { emptyStatus } from "../proto-helpers.js";
+import { emptyStatus, findToolCallRow } from "../proto-helpers.js";
 import { RecordingTurnSink } from "./recording-sink.js";
 import { scenario } from "./types.js";
 import type { HarnessContractSubject, TurnScenario } from "./types.js";
@@ -81,9 +84,7 @@ const OUTCOME_KINDS = ["completed", "awaiting_approval", "failed", "interrupted"
 /** Representative gated action shared by the invariants. */
 const WRITE_ALPHA: ProposedAction = { kind: "write", resource: "/work/alpha.txt" };
 
-const NO_DECISIONS: ReadonlyMap<string, ApprovalAction> = new Map();
-
-// ── The runtime stand-in ────────────────────────────────────────────────────
+// ── The runtime (and server) stand-in ───────────────────────────────────────
 
 export interface TurnRun {
   readonly input: TurnInput;
@@ -92,18 +93,42 @@ export interface TurnRun {
 }
 
 export interface TurnOptions {
-  /** This invocation's decisions, keyed by tool-call id. */
-  readonly decisions?: ReadonlyMap<string, ApprovalAction>;
   /** A prepared sink (e.g. one whose bind rejects); defaults to a fresh one over the threaded status. */
   readonly sink?: RecordingTurnSink;
   /** Called synchronously once `runTurn` has been entered, with the live sink — the hook that stops a turn mid-flight. */
   readonly onStarted?: (sink: RecordingTurnSink) => void;
 }
 
+export interface TurnInFlight {
+  readonly input: TurnInput;
+  readonly sink: RecordingTurnSink;
+  readonly settled: Promise<TurnOutcome>;
+}
+
+/**
+ * The runtime's one reader of approval decisions, as the two harnesses agree
+ * on it today: every tool-call row still WAITING_APPROVAL whose
+ * `approvalAction` the server has set. The runtime extraction exports this
+ * from `src/harness/` and this kit imports it from there; until then the kit
+ * carries the definition so the data flow it drives is the real one.
+ */
+function approvalDecisionsOf(status: AgentExecutionStatus): ReadonlyMap<string, ApprovalAction> {
+  const decisions = new Map<string, ApprovalAction>();
+  for (const message of status.messages) {
+    for (const row of message.toolCalls) {
+      if (row.status === ToolCallStatus.TOOL_CALL_WAITING_APPROVAL && row.approvalAction !== ApprovalAction.UNSPECIFIED) {
+        decisions.set(row.id, row.approvalAction);
+      }
+    }
+  }
+  return decisions;
+}
+
 /**
  * One execution's worth of turns against one subject, doing the runtime's
- * bookkeeping between them. A new driver per test: it carries the threaded
- * state id and the persisted status across reinvocations.
+ * and the server's bookkeeping between them. A new driver per test: it
+ * carries the threaded state id and the persisted status across
+ * reinvocations.
  */
 export class ExecutionDriver {
   readonly executionId: string;
@@ -122,7 +147,7 @@ export class ExecutionDriver {
   }
 
   /** Start a turn without awaiting it, for invariants about turns in flight. */
-  begin(turn: TurnScenario, options: TurnOptions = {}): { readonly input: TurnInput; readonly sink: RecordingTurnSink; readonly settled: Promise<TurnOutcome> } {
+  begin(turn: TurnScenario, options: TurnOptions = {}): TurnInFlight {
     this.subject.arrange(turn);
     const sink = options.sink ?? new RecordingTurnSink({ status: this.seedStatus() });
     const input: TurnInput = {
@@ -130,7 +155,7 @@ export class ExecutionDriver {
       threadId: this.threadId,
       turnSeq: this.turnSeq,
       sessionId: this.sessionId,
-      approvalDecisions: options.decisions ?? NO_DECISIONS,
+      approvalDecisions: approvalDecisionsOf(sink.status),
     };
     const settled = this.subject.adapter.runTurn(input, sink);
     options.onStarted?.(sink);
@@ -151,6 +176,19 @@ export class ExecutionDriver {
     const bound = sink.boundStateIds.at(-1);
     if (bound !== undefined) this.threadId = bound;
     this.turnSeq += 1;
+  }
+
+  /**
+   * The server's act between invocations: `SubmitApproval` writes the user's
+   * verdict onto the WAITING row it owns. A decision on a row that does not
+   * exist or is not waiting is a test bug, not a contract case.
+   */
+  decide(toolCallId: string, action: ApprovalAction): void {
+    const row = this.persisted ? findToolCallRow(this.persisted, toolCallId) : undefined;
+    if (!row || row.status !== ToolCallStatus.TOOL_CALL_WAITING_APPROVAL) {
+      throw new Error(`${this.subject.name}: kit bug — decide('${toolCallId}') but no WAITING row was persisted`);
+    }
+    row.approvalAction = action;
   }
 
   /** The status a reinvocation is seeded with: a clone of what was persisted. */
@@ -180,18 +218,33 @@ async function settleAsOutcome(subject: HarnessContractSubject, settled: Promise
 }
 
 /** Race a settlement against the interrupt bound; the timer is cleared on settle so a passing test holds nothing. */
-async function settleWithinBound<T>(subject: HarnessContractSubject, settled: Promise<T>, when: string): Promise<T> {
+async function settleWithinBound<T>(subject: HarnessContractSubject, settled: Promise<T>, when: string, boundMs: number): Promise<T> {
   let timer: NodeJS.Timeout | undefined;
   const bound = new Promise<never>((_, reject) => {
     timer = setTimeout(
-      () => reject(new Error(`${subject.name}: runTurn did not settle within ${INTERRUPT_SETTLE_BOUND_MS}ms ${when}; every adapter call must be bounded by stopSignal`)),
-      INTERRUPT_SETTLE_BOUND_MS,
+      () => reject(new Error(`${subject.name}: runTurn did not settle within ${boundMs}ms ${when}; every adapter call must be bounded by stopSignal`)),
+      boundMs,
     );
   });
   try {
     return await Promise.race([settled, bound]);
   } finally {
     if (timer) clearTimeout(timer);
+  }
+}
+
+/** Stop the turn on the next macrotask, after the adapter has reached whatever it was going to park on. */
+function stopSoon(reason: string): (sink: RecordingTurnSink) => void {
+  return (sink) => {
+    setImmediate(() => sink.abort(reason));
+  };
+}
+
+async function expectResolves(subject: HarnessContractSubject, call: Promise<void>, what: string): Promise<void> {
+  try {
+    await call;
+  } catch (err) {
+    throw new Error(`${subject.name}: ${what} rejected (${err instanceof Error ? err.message : String(err)}); it must resolve`);
   }
 }
 
@@ -203,29 +256,251 @@ async function settleWithinBound<T>(subject: HarnessContractSubject, settled: Pr
  * with an already-aborted signal; none may reject, none may settle with an
  * unknown kind.
  */
-export async function assertEveryExitIsAnOutcome(subject: HarnessContractSubject): Promise<void> {
+export async function assertEveryExitIsAnOutcome(subject: HarnessContractSubject, boundMs = INTERRUPT_SETTLE_BOUND_MS): Promise<void> {
   const driver = new ExecutionDriver(subject, "inv1");
   const plays: ReadonlyArray<{ readonly when: string; readonly turn: TurnScenario; readonly options?: TurnOptions }> = [
     { when: "on a plain text turn", turn: [scenario.say("hello")] },
     { when: "on a usage-only turn", turn: [scenario.usage({ inputTokens: 1, outputTokens: 1 })] },
     { when: "on an undecided proposal", turn: [scenario.propose("inv1-call", WRITE_ALPHA)] },
     { when: "on an engine failure", turn: [scenario.fail("engine exploded")] },
-    {
-      when: "on a hang stopped from the outside",
-      turn: [scenario.hang()],
-      options: { onStarted: (sink) => setImmediate(() => sink.abort("kit: stop")) },
-    },
+    { when: "on a hang stopped from the outside", turn: [scenario.hang()], options: { onStarted: stopSoon("kit: stop") } },
   ];
   for (const play of plays) {
     const { sink, settled } = driver.begin(play.turn, play.options);
-    await settleAsOutcome(subject, settleWithinBound(subject, settled, play.when), play.when);
+    await settleAsOutcome(subject, settleWithinBound(subject, settled, play.when, boundMs), play.when);
     driver.recordTurn(sink);
   }
 
   const preAborted = new RecordingTurnSink({ status: driver.seedStatus() });
   preAborted.abort("kit: aborted before the turn");
   const { settled } = driver.begin([scenario.say("never")], { sink: preAborted });
-  await settleAsOutcome(subject, settleWithinBound(subject, settled, "under a pre-aborted signal"), "under a pre-aborted signal");
+  await settleAsOutcome(subject, settleWithinBound(subject, settled, "under a pre-aborted signal", boundMs), "under a pre-aborted signal");
+}
+
+// ── Invariant 2 ─────────────────────────────────────────────────────────────
+
+/**
+ * Invariant 2: a proposal is a WAITING_APPROVAL row and never executes in its
+ * own turn. The row must carry `requiresApproval` and an UNSPECIFIED
+ * `approvalAction` (the server's field, untouched by the adapter), and the
+ * turn must end `awaiting_approval` — not `completed`, which would tell the
+ * workflow nothing is pending.
+ */
+export async function assertProposalIsWaitingAndUnexecuted(subject: HarnessContractSubject): Promise<void> {
+  const driver = new ExecutionDriver(subject, "inv2");
+  const id = "inv2-write";
+  const { outcome, sink } = await driver.turn([scenario.say("about to write"), scenario.propose(id, WRITE_ALPHA), scenario.say("after")]);
+
+  expect(outcome.kind, `${subject.name}: a turn that proposes an undecided action must end awaiting_approval`).toBe("awaiting_approval");
+  const row = findToolCallRow(sink.status, id);
+  expect(row, `${subject.name}: the proposal must be a tool-call row on sink.status when awaiting_approval resolves`).toBeDefined();
+  expect(row?.status, `${subject.name}: the proposal's row must be WAITING_APPROVAL`).toBe(ToolCallStatus.TOOL_CALL_WAITING_APPROVAL);
+  expect(row?.requiresApproval, `${subject.name}: the proposal's row must carry requiresApproval`).toBe(true);
+  expect(row?.approvalAction, `${subject.name}: the adapter must never write the server's approvalAction`).toBe(ApprovalAction.UNSPECIFIED);
+  expect(subject.executionCount(id), `${subject.name}: an undecided proposal must not execute in its own turn`).toBe(0);
+}
+
+// ── Invariant 3 ─────────────────────────────────────────────────────────────
+
+/**
+ * Invariant 3: the decision is honoured exactly. APPROVE executes once and
+ * only once, however many times the same decided row is seen again; REJECT
+ * and SKIP never execute and carry the row to SKIPPED (the enum's own
+ * transition). The reinvocation sees a CLONE of the persisted status, as it
+ * would from the server.
+ */
+export async function assertDecisionsExecuteExactlyOnce(subject: HarnessContractSubject): Promise<void> {
+  const driver = new ExecutionDriver(subject, "inv3");
+
+  const approved = "inv3-approve";
+  const first = await driver.turn([scenario.propose(approved, WRITE_ALPHA)]);
+  expect(first.outcome.kind, `${subject.name}: proposal must end awaiting_approval`).toBe("awaiting_approval");
+  driver.decide(approved, ApprovalAction.APPROVE);
+
+  const resumed = await driver.turn([scenario.propose(approved, WRITE_ALPHA), scenario.say("done")]);
+  expect(resumed.outcome.kind, `${subject.name}: after APPROVE the turn must run to completion`).toBe("completed");
+  expect(subject.executionCount(approved), `${subject.name}: an approved action must execute exactly once`).toBe(1);
+  expect(findToolCallRow(resumed.sink.status, approved)?.status, `${subject.name}: the approved row must be carried to COMPLETED`).toBe(ToolCallStatus.TOOL_CALL_COMPLETED);
+
+  const again = await driver.turn([scenario.propose(approved, WRITE_ALPHA), scenario.say("again")]);
+  expect(again.outcome.kind, `${subject.name}: a settled proposal seen again must not re-gate`).toBe("completed");
+  expect(subject.executionCount(approved), `${subject.name}: reinvoked again after the approval, the action must still have executed exactly once`).toBe(1);
+
+  for (const [label, action] of [["REJECT", ApprovalAction.REJECT], ["SKIP", ApprovalAction.SKIP]] as const) {
+    const id = `inv3-${label.toLowerCase()}`;
+    const proposed = await driver.turn([scenario.propose(id, WRITE_ALPHA)]);
+    expect(proposed.outcome.kind, `${subject.name}: proposal must end awaiting_approval`).toBe("awaiting_approval");
+    driver.decide(id, action);
+    const decided = await driver.turn([scenario.propose(id, WRITE_ALPHA), scenario.say("moving on")]);
+    expect(decided.outcome.kind, `${subject.name}: after ${label} the turn must continue to completion`).toBe("completed");
+    expect(subject.executionCount(id), `${subject.name}: a ${label}-ed action must never execute`).toBe(0);
+    expect(findToolCallRow(decided.sink.status, id)?.status, `${subject.name}: a ${label}-ed row must be carried to SKIPPED`).toBe(ToolCallStatus.TOOL_CALL_SKIPPED);
+  }
+}
+
+// ── Invariant 4 ─────────────────────────────────────────────────────────────
+
+/**
+ * Invariant 4: the stop signal is honoured promptly and completely. A turn
+ * stopped while hanging settles `interrupted` within the bound and executes
+ * nothing that came after the hang, even an already-approved action; a turn
+ * entered under an aborted signal does nothing at all.
+ */
+export async function assertStopSignalInterrupts(subject: HarnessContractSubject, boundMs = INTERRUPT_SETTLE_BOUND_MS): Promise<void> {
+  const driver = new ExecutionDriver(subject, "inv4");
+  const id = "inv4-approved-after-hang";
+
+  const proposed = await driver.turn([scenario.propose(id, WRITE_ALPHA)]);
+  expect(proposed.outcome.kind, `${subject.name}: proposal must end awaiting_approval`).toBe("awaiting_approval");
+  driver.decide(id, ApprovalAction.APPROVE);
+
+  const hanging = driver.begin([scenario.say("working"), scenario.hang(), scenario.propose(id, WRITE_ALPHA)], { onStarted: stopSoon("kit: user pause") });
+  const outcome = await settleWithinBound(subject, hanging.settled, "after stopSignal aborted mid-hang", boundMs);
+  expect(outcome.kind, `${subject.name}: a turn stopped mid-hang must settle interrupted`).toBe("interrupted");
+  expect(subject.executionCount(id), `${subject.name}: nothing after the stop may execute, even an approved action`).toBe(0);
+  driver.recordTurn(hanging.sink);
+
+  const preAborted = new RecordingTurnSink({ status: driver.seedStatus() });
+  preAborted.abort("kit: aborted before the turn");
+  const early = driver.begin([scenario.propose(id, WRITE_ALPHA)], { sink: preAborted });
+  const earlyOutcome = await settleWithinBound(subject, early.settled, "under a pre-aborted signal", boundMs);
+  expect(earlyOutcome.kind, `${subject.name}: a turn entered under an aborted signal must settle interrupted`).toBe("interrupted");
+  expect(subject.executionCount(id), `${subject.name}: a turn entered under an aborted signal must do no work`).toBe(0);
+  expect(preAborted.persistRequests, `${subject.name}: a turn entered under an aborted signal must not ask to persist`).toBe(0);
+}
+
+// ── Invariant 5 ─────────────────────────────────────────────────────────────
+
+function sumUsage(deltas: readonly UsageDelta[]): Required<UsageDelta> {
+  const total = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+  for (const d of deltas) {
+    total.inputTokens += d.inputTokens ?? 0;
+    total.outputTokens += d.outputTokens ?? 0;
+    total.cacheReadTokens += d.cacheReadTokens ?? 0;
+    total.cacheWriteTokens += d.cacheWriteTokens ?? 0;
+  }
+  return total;
+}
+
+/**
+ * Invariant 5: usage reaches the sink as deltas — non-negative, and summing
+ * to what the engine emitted. An adapter that reports cumulative totals
+ * instead of deltas would double-count in the runtime's accumulator and trip
+ * the cost cap early; one that reports a negative number would credit it.
+ */
+export async function assertUsageReachesSinkAsDeltas(subject: HarnessContractSubject): Promise<void> {
+  const driver = new ExecutionDriver(subject, "inv5");
+  const emitted: readonly UsageDelta[] = [
+    { inputTokens: 10, outputTokens: 5 },
+    { inputTokens: 3, cacheReadTokens: 2 },
+    { outputTokens: 4, cacheWriteTokens: 1 },
+  ];
+  const { outcome, sink } = await driver.turn([...emitted.map((d) => scenario.usage(d)), scenario.say("done")]);
+  expect(outcome.kind, `${subject.name}: a usage-reporting turn must complete`).toBe("completed");
+
+  for (const delta of sink.usageDeltas) {
+    for (const [field, value] of Object.entries(delta)) {
+      expect(value, `${subject.name}: usage delta field ${field} must be non-negative`).toBeGreaterThanOrEqual(0);
+    }
+  }
+  expect(sumUsage(sink.usageDeltas), `${subject.name}: the usage deltas must sum to what the engine emitted`).toEqual(sumUsage(emitted));
+}
+
+// ── Invariant 6 ─────────────────────────────────────────────────────────────
+
+/**
+ * Invariant 6: capability and behaviour agree on the state id. Engine-minted:
+ * the bind precedes the first persist (so a crash mid-turn still resumes),
+ * the id threaded back on the next invocation is accepted, and a rejected
+ * bind ends the turn `failed` with nothing done after it. Deterministic: the
+ * adapter never binds and accepts the runtime's id on every turn.
+ */
+export async function assertStateIdCapabilityAgrees(subject: HarnessContractSubject): Promise<void> {
+  const driver = new ExecutionDriver(subject, "inv6");
+  const first = await driver.turn([scenario.say("first turn")]);
+  expect(first.outcome.kind, `${subject.name}: a plain turn must complete`).toBe("completed");
+
+  if (subject.adapter.capabilities.stateIdSource === "engine-minted") {
+    expect(first.input.threadId, `${subject.name}: an engine-minted harness has no state id before its first turn`).toBe("");
+    const events = first.sink.events;
+    const firstBind = events.findIndex((e) => e.kind === "bind");
+    const firstPersist = events.findIndex((e) => e.kind === "persist");
+    expect(firstBind, `${subject.name}: an engine-minted adapter must bind its state id on the first turn`).toBeGreaterThanOrEqual(0);
+    expect(first.sink.boundStateIds[0], `${subject.name}: the bound state id must be non-empty`).toBeTruthy();
+    if (firstPersist >= 0) {
+      expect(firstBind, `${subject.name}: the state id must be bound BEFORE the first persist request, or a crash mid-turn cannot resume`).toBeLessThan(firstPersist);
+    }
+
+    const second = await driver.turn([scenario.say("second turn")]);
+    expect(second.input.threadId, `${subject.name}: the kit threads the bound id back as threadId`).toBe(first.sink.boundStateIds[0]);
+    expect(second.outcome.kind, `${subject.name}: resuming by the id the adapter bound must complete`).toBe("completed");
+    expect(second.sink.boundStateIds, `${subject.name}: a resumed turn must not bind a new state id`).toHaveLength(0);
+
+    const failing = new ExecutionDriver(subject, "inv6-bind-rejects");
+    const rejecting = new RecordingTurnSink({ bindRejectsWith: new Error("session write failed") });
+    const rejected = await failing.turn([scenario.say("never persisted")], { sink: rejecting });
+    expect(rejected.outcome.kind, `${subject.name}: a rejected bind must end the turn failed, not reject runTurn`).toBe("failed");
+    expect(rejecting.persistRequests, `${subject.name}: nothing may be persisted after a rejected bind`).toBe(0);
+    expect(rejecting.status.messages, `${subject.name}: nothing may be folded into the status after a rejected bind`).toHaveLength(0);
+  } else {
+    expect(first.input.threadId, `${subject.name}: a deterministic harness is handed the runtime's id on its first turn`).not.toBe("");
+    expect(first.sink.boundStateIds, `${subject.name}: a deterministic adapter must never bind a state id`).toHaveLength(0);
+    const second = await driver.turn([scenario.say("second turn")]);
+    expect(second.input.threadId, `${subject.name}: a deterministic id is the same on every turn`).toBe(first.input.threadId);
+    expect(second.outcome.kind, `${subject.name}: a deterministic resume must complete`).toBe("completed");
+    expect(second.sink.boundStateIds, `${subject.name}: a deterministic adapter must never bind a state id`).toHaveLength(0);
+  }
+}
+
+// ── Invariant 7 ─────────────────────────────────────────────────────────────
+
+/**
+ * Invariant 7: the three lifetimes resolve. Boot with the subject's config,
+ * serve a turn, release the served session and an unknown one, shut down.
+ * Each must resolve — a rejection in any would fail a worker's boot, leak a
+ * session's resources, or hang a drain.
+ */
+export async function assertLifetimesResolve(subject: HarnessContractSubject): Promise<void> {
+  const { adapter } = subject;
+  await expectResolves(subject, adapter.boot(subject.config), "boot(config)");
+
+  const driver = new ExecutionDriver(subject, "inv7");
+  const served = await driver.turn([scenario.say("served")]);
+  expect(served.outcome.kind, `${subject.name}: a plain turn must complete`).toBe("completed");
+
+  await expectResolves(subject, adapter.releaseSession(served.input.sessionId), `releaseSession('${served.input.sessionId}') for a served session`);
+  await expectResolves(subject, adapter.releaseSession("ses-never-served"), "releaseSession for an unknown session");
+  await expectResolves(subject, adapter.shutdown(), "shutdown() after release");
+}
+
+// ── Invariant 8 ─────────────────────────────────────────────────────────────
+
+/**
+ * Invariant 8: one adapter object, many turns. While one execution's turn
+ * hangs, another execution's turns propose, get decided and execute on the
+ * SAME adapter; stopping the hanging turn settles only it; nothing crosses.
+ * This is "the adapter holds no per-turn state" made observable — the
+ * property `maxConcurrentActivities` relies on.
+ */
+export async function assertConcurrentTurnsAreIndependent(subject: HarnessContractSubject, boundMs = INTERRUPT_SETTLE_BOUND_MS): Promise<void> {
+  const hangingExecution = new ExecutionDriver(subject, "inv8-hanging");
+  const busyExecution = new ExecutionDriver(subject, "inv8-busy");
+  const id = "inv8-busy-write";
+
+  const hanging = hangingExecution.begin([scenario.say("parked"), scenario.hang()]);
+
+  const proposed = await settleWithinBound(subject, busyExecution.turn([scenario.propose(id, WRITE_ALPHA)]), "on a second execution while another turn hangs", boundMs);
+  expect(proposed.outcome.kind, `${subject.name}: a second execution's proposal must settle while another turn hangs`).toBe("awaiting_approval");
+  busyExecution.decide(id, ApprovalAction.APPROVE);
+  const resumed = await settleWithinBound(subject, busyExecution.turn([scenario.propose(id, WRITE_ALPHA)]), "on a second execution's reinvocation while another turn hangs", boundMs);
+  expect(resumed.outcome.kind, `${subject.name}: a second execution's approved turn must complete while another turn hangs`).toBe("completed");
+  expect(subject.executionCount(id), `${subject.name}: the busy execution's action must execute exactly once`).toBe(1);
+
+  hanging.sink.abort("kit: stop the parked turn");
+  const stopped = await settleWithinBound(subject, hanging.settled, "after the hanging turn was stopped", boundMs);
+  expect(stopped.kind, `${subject.name}: the hanging turn must settle interrupted, and only it`).toBe("interrupted");
+  expect(subject.executionCount(id), `${subject.name}: stopping one execution must not touch another's execution count`).toBe(1);
+  expect(findToolCallRow(hanging.sink.status, id), `${subject.name}: one execution's rows must never appear on another's status`).toBeUndefined();
 }
 
 // ── The runnable suite ──────────────────────────────────────────────────────
@@ -235,6 +510,27 @@ export function describeHarnessContract(subject: HarnessContractSubject): void {
   describe(`harness contract — ${subject.name}`, () => {
     it("settles every turn with a TurnOutcome and never rejects (invariant 1)", async () => {
       await assertEveryExitIsAnOutcome(subject);
+    });
+    it("surfaces a proposal as a WAITING row and never executes it in its turn (invariant 2)", async () => {
+      await assertProposalIsWaitingAndUnexecuted(subject);
+    });
+    it("executes an approval exactly once and a rejection or skip never (invariant 3)", async () => {
+      await assertDecisionsExecuteExactlyOnce(subject);
+    });
+    it("settles interrupted promptly when stopSignal aborts and does nothing after it (invariant 4)", async () => {
+      await assertStopSignalInterrupts(subject);
+    });
+    it("reports usage as non-negative deltas that sum to what the engine emitted (invariant 5)", async () => {
+      await assertUsageReachesSinkAsDeltas(subject);
+    });
+    it(`binds its state id as its ${subject.adapter.capabilities.stateIdSource} capability declares (invariant 6)`, async () => {
+      await assertStateIdCapabilityAgrees(subject);
+    });
+    it("boots, serves, releases and shuts down without a rejection (invariant 7)", async () => {
+      await assertLifetimesResolve(subject);
+    });
+    it("serves concurrent turns on one adapter object independently (invariant 8)", async () => {
+      await assertConcurrentTurnsAreIndependent(subject);
     });
   });
 }

--- a/backend/services/runner/src/__test-utils__/harness-contract/contract.ts
+++ b/backend/services/runner/src/__test-utils__/harness-contract/contract.ts
@@ -1,0 +1,240 @@
+/**
+ * The harness adapter contract kit — the single authoritative statement of
+ * "these are THE things every `HarnessAdapter` must do," runnable against any
+ * {@link HarnessContractSubject}.
+ *
+ * Two halves exist in the program's design; this file is the ADAPTER-SIDE
+ * half: what an adapter owes the runtime through `runTurn`, `boot`,
+ * `shutdown` and `releaseSession`. The runtime-side half (the throw-vs-return
+ * table end to end, the whole-activity heartbeat, the single persist
+ * chokepoint, the byte-pinned copy) is proven against the real runtime once
+ * it exists, through the hermetic activity driver.
+ *
+ * The kit IS the runtime stand-in. {@link ExecutionDriver} does what the
+ * runtime does around a turn: builds the `TurnInput`, threads the engine's
+ * state id (empty on an engine-minted harness's first turn, then the id the
+ * adapter bound; one fixed id for a deterministic harness), advances
+ * `turnSeq`, hands each reinvocation a CLONE of the previous status (the
+ * runtime persists and reads back; nothing survives by object identity), and
+ * owns the sink. The subject owns the engine.
+ *
+ * ── Invariant catalog ───────────────────────────────────────────────────────
+ *  1. Every exit is a `TurnOutcome`. `runTurn` resolves, never rejects, under
+ *     every scenario kind and under a pre-aborted signal; a `CancelledFailure`
+ *     never escapes (the runtime, not the adapter, throws it).
+ *  2. A proposal is a WAITING_APPROVAL row on `sink.status` before
+ *     `awaiting_approval` resolves, and never executes in that turn.
+ *  3. Reinvoked with APPROVE for that id → executes exactly once; with REJECT
+ *     or SKIP → never; reinvoked twice with the same decision → still once.
+ *  4. Aborting `stopSignal` mid-turn settles `runTurn` as `interrupted` within
+ *     {@link INTERRUPT_SETTLE_BOUND_MS}; a signal aborted BEFORE `runTurn`
+ *     yields `interrupted` with nothing executed.
+ *  5. Usage reaches the sink as non-negative deltas summing to what the engine
+ *     emitted.
+ *  6. Capability and behaviour agree on the state id: an `engine-minted`
+ *     adapter binds before its first persist and resumes by the bound id, and
+ *     surfaces a rejected bind as `failed` with nothing executed after it; a
+ *     `deterministic` adapter never binds.
+ *  7. Lifetimes: `boot` then `shutdown` resolve; `releaseSession` for a served
+ *     session and for an unknown one both resolve; `shutdown` after a release
+ *     resolves.
+ *  8. One adapter object serves concurrent turns independently: a hanging turn
+ *     and a completing turn on the same adapter never cross outcomes or
+ *     execution counts.
+ *
+ * Every invariant is an exported plain async function first and an `it`
+ * block second, so `__tests__/harness-contract-self-check.test.ts` can run
+ * each one against a deliberately broken adapter and prove it fires — a kit
+ * that cannot fail proves nothing. Every message names the subject.
+ *
+ * Above the contract line the pause primitives are indistinguishable: both
+ * end a turn `awaiting_approval`, both take the decisions on reinvocation.
+ * The kit therefore never branches on `capabilities.pausePrimitive`, and the
+ * runner test runs the fake under both to prove it.
+ */
+
+import { describe, it, expect } from "vitest";
+import { CancelledFailure } from "@temporalio/activity";
+import { clone } from "@bufbuild/protobuf";
+import { AgentExecutionStatusSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { ApprovalAction } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+
+import type { TurnInput, TurnOutcome } from "../../harness/types.js";
+import type { ProposedAction } from "../approval-contract/types.js";
+import { emptyStatus } from "../proto-helpers.js";
+import { RecordingTurnSink } from "./recording-sink.js";
+import { scenario } from "./types.js";
+import type { HarnessContractSubject, TurnScenario } from "./types.js";
+
+/**
+ * How long a turn may take to settle `interrupted` after its signal aborts.
+ * Generous against a saturated CI runner (the fake settles in microtasks; a
+ * real adapter cancels an SDK run), tight enough that an adapter parked on
+ * anything but the signal fails here rather than at Temporal's heartbeat
+ * timeout in production. A timeout race, never a sleep.
+ */
+export const INTERRUPT_SETTLE_BOUND_MS = 5_000;
+
+const OUTCOME_KINDS = ["completed", "awaiting_approval", "failed", "interrupted"] as const satisfies readonly TurnOutcome["kind"][];
+
+/** Representative gated action shared by the invariants. */
+const WRITE_ALPHA: ProposedAction = { kind: "write", resource: "/work/alpha.txt" };
+
+const NO_DECISIONS: ReadonlyMap<string, ApprovalAction> = new Map();
+
+// ── The runtime stand-in ────────────────────────────────────────────────────
+
+export interface TurnRun {
+  readonly input: TurnInput;
+  readonly sink: RecordingTurnSink;
+  readonly outcome: TurnOutcome;
+}
+
+export interface TurnOptions {
+  /** This invocation's decisions, keyed by tool-call id. */
+  readonly decisions?: ReadonlyMap<string, ApprovalAction>;
+  /** A prepared sink (e.g. one whose bind rejects); defaults to a fresh one over the threaded status. */
+  readonly sink?: RecordingTurnSink;
+  /** Called synchronously once `runTurn` has been entered, with the live sink — the hook that stops a turn mid-flight. */
+  readonly onStarted?: (sink: RecordingTurnSink) => void;
+}
+
+/**
+ * One execution's worth of turns against one subject, doing the runtime's
+ * bookkeeping between them. A new driver per test: it carries the threaded
+ * state id and the persisted status across reinvocations.
+ */
+export class ExecutionDriver {
+  readonly executionId: string;
+  readonly sessionId: string;
+  private threadId: string;
+  private turnSeq = 0;
+  private persisted: AgentExecutionStatus | undefined;
+
+  constructor(private readonly subject: HarnessContractSubject, label: string) {
+    this.executionId = `exec-${label}`;
+    this.sessionId = `ses-${label}`;
+    // A deterministic harness's id is the runtime's, known before any engine
+    // exists (native's `thread-{sessionId}`); an engine-minted one has nothing
+    // until the adapter binds.
+    this.threadId = subject.adapter.capabilities.stateIdSource === "deterministic" ? `thread-${this.sessionId}` : "";
+  }
+
+  /** Start a turn without awaiting it, for invariants about turns in flight. */
+  begin(turn: TurnScenario, options: TurnOptions = {}): { readonly input: TurnInput; readonly sink: RecordingTurnSink; readonly settled: Promise<TurnOutcome> } {
+    this.subject.arrange(turn);
+    const sink = options.sink ?? new RecordingTurnSink({ status: this.seedStatus() });
+    const input: TurnInput = {
+      executionId: this.executionId,
+      threadId: this.threadId,
+      turnSeq: this.turnSeq,
+      sessionId: this.sessionId,
+      approvalDecisions: options.decisions ?? NO_DECISIONS,
+    };
+    const settled = this.subject.adapter.runTurn(input, sink);
+    options.onStarted?.(sink);
+    return { input, sink, settled };
+  }
+
+  /** Run a turn to its outcome and do the runtime's bookkeeping after it. */
+  async turn(turn: TurnScenario, options: TurnOptions = {}): Promise<TurnRun> {
+    const { input, sink, settled } = this.begin(turn, options);
+    const outcome = await settled;
+    this.recordTurn(sink);
+    return { input, sink, outcome };
+  }
+
+  /** The runtime's post-turn bookkeeping: persist the status, adopt a bound id, advance the cycle. */
+  recordTurn(sink: RecordingTurnSink): void {
+    this.persisted = sink.status;
+    const bound = sink.boundStateIds.at(-1);
+    if (bound !== undefined) this.threadId = bound;
+    this.turnSeq += 1;
+  }
+
+  /** The status a reinvocation is seeded with: a clone of what was persisted. */
+  seedStatus(): AgentExecutionStatus {
+    return this.persisted ? clone(AgentExecutionStatusSchema, this.persisted) : emptyStatus();
+  }
+}
+
+// ── Shared assertion helpers ────────────────────────────────────────────────
+
+/**
+ * Await a turn, translating a rejection into a contract violation that names
+ * the subject and the kind of throw. A `CancelledFailure` gets named
+ * specially because throwing it is the one thing an adapter is most tempted
+ * to do and must never do.
+ */
+async function settleAsOutcome(subject: HarnessContractSubject, settled: Promise<TurnOutcome>, when: string): Promise<TurnOutcome> {
+  let outcome: TurnOutcome;
+  try {
+    outcome = await settled;
+  } catch (err) {
+    const kind = err instanceof CancelledFailure ? "a CancelledFailure" : `an exception (${err instanceof Error ? err.message : String(err)})`;
+    throw new Error(`${subject.name}: runTurn rejected with ${kind} ${when}; every exit must be a TurnOutcome`);
+  }
+  expect(OUTCOME_KINDS, `${subject.name}: runTurn settled with an unknown outcome kind ${when}`).toContain(outcome.kind);
+  return outcome;
+}
+
+/** Race a settlement against the interrupt bound; the timer is cleared on settle so a passing test holds nothing. */
+async function settleWithinBound<T>(subject: HarnessContractSubject, settled: Promise<T>, when: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const bound = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${subject.name}: runTurn did not settle within ${INTERRUPT_SETTLE_BOUND_MS}ms ${when}; every adapter call must be bounded by stopSignal`)),
+      INTERRUPT_SETTLE_BOUND_MS,
+    );
+  });
+  try {
+    return await Promise.race([settled, bound]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+// ── Invariant 1 ─────────────────────────────────────────────────────────────
+
+/**
+ * Invariant 1: every exit is a `TurnOutcome`. Each scenario kind is played
+ * once, the hanging one is stopped from the outside, and one turn is entered
+ * with an already-aborted signal; none may reject, none may settle with an
+ * unknown kind.
+ */
+export async function assertEveryExitIsAnOutcome(subject: HarnessContractSubject): Promise<void> {
+  const driver = new ExecutionDriver(subject, "inv1");
+  const plays: ReadonlyArray<{ readonly when: string; readonly turn: TurnScenario; readonly options?: TurnOptions }> = [
+    { when: "on a plain text turn", turn: [scenario.say("hello")] },
+    { when: "on a usage-only turn", turn: [scenario.usage({ inputTokens: 1, outputTokens: 1 })] },
+    { when: "on an undecided proposal", turn: [scenario.propose("inv1-call", WRITE_ALPHA)] },
+    { when: "on an engine failure", turn: [scenario.fail("engine exploded")] },
+    {
+      when: "on a hang stopped from the outside",
+      turn: [scenario.hang()],
+      options: { onStarted: (sink) => setImmediate(() => sink.abort("kit: stop")) },
+    },
+  ];
+  for (const play of plays) {
+    const { sink, settled } = driver.begin(play.turn, play.options);
+    await settleAsOutcome(subject, settleWithinBound(subject, settled, play.when), play.when);
+    driver.recordTurn(sink);
+  }
+
+  const preAborted = new RecordingTurnSink({ status: driver.seedStatus() });
+  preAborted.abort("kit: aborted before the turn");
+  const { settled } = driver.begin([scenario.say("never")], { sink: preAborted });
+  await settleAsOutcome(subject, settleWithinBound(subject, settled, "under a pre-aborted signal"), "under a pre-aborted signal");
+}
+
+// ── The runnable suite ──────────────────────────────────────────────────────
+
+/** Register the adapter-side contract against one subject. */
+export function describeHarnessContract(subject: HarnessContractSubject): void {
+  describe(`harness contract — ${subject.name}`, () => {
+    it("settles every turn with a TurnOutcome and never rejects (invariant 1)", async () => {
+      await assertEveryExitIsAnOutcome(subject);
+    });
+  });
+}

--- a/backend/services/runner/src/__test-utils__/harness-contract/recording-sink.ts
+++ b/backend/services/runner/src/__test-utils__/harness-contract/recording-sink.ts
@@ -1,0 +1,96 @@
+/**
+ * A `TurnSink` that records everything an adapter asks of the runtime.
+ *
+ * The kit is the runtime stand-in, and this is the runtime's face during one
+ * turn: it owns the `AbortController` behind `stopSignal` (so a test can stop
+ * the turn from the outside, exactly as the runtime's watchdog, accounting or
+ * heartbeat would), and it keeps ONE ordered log of every call the adapter
+ * made. Counts and lists are derived from the log on read rather than kept
+ * as parallel counters, because the invariants care about ORDER as much as
+ * about counts ("bind before the first persist" is an ordering claim).
+ *
+ * `bindHarnessState` can be made to reject, standing in for a failed session
+ * write, so the kit can prove an adapter surfaces a runtime-side failure as
+ * `failed` instead of letting it escape `runTurn`.
+ *
+ * One sink per turn, like the runtime. A reinvocation gets a NEW sink whose
+ * `status` is a clone of the previous turn's — the runtime persists and reads
+ * back, so nothing survives between turns by object identity.
+ */
+
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+
+import type { TurnSink, UsageDelta } from "../../harness/types.js";
+import { emptyStatus } from "../proto-helpers.js";
+
+/** One call the adapter made on the sink, in the order it made it. */
+export type SinkEvent =
+  | { readonly kind: "persist" }
+  | { readonly kind: "activity" }
+  | { readonly kind: "usage"; readonly delta: UsageDelta }
+  | { readonly kind: "bind"; readonly harnessStateId: string };
+
+export interface RecordingTurnSinkOptions {
+  /** The status this turn folds into; a fresh empty one when omitted. */
+  readonly status?: AgentExecutionStatus;
+  /** When set, `bindHarnessState` rejects with this error (a failed session write). */
+  readonly bindRejectsWith?: Error;
+}
+
+export class RecordingTurnSink implements TurnSink {
+  readonly status: AgentExecutionStatus;
+  readonly stopSignal: AbortSignal;
+
+  private readonly controller = new AbortController();
+  private readonly log: SinkEvent[] = [];
+  private readonly bindRejectsWith: Error | undefined;
+
+  constructor(options: RecordingTurnSinkOptions = {}) {
+    this.status = options.status ?? emptyStatus();
+    this.stopSignal = this.controller.signal;
+    this.bindRejectsWith = options.bindRejectsWith;
+  }
+
+  /** Stop the turn from the outside, the way the runtime would. */
+  abort(reason?: unknown): void {
+    this.controller.abort(reason);
+  }
+
+  requestPersist(): void {
+    this.log.push({ kind: "persist" });
+  }
+
+  recordActivity(): void {
+    this.log.push({ kind: "activity" });
+  }
+
+  reportUsage(delta: UsageDelta): void {
+    this.log.push({ kind: "usage", delta });
+  }
+
+  async bindHarnessState(harnessStateId: string): Promise<void> {
+    if (this.bindRejectsWith) throw this.bindRejectsWith;
+    this.log.push({ kind: "bind", harnessStateId });
+  }
+
+  /** Every call, in order. */
+  get events(): readonly SinkEvent[] {
+    return this.log;
+  }
+
+  get persistRequests(): number {
+    return this.log.filter((e) => e.kind === "persist").length;
+  }
+
+  get activityMarks(): number {
+    return this.log.filter((e) => e.kind === "activity").length;
+  }
+
+  get usageDeltas(): readonly UsageDelta[] {
+    return this.log.flatMap((e) => (e.kind === "usage" ? [e.delta] : []));
+  }
+
+  get boundStateIds(): readonly string[] {
+    return this.log.flatMap((e) => (e.kind === "bind" ? [e.harnessStateId] : []));
+  }
+}

--- a/backend/services/runner/src/__test-utils__/harness-contract/scripted-adapter.ts
+++ b/backend/services/runner/src/__test-utils__/harness-contract/scripted-adapter.ts
@@ -35,7 +35,6 @@
  */
 
 import { ApprovalAction, ToolCallStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
-import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
 import type { ToolCall } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
 
 import type { Config } from "../../config.js";
@@ -52,13 +51,6 @@ export interface ScriptedHarnessOptions {
   readonly name?: string;
   readonly pausePrimitive: PausePrimitive;
   readonly stateIdSource: StateIdSource;
-}
-
-/** The lifecycle calls the adapter received, for the kit's lifetime invariants. */
-export interface RecordedLifecycle {
-  readonly boots: readonly Config[];
-  readonly shutdowns: number;
-  readonly releasedSessions: readonly string[];
 }
 
 /**
@@ -87,10 +79,6 @@ export class ScriptedHarnessAdapter implements HarnessAdapter {
   private readonly executions = new Map<string, number>();
   private mintCounter = 0;
 
-  private readonly boots: Config[] = [];
-  private shutdowns = 0;
-  private readonly releasedSessions: string[] = [];
-
   constructor(options: ScriptedHarnessOptions) {
     this.name = options.name ?? `scripted(${options.pausePrimitive}, ${options.stateIdSource})`;
     this.capabilities = {
@@ -114,24 +102,16 @@ export class ScriptedHarnessAdapter implements HarnessAdapter {
     return this.executions.get(toolCallId) ?? 0;
   }
 
-  get lifecycle(): RecordedLifecycle {
-    return { boots: this.boots, shutdowns: this.shutdowns, releasedSessions: this.releasedSessions };
-  }
-
   // ── HarnessAdapter ────────────────────────────────────────────────────────
 
-  async boot(config: Config): Promise<void> {
-    this.boots.push(config);
-  }
+  /** Nothing to install: a real adapter imports its SDK lazily and installs its transport here. */
+  async boot(_config: Config): Promise<void> {}
 
-  async shutdown(): Promise<void> {
-    this.shutdowns += 1;
-  }
+  /** Nothing held: a real adapter closes every engine it still has parked. */
+  async shutdown(): Promise<void> {}
 
-  /** Nothing is parked per session here; a real adapter releases its parked engine. */
-  async releaseSession(sessionId: string): Promise<void> {
-    this.releasedSessions.push(sessionId);
-  }
+  /** Nothing is parked per session here; a real adapter releases the engine it parked for `sessionId`. */
+  async releaseSession(_sessionId: string): Promise<void> {}
 
   async runTurn(input: TurnInput, sink: TurnSink): Promise<TurnOutcome> {
     const turn = this.queue.shift();

--- a/backend/services/runner/src/__test-utils__/harness-contract/scripted-adapter.ts
+++ b/backend/services/runner/src/__test-utils__/harness-contract/scripted-adapter.ts
@@ -44,7 +44,7 @@ import type { HarnessAdapter, TurnInput, TurnOutcome, TurnSink } from "../../har
 import { DEEP_AGENT_VISION_PROFILE } from "../../shared/attachment-vision.js";
 import type { ProposedAction } from "../approval-contract/types.js";
 import { testConfig } from "../config-fixture.js";
-import { aiMessage, waitingToolCall } from "../proto-helpers.js";
+import { aiMessage, findToolCallRow, waitingToolCall } from "../proto-helpers.js";
 import type { HarnessContractSubject, ScenarioStep, TurnScenario } from "./types.js";
 
 export interface ScriptedHarnessOptions {
@@ -70,14 +70,6 @@ export interface RecordedLifecycle {
 function whenAborted(signal: AbortSignal): Promise<void> {
   if (signal.aborted) return Promise.resolve();
   return new Promise((resolve) => signal.addEventListener("abort", () => resolve(), { once: true }));
-}
-
-function findToolCall(status: AgentExecutionStatus, toolCallId: string): ToolCall | undefined {
-  for (const message of status.messages) {
-    const row = message.toolCalls.find((tc) => tc.id === toolCallId);
-    if (row) return row;
-  }
-  return undefined;
 }
 
 /** A proposal already carried to a terminal row has been settled by an earlier invocation. */
@@ -238,7 +230,7 @@ export class ScriptedHarnessAdapter implements HarnessAdapter {
     input: TurnInput,
     sink: TurnSink,
   ): TurnOutcome | undefined {
-    const existing = findToolCall(sink.status, toolCallId);
+    const existing = findToolCallRow(sink.status, toolCallId);
     if (isSettled(existing)) return undefined;
 
     const decision = input.approvalDecisions.get(toolCallId) ?? ApprovalAction.UNSPECIFIED;

--- a/backend/services/runner/src/__test-utils__/harness-contract/scripted-adapter.ts
+++ b/backend/services/runner/src/__test-utils__/harness-contract/scripted-adapter.ts
@@ -1,0 +1,317 @@
+/**
+ * The scripted harness adapter — the reference implementation of
+ * `HarnessAdapter`, driven by a `TurnScenario` per turn instead of a vendor
+ * SDK.
+ *
+ * Two jobs. It is the fake the contract kit runs against under every
+ * capability combination, so the kit is proven before any real adapter
+ * implements the contract. And it is the TEMPLATE a future harness author
+ * reads first: every rule of the contract appears here as the smallest code
+ * that honours it, with the reason beside it. Its measured line count is the
+ * program's "lines a new harness must write" data point.
+ *
+ * The insight this fake makes visible: above the contract line, the two real
+ * pause primitives are indistinguishable. Whether the engine checkpoints at
+ * the gate (`interrupt`) or a hook denies the tool and the run is cancelled
+ * (`deny-and-retry`), the turn ends `awaiting_approval` with a WAITING row on
+ * the status, and the next invocation carries the decision. How the engine
+ * RESUMES is the adapter's business, below the line, and the runtime never
+ * sees it. So this fake takes `pausePrimitive` as an option and does not
+ * branch on it — and the kit runs it under both to prove the kit does not
+ * branch on it either.
+ *
+ * What is deliberately simple here and would be real work in an adapter:
+ * "executing" a side effect is incrementing a counter; the engine state id is
+ * a counter too; the transcript rows are built with the shared proto
+ * factories. What is NOT simplified is the contract behaviour itself —
+ * settling with an outcome and never rejecting, stopping at every step
+ * boundary and inside a hang, binding before the first persist, executing an
+ * approval exactly once, refusing to resume a state it never minted — because
+ * those are what the kit measures.
+ *
+ * A `runTurn` with no scenario arranged is a test bug and throws (the same
+ * rule as the scripted `@cursor/sdk` agent's `send()` with no script left);
+ * every other exit is a `TurnOutcome`.
+ */
+
+import { ApprovalAction, ToolCallStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import type { ToolCall } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/message_pb";
+
+import type { Config } from "../../config.js";
+import type { HarnessCapabilities, PausePrimitive, StateIdSource } from "../../harness/capabilities.js";
+import type { HarnessAdapter, TurnInput, TurnOutcome, TurnSink } from "../../harness/types.js";
+import { DEEP_AGENT_VISION_PROFILE } from "../../shared/attachment-vision.js";
+import type { ProposedAction } from "../approval-contract/types.js";
+import { testConfig } from "../config-fixture.js";
+import { aiMessage, waitingToolCall } from "../proto-helpers.js";
+import type { HarnessContractSubject, ScenarioStep, TurnScenario } from "./types.js";
+
+export interface ScriptedHarnessOptions {
+  /** Diagnostic name; defaults to a name that says which primitives this instance runs under. */
+  readonly name?: string;
+  readonly pausePrimitive: PausePrimitive;
+  readonly stateIdSource: StateIdSource;
+}
+
+/** The lifecycle calls the adapter received, for the kit's lifetime invariants. */
+export interface RecordedLifecycle {
+  readonly boots: readonly Config[];
+  readonly shutdowns: number;
+  readonly releasedSessions: readonly string[];
+}
+
+/**
+ * Resolves when the signal aborts; resolves at once if it already has. Parks
+ * on the abort EVENT, never on a timer, so a hanging turn holds nothing that
+ * could keep a process alive — the property the runtime's heartbeat relies
+ * on when it declares a stalled turn dead.
+ */
+function whenAborted(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => signal.addEventListener("abort", () => resolve(), { once: true }));
+}
+
+function findToolCall(status: AgentExecutionStatus, toolCallId: string): ToolCall | undefined {
+  for (const message of status.messages) {
+    const row = message.toolCalls.find((tc) => tc.id === toolCallId);
+    if (row) return row;
+  }
+  return undefined;
+}
+
+/** A proposal already carried to a terminal row has been settled by an earlier invocation. */
+function isSettled(row: ToolCall | undefined): boolean {
+  return row !== undefined
+    && (row.status === ToolCallStatus.TOOL_CALL_COMPLETED || row.status === ToolCallStatus.TOOL_CALL_SKIPPED);
+}
+
+export class ScriptedHarnessAdapter implements HarnessAdapter {
+  readonly name: string;
+  readonly capabilities: HarnessCapabilities;
+
+  private readonly queue: TurnScenario[] = [];
+  private readonly mintedStateIds = new Set<string>();
+  private readonly executions = new Map<string, number>();
+  private mintCounter = 0;
+
+  private readonly boots: Config[] = [];
+  private shutdowns = 0;
+  private readonly releasedSessions: string[] = [];
+
+  constructor(options: ScriptedHarnessOptions) {
+    this.name = options.name ?? `scripted(${options.pausePrimitive}, ${options.stateIdSource})`;
+    this.capabilities = {
+      pausePrimitive: options.pausePrimitive,
+      stateIdSource: options.stateIdSource,
+      systemPrompt: true,
+      subAgents: false,
+      toolRestriction: true,
+      visionProfile: DEEP_AGENT_VISION_PROFILE,
+    };
+  }
+
+  // ── Engine controls (the subject's side of the kit seam) ──────────────────
+
+  /** Queue what the next `runTurn` plays. */
+  arrange(turn: TurnScenario): void {
+    this.queue.push(turn);
+  }
+
+  executionCount(toolCallId: string): number {
+    return this.executions.get(toolCallId) ?? 0;
+  }
+
+  get lifecycle(): RecordedLifecycle {
+    return { boots: this.boots, shutdowns: this.shutdowns, releasedSessions: this.releasedSessions };
+  }
+
+  // ── HarnessAdapter ────────────────────────────────────────────────────────
+
+  async boot(config: Config): Promise<void> {
+    this.boots.push(config);
+  }
+
+  async shutdown(): Promise<void> {
+    this.shutdowns += 1;
+  }
+
+  /** Nothing is parked per session here; a real adapter releases its parked engine. */
+  async releaseSession(sessionId: string): Promise<void> {
+    this.releasedSessions.push(sessionId);
+  }
+
+  async runTurn(input: TurnInput, sink: TurnSink): Promise<TurnOutcome> {
+    const turn = this.queue.shift();
+    if (!turn) throw new Error(`${this.name}: runTurn called with no scenario arranged (test bug)`);
+
+    // The signal may be aborted before the turn is entered; do no work then.
+    if (sink.stopSignal.aborted) return { kind: "interrupted" };
+
+    const resumed = await this.resolveEngineState(input, sink);
+    if (resumed.kind !== "ok") return resumed.outcome;
+
+    for (const step of turn) {
+      // Stop at every step boundary — the Cursor loop's per-event isCancelled().
+      if (sink.stopSignal.aborted) return { kind: "interrupted" };
+      const ended = await this.play(step, input, sink);
+      if (ended) return ended;
+    }
+    return { kind: "completed" };
+  }
+
+  /**
+   * Create or resume the engine, per `stateIdSource`. An engine-minted id is
+   * bound BEFORE the turn proceeds so a crash mid-turn still resumes; a
+   * resume of an id this engine never minted fails the way `Agent.resume` of
+   * an unknown id fails, so a runtime that threads the wrong id is caught. A
+   * deterministic engine's id is the runtime's; nothing to bind.
+   */
+  private async resolveEngineState(
+    input: TurnInput,
+    sink: TurnSink,
+  ): Promise<{ kind: "ok" } | { kind: "ended"; outcome: TurnOutcome }> {
+    if (this.capabilities.stateIdSource === "deterministic") return { kind: "ok" };
+
+    if (input.threadId === "") {
+      const minted = `${this.name}#state-${++this.mintCounter}`;
+      this.mintedStateIds.add(minted);
+      try {
+        await sink.bindHarnessState(minted);
+      } catch (err) {
+        return {
+          kind: "ended",
+          outcome: { kind: "failed", message: `${this.name}: could not bind engine state`, cause: err },
+        };
+      }
+      return { kind: "ok" };
+    }
+
+    if (!this.mintedStateIds.has(input.threadId)) {
+      return {
+        kind: "ended",
+        outcome: { kind: "failed", message: `${this.name}: no engine state '${input.threadId}' to resume` },
+      };
+    }
+    return { kind: "ok" };
+  }
+
+  /** Play one step; returns the outcome that ends the turn, or undefined to continue. */
+  private async play(step: ScenarioStep, input: TurnInput, sink: TurnSink): Promise<TurnOutcome | undefined> {
+    switch (step.kind) {
+      case "say": {
+        sink.status.messages.push(aiMessage(step.text));
+        sink.recordActivity();
+        sink.requestPersist();
+        return undefined;
+      }
+      case "propose":
+        return this.propose(step.toolCallId, step.action, input, sink);
+      case "usage": {
+        sink.reportUsage(step.delta);
+        sink.recordActivity();
+        return undefined;
+      }
+      case "hang": {
+        await whenAborted(sink.stopSignal);
+        return { kind: "interrupted" };
+      }
+      case "fail":
+        return { kind: "failed", message: step.message };
+      default: {
+        const exhaustive: never = step;
+        throw new Error(`${this.name}: unknown scenario step ${JSON.stringify(exhaustive)}`);
+      }
+    }
+  }
+
+  /**
+   * The gate, above the contract line. The status is the single source of
+   * truth for whether the effect ran: a row already carried to COMPLETED or
+   * SKIPPED by an earlier invocation is settled and the step is a no-op, which
+   * is what makes "reinvoked twice with the same decision, still once" hold
+   * without a second ledger.
+   */
+  private propose(
+    toolCallId: string,
+    action: ProposedAction,
+    input: TurnInput,
+    sink: TurnSink,
+  ): TurnOutcome | undefined {
+    const existing = findToolCall(sink.status, toolCallId);
+    if (isSettled(existing)) return undefined;
+
+    const decision = input.approvalDecisions.get(toolCallId) ?? ApprovalAction.UNSPECIFIED;
+    switch (decision) {
+      case ApprovalAction.UNSPECIFIED: {
+        // Propose: surface the gated call as a WAITING row and stop the turn.
+        // Never write a second row for the same id on a resumed turn.
+        if (!existing) {
+          const message = aiMessage("");
+          message.toolCalls.push(waitingToolCall(toolCallId, action.kind, `Approve ${action.kind} ${action.resource}?`));
+          sink.status.messages.push(message);
+        }
+        sink.recordActivity();
+        sink.requestPersist();
+        return { kind: "awaiting_approval" };
+      }
+      case ApprovalAction.APPROVE:
+      case ApprovalAction.APPROVE_ALL: {
+        this.executions.set(toolCallId, this.executionCount(toolCallId) + 1);
+        this.settleRow(existing, toolCallId, action, ToolCallStatus.TOOL_CALL_COMPLETED, sink);
+        return undefined;
+      }
+      case ApprovalAction.SKIP:
+      case ApprovalAction.REJECT: {
+        this.settleRow(existing, toolCallId, action, ToolCallStatus.TOOL_CALL_SKIPPED, sink);
+        return undefined;
+      }
+      default: {
+        const exhaustive: never = decision;
+        throw new Error(`${this.name}: unknown approval action ${String(exhaustive)}`);
+      }
+    }
+  }
+
+  /**
+   * Carry the proposal's row to its terminal status. The row normally exists
+   * (the runtime seeded the status with last turn's WAITING row); a decision
+   * with no row is a runtime that decided out of band, and the adapter still
+   * records what happened rather than losing the fact.
+   */
+  private settleRow(
+    existing: ToolCall | undefined,
+    toolCallId: string,
+    action: ProposedAction,
+    status: ToolCallStatus,
+    sink: TurnSink,
+  ): void {
+    if (existing) {
+      existing.status = status;
+    } else {
+      const message = aiMessage("");
+      const row = waitingToolCall(toolCallId, action.kind, "");
+      row.status = status;
+      message.toolCalls.push(row);
+      sink.status.messages.push(message);
+    }
+    sink.recordActivity();
+    sink.requestPersist();
+  }
+}
+
+/** The scripted adapter as a kit subject: the adapter IS its own engine, so the seam is a thin view over it. */
+export interface ScriptedSubject extends HarnessContractSubject {
+  readonly adapter: ScriptedHarnessAdapter;
+}
+
+export function scriptedSubject(options: ScriptedHarnessOptions): ScriptedSubject {
+  const adapter = new ScriptedHarnessAdapter(options);
+  return {
+    name: adapter.name,
+    adapter,
+    config: testConfig(),
+    arrange: (turn) => adapter.arrange(turn),
+    executionCount: (toolCallId) => adapter.executionCount(toolCallId),
+  };
+}

--- a/backend/services/runner/src/__test-utils__/harness-contract/types.ts
+++ b/backend/services/runner/src/__test-utils__/harness-contract/types.ts
@@ -1,0 +1,100 @@
+/**
+ * The test-facing seam of the harness contract kit.
+ *
+ * `HarnessAdapter.runTurn(input, sink)` gives a test no way to make the
+ * engine DO anything: propose a gated action, emit usage, hang, fail. The
+ * approval-contract kit met the same problem with `GatewaySubstrate` — a
+ * small interface each real substrate adapts so one invariant catalog can
+ * drive all of them. This is that seam for harnesses: a
+ * {@link HarnessContractSubject} owns the ENGINE (what the next turn will
+ * do), and the kit owns everything the runtime would own (the sink, the
+ * `TurnInput`, the state id threading, the reinvocation).
+ *
+ * The scenario vocabulary is deliberately small and engine-neutral: it says
+ * what the kit needs to PROVOKE, never how an engine behaves. The scripted
+ * fake consumes it directly; a real harness's subject translates it onto that
+ * harness's own double (the Cursor subject onto the scripted `@cursor/sdk`
+ * agent of `execute-cursor/__test-utils__/`). One vocabulary, not one per
+ * engine, so the kit cannot drift from what the fake can do.
+ *
+ * Gated actions reuse `ProposedAction` from `approval-contract/types.ts`, the
+ * taxonomy-free action every enforcement substrate already translates, so the
+ * two kits speak of the same logical side effect and neither restates the
+ * HITL taxonomy.
+ */
+
+import type { Config } from "../../config.js";
+import type { HarnessAdapter, UsageDelta } from "../../harness/types.js";
+import type { ProposedAction } from "../approval-contract/types.js";
+
+/**
+ * One thing the engine does during a turn. A turn plays its steps in order
+ * and ends `completed` when none is left, unless a step ends it first.
+ *
+ *  - `say`: the engine emits assistant text (a transcript row).
+ *  - `propose`: the engine reaches a gated side effect identified by
+ *    `toolCallId`. Undecided → the turn ends `awaiting_approval` and later
+ *    steps do not run; APPROVE → the effect runs once and the turn continues;
+ *    REJECT / SKIP → the effect never runs and the turn continues.
+ *  - `usage`: the engine reports one turn's token counts.
+ *  - `hang`: the engine makes no further progress until told to stop. The
+ *    step that the stop-signal invariants and the runtime's stall watchdog
+ *    are built around; it must be parked on the signal, never on a timer.
+ *  - `fail`: the engine fails with a message the adapter can name; the turn
+ *    ends `failed`.
+ */
+export type ScenarioStep =
+  | { readonly kind: "say"; readonly text: string }
+  | { readonly kind: "propose"; readonly toolCallId: string; readonly action: ProposedAction }
+  | { readonly kind: "usage"; readonly delta: UsageDelta }
+  | { readonly kind: "hang" }
+  | { readonly kind: "fail"; readonly message: string };
+
+/** One turn's worth of engine behaviour. */
+export type TurnScenario = readonly ScenarioStep[];
+
+/** Step builders — the vocabulary a kit invariant reads as. */
+export const scenario = {
+  say(text: string): ScenarioStep {
+    return { kind: "say", text };
+  },
+  propose(toolCallId: string, action: ProposedAction): ScenarioStep {
+    return { kind: "propose", toolCallId, action };
+  },
+  usage(delta: UsageDelta): ScenarioStep {
+    return { kind: "usage", delta };
+  },
+  hang(): ScenarioStep {
+    return { kind: "hang" };
+  },
+  fail(message: string): ScenarioStep {
+    return { kind: "fail", message };
+  },
+} as const;
+
+/**
+ * One adapter under test, with the engine controls the kit needs. Adapters
+ * translate scenarios into their own double's drives and report what the
+ * double observed; they never reimplement contract behaviour.
+ */
+export interface HarnessContractSubject {
+  /** Stable name, used in suite titles and every assertion message. */
+  readonly name: string;
+  /** The adapter under test — the real implementation of the contract. */
+  readonly adapter: HarnessAdapter;
+  /** What `adapter.boot` needs. The subject knows its adapter's fields; the kit does not. */
+  readonly config: Config;
+  /**
+   * Arrange the engine so that the NEXT `runTurn` on this adapter plays
+   * `turn`. Called by the kit before every `runTurn`, including a
+   * reinvocation (the engine re-reaches the same gated call on resume, so the
+   * same proposal is arranged again).
+   */
+  arrange(turn: TurnScenario): void;
+  /**
+   * How many times the side effect behind `toolCallId` actually ran, as the
+   * subject's double observed it. The safety-critical observable; zero for an
+   * id the engine never reached.
+   */
+  executionCount(toolCallId: string): number;
+}

--- a/backend/services/runner/src/__test-utils__/proto-helpers.ts
+++ b/backend/services/runner/src/__test-utils__/proto-helpers.ts
@@ -40,6 +40,15 @@ export function toolCall(
   return create(ToolCallSchema, { id, name, status });
 }
 
+/** The tool-call row with this id, wherever it sits in the transcript. */
+export function findToolCallRow(status: AgentExecutionStatus, toolCallId: string): ToolCall | undefined {
+  for (const message of status.messages) {
+    const row = message.toolCalls.find((tc) => tc.id === toolCallId);
+    if (row) return row;
+  }
+  return undefined;
+}
+
 /**
  * A tool call withheld for approval — the row a harness writes when it
  * proposes a gated side effect: WAITING_APPROVAL, `requiresApproval` set, and

--- a/backend/services/runner/src/__test-utils__/proto-helpers.ts
+++ b/backend/services/runner/src/__test-utils__/proto-helpers.ts
@@ -39,3 +39,19 @@ export function toolCall(
 ): ToolCall {
   return create(ToolCallSchema, { id, name, status });
 }
+
+/**
+ * A tool call withheld for approval — the row a harness writes when it
+ * proposes a gated side effect: WAITING_APPROVAL, `requiresApproval` set, and
+ * the approval fields the server owns (`approvalAction`, `approvalDecidedAt`)
+ * left at their defaults for the decision to fill in.
+ */
+export function waitingToolCall(id: string, name: string, approvalMessage: string): ToolCall {
+  return create(ToolCallSchema, {
+    id,
+    name,
+    status: ToolCallStatus.TOOL_CALL_WAITING_APPROVAL,
+    requiresApproval: true,
+    approvalMessage,
+  });
+}

--- a/backend/services/runner/src/__tests__/harness-contract.test.ts
+++ b/backend/services/runner/src/__tests__/harness-contract.test.ts
@@ -1,0 +1,25 @@
+/**
+ * The runnable harness adapter contract.
+ *
+ * Runs the single, authoritative invariant catalog (see
+ * `__test-utils__/harness-contract/contract.ts`) against the scripted
+ * reference adapter under BOTH real pause primitives and BOTH state-id
+ * sources: `interrupt` with an engine-minted id and `deny-and-retry` with a
+ * deterministic id. Neither the kit nor the fake branches on the pause
+ * primitive — running both is what proves it.
+ *
+ * This is the consolidation home for what every harness owes the turn
+ * runtime. A real adapter joins the net by implementing
+ * `HarnessContractSubject` for its own SDK double and adding one line below;
+ * the runtime extraction (S2 of the program) adds the Cursor adapter here
+ * and runs the runtime-side half through the hermetic activity driver.
+ */
+
+import { describeHarnessContract } from "../__test-utils__/harness-contract/contract.js";
+import { scriptedSubject } from "../__test-utils__/harness-contract/scripted-adapter.js";
+
+const interruptEngineMinted = scriptedSubject({ pausePrimitive: "interrupt", stateIdSource: "engine-minted" });
+const denyAndRetryDeterministic = scriptedSubject({ pausePrimitive: "deny-and-retry", stateIdSource: "deterministic" });
+
+describeHarnessContract(interruptEngineMinted);
+describeHarnessContract(denyAndRetryDeterministic);

--- a/backend/services/runner/src/harness/__tests__/registry.test.ts
+++ b/backend/services/runner/src/harness/__tests__/registry.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Pins the harness registry's two load-bearing properties — ORDER and ERROR
+ * POSTURE — and the byte-pinned activity names.
+ *
+ * Order: boot in declaration order, one at a time (the Cursor interceptors
+ * must precede anything that dials the control plane); shutdown in reverse.
+ * Posture: boot validates the table before touching any adapter and fails
+ * fast at the first rejection; shutdown and release continue past a failing
+ * adapter and surface every failure in one AggregateError. Names: the map
+ * must equal the server's constants byte for byte; the runner cannot import
+ * the server, so the literals are asserted here and the server's file is
+ * cited beside them.
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { testConfig } from "../../__test-utils__/config-fixture.js";
+import { DEEP_AGENT_VISION_PROFILE } from "../../shared/attachment-vision.js";
+import { HARNESS_ACTIVITY_NAMES, bootHarnesses, releaseHarnessSession, shutdownHarnesses } from "../registry.js";
+import type { HarnessAdapter } from "../types.js";
+
+interface StubBehaviour {
+  readonly bootRejects?: Error;
+  readonly shutdownRejects?: Error;
+  readonly releaseRejects?: Error;
+}
+
+/** An adapter that only records lifecycle calls into a shared, ordered log. */
+function stubAdapter(name: string, log: string[], behaviour: StubBehaviour = {}): HarnessAdapter {
+  return {
+    name,
+    capabilities: {
+      pausePrimitive: "interrupt",
+      stateIdSource: "deterministic",
+      systemPrompt: true,
+      subAgents: false,
+      toolRestriction: true,
+      visionProfile: DEEP_AGENT_VISION_PROFILE,
+    },
+    async boot() {
+      log.push(`boot:${name}`);
+      if (behaviour.bootRejects) throw behaviour.bootRejects;
+    },
+    async shutdown() {
+      log.push(`shutdown:${name}`);
+      if (behaviour.shutdownRejects) throw behaviour.shutdownRejects;
+    },
+    async releaseSession(sessionId) {
+      log.push(`release:${name}:${sessionId}`);
+      if (behaviour.releaseRejects) throw behaviour.releaseRejects;
+    },
+    async runTurn() {
+      throw new Error(`${name}: runTurn is not under test here`);
+    },
+  };
+}
+
+describe("HARNESS_ACTIVITY_NAMES", () => {
+  it("equals the server's byte-pinned activity names (stigmer-server temporal/agentexecution/names.ts)", () => {
+    expect(HARNESS_ACTIVITY_NAMES.cursor).toBe("ExecuteCursor");
+    expect(HARNESS_ACTIVITY_NAMES["deep-agent"]).toBe("ExecuteDeepAgent");
+    expect(Object.keys(HARNESS_ACTIVITY_NAMES).sort()).toEqual(["cursor", "deep-agent"]);
+  });
+});
+
+describe("bootHarnesses", () => {
+  it("boots adapters in declaration order, one at a time", async () => {
+    const log: string[] = [];
+    await bootHarnesses([stubAdapter("first", log), stubAdapter("second", log), stubAdapter("third", log)], testConfig());
+    expect(log).toEqual(["boot:first", "boot:second", "boot:third"]);
+  });
+
+  it("hands every adapter the same config", async () => {
+    const seen: unknown[] = [];
+    const config = testConfig({ taskQueue: "registry-test-queue" });
+    const adapters = ["a", "b"].map((name) => ({
+      ...stubAdapter(name, []),
+      async boot(c: unknown) {
+        seen.push(c);
+      },
+    }));
+    await bootHarnesses(adapters, config);
+    expect(seen, "each adapter must receive the one worker config").toEqual([config, config]);
+  });
+
+  it("refuses duplicate adapter names before booting anything", async () => {
+    const log: string[] = [];
+    const adapters = [stubAdapter("cursor", log), stubAdapter("other", log), stubAdapter("cursor", log)];
+    await expect(bootHarnesses(adapters, testConfig())).rejects.toThrow(/duplicate adapter name 'cursor'/);
+    expect(log, "a table with a duplicate must not boot even its first adapter").toEqual([]);
+  });
+
+  it("fails fast: the first rejection propagates and later adapters never boot", async () => {
+    const log: string[] = [];
+    const adapters = [
+      stubAdapter("first", log),
+      stubAdapter("broken", log, { bootRejects: new Error("interceptor install failed") }),
+      stubAdapter("third", log),
+    ];
+    await expect(bootHarnesses(adapters, testConfig())).rejects.toThrow("interceptor install failed");
+    expect(log).toEqual(["boot:first", "boot:broken"]);
+  });
+
+  it("boots an empty table as a no-op", async () => {
+    await expect(bootHarnesses([], testConfig())).resolves.toBeUndefined();
+  });
+});
+
+describe("shutdownHarnesses", () => {
+  it("shuts adapters down in reverse declaration order", async () => {
+    const log: string[] = [];
+    await shutdownHarnesses([stubAdapter("first", log), stubAdapter("second", log), stubAdapter("third", log)]);
+    expect(log).toEqual(["shutdown:third", "shutdown:second", "shutdown:first"]);
+  });
+
+  it("continues past a failing adapter and reports every failure in one AggregateError", async () => {
+    const log: string[] = [];
+    const adapters = [
+      stubAdapter("first", log, { shutdownRejects: new Error("first leaked") }),
+      stubAdapter("second", log),
+      stubAdapter("third", log, { shutdownRejects: new Error("third leaked") }),
+    ];
+    const failure = await shutdownHarnesses(adapters).catch((e: unknown) => e);
+    expect(failure).toBeInstanceOf(AggregateError);
+    const aggregate = failure as AggregateError;
+    expect(aggregate.message).toContain("third: shutdown rejected: third leaked");
+    expect(aggregate.message).toContain("first: shutdown rejected: first leaked");
+    expect(aggregate.errors.map((e: Error) => e.message)).toEqual([
+      "third: shutdown rejected: third leaked",
+      "first: shutdown rejected: first leaked",
+    ]);
+    expect(log, "every adapter must be shut down even when an earlier one failed").toEqual([
+      "shutdown:third",
+      "shutdown:second",
+      "shutdown:first",
+    ]);
+  });
+
+  it("preserves the original error as the cause of each reported failure", async () => {
+    const original = new Error("socket already closed");
+    const failure = await shutdownHarnesses([stubAdapter("only", [], { shutdownRejects: original })]).catch((e: unknown) => e);
+    expect((failure as AggregateError).errors[0]?.cause).toBe(original);
+  });
+});
+
+describe("releaseHarnessSession", () => {
+  it("tells every adapter, in declaration order, with the session id", async () => {
+    const log: string[] = [];
+    await releaseHarnessSession([stubAdapter("first", log), stubAdapter("second", log)], "ses-42");
+    expect(log).toEqual(["release:first:ses-42", "release:second:ses-42"]);
+  });
+
+  it("continues past a failing adapter and reports the failure with the session id", async () => {
+    const log: string[] = [];
+    const adapters = [
+      stubAdapter("first", log, { releaseRejects: new Error("executor busy") }),
+      stubAdapter("second", log),
+    ];
+    const failure = await releaseHarnessSession(adapters, "ses-7").catch((e: unknown) => e);
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).message).toContain("releaseSession('ses-7') failed");
+    expect((failure as AggregateError).errors.map((e: Error) => e.message)).toEqual([
+      "first: releaseSession('ses-7') rejected: executor busy",
+    ]);
+    expect(log).toEqual(["release:first:ses-7", "release:second:ses-7"]);
+  });
+});

--- a/backend/services/runner/src/harness/capabilities.ts
+++ b/backend/services/runner/src/harness/capabilities.ts
@@ -1,0 +1,75 @@
+/**
+ * Harness capability flags — the facts about an engine the runtime branches
+ * on, declared once per adapter and read nowhere else.
+ *
+ * The runtime is written against the flags, not against harness names: a
+ * phase that must differ per engine asks "does this harness accept a system
+ * prompt?" rather than "is this Cursor?". That is what keeps a new harness a
+ * registry row and an SDK slice instead of a new branch in every phase.
+ * Every row of the matrix below is either a flag here or internal to one
+ * adapter; nothing in it needed a third kind of thing.
+ *
+ * The matrix the contract was designed against (2026-09; Claude and Codex are
+ * the surveyed SDKs, not built harnesses):
+ *
+ * | Capability        | Native (LangGraph)          | Cursor (`@cursor/sdk`)                  | Claude (`@anthropic-ai/claude-agent-sdk`)     | Codex (`@openai/codex-sdk`)                    |
+ * |-------------------|-----------------------------|-----------------------------------------|-----------------------------------------------|------------------------------------------------|
+ * | `pausePrimitive`  | `interrupt` (checkpoint)    | `deny-and-retry` (hook, ledger, cancel) | `callback` (`canUseTool`, in-process)         | `none` (approvalPolicy only) → capture-only    |
+ * | `stateIdSource`   | `deterministic` (thread id) | `engine-minted` (agent id)              | either (caller-supplied or minted)            | `engine-minted` (thread id)                    |
+ * | `systemPrompt`    | yes                         | no (rides the first message)            | yes                                           | no (`AGENTS.md` or first message)              |
+ * | `subAgents`       | yes (compiled sub-graphs)   | yes (`agents` option)                   | yes (`AgentDefinition`)                       | no                                             |
+ * | `toolRestriction` | yes (tool list)             | no (the hook enforces)                  | yes (`disallowedTools`, `tools`)              | per-server config                              |
+ * | `visionProfile`   | PNG, JPEG, WebP, GIF        | PNG, JPEG (transport re-sniffs)         | (surveyed later)                              | (surveyed later)                               |
+ *
+ * Adapter-internal, deliberately NOT flags: how MCP servers are bound, how
+ * metering is routed, how the cost cap is applied inside the engine, how a
+ * run is cancelled. Those differ per engine but the runtime never needs to
+ * know.
+ *
+ * Two flags matter to the contract kit directly: `pausePrimitive` (the kit
+ * proves the two real primitives are indistinguishable above the contract
+ * line — both end a turn `awaiting_approval` and both take the decisions on
+ * reinvocation) and `stateIdSource` (an `engine-minted` adapter must bind its
+ * id before its first persist; a `deterministic` one must never bind).
+ */
+
+import type { VisionProfile } from "../shared/attachment-vision.js";
+
+/**
+ * How the engine can be made to stop before a gated side effect.
+ *
+ *  - `interrupt`: the engine checkpoints and stops at the gate (LangGraph
+ *    `interrupt`); the adapter resumes it with the decisions.
+ *  - `deny-and-retry`: an out-of-process hook denies the tool, the adapter
+ *    records the denial, cancels the run, and re-runs with grants on the next
+ *    invocation.
+ *  - `callback`: an in-process callback decides per tool; the runtime still
+ *    returns `awaiting_approval` and reinvokes, so the adapter answers the
+ *    callback with "deny, stop" and resumes with the decisions.
+ *  - `none`: the engine offers no gate; the runtime confines it to
+ *    capture-only work (a read-only sandbox) and gated actions never reach
+ *    the engine.
+ */
+export type PausePrimitive = "interrupt" | "deny-and-retry" | "callback" | "none";
+
+/**
+ * Who mints the engine's state id. `deterministic`: the runtime derives it
+ * from the session before the first turn (`EnsureThread`), so it is known
+ * before any engine exists. `engine-minted`: the engine issues it on first
+ * use and the adapter must hand it to the runtime at once
+ * (`TurnSink.bindHarnessState`) so a crash mid-turn still resumes.
+ */
+export type StateIdSource = "deterministic" | "engine-minted";
+
+export interface HarnessCapabilities {
+  readonly pausePrimitive: PausePrimitive;
+  readonly stateIdSource: StateIdSource;
+  /** The engine accepts a system prompt; otherwise instructions ride the first user message. */
+  readonly systemPrompt: boolean;
+  /** The engine runs delegated sub-agents from a definition map. */
+  readonly subAgents: boolean;
+  /** The engine can hide or deny tools by name; otherwise the gate enforces `enabledTools`. */
+  readonly toolRestriction: boolean;
+  /** Which image types the engine can display inline; the runtime degrades the rest before the turn. */
+  readonly visionProfile: VisionProfile;
+}

--- a/backend/services/runner/src/harness/registry.ts
+++ b/backend/services/runner/src/harness/registry.ts
@@ -1,0 +1,123 @@
+/**
+ * The harness registry — the lifecycle fan-out over the adapters a worker
+ * runs, and the byte-pinned binding from harness to Temporal activity name.
+ *
+ * Plain functions over an `adapters` argument, no module state and no DI
+ * (the composition roots are staged plain functions; a missing adapter is a
+ * compile error or a loud boot throw, never a silent no-op). ORDER IS
+ * LOAD-BEARING: `bootHarnesses` runs adapters in declaration order because
+ * the Cursor harness's interceptors must patch `node:http2` before anything
+ * dials the control plane, and `shutdownHarnesses` runs them in reverse so
+ * what was set up last is torn down first.
+ *
+ * Error posture, ruled at the entry's gate (Q-S1-10):
+ *  - Boot validates the whole table BEFORE booting anything (a duplicate name
+ *    is a configuration defect, and a half-booted worker is the worst state to
+ *    discover it in), then fails fast at the first adapter that rejects. A
+ *    worker that cannot boot a harness must not start.
+ *  - Shutdown and session release CONTINUE past a failing adapter and throw
+ *    one `AggregateError` at the end naming each failure, so one bad teardown
+ *    never leaks the others' resources.
+ *
+ * What is NOT here yet: `createHarnessActivities` (its body is the turn
+ * runtime, which does not exist until the extraction entry) and the table of
+ * real adapters (they exist once the Cursor and native harnesses implement
+ * the contract). Both land with the runtime; no empty table sits on `main`
+ * between the two.
+ *
+ * `HarnessName` lives here and not in `types.ts` on purpose: the wire
+ * vocabulary is the registry's concern. An adapter never declares the
+ * activity it is bound to (its `name` is a diagnostic identity); the registry
+ * row does.
+ */
+
+import type { Config } from "../config.js";
+import type { HarnessAdapter } from "./types.js";
+
+/** The harnesses the control plane can dispatch to, as the registry knows them. */
+export type HarnessName = "cursor" | "deep-agent";
+
+/**
+ * Byte-pinned Temporal activity names, one per harness. The server side of
+ * the pin is `stigmer-server/src/temporal/agentexecution/names.ts`
+ * (`EXECUTE_CURSOR_ACTIVITY_NAME`, `EXECUTE_DEEP_AGENT_ACTIVITY_NAME`); the
+ * two must stay byte-identical or the workflow schedules an activity no
+ * worker registers. Never "cleaned up".
+ */
+export const HARNESS_ACTIVITY_NAMES = {
+  cursor: "ExecuteCursor",
+  "deep-agent": "ExecuteDeepAgent",
+} as const satisfies Record<HarnessName, string>;
+
+export type HarnessActivityName = (typeof HARNESS_ACTIVITY_NAMES)[HarnessName];
+
+/**
+ * Refuse a table two of whose adapters share a name. Names are the registry's
+ * identity for diagnostics and for this check; a duplicate means two adapters
+ * would be indistinguishable in every log line and kit message.
+ */
+function assertUniqueNames(adapters: readonly HarnessAdapter[]): void {
+  const seen = new Set<string>();
+  for (const adapter of adapters) {
+    if (seen.has(adapter.name)) {
+      throw new Error(`harness registry: duplicate adapter name '${adapter.name}'; every adapter must have a unique name`);
+    }
+    seen.add(adapter.name);
+  }
+}
+
+/**
+ * Boot every adapter in declaration order, one at a time, awaiting each. The
+ * table is validated first; the first rejection stops the boot and propagates
+ * (adapters after it are never booted; adapters before it stay booted for the
+ * caller's shutdown path to release).
+ */
+export async function bootHarnesses(adapters: readonly HarnessAdapter[], config: Config): Promise<void> {
+  assertUniqueNames(adapters);
+  for (const adapter of adapters) {
+    await adapter.boot(config);
+  }
+}
+
+/**
+ * Shut every adapter down in reverse declaration order, continuing past
+ * failures. Rejects with one `AggregateError` carrying every failure once all
+ * adapters have been given their chance.
+ */
+export async function shutdownHarnesses(adapters: readonly HarnessAdapter[]): Promise<void> {
+  const failures: Error[] = [];
+  for (const adapter of [...adapters].reverse()) {
+    try {
+      await adapter.shutdown();
+    } catch (err) {
+      failures.push(describeFailure(adapter, "shutdown", err));
+    }
+  }
+  throwIfAny(failures, "harness registry: shutdown failed for one or more adapters");
+}
+
+/**
+ * Tell every adapter the session is done on this host, in declaration order,
+ * continuing past failures. An adapter that parks nothing per session
+ * resolves as a no-op; the registry does not know which do.
+ */
+export async function releaseHarnessSession(adapters: readonly HarnessAdapter[], sessionId: string): Promise<void> {
+  const failures: Error[] = [];
+  for (const adapter of adapters) {
+    try {
+      await adapter.releaseSession(sessionId);
+    } catch (err) {
+      failures.push(describeFailure(adapter, `releaseSession('${sessionId}')`, err));
+    }
+  }
+  throwIfAny(failures, `harness registry: releaseSession('${sessionId}') failed for one or more adapters`);
+}
+
+function describeFailure(adapter: HarnessAdapter, call: string, err: unknown): Error {
+  const cause = err instanceof Error ? err : new Error(String(err));
+  return new Error(`${adapter.name}: ${call} rejected: ${cause.message}`, { cause });
+}
+
+function throwIfAny(failures: readonly Error[], message: string): void {
+  if (failures.length > 0) throw new AggregateError(failures, `${message}: ${failures.map((f) => f.message).join("; ")}`);
+}

--- a/backend/services/runner/src/harness/types.ts
+++ b/backend/services/runner/src/harness/types.ts
@@ -1,0 +1,278 @@
+/**
+ * The harness adapter contract — the line between what the turn runtime owns
+ * and what a harness owns.
+ *
+ * Stigmer runs an agent turn through one of several engines ("harnesses"):
+ * the native LangGraph deep-agent, the Cursor SDK, and in future the Claude
+ * Agent SDK and the Codex SDK. Everything about a turn that does NOT touch a
+ * vendor SDK — fetching the execution, resolving the blueprint and the
+ * environment, provisioning and locking the workspace, mounting skills,
+ * resolving MCP servers and approval policies, seeding the transcript, the
+ * persist cadence, the stall watchdog, the Temporal heartbeat, pause vs
+ * shutdown, the cost cap, the file-review boundary, the terminal mapping —
+ * is the RUNTIME's, written once. What a harness owns is its SDK slice: how
+ * the engine is created or resumed, how the prompt is placed, how MCP servers
+ * are bound, how the engine is made to stop before a gated side effect, and
+ * how its events become transcript rows. This file is the whole of what a
+ * harness author has to implement; `__test-utils__/harness-contract/` is the
+ * kit every implementation has to pass.
+ *
+ * Every member here is a rename of a function the Cursor loop already injects
+ * (`execute-cursor/turn-stream.ts` `CursorTurnStreamDeps`) or a fact the
+ * runtime cannot read anywhere else. Nothing here is speculative: where the
+ * program's original sketch and the code disagreed, the code won, and the
+ * disagreement was ruled at the entry's gate
+ * (stigmer-cloud `_projects/2026-09/20260911.02.sp.harness-contract-and-kit/`).
+ *
+ * What is deliberately NOT on this contract, and why:
+ *
+ *  - No `dispose()`. One adapter object serves many concurrent turns
+ *    (`maxConcurrentActivities`), so a per-turn teardown method on the
+ *    adapter is a race. The adapter owns its per-turn teardown in its own
+ *    `finally` inside `runTurn` (the Cursor harness already parks its agent
+ *    there).
+ *  - No `isCancelled()`, no `heartbeat(details)`, no `ExecutionStatusWriter`
+ *    base. Each would be a second way of saying something `stopSignal`,
+ *    `recordActivity()` or `requestPersist()` already says, and two writers of
+ *    one fact drift (the native builders' `forceNextUpdate` flag is the same
+ *    fact as a `requestPersist()` call).
+ *  - No `reason` on `interrupted`, no payload on `completed`, no `retryable`
+ *    on `failed`. Every cause of stopping is the runtime's own evidence; the
+ *    final text and structured output are already folded onto the status;
+ *    Temporal never retries a returned activity, so a retryable flag would
+ *    have no reader.
+ *  - No token-rotation hook. `Config.stigmerTokenRef` is the canonical
+ *    mutable ref; an adapter's transport reads it per request.
+ *  - No `TurnInput.status`. The runtime seeds `TurnSink.status` from the
+ *    persisted transcript; a second copy on the input is the drift the
+ *    single-source-of-truth mandate forbids.
+ *
+ * Module shape follows `shared/checkpointer/`: `types.ts`, `capabilities.ts`,
+ * `registry.ts`, no barrel. Nothing production-facing imports this module
+ * until the runtime that consumes it lands (S2 of the program).
+ */
+
+import type { ApprovalAction } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/enum_pb";
+import type { AgentExecutionStatus } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+
+import type { Config } from "../config.js";
+import type { NormalizedActivityInput } from "../shared/activity-input.js";
+import type { HarnessCapabilities } from "./capabilities.js";
+
+/**
+ * One harness, as the runtime sees it. ONE adapter object exists per worker
+ * process; it serves every concurrent turn of its harness and holds no
+ * per-turn state (per-turn state lives in the `runTurn` frame). Three
+ * lifetimes meet here — worker (`boot`/`shutdown`), session
+ * (`releaseSession`) and turn (`runTurn`) — because the Cursor harness parks
+ * an engine per SESSION between turns, longer than a turn and shorter than
+ * the worker.
+ *
+ * `name` is a diagnostic identity (log lines, kit messages, the registry's
+ * duplicate check). It is NOT the activity the harness is bound to: the wire
+ * binding is the registry row's (`registry.ts` `HARNESS_ACTIVITY_NAMES`),
+ * so an adapter never declares a byte-pinned wire name and a test double can
+ * implement this interface under its own name.
+ */
+export interface HarnessAdapter {
+  readonly name: string;
+  readonly capabilities: HarnessCapabilities;
+
+  /**
+   * Worker lifetime, once per process, run by the registry in declaration
+   * order in BOTH composition roots (`runner.ts`, `runner-manager.ts`). Runs
+   * BEFORE bootstrap resolution — the Cursor interceptors must patch
+   * `node:http2` before the control plane is dialled — so `config` carries
+   * no Temporal coordinates yet. Vendor SDKs are imported lazily inside, so a
+   * harness that is not selected costs nothing at boot. A rejection here
+   * fails the worker's boot; a worker that cannot boot a harness must not
+   * start.
+   */
+  boot(config: Config): Promise<void>;
+
+  /**
+   * Worker lifetime, once per process, after the Temporal worker has drained.
+   * Releases everything the adapter still holds (the Cursor harness closes
+   * every parked agent). Must resolve even when nothing is held.
+   */
+  shutdown(): Promise<void>;
+
+  /**
+   * Session lifetime: the session is done on this host, release anything
+   * parked for it (the Cursor harness: the parked agent, its executor and the
+   * MCP subprocesses the lease pins, #215). Called by the registry from the
+   * manager's `removeSession`. A harness that parks nothing per session
+   * resolves as a no-op and says so in its header. Unknown session ids are a
+   * no-op, never an error: the runtime does not track which host parked what.
+   */
+  releaseSession(sessionId: string): Promise<void>;
+
+  /**
+   * Turn lifetime: run ONE engine turn against the resolved input, folding
+   * the engine's transcript rows into `sink.status` as they arrive, and
+   * settle with a {@link TurnOutcome}.
+   *
+   * The rules every implementation is held to (the kit's invariants):
+   *
+   *  - Resolves, never rejects. A vendor failure becomes
+   *    `{ kind: "failed", message }` with the user-facing sentence the
+   *    adapter's classifier produced. A `CancelledFailure` never escapes: the
+   *    runtime, not the adapter, decides what is a pause and what is a
+   *    shutdown, and it throws exactly where Temporal semantics require.
+   *  - Stops promptly when `sink.stopSignal` aborts, whatever the cause,
+   *    settling `interrupted`. Every call the adapter makes is bounded: the
+   *    runtime's heartbeat is live for the whole activity, and a live
+   *    heartbeat over an unbounded call keeps a dead activity alive forever.
+   *  - Proposes, never adjudicates. A gated side effect surfaces as a
+   *    WAITING_APPROVAL row on `sink.status` and the turn ends
+   *    `awaiting_approval`; the decision arrives on the next invocation in
+   *    `input.approvalDecisions`. APPROVE executes exactly once; REJECT and
+   *    SKIP never execute.
+   *  - Owns its own per-turn teardown in a `finally` inside this method.
+   */
+  runTurn(input: TurnInput, sink: TurnSink): Promise<TurnOutcome>;
+}
+
+/**
+ * What the runtime resolved for this turn and the adapter cannot read
+ * anywhere else. This is the core; the runtime extraction (S2) grows it one
+ * typed field per phase it takes over from the orchestrators (environment,
+ * workspace, skills, MCP servers with merged policies, attachments, memory,
+ * prompt bundle, model), in the `setup.ts` `SetupResult` mold.
+ *
+ * `threadId` is the engine's state id as the runtime knows it: empty on an
+ * `engine-minted` harness's first turn (nothing minted yet) and the id the
+ * adapter bound through {@link TurnSink.bindHarnessState} on every later
+ * invocation; the runtime-minted id on every turn of a `deterministic`
+ * harness. An adapter derives create-vs-resume from it and its own state; the
+ * contract carries no `isReinvocation` flag because the two harnesses would
+ * derive it differently.
+ */
+export interface TurnInput extends NormalizedActivityInput {
+  /**
+   * The session this turn belongs to. Read by the runtime from the fetched
+   * execution; the adapter needs it to key anything it parks per session and
+   * to recognise a later {@link HarnessAdapter.releaseSession}.
+   */
+  readonly sessionId: string;
+  /**
+   * The approval decisions the user has made on this execution's WAITING
+   * rows, keyed by tool-call id: the one projection both harness readers
+   * agree on (`status.messages[].toolCalls[]` where `approvalAction` is set
+   * and `status` is WAITING_APPROVAL). Derived by the runtime from
+   * `sink.status` on every invocation, never stored, so it cannot drift from
+   * the rows. An adapter reads the ROW for anything else it needs (args,
+   * content digest) and this map for the verdict; it never re-derives the
+   * verdict from the rows itself.
+   */
+  readonly approvalDecisions: ReadonlyMap<string, ApprovalAction>;
+}
+
+/**
+ * The runtime's face during one turn: the five things an adapter may ask of
+ * it, and the one status it folds into. One sink per turn, owned by the
+ * runtime; the adapter never constructs one.
+ *
+ * Field ownership on `status` before the canonical transcript lands (S4):
+ * the adapter appends the engine's transcript rows (assistant messages,
+ * tool-call rows and their approval status, sub-agent rows, todos); the
+ * runtime writes the phase, the terminal system messages, `streamingUsage`,
+ * artifacts, write-backs and the file-review projection. An adapter never
+ * writes a phase or a terminal copy: those are Temporal semantics the
+ * runtime owns once.
+ */
+export interface TurnSink {
+  /**
+   * The one execution status this turn folds into. On a reinvocation it is
+   * seeded by the runtime from the persisted transcript, so the WAITING rows
+   * the adapter wrote last time, and their decisions, are already on it.
+   */
+  readonly status: AgentExecutionStatus;
+
+  /**
+   * The ONE way a turn is told to stop, whatever the cause: user pause,
+   * worker shutdown, stall, cost cap, platform STOP. The runtime knows why
+   * and maps the outcome; the adapter's only job is to settle promptly as
+   * `interrupted`. `stopSignal.reason` is the runtime's own evidence — an
+   * adapter never branches on it. Check `aborted` at every step boundary and
+   * listen for `abort` inside anything long-running. May already be aborted
+   * when `runTurn` is entered; then return `interrupted` before doing any
+   * work.
+   */
+  readonly stopSignal: AbortSignal;
+
+  /**
+   * "Persist the status soon": schedules a write through the runtime's single
+   * persist chokepoint (tool-output offload, size cap, secret withholding,
+   * the streaming scheduler). Fire and forget — never awaited by the adapter,
+   * never a promise. The runtime persists unconditionally when the turn
+   * settles, so no adapter has to flush before returning.
+   */
+  requestPersist(): void;
+
+  /**
+   * "I made progress": resets the runtime's stall watchdog and is carried
+   * into the next Temporal heartbeat. Call it on every engine event and every
+   * token delta — a long generation emits deltas but few discrete events, and
+   * resetting only on events false-positives a stall. Never throws.
+   */
+  recordActivity(): void;
+
+  /**
+   * Token counts for one engine turn. The runtime accumulates, prices and
+   * enforces `max_cost_usd`; an adapter reports and never accounts. Every
+   * count is a non-negative delta since the previous report.
+   */
+  reportUsage(delta: UsageDelta): void;
+
+  /**
+   * The engine-minted state id, the moment it exists and BEFORE the turn
+   * proceeds, so a crash mid-turn still resumes on the next invocation. The
+   * runtime writes it to the session at once (the Cursor harness's
+   * `harness_state_id`). Called only by adapters whose
+   * `capabilities.stateIdSource` is `"engine-minted"`, and before their first
+   * `requestPersist`; a `deterministic` harness never calls it. Rejects when
+   * the session write fails; the adapter then ends the turn `failed` with
+   * that error and executes nothing further.
+   */
+  bindHarnessState(harnessStateId: string): Promise<void>;
+}
+
+/**
+ * Token counts for one engine turn, as the Cursor loop reads them from the
+ * SDK's `turn-ended` delta (`execute-cursor/usage-accumulator.ts`
+ * `TurnUsage` is this shape; the runtime extraction collapses the two). Every
+ * field is optional because engines report different subsets; a missing
+ * field means zero, never "unknown".
+ */
+export interface UsageDelta {
+  readonly inputTokens?: number;
+  readonly outputTokens?: number;
+  readonly cacheReadTokens?: number;
+  readonly cacheWriteTokens?: number;
+}
+
+/**
+ * How one turn ended, carrying ONLY what the runtime cannot read from
+ * `sink.status` or its own evidence.
+ *
+ *  - `completed`: the engine finished. The final text and any structured
+ *    output are already folded onto the status; nothing rides here.
+ *  - `awaiting_approval`: the engine proposed at least one gated side effect
+ *    and stopped. The WAITING_APPROVAL rows are already on the status; the
+ *    runtime persists them and returns to the workflow, which reinvokes with
+ *    the decisions.
+ *  - `failed`: the engine or its transport failed in a way the adapter can
+ *    name. `message` is the user-facing sentence; `cause` is for the log.
+ *    The runtime persists FAILED and RETURNS (Temporal does not retry a
+ *    returned activity; re-running the same prompt would fail the same way).
+ *  - `interrupted`: `sink.stopSignal` aborted and the adapter stopped. WHY it
+ *    aborted is the runtime's evidence (its watchdog, its accounting, its
+ *    heartbeat, its shutdown signal), so no reason rides here; the runtime
+ *    classifies and applies the throw-vs-return table.
+ */
+export type TurnOutcome =
+  | { readonly kind: "completed" }
+  | { readonly kind: "awaiting_approval" }
+  | { readonly kind: "failed"; readonly message: string; readonly cause?: unknown }
+  | { readonly kind: "interrupted" };


### PR DESCRIPTION
## Summary
The line between the turn runtime and a harness, as code: one small `HarnessAdapter` contract under `src/harness/`, a scripted reference adapter that implements it, an adapter-side contract kit every implementation must pass (with a self-check proving each invariant can fail), and the registry's lifecycle fan-out with the byte-pinned activity names. Nothing production-facing changes and nothing production-facing imports `src/harness/` yet.

## Context
S1 of the harness runtime program (stigmer-cloud `_projects/2026-09/20260908.02.harness-runtime-and-adapter-contract`, entry `20260911.02.sp.harness-contract-and-kit`). Adding a third harness today would mean a third copy of ~2,000 lines of turn lifecycle. Before S2 pulls that lifecycle out of `ExecuteCursor` into one runtime, the contract the runtime consumes has to exist, be implemented by a fake, and be pinned by a kit. Every member of the contract is a rename of a function the Cursor loop already injects (`turn-stream.ts` `CursorTurnStreamDeps`) or a fact the runtime cannot read elsewhere; the design was ruled at the entry's gate (13 questions, 3 refinements) against the code rather than the original sketch.

## Changes
- **`src/harness/types.ts`** — `HarnessAdapter { name; capabilities; boot; shutdown; releaseSession; runTurn }`, `TurnInput` (`executionId`, `threadId`, `turnSeq`, `sessionId`, `approvalDecisions: ReadonlyMap<string, ApprovalAction>`), `TurnSink` (`status`, `stopSignal`, `requestPersist`, `recordActivity`, `reportUsage`, `bindHarnessState`), `TurnOutcome` (`completed | awaiting_approval | failed | interrupted`), `UsageDelta`. Headers state each member's why, the deliberate omissions (no `dispose`, no `isCancelled`, no `heartbeat(details)`, no `reason`/`retryable`), and the field-ownership split on `status` before S4.
- **`src/harness/capabilities.ts`** — `HarnessCapabilities` with the four-harness matrix as its header; `PausePrimitive` and `StateIdSource` named.
- **`src/harness/registry.ts`** — `HarnessName`, `HARNESS_ACTIVITY_NAMES` (pinned to the server's `names.ts`), `bootHarnesses` (validate, declaration order, fail fast), `shutdownHarnesses` (reverse, continue, one `AggregateError`), `releaseHarnessSession` (continue, aggregate). `createHarnessActivities` and the real adapter table land with the runtime.
- **`src/__test-utils__/harness-contract/`** — `types.ts` (the kit's subject seam and a five-step scenario vocabulary, reusing `approval-contract`'s `ProposedAction`), `scripted-adapter.ts` (the reference fake, driven by scenarios, 204 code lines), `recording-sink.ts` (owns the `AbortController`, one ordered log), `contract.ts` (the runtime stand-in `ExecutionDriver` and the eight invariants as plain assertion functions wrapped by `it`).
- **`src/__test-utils__/config-fixture.ts`** — `testConfig(overrides)`, one inert `Config` for tests (existing inline literals untouched).
- **`src/__test-utils__/proto-helpers.ts`** — `waitingToolCall`, `findToolCallRow`.
- **Tests** — `src/__tests__/harness-contract.test.ts` (the kit against the fake under `interrupt`+engine-minted and `deny-and-retry`+deterministic), `src/__test-utils__/__tests__/harness-contract-self-check.test.ts` (eight broken adapters, each failing one invariant by name), `src/harness/__tests__/registry.test.ts`.

## Implementation notes
- **The kit is the runtime AND the server stand-in.** `ExecutionDriver` builds every `TurnInput`, threads the engine-minted id back as `threadId` (empty on the first turn), holds a deterministic id fixed, advances `turnSeq`, seeds a reinvocation with a `clone()` of the persisted status, writes a decision onto the WAITING row's `approvalAction` the way `SubmitApproval` does, and derives `approvalDecisions` from the rows on the next invocation. One source, derived on read; the kit cannot hand an adapter a decision that is not on a row.
- **The fake treats the status as the single source of truth** for "did the effect run": a row already COMPLETED or SKIPPED is settled, so "reinvoked again after the approval, still once" holds without a second ledger. It checks `stopSignal.aborted` at every step boundary and parks a hang on the abort event, never a timer.
- **Above the contract line the two pause primitives are indistinguishable** — both end `awaiting_approval`, both take the decisions on reinvocation. Neither the kit nor the fake branches on `pausePrimitive`; running both proves it.
- **`name: string`, not the closed `HarnessName`.** The adapter's name is a diagnostic identity; the wire binding is the registry row's. A test double can implement the contract under its own name without lying.
- **Invariants:** 1 every exit is a `TurnOutcome` (no `CancelledFailure` escapes); 2 a proposal is a WAITING row and never executes in its turn; 3 APPROVE once, REJECT/SKIP never, a settled row never re-gated; 4 `stopSignal` settles `interrupted` within a bound and nothing after it runs, a pre-aborted signal does no work; 5 usage as non-negative deltas that sum; 6 capability and behaviour agree on the state id (bind before first persist, resume by the bound id, a rejected bind ends `failed`); 7 the three lifetimes resolve; 8 concurrent turns on one adapter object are independent.

## Breaking changes
- None. No file under `activities/` or `shared/`, no composition root, no proto, activity name, env var, config, or dependency changes.

## Test plan
- `cd backend/services/runner && npm run typecheck` — green.
- `npx vitest run src/__tests__/harness-contract.test.ts src/__test-utils__/__tests__/harness-contract-self-check.test.ts src/harness` — 35 tests green (16 kit, 8 self-check, 11 registry).
- Self-check evidence: each of the eight invariants rejects a deliberately broken adapter with a message naming the subject and the violation (throws `CancelledFailure`; executes undecided proposals; re-gates a settled row; ignores `stopSignal`; reports cumulative usage; claims engine-minted and never binds; refuses an unknown release; serialises turns through shared state).
- `CI=1 npm test` on the final tree: 286 files passed, 4 skipped; 4,778 tests passed, 7 skipped; 0 failures. One unhandled `[vitest-worker]: Timeout calling "onTaskUpdate"` — the reporter-RPC timeout `vitest.config.ts` documents as spurious under subprocess load; S0 (#1048) recorded the identical single error on the suite without its tests. Delta against S0's count is exactly this PR's 3 files / 35 tests.
- `rg "from \"\.\./harness|from \"\./harness|from \"\.\./\.\./harness" src --glob '!**/__tests__/**' --glob '!**/__test-utils__/**'` returns nothing: no production module imports `src/harness/`.
- Measured: the fake is 289 lines with headers, 204 code lines — the program's second "lines a new harness must write" data point.

## Risks
- None at runtime: every file is new and unreferenced by production code; the build (`tsconfig.build.json`) excludes `__test-utils__` and tests, so `@stigmer/runner` ships `src/harness/{types,capabilities,registry}.js` and nothing else from this PR. Rollback is deleting the files.

## Checklist
- [x] Tests added (kit, self-check, registry)
- [x] Backward compatible
- [ ] Docs — none needed; the adapter guide is S5 of the program

Made with [Cursor](https://cursor.com)