### PR TITLE
fix(stigmer-server): add the run gate — AuthorizeRunTarget in the three create chains

### DIFF
--- a/backend/services/stigmer-server/docs/authorization-coverage.md
+++ b/backend/services/stigmer-server/docs/authorization-coverage.md
@@ -129,7 +129,7 @@ All six RPCs are chains, and the proto deliberately marks every one `is_skip_aut
 | Method | Annotation | Handler |
 |---|---|---|
 | SessionCommandController.apply | none | chain-with-Authorize |
-| SessionCommandController.create | config: can_create_session on organization (field metadata.org), error_msg yes | chain-with-Authorize |
+| SessionCommandController.create | config: can_create_session on organization (field metadata.org), error_msg yes | chain-with-Authorize (plus the AuthorizeRunTarget mid-chain can_execute on the agent_instance the session binds to — the caller's or the resolved default — right after ResolveDefaultAgentInstance; P1 sp.run-gate, stigmer-cloud#709. `apply` routes here on the create arm.) |
 | SessionCommandController.update | config: can_edit on session (field metadata.id), error_msg yes | chain-with-Authorize |
 | SessionCommandController.updateSubject | config: can_edit on session (field id), error_msg yes | direct: field-level read-modify-write (ports Go update_subject.go); authorizeDirect AFTER the load — the Java load-before-authorize order (#224) |
 | SessionCommandController.delete | config: can_delete on session (field value), error_msg yes | chain-with-Authorize |
@@ -239,7 +239,7 @@ The conversation surface is a cloud capability; OSS serves edition stubs, all di
 
 | Method | Annotation | Handler |
 |---|---|---|
-| AgentExecutionCommandController.create | is_skip_authorization | chain-with-Authorize |
+| AgentExecutionCommandController.create | is_skip_authorization | chain-with-Authorize (the AuthorizeRunTarget mid-chain check by request shape, right after EnsureSessionOrAgentResolved: can_create_execution_in on the session (session_id), can_execute on the agent_instance (session_spec.agent_instance_id) or on the agent (agent_id) — the annotation cannot express the three-shape dispatch; P1 sp.run-gate, stigmer-cloud#709) |
 | AgentExecutionCommandController.update | config: can_edit on agent_execution (field metadata.id), error_msg yes | chain-with-Authorize |
 | AgentExecutionCommandController.updateStatus | config: can_edit on agent_execution (field execution_id), error_msg yes | chain-with-Authorize (update-status.ts) |
 | AgentExecutionCommandController.submitApproval | config: can_edit on agent_execution (field agent_execution_id), error_msg yes | chain-with-Authorize (submit-approval.ts) |
@@ -297,7 +297,7 @@ The conversation surface is a cloud capability; OSS serves edition stubs, all di
 
 | Method | Annotation | Handler |
 |---|---|---|
-| WorkflowExecutionCommandController.create | is_skip_authorization | chain-with-Authorize |
+| WorkflowExecutionCommandController.create | is_skip_authorization | chain-with-Authorize (the AuthorizeRunTarget mid-chain check by request shape, right after ValidateWorkflowOrInstance: can_execute on the workflow_instance (workflow_instance_id) or on the workflow (workflow_id); P1 sp.run-gate, stigmer-cloud#709) |
 | WorkflowExecutionCommandController.update | config: can_edit on workflow_execution (field metadata.id), error_msg yes | chain-with-Authorize |
 | WorkflowExecutionCommandController.updateStatus | config: can_edit on workflow_execution (field execution_id), error_msg yes | chain-with-Authorize (update-status.ts) |
 | WorkflowExecutionCommandController.submitApproval | config: can_edit on workflow_execution (field execution_id), error_msg yes | chain-with-Authorize (submit-approval.ts) |

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/run-gate.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/run-gate.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Pins the run gate's SPLICE in agent-execution-create over the real router
+ * (P1 sp.run-gate): AuthorizeRunTarget sits after EnsureSessionOrAgentResolved
+ * and BEFORE EnsureEngineAvailable, the pre-side-effect slot and
+ * CreateDefaultInstanceIfNeeded. Pinned here: (1) each request shape is
+ * checked against its own target with its own byte-pinned copy; (2) a
+ * denial leaves no execution row AND creates no default instance — the
+ * "no side effect precedes the check" property; (3) the gate precedes the
+ * engine gate: an ALLOWED create on this engineless server answers the
+ * engine's UNAVAILABLE, a DENIED one PERMISSION_DENIED. The authorizer
+ * under test answers only run-gate checks (runGateOnlyAuthorizer), so every
+ * refusal here is the run gate's and nobody else's.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Client, Transport } from "@connectrpc/connect";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/command_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import type { AuthzDecision } from "../../../extensions/authorizer.js";
+import { runGateOnlyAuthorizer } from "../../../pipeline/__tests__/support.js";
+import {
+  ENGINE_UNAVAILABLE_MESSAGE,
+  addExecutionToSessionDeniedMessage,
+  runAgentDeniedMessage,
+  runAgentInstanceDeniedMessage,
+} from "../constants.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const ORG = "acme";
+
+let dir: string;
+let server: ComposedServer;
+let decision: AuthzDecision = { kind: "allow" };
+const gate = runGateOnlyAuthorizer(() => decision);
+let agentCommand: Client<typeof AgentCommandController>;
+let command: Client<typeof AgentExecutionCommandController>;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "agentexecution-run-gate-test-"));
+  server = await composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      TEMPORAL_HOST_PORT: "127.0.0.1:1",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      STORAGE_PATH: path.join(dir, "storage"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+    extensions: [{ name: "run-gate-test", authorizer: gate.authorizer }],
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  agentCommand = createClient(AgentCommandController, transport);
+  command = createClient(AgentExecutionCommandController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function count(kind: ApiResourceKind): Promise<number> {
+  return (await server.store.listResources(kind)).length;
+}
+
+/**
+ * An agent whose stored status names NO default instance, so a create by
+ * agent_id would have CreateDefaultInstanceIfNeeded mint one — the side
+ * effect the gate must precede.
+ */
+async function createAgentWithoutDefaultInstance(
+  name: string,
+): Promise<string> {
+  const agent = await agentCommand.create({
+    apiVersion: API_VERSION,
+    kind: "Agent",
+    metadata: { name, org: ORG },
+    spec: { instructions: "You are the agent the run-gate tests target." },
+  });
+  const id = agent.metadata!.id;
+  const stored = await server.store.getResource(
+    ApiResourceKind.agent,
+    id,
+    AgentSchema,
+  );
+  if (stored.status !== undefined) {
+    stored.status.defaultInstanceId = "";
+  }
+  await server.store.saveResource(
+    ApiResourceKind.agent,
+    id,
+    AgentSchema,
+    stored,
+  );
+  return id;
+}
+
+async function captureError(
+  run: () => Promise<unknown>,
+): Promise<ConnectError> {
+  try {
+    await run();
+  } catch (error) {
+    return ConnectError.from(error);
+  }
+  throw new Error("expected the create to reject");
+}
+
+function createInput(spec: {
+  agentId?: string;
+  sessionId?: string;
+  sessionSpec?: { agentInstanceId: string };
+}) {
+  return {
+    apiVersion: API_VERSION,
+    kind: "AgentExecution",
+    metadata: { name: "run-gate-exec", org: ORG },
+    spec: { message: "hello", ...spec },
+  };
+}
+
+describe("agent-execution-create run gate (composed server)", () => {
+  it("agent_id: denies with the agent copy, persists nothing, mints no default instance", async () => {
+    decision = { kind: "deny", reason: "" };
+    gate.runGateChecks.length = 0;
+    const agentId = await createAgentWithoutDefaultInstance("Private agent");
+    const executionsBefore = await count(ApiResourceKind.agent_execution);
+    const instancesBefore = await count(ApiResourceKind.agent_instance);
+
+    const err = await captureError(() =>
+      command.create(createInput({ agentId })),
+    );
+
+    expect(err.code).toBe(Code.PermissionDenied);
+    expect(err.rawMessage).toBe(runAgentDeniedMessage(agentId));
+    expect(gate.runGateChecks).toEqual([
+      {
+        permission: IamPermission.can_execute,
+        resourceKind: ApiResourceKind.agent,
+        resourceId: agentId,
+      },
+    ]);
+    expect(
+      await count(ApiResourceKind.agent_execution),
+      "no execution row",
+    ).toBe(executionsBefore);
+    expect(
+      await count(ApiResourceKind.agent_instance),
+      "no default instance minted",
+    ).toBe(instancesBefore);
+    const stored = await server.store.getResource(
+      ApiResourceKind.agent,
+      agentId,
+      AgentSchema,
+    );
+    expect(stored.status?.defaultInstanceId ?? "").toBe("");
+  });
+
+  it("session_id: denies with the session copy on session#can_create_execution_in", async () => {
+    decision = { kind: "deny", reason: "" };
+    gate.runGateChecks.length = 0;
+
+    const err = await captureError(() =>
+      command.create(createInput({ sessionId: "ses_01someoneelses" })),
+    );
+
+    expect(err.code).toBe(Code.PermissionDenied);
+    expect(err.rawMessage).toBe(
+      addExecutionToSessionDeniedMessage("ses_01someoneelses"),
+    );
+    expect(gate.runGateChecks).toEqual([
+      {
+        permission: IamPermission.can_create_execution_in,
+        resourceKind: ApiResourceKind.session,
+        resourceId: "ses_01someoneelses",
+      },
+    ]);
+  });
+
+  it("session_spec.agent_instance_id: denies with the instance copy", async () => {
+    decision = { kind: "deny", reason: "" };
+    gate.runGateChecks.length = 0;
+
+    const err = await captureError(() =>
+      command.create(
+        createInput({ sessionSpec: { agentInstanceId: "agi_01private" } }),
+      ),
+    );
+
+    expect(err.code).toBe(Code.PermissionDenied);
+    expect(err.rawMessage).toBe(runAgentInstanceDeniedMessage("agi_01private"));
+    expect(gate.runGateChecks[0]?.resourceKind).toBe(
+      ApiResourceKind.agent_instance,
+    );
+  });
+
+  it("not-found answers NOT_FOUND naming the target (the stigmer#224 order)", async () => {
+    decision = { kind: "not-found" };
+    const err = await captureError(() =>
+      command.create(createInput({ agentId: "agt_01missing" })),
+    );
+    expect(err.code).toBe(Code.NotFound);
+    expect(err.rawMessage).toContain("agt_01missing");
+  });
+
+  it("the gate precedes the engine gate: an ALLOWED create reaches EnsureEngineAvailable", async () => {
+    decision = { kind: "allow" };
+    gate.runGateChecks.length = 0;
+    const agentId = await createAgentWithoutDefaultInstance("Allowed agent");
+
+    const err = await captureError(() =>
+      command.create(createInput({ agentId })),
+    );
+
+    // The engineless composed server refuses at EnsureEngineAvailable —
+    // AFTER the run gate ran and allowed.
+    expect(err.code).toBe(Code.Unavailable);
+    expect(err.rawMessage).toBe(ENGINE_UNAVAILABLE_MESSAGE);
+    expect(gate.runGateChecks.map((c) => c.resourceId)).toEqual([agentId]);
+  });
+});

--- a/backend/services/stigmer-server/src/domain/agentexecution/__tests__/run-target.test.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/__tests__/run-target.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Pins the agent-execution run-target resolver (P1 sp.run-gate, ruling
+ * Q-RG-2): the target is dispatched on the request shape in the CHAIN's
+ * own precedence — session_id, then session_spec.agent_instance_id, then
+ * agent_id (CreateDefaultInstanceIfNeeded / CreateSessionIfNeeded read
+ * them in exactly that order) — so the gate authorizes the target the
+ * chain will actually use. Each shape carries its own permission and its
+ * own byte-pinned deny copy; a record with none of the three has no
+ * target (EnsureSessionOrAgentResolved owns that arm as an invariant).
+ */
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import { AgentExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import {
+  addExecutionToSessionDeniedMessage,
+  runAgentDeniedMessage,
+  runAgentInstanceDeniedMessage,
+} from "../constants.js";
+import { agentExecutionRunTarget } from "../run-target.js";
+
+describe("agentExecutionRunTarget", () => {
+  it("session_id → session#can_create_execution_in", () => {
+    expect(
+      agentExecutionRunTarget(
+        create(AgentExecutionSchema, { spec: { sessionId: "ses_01abc" } }),
+      ),
+    ).toEqual({
+      permission: IamPermission.can_create_execution_in,
+      resourceKind: ApiResourceKind.session,
+      resourceId: "ses_01abc",
+      deniedMessage: addExecutionToSessionDeniedMessage("ses_01abc"),
+    });
+    expect(addExecutionToSessionDeniedMessage("ses_01abc")).toBe(
+      "unauthorized to add an execution to session 'ses_01abc'",
+    );
+  });
+
+  it("session_spec.agent_instance_id → agent_instance#can_execute", () => {
+    expect(
+      agentExecutionRunTarget(
+        create(AgentExecutionSchema, {
+          spec: { sessionSpec: { agentInstanceId: "agi_01abc" } },
+        }),
+      ),
+    ).toEqual({
+      permission: IamPermission.can_execute,
+      resourceKind: ApiResourceKind.agent_instance,
+      resourceId: "agi_01abc",
+      deniedMessage: runAgentInstanceDeniedMessage("agi_01abc"),
+    });
+    expect(runAgentInstanceDeniedMessage("agi_01abc")).toBe(
+      "unauthorized to run agent instance 'agi_01abc'",
+    );
+  });
+
+  it("agent_id → agent#can_execute", () => {
+    expect(
+      agentExecutionRunTarget(
+        create(AgentExecutionSchema, { spec: { agentId: "agt_01abc" } }),
+      ),
+    ).toEqual({
+      permission: IamPermission.can_execute,
+      resourceKind: ApiResourceKind.agent,
+      resourceId: "agt_01abc",
+      deniedMessage: runAgentDeniedMessage("agt_01abc"),
+    });
+    expect(runAgentDeniedMessage("agt_01abc")).toBe(
+      "unauthorized to run agent 'agt_01abc'",
+    );
+  });
+
+  it("precedence is the chain's: session_id wins over both, the instance over agent_id", () => {
+    const all = agentExecutionRunTarget(
+      create(AgentExecutionSchema, {
+        spec: {
+          sessionId: "ses_01abc",
+          agentId: "agt_01abc",
+          sessionSpec: { agentInstanceId: "agi_01abc" },
+        },
+      }),
+    );
+    expect(all?.resourceKind).toBe(ApiResourceKind.session);
+    expect(all?.resourceId).toBe("ses_01abc");
+
+    const instanceAndAgent = agentExecutionRunTarget(
+      create(AgentExecutionSchema, {
+        spec: {
+          agentId: "agt_01abc",
+          sessionSpec: { agentInstanceId: "agi_01abc" },
+        },
+      }),
+    );
+    expect(instanceAndAgent?.resourceKind).toBe(ApiResourceKind.agent_instance);
+    expect(instanceAndAgent?.resourceId).toBe("agi_01abc");
+  });
+
+  it("answers no target when none of the three references is set", () => {
+    expect(
+      agentExecutionRunTarget(create(AgentExecutionSchema, {})),
+    ).toBeUndefined();
+    expect(
+      agentExecutionRunTarget(
+        create(AgentExecutionSchema, {
+          spec: {
+            sessionId: "",
+            agentId: "",
+            sessionSpec: { agentInstanceId: "" },
+          },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/backend/services/stigmer-server/src/domain/agentexecution/constants.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/constants.ts
@@ -28,3 +28,28 @@ export function executionUsageReportNotFoundMessage(
 ): string {
   return `agent execution '%s' not found not found: ${executionId}`;
 }
+
+/**
+ * The run gate's deny copy per request shape (P1 sp.run-gate, ruling
+ * Q-RG-4; wire once merged, asserted by the conformance run-gate suite).
+ * NEW copy quotes the handle single-quoted (the ratified 2026-08-26 rule).
+ * An AgentExecution is a RUN in the ubiquitous language, hence "run";
+ * a turn added to an existing conversation is "an execution in a session",
+ * the session's own permission.
+ */
+export function runAgentDeniedMessage(agentId: string): string {
+  return `unauthorized to run agent '${agentId}'`;
+}
+
+/**
+ * Identical to the session domain's instance copy on purpose — one fact,
+ * one sentence (the ENGINE_UNAVAILABLE_MESSAGE precedent for cross-domain
+ * twins: each domain owns its constant, the twin is named here).
+ */
+export function runAgentInstanceDeniedMessage(agentInstanceId: string): string {
+  return `unauthorized to run agent instance '${agentInstanceId}'`;
+}
+
+export function addExecutionToSessionDeniedMessage(sessionId: string): string {
+  return `unauthorized to add an execution to session '${sessionId}'`;
+}

--- a/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/controller.ts
@@ -44,6 +44,7 @@ import { newPipeline } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newAuthorizeRunTargetStep } from "../../pipeline/steps/authorize-run-target.js";
 import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import type { RunnerCredentialProvider } from "../../runnerauth/runner-credential-provider.js";
 import { newRecordRunnerLineageLabelsStep } from "./record-runner-lineage-labels.js";
@@ -113,6 +114,7 @@ import {
   resumeExecution,
   terminateExecution,
 } from "./lifecycle.js";
+import { agentExecutionRunTarget } from "./run-target.js";
 import { agentExecutionSearchExtractor } from "./search-extractor.js";
 import type { StreamBroker } from "./stream-broker.js";
 import { submitApproval } from "./submit-approval.js";
@@ -278,9 +280,13 @@ export function registerAgentExecutionServices(
 /**
  * Create — create.go buildCreatePipeline, step-for-step: validation
  * (proto → visibility → tier #357 → thinking #772) → target resolution
- * (default agent → invariant guard) → the standard build → the engine
- * gate (fail fast BEFORE the first side effect, so a down engine orphans
- * nothing) → the pre-side-effect gate slot (O4; empty in OSS) → the
+ * (default agent → invariant guard) → the run gate (AuthorizeRunTarget,
+ * P1 sp.run-gate: the first step after the target is guaranteed, asking
+ * the target's own permission by request shape — session, instance or
+ * blueprint — before the engine gate so a denied caller learns nothing
+ * about engine state, and before every side effect) → the standard build
+ * → the engine gate (fail fast BEFORE the first side effect, so a down
+ * engine orphans nothing) → the pre-side-effect gate slot (O4; empty in OSS) → the
  * side-effecting steps (default instance, session bootstrap,
  * preference/memory snapshots, initial phase, the ExecutionContext with
  * merged env, attachment validation) → Persist → IndexSearch →
@@ -314,6 +320,7 @@ async function createExecution(
     .addStep(newValidateThinkingModeStep(deps.modelRegistry))
     .addStep(newResolveDefaultAgentStep(deps.store, deps.logger))
     .addStep(newEnsureSessionOrAgentResolvedStep(deps.logger))
+    .addStep(newAuthorizeRunTargetStep(deps.authorizer, agentExecutionRunTarget))
     .addStep(newResolveSlugStep())
     .addStep(newBuildNewStateStep())
     // Vouches the runner-stamped workflow lineage labels (or refuses a

--- a/backend/services/stigmer-server/src/domain/agentexecution/run-target.ts
+++ b/backend/services/stigmer-server/src/domain/agentexecution/run-target.ts
@@ -1,0 +1,64 @@
+/**
+ * The agent-execution run-target resolver (P1 sp.run-gate, ruling Q-RG-2):
+ * an execution names its run target in one of three shapes, and the gate
+ * dispatches on them in the CHAIN's own precedence so it authorizes the
+ * target the chain will actually use (CreateDefaultInstanceIfNeeded and
+ * CreateSessionIfNeeded read them in exactly this order):
+ *
+ *   1. spec.session_id — a turn added to an existing conversation: the
+ *      session's own permission, session#can_create_execution_in;
+ *   2. spec.session_spec.agent_instance_id — a new conversation on an
+ *      explicit instance: agent_instance#can_execute;
+ *   3. spec.agent_id — a new conversation on the blueprint's default
+ *      instance, which the chain resolves (or mints) only AFTER the gate:
+ *      agent#can_execute, the blueprint's permission (the model derives
+ *      the default instance's viewers from the blueprint's, so the two
+ *      questions have one answer; asking the blueprint's is what lets the
+ *      gate precede the side effect).
+ *
+ * None of the three set is EnsureSessionOrAgentResolved's invariant arm
+ * (ResolveDefaultAgent guarantees one), never a check. Pure over the record
+ * being built, where ResolveDefaultAgent writes the resolved agent_id.
+ */
+import type { AgentExecution } from "@stigmer/protos/ai/stigmer/agentic/agentexecution/v1/api_pb";
+
+import {
+  RUN_GATE_CHECKS,
+  type RunTarget,
+} from "../../pipeline/steps/authorize-run-target.js";
+import {
+  addExecutionToSessionDeniedMessage,
+  runAgentDeniedMessage,
+  runAgentInstanceDeniedMessage,
+} from "./constants.js";
+
+export function agentExecutionRunTarget(
+  execution: AgentExecution,
+): RunTarget | undefined {
+  const spec = execution.spec;
+  const sessionId = spec?.sessionId ?? "";
+  if (sessionId !== "") {
+    return {
+      ...RUN_GATE_CHECKS.session,
+      resourceId: sessionId,
+      deniedMessage: addExecutionToSessionDeniedMessage(sessionId),
+    };
+  }
+  const agentInstanceId = spec?.sessionSpec?.agentInstanceId ?? "";
+  if (agentInstanceId !== "") {
+    return {
+      ...RUN_GATE_CHECKS.agentInstance,
+      resourceId: agentInstanceId,
+      deniedMessage: runAgentInstanceDeniedMessage(agentInstanceId),
+    };
+  }
+  const agentId = spec?.agentId ?? "";
+  if (agentId !== "") {
+    return {
+      ...RUN_GATE_CHECKS.agent,
+      resourceId: agentId,
+      deniedMessage: runAgentDeniedMessage(agentId),
+    };
+  }
+  return undefined;
+}

--- a/backend/services/stigmer-server/src/domain/session/__tests__/run-gate.test.ts
+++ b/backend/services/stigmer-server/src/domain/session/__tests__/run-gate.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Pins the run gate's SPLICE in session-create over the real router (P1
+ * sp.run-gate): the AuthorizeRunTarget step sits after
+ * ResolveDefaultAgentInstance and before Persist, so (1) a denied caller
+ * answers PERMISSION_DENIED with the domain's byte-pinned copy and leaves
+ * no session row; (2) the check names the instance the CHAIN resolved,
+ * not only the one the caller typed — the session-first shape (empty
+ * spec) is checked against the platform default agent's default instance;
+ * (3) an allowed caller creates the session exactly as before. The
+ * authorizer under test answers only run-gate checks (runGateOnlyAuthorizer),
+ * so every refusal here is the run gate's and nobody else's.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { Client, Transport } from "@connectrpc/connect";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+
+import { AgentCommandController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/command_pb";
+import { AgentSchema } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/api_pb";
+import { AgentQueryController } from "@stigmer/protos/ai/stigmer/agentic/agent/v1/query_pb";
+import { SessionCommandController } from "@stigmer/protos/ai/stigmer/agentic/session/v1/command_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import type { AuthzDecision } from "../../../extensions/authorizer.js";
+import { runGateOnlyAuthorizer } from "../../../pipeline/__tests__/support.js";
+import {
+  DEFAULT_AGENT_LABEL,
+  DEFAULT_AGENT_LABEL_VALUE,
+} from "../../agent/defaultagent.js";
+import { runAgentInstanceDeniedMessage } from "../constants.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const ORG = "acme";
+
+let dir: string;
+let server: ComposedServer;
+let decision: AuthzDecision = { kind: "allow" };
+const gate = runGateOnlyAuthorizer(() => decision);
+let agentCommand: Client<typeof AgentCommandController>;
+let agentQuery: Client<typeof AgentQueryController>;
+let sessionCommand: Client<typeof SessionCommandController>;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "session-run-gate-test-"));
+  server = await composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      TEMPORAL_HOST_PORT: "127.0.0.1:1",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      STORAGE_PATH: path.join(dir, "storage"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+    extensions: [{ name: "run-gate-test", authorizer: gate.authorizer }],
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  agentCommand = createClient(AgentCommandController, transport);
+  agentQuery = createClient(AgentQueryController, transport);
+  sessionCommand = createClient(SessionCommandController, transport);
+});
+
+afterAll(async () => {
+  await server.shutdown();
+  rmSync(dir, { recursive: true, force: true });
+});
+
+async function sessionCount(): Promise<number> {
+  return (await server.store.listResources(ApiResourceKind.session)).length;
+}
+
+async function createAgent(name: string): Promise<string> {
+  const agent = await agentCommand.create({
+    apiVersion: API_VERSION,
+    kind: "Agent",
+    metadata: { name, org: ORG },
+    spec: { instructions: "You are the agent the run-gate tests target." },
+  });
+  return agent.metadata!.id;
+}
+
+/** The default-agent label is operator-seeded state; stamp it on the row. */
+async function markDefaultAgent(agentId: string): Promise<void> {
+  const stored = await server.store.getResource(
+    ApiResourceKind.agent,
+    agentId,
+    AgentSchema,
+  );
+  stored.metadata!.labels[DEFAULT_AGENT_LABEL] = DEFAULT_AGENT_LABEL_VALUE;
+  stored.metadata!.visibility = ApiResourceVisibility.visibility_public;
+  await server.store.saveResource(
+    ApiResourceKind.agent,
+    agentId,
+    AgentSchema,
+    stored,
+  );
+}
+
+async function captureError(
+  run: () => Promise<unknown>,
+): Promise<ConnectError> {
+  try {
+    await run();
+  } catch (error) {
+    return ConnectError.from(error);
+  }
+  throw new Error("expected the create to reject");
+}
+
+describe("session-create run gate (composed server)", () => {
+  it("denies a caller-named instance with the pinned copy and persists nothing", async () => {
+    decision = { kind: "deny", reason: "" };
+    gate.runGateChecks.length = 0;
+    const before = await sessionCount();
+
+    const err = await captureError(() =>
+      sessionCommand.create({
+        apiVersion: API_VERSION,
+        kind: "Session",
+        metadata: { name: "Denied session", org: ORG },
+        spec: { agentInstanceId: "agi_01private" },
+      }),
+    );
+
+    expect(err.code).toBe(Code.PermissionDenied);
+    expect(err.rawMessage).toBe(runAgentInstanceDeniedMessage("agi_01private"));
+    expect(gate.runGateChecks).toEqual([
+      {
+        permission: IamPermission.can_execute,
+        resourceKind: ApiResourceKind.agent_instance,
+        resourceId: "agi_01private",
+      },
+    ]);
+    expect(await sessionCount(), "no row behind a denial").toBe(before);
+  });
+
+  it("checks the instance the chain RESOLVED for the session-first shape", async () => {
+    decision = { kind: "deny", reason: "" };
+    gate.runGateChecks.length = 0;
+    const agentId = await createAgent("Default agent for the run gate");
+    await markDefaultAgent(agentId);
+
+    const err = await captureError(() =>
+      sessionCommand.create({
+        apiVersion: API_VERSION,
+        kind: "Session",
+        metadata: { name: "Session-first", org: ORG },
+        spec: {},
+      }),
+    );
+
+    expect(err.code).toBe(Code.PermissionDenied);
+    // ResolveDefaultAgentInstance created (or found) the default agent's
+    // default instance BEFORE the gate — the inherited pre-gate side
+    // effect the slot table records — and the gate names exactly it.
+    const agent = await agentQuery.get({ value: agentId });
+    const resolvedInstanceId = agent.status?.defaultInstanceId ?? "";
+    expect(resolvedInstanceId).not.toBe("");
+    expect(gate.runGateChecks).toHaveLength(1);
+    expect(gate.runGateChecks[0].resourceId).toBe(resolvedInstanceId);
+    expect(err.rawMessage).toBe(
+      runAgentInstanceDeniedMessage(resolvedInstanceId),
+    );
+  });
+
+  it("not-found answers NOT_FOUND naming the instance (the stigmer#224 order)", async () => {
+    decision = { kind: "not-found" };
+    const err = await captureError(() =>
+      sessionCommand.create({
+        apiVersion: API_VERSION,
+        kind: "Session",
+        metadata: { name: "Missing instance", org: ORG },
+        spec: { agentInstanceId: "agi_01missing" },
+      }),
+    );
+    expect(err.code).toBe(Code.NotFound);
+    expect(err.rawMessage).toContain("agi_01missing");
+  });
+
+  it("an allowed caller creates the session exactly as before", async () => {
+    decision = { kind: "allow" };
+    gate.runGateChecks.length = 0;
+    const agentId = await createAgent("Allowed agent");
+    const agent = await agentQuery.get({ value: agentId });
+    const instanceId = agent.status?.defaultInstanceId ?? "";
+    expect(instanceId, "agent create seeds a default instance").not.toBe("");
+
+    const session = await sessionCommand.create({
+      apiVersion: API_VERSION,
+      kind: "Session",
+      metadata: { name: "Allowed session", org: ORG },
+      spec: { agentInstanceId: instanceId },
+    });
+
+    expect(session.metadata?.id).toMatch(/^ses_/);
+    expect(session.spec?.agentInstanceId).toBe(instanceId);
+    expect(gate.runGateChecks.map((c) => c.resourceId)).toEqual([instanceId]);
+  });
+});

--- a/backend/services/stigmer-server/src/domain/session/__tests__/run-target.test.ts
+++ b/backend/services/stigmer-server/src/domain/session/__tests__/run-target.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Pins the session run-target resolver (P1 sp.run-gate): a session's run
+ * target is the agent instance it binds to — agent_instance#can_execute on
+ * spec.agent_instance_id, with the domain's byte-pinned deny copy — and a
+ * session with no instance yet has no target (ResolveDefaultAgentInstance
+ * guarantees one before the step runs; an empty id reaching the resolver
+ * is the guard's arm, not a check to make).
+ */
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import { runAgentInstanceDeniedMessage } from "../constants.js";
+import { sessionRunTarget } from "../run-target.js";
+
+describe("sessionRunTarget", () => {
+  it("targets the bound agent instance with can_execute and the pinned copy", () => {
+    const target = sessionRunTarget(
+      create(SessionSchema, { spec: { agentInstanceId: "agi_01abc" } }),
+    );
+    expect(target).toEqual({
+      permission: IamPermission.can_execute,
+      resourceKind: ApiResourceKind.agent_instance,
+      resourceId: "agi_01abc",
+      deniedMessage: "unauthorized to run agent instance 'agi_01abc'",
+    });
+    expect(target?.deniedMessage).toBe(
+      runAgentInstanceDeniedMessage("agi_01abc"),
+    );
+  });
+
+  it("answers no target when the session names no instance", () => {
+    expect(sessionRunTarget(create(SessionSchema, {}))).toBeUndefined();
+    expect(
+      sessionRunTarget(
+        create(SessionSchema, { spec: { agentInstanceId: "" } }),
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/backend/services/stigmer-server/src/domain/session/constants.ts
+++ b/backend/services/stigmer-server/src/domain/session/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Session byte-pinned wire copy — every string a client can observe from
+ * this domain that is not already a proto annotation's error_msg. Wire
+ * once merged: the conformance run-gate suite asserts these characters.
+ */
+
+/**
+ * The run gate's deny copy when a session names an agent instance the
+ * caller may not run (P1 sp.run-gate, ruling Q-RG-4). NEW copy quotes the
+ * handle single-quoted (the ratified 2026-08-26 quoting rule). Identical to
+ * the agent-execution domain's instance copy on purpose — one fact, one
+ * sentence — the ENGINE_UNAVAILABLE_MESSAGE precedent for cross-domain
+ * twins: each domain owns its constant, the twin is named here.
+ */
+export function runAgentInstanceDeniedMessage(agentInstanceId: string): string {
+  return `unauthorized to run agent instance '${agentInstanceId}'`;
+}

--- a/backend/services/stigmer-server/src/domain/session/controller.ts
+++ b/backend/services/stigmer-server/src/domain/session/controller.ts
@@ -55,6 +55,7 @@ import {
   authorizeDirect,
   newAuthorizeStep,
 } from "../../pipeline/steps/authorize.js";
+import { newAuthorizeRunTargetStep } from "../../pipeline/steps/authorize-run-target.js";
 import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import {
   newBuildNewStateStep,
@@ -97,6 +98,7 @@ import { ResourceNotFoundError } from "../../store/interface.js";
 import type { Store } from "../../store/interface.js";
 import type { SandboxLane } from "../../sandbox/lane.js";
 import { deprovisionSessionSandboxBestEffort } from "../../sandbox/steps.js";
+import { sessionRunTarget } from "./run-target.js";
 import { sessionSearchExtractor } from "./search-extractor.js";
 import type { ListReadScope } from "../../extensions/list-read-scope.js";
 import {
@@ -179,6 +181,13 @@ function kindOf(ctx: HandlerContext): ApiResourceKind {
  * runs BEFORE ValidateProto: when agent_instance_id is omitted, the
  * resolution fills it in before validation sees the spec.
  *
+ * AuthorizeRunTarget (the run gate, P1 sp.run-gate) follows it directly:
+ * the first step after the instance the session binds to is known, so a
+ * caller who may not run that instance is refused before validation reads
+ * anything further and before any step the chain owns side-effects. The
+ * default-instance creation INSIDE the resolution step still precedes it —
+ * the inherited pre-gate side effect recorded below, unchanged here.
+ *
  * The pre-side-effect gate slot splices before Persist, after the last
  * pure step (O4 plan-gate ruling Q2, mirroring the Java baseline's
  * post-resolution gate position). The default-instance resolution above
@@ -212,6 +221,7 @@ async function createSession(
         deps.authorizationLifecycle,
       ),
     )
+    .addStep(newAuthorizeRunTargetStep(deps.authorizer, sessionRunTarget))
     .addStep(newValidateProtoStep())
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveSlugStep())

--- a/backend/services/stigmer-server/src/domain/session/run-target.ts
+++ b/backend/services/stigmer-server/src/domain/session/run-target.ts
@@ -1,0 +1,30 @@
+/**
+ * The session run-target resolver (P1 sp.run-gate): a session is a
+ * conversation bound to ONE agent instance, so its run target is that
+ * instance — agent_instance#can_execute on spec.agent_instance_id.
+ *
+ * Pure over the record being built. ResolveDefaultAgentInstance runs before
+ * the gate and guarantees the id (the caller's, or the platform default
+ * agent's default instance), so an empty id here is that step's own
+ * refusal already thrown, never a check to make. Read from newState, where
+ * the resolution writes — the same clone gotcha steps.ts records.
+ */
+import type { Session } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+
+import {
+  RUN_GATE_CHECKS,
+  type RunTarget,
+} from "../../pipeline/steps/authorize-run-target.js";
+import { runAgentInstanceDeniedMessage } from "./constants.js";
+
+export function sessionRunTarget(session: Session): RunTarget | undefined {
+  const agentInstanceId = session.spec?.agentInstanceId ?? "";
+  if (agentInstanceId === "") {
+    return undefined;
+  }
+  return {
+    ...RUN_GATE_CHECKS.agentInstance,
+    resourceId: agentInstanceId,
+    deniedMessage: runAgentInstanceDeniedMessage(agentInstanceId),
+  };
+}

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/run-gate.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/run-gate.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Pins the run gate's SPLICE in workflow-execution-create over the real
+ * router (P1 sp.run-gate): AuthorizeRunTarget sits after
+ * ValidateWorkflowOrInstance and BEFORE EnsureEngineAvailable and
+ * CreateDefaultInstanceIfNeeded (the chain's first side effect and its
+ * first store read). Pinned here: (1) each shape is checked against its
+ * own target with its own byte-pinned copy; (2) a denial leaves no
+ * execution row and reads nothing — a nonexistent workflow_id is DENIED,
+ * not NOT_FOUND, because the gate answers before the lookup; (3) the gate
+ * precedes the engine gate: an ALLOWED create on this engineless server
+ * answers the engine's UNAVAILABLE; (4) the shape-less request is still
+ * INVALID_ARGUMENT from ValidateWorkflowOrInstance, which runs first. The
+ * authorizer under test answers only run-gate checks.
+ */
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import type { Client, Transport } from "@connectrpc/connect";
+import { Code, ConnectError, createClient } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+
+import { WorkflowExecutionCommandController } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/command_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import { loadConfig } from "../../../boot/config.js";
+import { composeServer } from "../../../boot/compose.js";
+import type { ComposedServer } from "../../../boot/compose.js";
+import { createLogger } from "../../../boot/logger.js";
+import type { AuthzDecision } from "../../../extensions/authorizer.js";
+import { runGateOnlyAuthorizer } from "../../../pipeline/__tests__/support.js";
+import {
+  ENGINE_UNAVAILABLE_MESSAGE,
+  runWorkflowDeniedMessage,
+  runWorkflowInstanceDeniedMessage,
+} from "../constants.js";
+
+const silentLogger = createLogger({
+  level: "error",
+  pretty: false,
+  write: () => {},
+});
+
+const API_VERSION = "agentic.stigmer.ai/v1";
+const ORG = "acme";
+
+let dir: string;
+let server: ComposedServer;
+let decision: AuthzDecision = { kind: "allow" };
+const gate = runGateOnlyAuthorizer(() => decision);
+let command: Client<typeof WorkflowExecutionCommandController>;
+
+beforeAll(async () => {
+  dir = mkdtempSync(path.join(tmpdir(), "wfexec-run-gate-test-"));
+  vi.stubEnv("STIGMER_ENCRYPTION_KEY", Buffer.alloc(32, 7).toString("base64"));
+  vi.stubEnv(
+    "STIGMER_RUNNER_TOKEN_KEY",
+    Buffer.alloc(32, 8).toString("base64"),
+  );
+  server = await composeServer({
+    config: loadConfig({
+      STIGMER_MODEL_REGISTRY_REFRESH: "off",
+      TEMPORAL_HOST_PORT: "127.0.0.1:1",
+      DB_PATH: path.join(dir, "stigmer.db"),
+      ARTIFACT_LOCAL_BASE_PATH: path.join(dir, "artifacts"),
+    }),
+    logger: silentLogger,
+    portOverride: 0,
+    host: "127.0.0.1",
+    extensions: [{ name: "run-gate-test", authorizer: gate.authorizer }],
+  });
+  const port = await server.start();
+  const transport: Transport = createGrpcTransport({
+    baseUrl: `http://127.0.0.1:${port}`,
+  });
+  command = createClient(WorkflowExecutionCommandController, transport);
+});
+
+afterAll(async () => {
+  try {
+    await server?.shutdown();
+    rmSync(dir, { recursive: true, force: true });
+  } finally {
+    vi.unstubAllEnvs();
+  }
+});
+
+async function captureError(
+  run: () => Promise<unknown>,
+): Promise<ConnectError> {
+  try {
+    await run();
+  } catch (error) {
+    return ConnectError.from(error);
+  }
+  throw new Error("expected the create to reject");
+}
+
+function createInput(spec: {
+  workflowId?: string;
+  workflowInstanceId?: string;
+}) {
+  return {
+    apiVersion: API_VERSION,
+    kind: "WorkflowExecution",
+    metadata: { name: "run-gate-wf-exec", org: ORG },
+    spec,
+  };
+}
+
+describe("workflow-execution-create run gate (composed server)", () => {
+  it("workflow_id: denies with the workflow copy before any lookup, persists nothing", async () => {
+    decision = { kind: "deny", reason: "" };
+    gate.runGateChecks.length = 0;
+    const before = (
+      await server.store.listResources(ApiResourceKind.workflow_execution)
+    ).length;
+
+    // A workflow that does not exist: a lookup-first chain would answer
+    // NOT_FOUND; the gate answers first.
+    const err = await captureError(() =>
+      command.create(createInput({ workflowId: "wf_01private" })),
+    );
+
+    expect(err.code).toBe(Code.PermissionDenied);
+    expect(err.rawMessage).toBe(runWorkflowDeniedMessage("wf_01private"));
+    expect(gate.runGateChecks).toEqual([
+      {
+        permission: IamPermission.can_execute,
+        resourceKind: ApiResourceKind.workflow,
+        resourceId: "wf_01private",
+      },
+    ]);
+    expect(
+      (await server.store.listResources(ApiResourceKind.workflow_execution))
+        .length,
+      "no execution row behind a denial",
+    ).toBe(before);
+  });
+
+  it("workflow_instance_id: denies with the instance copy on workflow_instance#can_execute", async () => {
+    decision = { kind: "deny", reason: "" };
+    gate.runGateChecks.length = 0;
+
+    const err = await captureError(() =>
+      command.create(createInput({ workflowInstanceId: "wfi_01private" })),
+    );
+
+    expect(err.code).toBe(Code.PermissionDenied);
+    expect(err.rawMessage).toBe(
+      runWorkflowInstanceDeniedMessage("wfi_01private"),
+    );
+    expect(gate.runGateChecks).toEqual([
+      {
+        permission: IamPermission.can_execute,
+        resourceKind: ApiResourceKind.workflow_instance,
+        resourceId: "wfi_01private",
+      },
+    ]);
+  });
+
+  it("not-found answers NOT_FOUND naming the target (the stigmer#224 order)", async () => {
+    decision = { kind: "not-found" };
+    const err = await captureError(() =>
+      command.create(createInput({ workflowId: "wf_01missing" })),
+    );
+    expect(err.code).toBe(Code.NotFound);
+    expect(err.rawMessage).toContain("wf_01missing");
+  });
+
+  it("the gate precedes the engine gate: an ALLOWED create reaches EnsureEngineAvailable", async () => {
+    decision = { kind: "allow" };
+    gate.runGateChecks.length = 0;
+
+    const err = await captureError(() =>
+      command.create(createInput({ workflowId: "wf_01allowed" })),
+    );
+
+    expect(err.code).toBe(Code.Unavailable);
+    expect(err.rawMessage).toBe(ENGINE_UNAVAILABLE_MESSAGE);
+    expect(gate.runGateChecks.map((c) => c.resourceId)).toEqual([
+      "wf_01allowed",
+    ]);
+  });
+
+  it("the shape-less request is still ValidateWorkflowOrInstance's INVALID_ARGUMENT, and the gate makes no check", async () => {
+    decision = { kind: "deny", reason: "" };
+    gate.runGateChecks.length = 0;
+
+    const err = await captureError(() => command.create(createInput({})));
+
+    expect(err.code).toBe(Code.InvalidArgument);
+    expect(err.rawMessage).toBe(
+      "either workflow_id or workflow_instance_id must be provided",
+    );
+    expect(gate.runGateChecks).toEqual([]);
+  });
+});

--- a/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/run-target.test.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/__tests__/run-target.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Pins the workflow-execution run-target resolver (P1 sp.run-gate): the
+ * chain's own precedence — an explicit workflow_instance_id fully names
+ * the target (CreateDefaultInstanceIfNeeded returns early on it), else
+ * workflow_id names the blueprint whose default instance the chain will
+ * resolve — each with its own byte-pinned deny copy. Neither set has no
+ * target (ValidateWorkflowOrInstance refuses that shape as INVALID_ARGUMENT
+ * before this step runs).
+ */
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+
+import { WorkflowExecutionSchema } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import {
+  runWorkflowDeniedMessage,
+  runWorkflowInstanceDeniedMessage,
+} from "../constants.js";
+import { workflowExecutionRunTarget } from "../run-target.js";
+
+describe("workflowExecutionRunTarget", () => {
+  it("workflow_instance_id → workflow_instance#can_execute", () => {
+    expect(
+      workflowExecutionRunTarget(
+        create(WorkflowExecutionSchema, {
+          spec: { workflowInstanceId: "wfi_01abc" },
+        }),
+      ),
+    ).toEqual({
+      permission: IamPermission.can_execute,
+      resourceKind: ApiResourceKind.workflow_instance,
+      resourceId: "wfi_01abc",
+      deniedMessage: runWorkflowInstanceDeniedMessage("wfi_01abc"),
+    });
+    expect(runWorkflowInstanceDeniedMessage("wfi_01abc")).toBe(
+      "unauthorized to run workflow instance 'wfi_01abc'",
+    );
+  });
+
+  it("workflow_id → workflow#can_execute", () => {
+    expect(
+      workflowExecutionRunTarget(
+        create(WorkflowExecutionSchema, { spec: { workflowId: "wf_01abc" } }),
+      ),
+    ).toEqual({
+      permission: IamPermission.can_execute,
+      resourceKind: ApiResourceKind.workflow,
+      resourceId: "wf_01abc",
+      deniedMessage: runWorkflowDeniedMessage("wf_01abc"),
+    });
+    expect(runWorkflowDeniedMessage("wf_01abc")).toBe(
+      "unauthorized to run workflow 'wf_01abc'",
+    );
+  });
+
+  it("precedence is the chain's: the explicit instance wins over the blueprint", () => {
+    const target = workflowExecutionRunTarget(
+      create(WorkflowExecutionSchema, {
+        spec: { workflowId: "wf_01abc", workflowInstanceId: "wfi_01abc" },
+      }),
+    );
+    expect(target?.resourceKind).toBe(ApiResourceKind.workflow_instance);
+    expect(target?.resourceId).toBe("wfi_01abc");
+  });
+
+  it("answers no target when neither reference is set", () => {
+    expect(
+      workflowExecutionRunTarget(create(WorkflowExecutionSchema, {})),
+    ).toBeUndefined();
+    expect(
+      workflowExecutionRunTarget(
+        create(WorkflowExecutionSchema, {
+          spec: { workflowId: "", workflowInstanceId: "" },
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/backend/services/stigmer-server/src/domain/workflowexecution/constants.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/constants.ts
@@ -17,6 +17,23 @@ export const ENGINE_UNAVAILABLE_MESSAGE =
   "The execution engine is temporarily unavailable. Please try again shortly.";
 
 /**
+ * The run gate's deny copy per request shape (P1 sp.run-gate, ruling
+ * Q-RG-4; wire once merged, asserted by the conformance run-gate suite).
+ * NEW copy quotes the handle single-quoted (the ratified 2026-08-26 rule).
+ * The agent-execution domain's `runAgent*` functions are these copies'
+ * twins; each domain owns its own.
+ */
+export function runWorkflowDeniedMessage(workflowId: string): string {
+  return `unauthorized to run workflow '${workflowId}'`;
+}
+
+export function runWorkflowInstanceDeniedMessage(
+  workflowInstanceId: string,
+): string {
+  return `unauthorized to run workflow instance '${workflowInstanceId}'`;
+}
+
+/**
  * The lifecycle steps' engineless refusal (lifecycle_steps.go, five
  * sites: pause/resume/cancel/terminate signal steps and recover's
  * terminate-existing). FailedPrecondition, not Unavailable — the ratified

--- a/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/controller.ts
@@ -49,6 +49,7 @@ import { newPipeline } from "../../pipeline/pipeline.js";
 import { callerIdentityOf } from "../../pipeline/interceptors/auth.js";
 import { RequestContext } from "../../pipeline/request-context.js";
 import { newAuthorizeStep } from "../../pipeline/steps/authorize.js";
+import { newAuthorizeRunTargetStep } from "../../pipeline/steps/authorize-run-target.js";
 import { newGuardReservedLabelsStep } from "../../pipeline/steps/guard-reserved-labels.js";
 import { newBuildUpdateStateStep } from "../../pipeline/steps/build-update-state.js";
 import { newBuildNewStateStep } from "../../pipeline/steps/defaults.js";
@@ -116,6 +117,7 @@ import { getEventLog } from "./get-event-log.js";
 import { getExecutionSummary } from "./get-execution-summary.js";
 import { listPendingApprovals } from "./list-pending-approvals.js";
 import { loadAllWorkflowExecutions } from "./queries.js";
+import { workflowExecutionRunTarget } from "./run-target.js";
 import { workflowExecutionSearchExtractor } from "./search-extractor.js";
 import type { SandboxLane } from "../../sandbox/lane.js";
 import type { WorkflowSandboxTerminalObserver } from "../../sandbox/steps.js";
@@ -243,6 +245,11 @@ export function registerWorkflowExecutionServices(
  * Create — create.go buildCreatePipeline, step-for-step (the numbered
  * 15-step chain): validation (proto → visibility → slug →
  * workflow-or-instance presence, the #196 InvalidArgument contrast) →
+ * the run gate (AuthorizeRunTarget, P1 sp.run-gate: the first step after
+ * the target reference is guaranteed, asking workflow_instance#can_execute
+ * or workflow#can_execute by request shape — before the engine gate so a
+ * denied caller learns nothing about engine state, and before the workflow
+ * lookup, so a denial reads nothing) →
  * the ENGINE GATE at its pinned position (before every side effect — a
  * down engine orphans nothing; Go's unit test pins that it precedes even
  * the workflow lookup) → default-instance resolution → the standard
@@ -276,6 +283,9 @@ async function createExecution(
     .addStep(newValidateVisibilityStep())
     .addStep(newResolveSlugStep())
     .addStep(newValidateWorkflowOrInstanceStep())
+    .addStep(
+      newAuthorizeRunTargetStep(deps.authorizer, workflowExecutionRunTarget),
+    )
     .addStep(newEnsureEngineAvailableStep(deps.engineState))
     .addStep(
       newCreateDefaultInstanceIfNeededStep({

--- a/backend/services/stigmer-server/src/domain/workflowexecution/run-target.ts
+++ b/backend/services/stigmer-server/src/domain/workflowexecution/run-target.ts
@@ -1,0 +1,47 @@
+/**
+ * The workflow-execution run-target resolver (P1 sp.run-gate): the chain's
+ * own precedence — an explicit workflow_instance_id fully names the target
+ * (CreateDefaultInstanceIfNeeded returns early on it):
+ * workflow_instance#can_execute; else workflow_id names the blueprint whose
+ * default instance the chain resolves (or mints) only AFTER the gate:
+ * workflow#can_execute (the model derives the default instance's viewers
+ * from the blueprint's, so asking the blueprint's question is what lets the
+ * gate precede the side effect).
+ *
+ * Neither set is ValidateWorkflowOrInstance's INVALID_ARGUMENT, thrown
+ * before this resolver runs — never a check. Pure over the record being
+ * built.
+ */
+import type { WorkflowExecution } from "@stigmer/protos/ai/stigmer/agentic/workflowexecution/v1/api_pb";
+
+import {
+  RUN_GATE_CHECKS,
+  type RunTarget,
+} from "../../pipeline/steps/authorize-run-target.js";
+import {
+  runWorkflowDeniedMessage,
+  runWorkflowInstanceDeniedMessage,
+} from "./constants.js";
+
+export function workflowExecutionRunTarget(
+  execution: WorkflowExecution,
+): RunTarget | undefined {
+  const spec = execution.spec;
+  const workflowInstanceId = spec?.workflowInstanceId ?? "";
+  if (workflowInstanceId !== "") {
+    return {
+      ...RUN_GATE_CHECKS.workflowInstance,
+      resourceId: workflowInstanceId,
+      deniedMessage: runWorkflowInstanceDeniedMessage(workflowInstanceId),
+    };
+  }
+  const workflowId = spec?.workflowId ?? "";
+  if (workflowId !== "") {
+    return {
+      ...RUN_GATE_CHECKS.workflow,
+      resourceId: workflowId,
+      deniedMessage: runWorkflowDeniedMessage(workflowId),
+    };
+  }
+  return undefined;
+}

--- a/backend/services/stigmer-server/src/index.ts
+++ b/backend/services/stigmer-server/src/index.ts
@@ -194,6 +194,13 @@ export {
 } from "./pipeline/interceptors/auth.js";
 export { newPipeline } from "./pipeline/pipeline.js";
 export { newAuthorizeStep } from "./pipeline/steps/authorize.js";
+// The run gate's check set (P1 sp.run-gate): an edition's Authorizer keys
+// its lane admission on this predicate — the runtime lanes it mints (a
+// guest share, a channel, a schedule fire, a workflow sandbox) were
+// admitted upstream by their own gate steps and are not re-asked here.
+// OSS defines the gate, so OSS defines which checks are the gate; a
+// composition never re-derives the set.
+export { isRunGateCheck } from "./pipeline/steps/authorize-run-target.js";
 export { newValidateProtoStep } from "./pipeline/steps/validation.js";
 
 // The driver interfaces and the store-fault classes the ratified mapping

--- a/backend/services/stigmer-server/src/pipeline/__tests__/support.ts
+++ b/backend/services/stigmer-server/src/pipeline/__tests__/support.ts
@@ -5,7 +5,13 @@
  * site in production code. Overrides let adversarial tests pin specific
  * caller classes.
  */
+import type {
+  Authorizer,
+  AuthzCheck,
+  AuthzDecision,
+} from "../../extensions/authorizer.js";
 import type { CallerIdentity } from "../../extensions/identity.js";
+import { isRunGateCheck } from "../steps/authorize-run-target.js";
 
 export function testCallerIdentity(
   overrides: Partial<CallerIdentity> = {},
@@ -16,5 +22,33 @@ export function testCallerIdentity(
     issuer: "",
     rawToken: "",
     ...overrides,
+  };
+}
+
+/**
+ * An Authorizer that answers `decide()` to run-gate checks ONLY and allows
+ * everything else (the position-1 organization checks, the reserved-label
+ * guard's operator check), recording the run-gate checks it saw. Composed
+ * into a test server as an extension unit, it isolates the AuthorizeRunTarget
+ * splice from every other authorization site on the chain: a refusal it
+ * produces can only have come from the run gate. `decide` is read per
+ * check so one composed server can pin the allow and the deny arms.
+ */
+export function runGateOnlyAuthorizer(decide: () => AuthzDecision): {
+  authorizer: Authorizer;
+  runGateChecks: AuthzCheck[];
+} {
+  const runGateChecks: AuthzCheck[] = [];
+  return {
+    runGateChecks,
+    authorizer: {
+      authorize(_caller, check) {
+        if (!isRunGateCheck(check)) {
+          return Promise.resolve({ kind: "allow" });
+        }
+        runGateChecks.push(check);
+        return Promise.resolve(decide());
+      },
+    },
   };
 }

--- a/backend/services/stigmer-server/src/pipeline/steps/__tests__/authorize-run-target.test.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/__tests__/authorize-run-target.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Pins the AuthorizeRunTarget step's contract (P1 sp.run-gate, 2026-09-11):
+ * the step is a thin shell around authorizeResolvedResource — a resolver
+ * that answers no target makes NO check (the chain's own invariant guards
+ * own the shape-less arm); a resolved target reaches the Authorizer
+ * verbatim; deny carries the RESOLVER's copy; not-found answers the
+ * load-first NOT_FOUND; unavailable is INTERNAL; the internal caller class
+ * skips. Also pins isRunGateCheck: exactly the five (kind, permission)
+ * pairs the resolvers can produce, and nothing adjacent — the cloud's
+ * lane-admission decorator keys on this predicate, so a drift here would
+ * either deny a schedule fire or admit a lane to a check it never owned.
+ */
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import { Code, ConnectError } from "@connectrpc/connect";
+
+import { SessionSchema } from "@stigmer/protos/ai/stigmer/agentic/session/v1/api_pb";
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import type {
+  Authorizer,
+  AuthzCheck,
+  AuthzDecision,
+} from "../../../extensions/authorizer.js";
+import { testCallerIdentity } from "../../__tests__/support.js";
+import { RequestContext } from "../../request-context.js";
+import { AUTHORIZATION_UNAVAILABLE_MESSAGE } from "../authorize.js";
+import {
+  RUN_GATE_CHECKS,
+  isRunGateCheck,
+  newAuthorizeRunTargetStep,
+} from "../authorize-run-target.js";
+import type { RunTarget } from "../authorize-run-target.js";
+
+function fakeAuthorizer(decision: AuthzDecision): {
+  authorizer: Authorizer;
+  checks: AuthzCheck[];
+} {
+  const checks: AuthzCheck[] = [];
+  return {
+    checks,
+    authorizer: {
+      authorize(_caller, check) {
+        checks.push(check);
+        return Promise.resolve(decision);
+      },
+    },
+  };
+}
+
+async function captureError(
+  run: () => void | Promise<void>,
+): Promise<ConnectError> {
+  try {
+    await run();
+  } catch (error) {
+    return ConnectError.from(error);
+  }
+  throw new Error("expected the step to reject");
+}
+
+const TARGET: RunTarget = {
+  ...RUN_GATE_CHECKS.agentInstance,
+  resourceId: "agi_01target",
+  deniedMessage: "unauthorized to run agent instance 'agi_01target'",
+};
+
+function sessionCtx(callerClass?: string) {
+  return new RequestContext(
+    SessionSchema,
+    create(SessionSchema, { metadata: { name: "s", org: "acme" } }),
+    callerClass === undefined
+      ? testCallerIdentity()
+      : testCallerIdentity({ callerClass }),
+    ApiResourceKind.session,
+  );
+}
+
+describe("AuthorizeRunTarget — the step shell", () => {
+  it("is named AuthorizeRunTarget in every chain (shared vocabulary)", () => {
+    const { authorizer } = fakeAuthorizer({ kind: "allow" });
+    const step = newAuthorizeRunTargetStep<typeof SessionSchema>(
+      authorizer,
+      () => TARGET,
+    );
+    expect(step.name).toBe("AuthorizeRunTarget");
+  });
+
+  it("makes NO check when the resolver answers no target", async () => {
+    const { authorizer, checks } = fakeAuthorizer({ kind: "deny", reason: "" });
+    const step = newAuthorizeRunTargetStep<typeof SessionSchema>(
+      authorizer,
+      () => undefined,
+    );
+    await step.execute(sessionCtx());
+    expect(checks).toEqual([]);
+  });
+
+  it("hands the resolved target to the Authorizer verbatim and proceeds on allow", async () => {
+    const { authorizer, checks } = fakeAuthorizer({ kind: "allow" });
+    const seen: unknown[] = [];
+    const step = newAuthorizeRunTargetStep<typeof SessionSchema>(
+      authorizer,
+      (record) => {
+        seen.push(record);
+        return TARGET;
+      },
+    );
+    const ctx = sessionCtx();
+    await step.execute(ctx);
+    expect(checks).toEqual([
+      {
+        permission: IamPermission.can_execute,
+        resourceKind: ApiResourceKind.agent_instance,
+        resourceId: "agi_01target",
+      },
+    ]);
+    // The resolver reads the record being BUILT (newState), where the
+    // chain's own resolution steps write, never the immutable input.
+    expect(seen).toEqual([ctx.newState]);
+  });
+
+  it("deny → PERMISSION_DENIED carrying the resolver's copy", async () => {
+    const { authorizer } = fakeAuthorizer({
+      kind: "deny",
+      reason: "fga said no",
+    });
+    const step = newAuthorizeRunTargetStep<typeof SessionSchema>(
+      authorizer,
+      () => TARGET,
+    );
+    const err = await captureError(() => step.execute(sessionCtx()));
+    expect(err.code).toBe(Code.PermissionDenied);
+    expect(err.rawMessage).toBe(TARGET.deniedMessage);
+  });
+
+  it("not-found → the load-first chain's NOT_FOUND naming the target", async () => {
+    const { authorizer } = fakeAuthorizer({ kind: "not-found" });
+    const step = newAuthorizeRunTargetStep<typeof SessionSchema>(
+      authorizer,
+      () => TARGET,
+    );
+    const err = await captureError(() => step.execute(sessionCtx()));
+    expect(err.code).toBe(Code.NotFound);
+    expect(err.rawMessage).toContain("agi_01target");
+  });
+
+  it("unavailable → INTERNAL, never a softened denial", async () => {
+    const { authorizer } = fakeAuthorizer({
+      kind: "unavailable",
+      cause: new Error("fga down"),
+    });
+    const step = newAuthorizeRunTargetStep<typeof SessionSchema>(
+      authorizer,
+      () => TARGET,
+    );
+    const err = await captureError(() => step.execute(sessionCtx()));
+    expect(err.code).toBe(Code.Internal);
+    expect(err.rawMessage).toBe(AUTHORIZATION_UNAVAILABLE_MESSAGE);
+  });
+
+  it("the internal caller class skips (the server acting as itself)", async () => {
+    const { authorizer, checks } = fakeAuthorizer({ kind: "deny", reason: "" });
+    const step = newAuthorizeRunTargetStep<typeof SessionSchema>(
+      authorizer,
+      () => TARGET,
+    );
+    await step.execute(sessionCtx("internal"));
+    expect(checks).toEqual([]);
+  });
+
+  it("every other caller class is checked — a lane is admitted by its Authorizer, never by this step", async () => {
+    for (const callerClass of [
+      "user",
+      "machine",
+      "runner",
+      "guest",
+      "schedule",
+      "workflow_sandbox",
+    ]) {
+      const { authorizer, checks } = fakeAuthorizer({ kind: "allow" });
+      const step = newAuthorizeRunTargetStep<typeof SessionSchema>(
+        authorizer,
+        () => TARGET,
+      );
+      await step.execute(sessionCtx(callerClass));
+      expect(checks, callerClass).toHaveLength(1);
+    }
+  });
+});
+
+describe("isRunGateCheck — the one definition of the run-gate check set", () => {
+  const pairs: ReadonlyArray<[string, ApiResourceKind, IamPermission]> = [
+    ["agent", ApiResourceKind.agent, IamPermission.can_execute],
+    [
+      "agent_instance",
+      ApiResourceKind.agent_instance,
+      IamPermission.can_execute,
+    ],
+    ["session", ApiResourceKind.session, IamPermission.can_create_execution_in],
+    ["workflow", ApiResourceKind.workflow, IamPermission.can_execute],
+    [
+      "workflow_instance",
+      ApiResourceKind.workflow_instance,
+      IamPermission.can_execute,
+    ],
+  ];
+
+  it.each(pairs)(
+    "%s is a run-gate check",
+    (_name, resourceKind, permission) => {
+      expect(
+        isRunGateCheck({ permission, resourceKind, resourceId: "x" }),
+      ).toBe(true);
+    },
+  );
+
+  it("names exactly five checks, one per entry the resolvers draw from", () => {
+    expect(Object.keys(RUN_GATE_CHECKS).sort()).toEqual(
+      [
+        "agent",
+        "agentInstance",
+        "session",
+        "workflow",
+        "workflowInstance",
+      ].sort(),
+    );
+    for (const [, resourceKind, permission] of pairs) {
+      expect(
+        Object.values(RUN_GATE_CHECKS).filter(
+          (c) => c.resourceKind === resourceKind && c.permission === permission,
+        ),
+      ).toHaveLength(1);
+    }
+  });
+
+  it.each([
+    ["session#can_view", ApiResourceKind.session, IamPermission.can_view],
+    ["agent#can_edit", ApiResourceKind.agent, IamPermission.can_edit],
+    ["agent#can_view", ApiResourceKind.agent, IamPermission.can_view],
+    [
+      "agent_execution#can_execute",
+      ApiResourceKind.agent_execution,
+      IamPermission.can_execute,
+    ],
+    [
+      "organization#can_create_session",
+      ApiResourceKind.organization,
+      IamPermission.can_create_session,
+    ],
+    ["session#can_execute", ApiResourceKind.session, IamPermission.can_execute],
+  ] as const)(
+    "%s is NOT a run-gate check",
+    (_name, resourceKind, permission) => {
+      expect(
+        isRunGateCheck({ permission, resourceKind, resourceId: "x" }),
+      ).toBe(false);
+    },
+  );
+});

--- a/backend/services/stigmer-server/src/pipeline/steps/authorize-run-target.ts
+++ b/backend/services/stigmer-server/src/pipeline/steps/authorize-run-target.ts
@@ -1,0 +1,148 @@
+/**
+ * AuthorizeRunTarget — the run gate (P1 sp.run-gate, 2026-09-11;
+ * stigmer-cloud#709): may this caller RUN what this record targets?
+ *
+ * Every create that starts or continues a run names a target — a blueprint
+ * (`agent`, `workflow`), an instance (`agent_instance`, `workflow_instance`)
+ * or a conversation (`session`) — and until this step nothing asked whether
+ * the caller may use it: session-create authorized only the organization's
+ * `can_create_session`, agent- and workflow-execution create are
+ * `is_skip_authorization`, and `can_execute` was defined on every blueprint
+ * and instance type of the FGA model and checked nowhere. The invariant the
+ * model states ("you can run what you can read") is enforced here.
+ *
+ * One shared step, one domain resolver: the shape of IndexSearch (a shared
+ * step over a domain extractor). The resolver is a PURE function of the
+ * record being built (`ctx.newState`, where the chain's own resolution
+ * steps write) that names the target and the domain's byte-pinned deny
+ * copy; this step hands it to authorizeResolvedResource — the ratified
+ * mid-chain resolved-id form (DD-007; the ListVersions and listByChannel
+ * precedent) for lanes the position-1 annotation cannot express. A
+ * resolver that answers no target makes NO check: the chain's own
+ * invariant guards (EnsureSessionOrAgentResolved,
+ * ValidateWorkflowOrInstance) own the shape-less arm, and this step never
+ * second-guesses them.
+ *
+ * Position, in every chain: immediately after the step that guarantees the
+ * target reference exists — before EnsureEngineAvailable (a denied caller
+ * learns nothing about engine state), before every gate slot, before every
+ * side effect the chain owns. The chains' own convention, Authorize before
+ * Validate, is what places it there.
+ *
+ * Admission has one owner per lane. This step asks for EVERY caller but the
+ * `internal` class (authorizeResolvedResource's contract): a direct
+ * principal is admitted by the Authorizer; a runtime lane (a guest share, a
+ * channel, a schedule fire, a workflow sandbox's child run) is admitted by
+ * the gate step that vouches for it, and the edition's Authorizer says so
+ * for the lanes it mints — the OSS chain stays policy-free. RUN_GATE_CHECKS
+ * is the one definition of "the run-gate checks" that such an Authorizer
+ * keys on (isRunGateCheck, exported on the barrel); the resolvers draw their
+ * (kind, permission) pairs from the same table, so the predicate cannot
+ * drift from what the step actually asks.
+ */
+import type { DescMessage, MessageShape } from "@bufbuild/protobuf";
+
+import { ApiResourceKind } from "@stigmer/protos/ai/stigmer/commons/apiresource/apiresourcekind/api_resource_kind_pb";
+import { IamPermission } from "@stigmer/protos/ai/stigmer/iam/v1/enum_pb";
+
+import type { Authorizer, AuthzCheck } from "../../extensions/authorizer.js";
+import type { PipelineStep } from "../pipeline.js";
+import type { RequestContext } from "../request-context.js";
+import { authorizeResolvedResource } from "./authorize.js";
+
+/** One (kind, permission) pair the run gate asks about. */
+export interface RunGateCheck {
+  readonly permission: IamPermission;
+  readonly resourceKind: ApiResourceKind;
+}
+
+/**
+ * The run-gate check set — exactly the pairs a resolver can produce. Each
+ * is the FGA model's own relation for "may run this": `can_execute` on the
+ * blueprints and instances (`agent.fga` `can_execute: viewer`;
+ * `agent_instance.fga` `can_execute: can_view`; the workflow twins), and
+ * `can_create_execution_in` on a session (`session.fga`: adding a turn to a
+ * conversation is the session's own permission, not the agent's).
+ */
+export const RUN_GATE_CHECKS = {
+  agent: {
+    permission: IamPermission.can_execute,
+    resourceKind: ApiResourceKind.agent,
+  },
+  agentInstance: {
+    permission: IamPermission.can_execute,
+    resourceKind: ApiResourceKind.agent_instance,
+  },
+  session: {
+    permission: IamPermission.can_create_execution_in,
+    resourceKind: ApiResourceKind.session,
+  },
+  workflow: {
+    permission: IamPermission.can_execute,
+    resourceKind: ApiResourceKind.workflow,
+  },
+  workflowInstance: {
+    permission: IamPermission.can_execute,
+    resourceKind: ApiResourceKind.workflow_instance,
+  },
+} as const satisfies Record<string, RunGateCheck>;
+
+const RUN_GATE_CHECK_LIST: ReadonlyArray<RunGateCheck> =
+  Object.values(RUN_GATE_CHECKS);
+
+/**
+ * Whether `check` is one of the run gate's — the predicate an edition's
+ * Authorizer keys its lane admission on. Reads only the pair (an AuthzCheck
+ * is one); the resource id is the target's identity, not part of the
+ * question.
+ */
+export function isRunGateCheck(check: RunGateCheck | AuthzCheck): boolean {
+  return RUN_GATE_CHECK_LIST.some(
+    (candidate) =>
+      candidate.permission === check.permission &&
+      candidate.resourceKind === check.resourceKind,
+  );
+}
+
+/**
+ * A resolved run target: the check plus the domain's byte-pinned deny copy
+ * for it (the lane's error_msg, in the position-1 annotation's terms).
+ */
+export interface RunTarget extends RunGateCheck {
+  readonly resourceId: string;
+  readonly deniedMessage: string;
+}
+
+/**
+ * Names a record's run target, or `undefined` when the record names none
+ * (a state the chain's own guards refuse; never this step's arm). Pure over
+ * the record being built — no store, no clock, no caller.
+ */
+export type RunTargetResolver<Desc extends DescMessage> = (
+  record: MessageShape<Desc>,
+) => RunTarget | undefined;
+
+export function newAuthorizeRunTargetStep<Desc extends DescMessage>(
+  authorizer: Authorizer,
+  resolveRunTarget: RunTargetResolver<Desc>,
+): PipelineStep<Desc> {
+  return {
+    name: "AuthorizeRunTarget",
+    async execute(ctx: RequestContext<Desc>): Promise<void> {
+      const target = resolveRunTarget(ctx.newState);
+      if (target === undefined) {
+        return;
+      }
+      await authorizeResolvedResource(
+        authorizer,
+        ctx.callerIdentity,
+        {
+          permission: target.permission,
+          resourceKind: target.resourceKind,
+          resourceId: target.resourceId,
+        },
+        target.deniedMessage,
+      );
+    },
+  };
+}

--- a/test/conformance/src/harness/__tests__/cloud-env.test.ts
+++ b/test/conformance/src/harness/__tests__/cloud-env.test.ts
@@ -1,0 +1,48 @@
+// Pins the pure arms of the cloud-env identity helpers: the JWT subject read
+// the grants key on (the server-chosen identity-account id, never the mint's
+// userId), and the member grant's shape — the ordinary IamPolicy create the
+// Members page performs, naming the organization by ID (the FGA object) and
+// the `member` role the organization kind declares grantable.
+import { describe, expect, it } from "vitest";
+import { jwtSubject, organizationMemberGrant } from "../cloud-env";
+
+function unsignedJwt(payload: Record<string, unknown>): string {
+  const b64 = (value: unknown): string =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${b64({ alg: "none" })}.${b64(payload)}.`;
+}
+
+describe("jwtSubject", () => {
+  it("reads the sub claim of a compact JWT", () => {
+    expect(
+      jwtSubject(unsignedJwt({ sub: "ida_01member", iss: "stigmer" })),
+    ).toBe("ida_01member");
+  });
+
+  it("refuses a token without a subject, or one that is not a JWT", () => {
+    expect(() => jwtSubject(unsignedJwt({ iss: "stigmer" }))).toThrow(
+      /no sub claim/,
+    );
+    expect(() => jwtSubject(unsignedJwt({ sub: "" }))).toThrow(/no sub claim/);
+    expect(() => jwtSubject("not-a-jwt")).toThrow(/not a JWT/);
+  });
+});
+
+describe("organizationMemberGrant", () => {
+  it("names the identity account as principal, the organization by id, and the member role", () => {
+    expect(organizationMemberGrant("org_01acme", "ida_01member")).toEqual({
+      principal: { kind: "identity_account", id: "ida_01member" },
+      resource: { kind: "organization", id: "org_01acme" },
+      relation: "member",
+    });
+  });
+
+  it("refuses empty ids rather than minting a grant on nothing", () => {
+    expect(() => organizationMemberGrant("", "ida_01member")).toThrow(
+      /non-empty/,
+    );
+    expect(() => organizationMemberGrant("org_01acme", "")).toThrow(
+      /non-empty/,
+    );
+  });
+});

--- a/test/conformance/src/harness/cloud-env.ts
+++ b/test/conformance/src/harness/cloud-env.ts
@@ -204,9 +204,9 @@ async function bootstrapOperatorIdentity(
 }
 
 // The minted JWT's `sub` is the JIT-provisioned identity-account id — the
-// principal the operator grant must name (the server chooses it; it is not
-// the userId the mint request carried).
-function jwtSubject(token: string): string {
+// principal any grant must name (the server chooses it; it is not the userId
+// the mint request carried). Exported for the targets' member provisioning.
+export function jwtSubject(token: string): string {
   const payloadSegment = token.split(".")[1];
   if (payloadSegment === undefined) {
     throw new Error("minted token is not a JWT (no payload segment)");
@@ -218,6 +218,26 @@ function jwtSubject(token: string): string {
     throw new Error("minted token carries no sub claim; cannot grant the operator role");
   }
   return payload.sub;
+}
+
+// The ordinary IamPolicy grant that makes an identity a `member` of an
+// organization — the Members-page grant, through IamPolicyCommandController.
+// create as the org's owner (never bootstrapPolicy, which is the operator
+// lane for grants the ordinary create cannot express). `member` is in the
+// organization kind's grantable_roles; the resource id is the organization's
+// ID (the FGA object `organization:<id>`), not its slug.
+export function organizationMemberGrant(
+  organizationId: string,
+  identityAccountId: string,
+): { principal: { kind: string; id: string }; resource: { kind: string; id: string }; relation: string } {
+  if (organizationId === "" || identityAccountId === "") {
+    throw new Error("organizationMemberGrant needs a non-empty organization id and identity-account id");
+  }
+  return {
+    principal: { kind: "identity_account", id: identityAccountId },
+    resource: { kind: "organization", id: organizationId },
+    relation: "member",
+  };
 }
 
 // Mints a Stigmer JWT for the given user id. mintUserToken authenticates via

--- a/test/conformance/src/suites/run-gate.conformance.test.ts
+++ b/test/conformance/src/suites/run-gate.conformance.test.ts
@@ -1,0 +1,289 @@
+// Run-gate conformance (P1 sp.run-gate, 2026-09-11; stigmer-cloud#709).
+//
+// The contract: a caller may START or CONTINUE a run only on what they can
+// see. The three create chains — session, agent execution, workflow
+// execution — carry one AuthorizeRunTarget step that asks the edition's
+// Authorizer about the record's run target (agent_instance#can_execute,
+// agent#can_execute, session#can_create_execution_in, workflow#can_execute,
+// workflow_instance#can_execute) before any engine check, gate slot or side
+// effect. Pinned here on the multi-tenant edition with a COLLEAGUE — a fresh
+// identity holding exactly `member` on the organization (provisionMember),
+// so the organization-level checks pass and only the resource-level rule can
+// refuse:
+//
+//   - a member cannot open a session on a PRIVATE agent's instance, cannot
+//     start an execution on a PRIVATE agent, cannot add an execution to a
+//     session they cannot see, cannot run a PRIVATE workflow — each
+//     PERMISSION_DENIED with the domain's byte-pinned copy, and side-effect
+//     free (no session row appears for the owner);
+//   - a member CAN open a session on an ORG-visible agent (the positive arm
+//     is a session create on purpose: it starts nothing, so a Class A target
+//     is left with no orphan workflow);
+//   - an unknown instance id answers NOT_FOUND — the authorizer's deny-path
+//     existence probe, the ruled stigmer#224 order (a missing target is
+//     never dressed as a denial).
+//
+// Deliberately out of scope: the runtime lanes (guest, channel, schedule,
+// workflow sandbox), whose admission is decided by their own gate steps and
+// pinned by their own suites; and the OSS edition's denial, which waits for
+// P1's owner-or-admin authorizer (sp.oss-owner-or-admin-authorizer) — the
+// permissive single-team posture admits every caller today, so on the
+// single-user targets these arms SKIP visibly rather than assert an allow
+// that the next entry is meant to flip.
+import { Code } from "@connectrpc/connect";
+import { ApiResourceVisibility } from "@stigmer/protos/ai/stigmer/commons/apiresource/enum_pb";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import type { ConformanceClients } from "../harness/clients";
+import {
+  createTarget,
+  type TargetProfile,
+  type TenancyContext,
+} from "../targets";
+import { FixtureTracker } from "../harness/fixtures";
+import { expectGrpcCode } from "../contract/errors";
+import { makeAgent } from "../support/agents";
+import { makeAgentExecution } from "../support/agentexecutions";
+import { makeSession } from "../support/sessions";
+import { makeWorkflow } from "../support/workflows";
+import { makeWorkflowExecution } from "../support/workflowexecutions";
+import { uniqueName } from "../support/naming";
+
+let target: TargetProfile;
+let clients: ConformanceClients;
+const fixtures = new FixtureTracker();
+
+beforeAll(async () => {
+  target = createTarget();
+  await target.setup();
+  clients = target.clients();
+});
+
+afterEach(async () => {
+  await fixtures.cleanup();
+});
+
+afterAll(async () => {
+  await target?.teardown();
+});
+
+// The colleague exists only where roles do. A multi-tenant target that
+// cannot provision one is a harness gap, not a skip.
+function canProvisionMember(): boolean {
+  if (!target.capabilities.multiTenant) return false;
+  if (target.provisionMember === undefined) {
+    throw new Error(
+      `target "${target.name}" declares multiTenant but provides no provisionMember()`,
+    );
+  }
+  return true;
+}
+
+async function tenancy(): Promise<TenancyContext> {
+  const context = await target.provisionTenancy();
+  fixtures.defer(() => target.cleanupTenancy(context));
+  return context;
+}
+
+async function createAgent(
+  org: string,
+  visibility: ApiResourceVisibility,
+  label: string,
+) {
+  const input = makeAgent({ org, name: uniqueName(label) });
+  input.metadata = { ...input.metadata, visibility };
+  const agent = await clients.agentCommand.create(input);
+  fixtures.defer(() =>
+    clients.agentCommand.delete({ value: agent.metadata!.id }),
+  );
+  expect(
+    agent.status?.defaultInstanceId,
+    "agent create seeds a default instance",
+  ).toBeTruthy();
+  return agent;
+}
+
+async function createPrivateWorkflow(org: string) {
+  const input = makeWorkflow({ org, name: uniqueName("run-gate-private-wf") });
+  input.metadata = {
+    ...input.metadata,
+    visibility: ApiResourceVisibility.visibility_private,
+  };
+  const workflow = await clients.workflowCommand.create(input);
+  fixtures.defer(() =>
+    clients.workflowCommand.delete({ value: workflow.metadata!.id }),
+  );
+  return workflow;
+}
+
+describe("run gate — a member may run only what they can see (multi-tenant only)", () => {
+  it("session create on a PRIVATE agent's instance is denied with the instance copy and leaves no row", async (ctx) => {
+    if (!canProvisionMember()) return ctx.skip();
+    const context = await tenancy();
+    const member = await target.provisionMember!(context);
+    const agent = await createAgent(
+      context.org,
+      ApiResourceVisibility.visibility_private,
+      "run-gate-private-agent",
+    );
+    const instanceId = agent.status!.defaultInstanceId;
+
+    const denied = await expectGrpcCode(
+      () =>
+        member.sessionCommand.create(
+          makeSession({
+            org: context.org,
+            name: uniqueName("member-session"),
+            agentInstanceId: instanceId,
+          }),
+        ),
+      Code.PermissionDenied,
+      "member session create on a private agent's instance",
+    );
+    expect(denied.rawMessage).toBe(
+      `unauthorized to run agent instance '${instanceId}'`,
+    );
+
+    // Side-effect free: the owner sees no session on the instance.
+    const sessions = await clients.sessionQuery.listByAgentInstance({
+      agentInstanceId: instanceId,
+    });
+    expect(sessions.entries, "no session row behind the denial").toHaveLength(
+      0,
+    );
+  });
+
+  it("execution create by agent_id on a PRIVATE agent is denied with the agent copy", async (ctx) => {
+    if (!canProvisionMember()) return ctx.skip();
+    const context = await tenancy();
+    const member = await target.provisionMember!(context);
+    const agent = await createAgent(
+      context.org,
+      ApiResourceVisibility.visibility_private,
+      "run-gate-private-agent",
+    );
+    const agentId = agent.metadata!.id;
+
+    const denied = await expectGrpcCode(
+      () =>
+        member.agentExecutionCommand.create(
+          makeAgentExecution({
+            org: context.org,
+            name: uniqueName("member-exec"),
+            agentId,
+          }),
+        ),
+      Code.PermissionDenied,
+      "member execution create on a private agent",
+    );
+    expect(denied.rawMessage).toBe(`unauthorized to run agent '${agentId}'`);
+  });
+
+  it("execution create by session_id on a session the member cannot see is denied with the session copy", async (ctx) => {
+    if (!canProvisionMember()) return ctx.skip();
+    const context = await tenancy();
+    const member = await target.provisionMember!(context);
+    const agent = await createAgent(
+      context.org,
+      ApiResourceVisibility.visibility_org,
+      "run-gate-org-agent",
+    );
+    const ownerSession = await clients.sessionCommand.create(
+      makeSession({
+        org: context.org,
+        name: uniqueName("owner-session"),
+        agentInstanceId: agent.status!.defaultInstanceId,
+      }),
+    );
+    fixtures.defer(() =>
+      clients.sessionCommand.delete({ value: ownerSession.metadata!.id }),
+    );
+    const sessionId = ownerSession.metadata!.id;
+
+    const denied = await expectGrpcCode(
+      () =>
+        member.agentExecutionCommand.create(
+          makeAgentExecution({
+            org: context.org,
+            name: uniqueName("member-turn"),
+            sessionId,
+          }),
+        ),
+      Code.PermissionDenied,
+      "member execution create in the owner's session",
+    );
+    expect(denied.rawMessage).toBe(
+      `unauthorized to add an execution to session '${sessionId}'`,
+    );
+  });
+
+  it("workflow execution create on a PRIVATE workflow is denied with the workflow copy", async (ctx) => {
+    if (!canProvisionMember()) return ctx.skip();
+    const context = await tenancy();
+    const member = await target.provisionMember!(context);
+    const workflow = await createPrivateWorkflow(context.org);
+    const workflowId = workflow.metadata!.id;
+
+    const denied = await expectGrpcCode(
+      () =>
+        member.workflowExecutionCommand.create(
+          makeWorkflowExecution({
+            org: context.org,
+            name: uniqueName("member-wf-exec"),
+            workflowId,
+          }),
+        ),
+      Code.PermissionDenied,
+      "member workflow execution create on a private workflow",
+    );
+    expect(denied.rawMessage).toBe(
+      `unauthorized to run workflow '${workflowId}'`,
+    );
+  });
+
+  it("session create on an ORG-visible agent's instance is allowed (the positive arm)", async (ctx) => {
+    if (!canProvisionMember()) return ctx.skip();
+    const context = await tenancy();
+    const member = await target.provisionMember!(context);
+    const agent = await createAgent(
+      context.org,
+      ApiResourceVisibility.visibility_org,
+      "run-gate-org-agent",
+    );
+    const instanceId = agent.status!.defaultInstanceId;
+
+    const session = await member.sessionCommand.create(
+      makeSession({
+        org: context.org,
+        name: uniqueName("member-session"),
+        agentInstanceId: instanceId,
+      }),
+    );
+    fixtures.defer(() =>
+      clients.sessionCommand.delete({ value: session.metadata!.id }),
+    );
+    expect(session.metadata?.id).toMatch(/^ses_/);
+    expect(session.spec?.agentInstanceId).toBe(instanceId);
+  });
+
+  it("an unknown instance id answers NOT_FOUND, never a denial (stigmer#224)", async (ctx) => {
+    if (!canProvisionMember()) return ctx.skip();
+    const context = await tenancy();
+    const member = await target.provisionMember!(context);
+    const missing = `agi_${uniqueName("missing").replaceAll("-", "")}`;
+
+    const notFound = await expectGrpcCode(
+      () =>
+        member.sessionCommand.create(
+          makeSession({
+            org: context.org,
+            name: uniqueName("member-session"),
+            agentInstanceId: missing,
+          }),
+        ),
+      Code.NotFound,
+      "member session create on an unknown instance id",
+    );
+    expect(notFound.rawMessage).toContain(missing);
+  });
+});

--- a/test/conformance/src/targets/cloud-execution.ts
+++ b/test/conformance/src/targets/cloud-execution.ts
@@ -202,6 +202,10 @@ export class CloudExecutionTarget implements TargetProfile {
     return this.cloud.provisionIdentity();
   }
 
+  provisionMember(tenancy: TenancyContext): Promise<ConformanceClients> {
+    return this.cloud.provisionMember(tenancy);
+  }
+
   async teardown(): Promise<void> {
     // Reverse boot order: runner, then the fixtures it dials, then the client
     // connection. The environment itself outlives us (global-setup owns it).

--- a/test/conformance/src/targets/cloud.ts
+++ b/test/conformance/src/targets/cloud.ts
@@ -12,8 +12,15 @@
 // organization created via the production RPC, whose creation grants the
 // primary user ownership (IAM policies) and provisions a zero-balance billing
 // account — sufficient for the Class A (CRUD) domains.
+import { createClient } from "@connectrpc/connect";
+import { IamPolicyCommandController } from "@stigmer/protos/ai/stigmer/iam/iampolicy/v1/command_pb";
 import { ServerEdition } from "@stigmer/protos/ai/stigmer/platform/v1/server_info_pb";
-import { CLOUD_ENV, mintCloudUserToken } from "../harness/cloud-env";
+import {
+  CLOUD_ENV,
+  jwtSubject,
+  mintCloudUserToken,
+  organizationMemberGrant,
+} from "../harness/cloud-env";
 import { createTransport, makeClients, type ConformanceClients } from "../harness/clients";
 import {
   newDirectLoginTenant,
@@ -312,6 +319,37 @@ export class CloudTarget implements TargetProfile {
         clientSecret: requireEnv(CLOUD_ENV.platformClientSecret),
       },
       uniqueName("conf-outsider"),
+    );
+    return makeClients(createTransport(this.grpcBaseUrl, { bearerToken: token }));
+  }
+
+  // Mints a brand-new user and grants it exactly `member` on the tenancy, as
+  // the primary (the org's owner, through the ordinary IamPolicy create). The
+  // colleague for within-organization authorization assertions: past the
+  // organization-level checks, subject to every resource-level rule.
+  async provisionMember(tenancy: TenancyContext): Promise<ConformanceClients> {
+    if (this.grpcBaseUrl === undefined) {
+      throw new Error("CloudTarget.setup() must be called before provisionMember()");
+    }
+    const organizationId = this.provisionedOrgIds.get(tenancy.org);
+    if (organizationId === undefined) {
+      throw new Error(
+        `provisionMember: tenancy "${tenancy.org}" was not provisioned by this target (provisionTenancy() first)`,
+      );
+    }
+    const token = await mintCloudUserToken(
+      this.grpcBaseUrl,
+      {
+        clientId: requireEnv(CLOUD_ENV.platformClientId),
+        clientSecret: requireEnv(CLOUD_ENV.platformClientSecret),
+      },
+      uniqueName("conf-member"),
+    );
+    const primaryTransport = createTransport(this.grpcBaseUrl, {
+      bearerToken: requireEnv(CLOUD_ENV.token),
+    });
+    await createClient(IamPolicyCommandController, primaryTransport).create(
+      organizationMemberGrant(organizationId, jwtSubject(token)),
     );
     return makeClients(createTransport(this.grpcBaseUrl, { bearerToken: token }));
   }

--- a/test/conformance/src/targets/target.ts
+++ b/test/conformance/src/targets/target.ts
@@ -494,6 +494,16 @@ export interface TargetProfile {
   // implicit caller, so isolation is untestable there by construction.
   provisionIdentity?(): Promise<ConformanceClients>;
 
+  // Clients authenticated as a fresh identity holding exactly ONE grant: the
+  // `member` role on the given tenancy — the "colleague" for
+  // within-organization authorization assertions (the run gate: a member may
+  // start runs only on the agents and workflows they can see, P1
+  // sp.run-gate). Distinct from provisionIdentity's outsider, whom the
+  // organization-level checks already refuse before any resource-level rule
+  // is reached. Present only on multi-tenant targets, where roles exist;
+  // local targets have a single implicit caller.
+  provisionMember?(tenancy: TenancyContext): Promise<ConformanceClients>;
+
   // Base URL of the server's unified HTTP port, for the plain-HTTP lanes that
   // route AROUND gRPC (the registry proxies). Present only on targets whose
   // OSS-lane HTTP surface is under test: the local targets own their spawned

--- a/test/extension-consumer/src/fake-extension.ts
+++ b/test/extension-consumer/src/fake-extension.ts
@@ -51,6 +51,7 @@ import {
   EncryptionScope,
   EncryptionUnavailableError,
   InvalidTokenError,
+  isRunGateCheck,
   loadConfig,
   LOADED_EXECUTION_KEY,
   MintingDisabledError,
@@ -108,11 +109,18 @@ import type {
   WorkflowExecutionTemporalConfig,
 } from "@stigmer/server";
 
-/** A permissive Authorizer in the consumer's own code (the O2 shape). */
+/**
+ * A permissive Authorizer in the consumer's own code (the O2 shape), with
+ * the lane-admission arm a composition builds over the run gate (P1
+ * sp.run-gate): a runtime lane this consumer mints is admitted on the
+ * run-gate checks — isRunGateCheck is the OSS-owned definition of that
+ * set — and every other check falls to the consumer's own decision.
+ */
 const authorizer: Authorizer = {
-  authorize: (caller: CallerIdentity) =>
+  authorize: (caller: CallerIdentity, check) =>
     Promise.resolve(
-      caller.callerClass === "user"
+      (caller.callerClass === "fake-lane" && isRunGateCheck(check)) ||
+        caller.callerClass === "user"
         ? { kind: "allow" as const }
         : { kind: "deny" as const, reason: "machine callers are refused here" },
     ),


### PR DESCRIPTION
## Summary
Adds the run gate: one shared `AuthorizeRunTarget` pipeline step in the session, agent-execution and workflow-execution create chains of `@stigmer/server`, so a caller may start or continue a run only on an agent, agent instance, session or workflow they may run. Exports `isRunGateCheck`, the one definition of the run-gate check set, for compositions.

## Context
`session-create` authorized only the organization-level `can_create_session`; `agent-execution-create` and `workflow-execution-create` are `is_skip_authorization`. No step asked whether the caller may use the target the record names; `IamPermission.can_execute` was defined on every blueprint and instance type and checked nowhere. In an edition with an enforcing Authorizer, an organization member who knew a private agent's id could open a session on it and run it; the same held for private workflows. Confirmed live on the hermetic cloud readout before this change (recorded on the private tracking issue) and green with it.

## Changes
- `src/pipeline/steps/authorize-run-target.ts` (new): `AuthorizeRunTarget`, `RunTarget`, `RUN_GATE_CHECKS`, `isRunGateCheck` — the IndexSearch shape (a shared step over a pure per-domain resolver), delegating to the ratified `authorizeResolvedResource` form.
- `src/domain/{session,agentexecution,workflowexecution}/run-target.ts` (new): pure resolvers dispatching on the request shape in each chain's own precedence; byte-pinned deny copy per domain in `constants.ts` (`src/domain/session/constants.ts` is new).
- Controllers: the step spliced immediately after the step that guarantees the target reference (`ResolveDefaultAgentInstance`; `EnsureSessionOrAgentResolved`; `ValidateWorkflowOrInstance`) — before the engine gate, every gate slot and every side effect the chain owns.
- `src/index.ts`: exports `isRunGateCheck`; `test/extension-consumer` uses it (the compile proof).
- `docs/authorization-coverage.md`: the three `create` rows record the mid-chain check.
- Conformance: `suites/run-gate.conformance.test.ts` (new) over a new optional `provisionMember(tenancy)` on the cloud targets (a fresh identity granted exactly `member`, through the ordinary IamPolicy create); `harness/cloud-env.ts` gains `organizationMemberGrant` and exports `jwtSubject`.

## Implementation notes
- The two `is_skip_authorization` annotations stay: the position-1 annotation cannot express a three-shape dispatch; the mid-chain resolved-id pattern is the ratified form, and the coverage inventory records it.
- `can_execute` already exists on `agent`, `agent_instance`, `workflow`, `workflow_instance` (`can_execute: viewer` / `can_view`) and `can_create_execution_in` on `session`, so no fallback permission is needed.
- The step asks for every caller but the `internal` class. Runtime lanes (guest, channel, schedule, workflow sandbox) are admitted by the gate steps that vouch for them; the edition's Authorizer says so by keying on `isRunGateCheck`. OSS stays policy-free; under the permissive single-team default nothing changes for OSS users until P1's owner-or-admin authorizer lands.
- Precedence mirrors the chain: `session_id`, then `session_spec.agent_instance_id`, then `agent_id` (`CreateDefaultInstanceIfNeeded` / `CreateSessionIfNeeded` read them in that order), so the gate authorizes the target the chain will actually use. Asking the blueprint's permission for the `agent_id` / `workflow_id` shape is what lets the gate precede the default-instance side effect.
- Existence disclosure keeps the ratified order: a missing target answers NOT_FOUND before a present one answers PERMISSION_DENIED (stigmer#224).

## Breaking changes
- None on the wire for any caller an edition already admits. New refusals: PERMISSION_DENIED (`unauthorized to run agent '<id>'`, `unauthorized to run agent instance '<id>'`, `unauthorized to add an execution to session '<id>'`, `unauthorized to run workflow '<id>'`, `unauthorized to run workflow instance '<id>'`) for callers an enforcing Authorizer refuses on the target; NOT_FOUND for a nonexistent target where the Authorizer probes existence. A composition with an enforcing Authorizer must admit its own runtime lanes on `isRunGateCheck` before it adopts this release (the cloud composition's change is on its `fix/20260911.09.sp.run-gate` branch and lands as its re-pin PR).

## Test plan
- Unit: `authorize-run-target.test.ts` (20), the three resolver suites (11), and composed-server `run-gate.test.ts` in all three domains (14): denial with the pinned copy, no row persisted, no default instance minted, the engine gate reached only after an allow, the session-first shape checked against the resolved default instance. Server suite: 2262 passed.
- Conformance package: typecheck, `test:unit` (78, incl. the grant helper), `inventory:check` clean. Class A on `local`: `run-gate` (skips visibly), `session`, `agentexecution`, `workflowexecution`, `direct-handler-authorization` green. Execution class on `local-execution`: `agentexecution`, `workflowexecution`, `schedule-firing` green (79).
- `npm run verify:consumer` PASS (packed install boots with workers; the extension consumer typechecks against the published `isRunGateCheck`).
- Hermetic cloud readout (spike recipe): at pin 3.14.0 the `run-gate` suite's five denial arms fail (the member's session on a private agent is created; a private workflow runs; an unknown instance id is accepted); with this branch linked and the composition's lane admission, `run-gate` 6/6 and the lane net (`agentshare`, `agentchannel`, `channelapp`, `schedule`, `session`, `agentexecution`, `workflowexecution`, `direct-handler-authorization`) 125 passed, 12 skipped.

## Risks
- Deny copy is wire once merged.
- A composition that re-pins onto this release without admitting its runtime lanes would refuse them; the cloud's admission and its re-pin are one PR by design.

## Checklist
- [x] Docs updated (`docs/authorization-coverage.md`)
- [x] Tests added/updated
- [x] Backward compatible for every caller an edition already admits

Closes stigmer/stigmer-cloud#709
