### PR TITLE
ci(release): end the standing reds on the release lanes (bridge install retry, dead visibility PUTs, compose pin in the release commit)

### DIFF
--- a/.cursor/rules/release-stigmer-oss.mdc
+++ b/.cursor/rules/release-stigmer-oss.mdc
@@ -58,25 +58,30 @@ git status --short
 
 If there are uncommitted changes, warn the user and ask whether to commit first or abort.
 
-### 5. Bump the mcp-server Bridge Pin (MANDATORY before tagging)
+### 5. Bump the Release Pins (MANDATORY before tagging)
 
-`mcp-server/Dockerfile` pins the npm version the production bridge image installs
-(`ARG MCP_SERVER_VERSION=X.Y.Z`). The `release.npm-libs` workflow has a hard
-pre-publish gate: it refuses to publish a release whose version does not match
-this pin — prod deploys the pin, not the tag. The pin must be bumped **in a
-commit that is included in the tag** (the v3.8.0 release failed this gate,
-2026-08-08).
+Three pins travel in the commit the tag is cut from:
+
+- `mcp-server/Dockerfile` `ARG MCP_SERVER_VERSION=X.Y.Z` — the npm version the
+  production bridge image installs. `release.npm-libs` has a hard pre-publish
+  gate: it refuses to publish a release whose version does not match this pin —
+  prod deploys the pin, not the tag (the v3.8.0 release failed this gate,
+  2026-08-08).
+- `docker-compose.yml` `STIGMER_VERSION:-vX.Y.Z` (both image lines) and
+  `.env.example` `#STIGMER_VERSION=vX.Y.Z` — the stack a fresh clone runs.
+  Until v3.14.1 the release lane bumped these itself after the compose smokes
+  passed; every automated route to `main` was refused (a PR needed an org
+  setting, the direct push hits branch protection GH006), so the bump moved
+  here, next to the pin it already required.
 
 ```bash
-# Verify the pin at HEAD matches the new version
-git show HEAD:mcp-server/Dockerfile | sed -n 's/^ARG MCP_SERVER_VERSION=//p'
+make release-pins version=<NEW_VERSION>
+git commit -am "chore(release): bump the release pins to <NEW_VERSION>"
+git push origin main
 ```
 
-If it does not match, update the `ARG MCP_SERVER_VERSION=` line in
-`mcp-server/Dockerfile` to the new version, commit it to main
-(`chore(mcp-server): bump the Dockerfile bridge pin to <NEW_VERSION>`), push,
-and tag that commit. `make release` also enforces this check before creating
-any tags.
+Tag THAT commit. `make release` refuses to create any tag until all three pins
+name the new version, and prints the two commands above when they do not.
 
 > Note: the pin-bump push to main triggers a Planton bridge build that can fail
 > once with an npm 404 (the version isn't published yet). Re-run it after
@@ -170,6 +175,6 @@ Tags pushed. CI will handle:
 
 - **Never force-push tags** — if a tag already exists, stop and tell the user
 - **Always confirm** the version bump with the user before creating tags
-- **Never tag without the bridge pin bumped** — `release.npm-libs` will hard-fail the publish if `mcp-server/Dockerfile` pins a different version than the tag (see step 5)
+- **Never tag without the release pins bumped** (`make release-pins`) — `release.npm-libs` will hard-fail the publish if `mcp-server/Dockerfile` pins a different version than the tag, and a stale compose pin points fresh clones at the previous stack (see step 5)
 - **Clean working tree required** — do not tag with uncommitted changes unless the user explicitly approves
 - If the user specifies a bump type (`patch`, `minor`, `major`), use it; otherwise infer from commits

--- a/.env.example
+++ b/.env.example
@@ -45,5 +45,5 @@ STIGMER_RUNNER_TOKEN_KEY=
 #STIGMER_OPERATOR_NAME=Your Name
 
 # Run a specific released stack version (both images move together; the
-# default pin in docker-compose.yml is managed by the release lane).
+# default pin in docker-compose.yml is bumped in each release commit).
 #STIGMER_VERSION=v3.14.1

--- a/.github/workflows/release.npm-libs.yaml
+++ b/.github/workflows/release.npm-libs.yaml
@@ -461,20 +461,13 @@ jobs:
             --push \
             backend/services/stigmer-server
 
-      # New GHCR packages default to private; this image is the OSS
-      # self-host artifact. Idempotent, so it rides every release. The
-      # first push above came from this repo's workflow, which auto-links
-      # the package to stigmer/stigmer — keeping GITHUB_TOKEN write access
-      # (the linkage whose absence broke the mirror packages).
-      - name: Ensure GHCR package is public
-        continue-on-error: true
-        run: |
-          gh api \
-            -X PUT \
-            /orgs/${{ github.repository_owner }}/packages/container/stigmer-server/visibility \
-            -f visibility=public
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Package visibility is an org-settings fact, not a step: GHCR has no
+      # REST endpoint to set it (the `PUT .../packages/container/<name>/
+      # visibility` call this job carried until v3.14.1 answered 404 on
+      # every release, masked by continue-on-error into a standing error
+      # annotation). stigmer-server and stigmer-runner are public; a NEW
+      # image package is made public once, by hand, in the org's package
+      # settings after its first push.
 
   # Native smokes of the PUSHED tag — the same script PR CI and local dev
   # run (scripts/smoke-docker-image.mjs): docker health, Connect-JSON
@@ -656,23 +649,15 @@ jobs:
             --tag "ghcr.io/${{ github.repository_owner }}/stigmer-runner:v${VERSION}" \
             "ghcr.io/${{ github.repository_owner }}/stigmer-runner:v${VERSION}-amd64" \
             "ghcr.io/${{ github.repository_owner }}/stigmer-runner:v${VERSION}-arm64"
-
-      - name: Ensure GHCR package is public
-        continue-on-error: true
-        run: |
-          gh api \
-            -X PUT \
-            /orgs/${{ github.repository_owner }}/packages/container/stigmer-runner/visibility \
-            -f visibility=public
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # (Package visibility: see the note on publish-server-image.)
 
   # The published-tag re-verification the P5 gate ruled (Q-A): the SAME
   # scripts/smoke-compose.mjs that gates PRs (there: build-from-source)
   # runs the full stack — Postgres, Temporal, server, runner — from the
   # images just pushed, up to one end-to-end workflow run, natively per
-  # arch. `stigmer-runner:latest` and the compose pin only move after
-  # the stack these tags name has actually run somewhere.
+  # arch. `stigmer-runner:latest` only moves after the stack these tags
+  # name has actually run somewhere (the compose pin travels with the
+  # release commit instead; see the note after promote-runner-image-latest).
   smoke-compose-amd64:
     needs: [determine-version, publish-server-image, publish-runner-image]
     runs-on: ubuntu-latest
@@ -745,46 +730,15 @@ jobs:
             --tag "ghcr.io/${{ github.repository_owner }}/stigmer-runner:latest" \
             "ghcr.io/${{ github.repository_owner }}/stigmer-runner:v${VERSION}"
 
-  # The compose pin is release-lane-managed (P5 gate ruling Q-A): after
-  # both published-tag compose smokes pass on a stable release, open a PR
-  # re-pointing docker-compose.yml's STIGMER_VERSION default (and the
-  # .env.example doc line) at this version. Pushed DIRECTLY to main (owner
-  # ruling, oss#915): the bump is mechanical and is proven by this very run
-  # — both published-tag compose smokes gate this job — and the PR route
-  # required an org setting that blocked the v3.13.0 lane. The push uses
-  # the workflow's own GITHUB_TOKEN, so it never retriggers push workflows
-  # (the SDK-docs self-heal precedent, ci.docs.yaml).
-  bump-compose-pins:
-    needs: [determine-version, smoke-compose-amd64, smoke-compose-arm64]
-    if: ${{ !contains(needs.determine-version.outputs.version, '-') }}
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout main
-        uses: actions/checkout@v4
-        with:
-          ref: main
-
-      - name: Re-point the compose pins and push to main
-        env:
-          VERSION: ${{ needs.determine-version.outputs.version }}
-        run: |
-          set -euo pipefail
-          sed -i -E "s/STIGMER_VERSION:-v[0-9A-Za-z.+-]+/STIGMER_VERSION:-v${VERSION}/g" docker-compose.yml
-          sed -i -E "s/^#STIGMER_VERSION=.*/#STIGMER_VERSION=v${VERSION}/" .env.example
-          if git diff --quiet; then
-            echo "pins already at v${VERSION} — nothing to bump"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit \
-            -am "chore(release): pin the compose stack to v${VERSION}" \
-            -m "Automated by release.npm-libs.yaml after both published-tag compose smokes passed (amd64 + arm64)."
-          # Race-resilient like the SDK-docs self-heal, but a lost pin must
-          # FAIL loudly (a stale pin points fresh clones at the wrong
-          # images), so no warning fallback: rebase once, then give up.
-          git push origin HEAD:main \
-            || { git pull --rebase origin main && git push origin HEAD:main; }
+  # The compose pin (docker-compose.yml's STIGMER_VERSION default and the
+  # .env.example doc line) is NOT bumped here. Every automated route to
+  # main has been tried and refused: a PR needed an org setting that
+  # blocked the v3.13.0 lane; the direct push (owner ruling, oss#915) is
+  # refused by main's branch protection (GH006) with the workflow's own
+  # GITHUB_TOKEN, which failed loudly on v3.14.0 and v3.14.1. The pin now
+  # travels with the mcp-server bridge pin in the release commit that the
+  # tag is cut from (`make release` refuses to tag without it; the
+  # @release-stigmer-oss rule's step 5). The published-tag compose smokes
+  # above still gate `latest`: a red smoke is a broken release, acted on
+  # by a human, and the pin ahead of it by minutes points a fresh clone at
+  # images the same run is proving.

--- a/.github/workflows/release.sandbox-cloud.yaml
+++ b/.github/workflows/release.sandbox-cloud.yaml
@@ -116,15 +116,9 @@ jobs:
             --push \
             .
 
-      - name: Ensure GHCR package is public
-        continue-on-error: true
-        run: |
-          gh api \
-            -X PUT \
-            /orgs/${{ github.repository_owner }}/packages/container/runner/visibility \
-            -f visibility=public
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Package visibility is an org-settings fact, not a step (GHCR has no
+      # REST endpoint for it; the PUT this job carried answered 404 on
+      # every run, masked into an error annotation). `runner` is public.
 
       - name: Smoke-test runner image
         # Gate before blessing :prod. Boot a sandbox from the freshly built SHA image:

--- a/Makefile
+++ b/Makefile
@@ -1001,8 +1001,24 @@ gen-llms: ## Generate LLM-friendly output (llms.txt, llms-full.txt, per-page .md
 
 # ─── Release ──────────────────────────────────
 
-.PHONY: release
-release: ## Tag and push a release (usage: make release [bump=patch|minor|major])
+.PHONY: release release-pins
+# The three release pins travel in the commit the tag is cut from: the
+# mcp-server bridge pin (release.npm-libs refuses to publish on a mismatch)
+# and the compose stack pin in docker-compose.yml + .env.example (the
+# release lane cannot push the bump to the protected main — GH006 on
+# v3.14.0 and v3.14.1 — so it moved here, next to the pin it already
+# required). `make release` refuses to tag until all three name the new
+# version. perl, not sed -i: the recipe must run the same on macOS and
+# Linux.
+release-pins: ## Bump the release pins to version=X.Y.Z (mcp-server bridge, compose stack); commit before `make release`
+	@[ -n "$(version)" ] || { echo "usage: make release-pins version=X.Y.Z"; exit 1; }
+	@echo "$(version)" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$$' || { echo "error: version must be X.Y.Z (got '$(version)')"; exit 1; }
+	@perl -pi -e 's/^ARG MCP_SERVER_VERSION=.*/ARG MCP_SERVER_VERSION=$(version)/' mcp-server/Dockerfile
+	@perl -pi -e 's/STIGMER_VERSION:-v[0-9A-Za-z.+-]+/STIGMER_VERSION:-v$(version)/g' docker-compose.yml
+	@perl -pi -e 's/^#STIGMER_VERSION=.*/#STIGMER_VERSION=v$(version)/' .env.example
+	@echo "release pins set to $(version):"; git --no-pager diff --stat -- mcp-server/Dockerfile docker-compose.yml .env.example
+
+release: ## Tag and push a release (usage: make release [bump=patch|minor|major]); run `make release-pins` and commit first
 	@LATEST_TAG=$$(git tag -l "v*" | sort -V | tail -n1); \
 	[ -z "$$LATEST_TAG" ] && LATEST_TAG="v0.0.0"; \
 	VERSION=$$(echo $$LATEST_TAG | sed 's/^v//'); \
@@ -1021,15 +1037,19 @@ release: ## Tag and push a release (usage: make release [bump=patch|minor|major]
 	fi; \
 	NEW_VERSION="$$MAJOR.$$MINOR.$$PATCH"; \
 	PIN=$$(git show HEAD:mcp-server/Dockerfile | sed -n 's/^ARG MCP_SERVER_VERSION=//p'); \
-	if [ "$$PIN" != "$$NEW_VERSION" ]; then \
-		echo "error: mcp-server/Dockerfile at HEAD pins MCP_SERVER_VERSION=$$PIN but this release is $$NEW_TAG."; \
-		echo "release.npm-libs will refuse to publish (prod deploys the pin, not the tag)."; \
-		echo "Bump the pin and COMMIT it before tagging:"; \
-		echo "  sed -i '' 's/^ARG MCP_SERVER_VERSION=.*/ARG MCP_SERVER_VERSION=$$NEW_VERSION/' mcp-server/Dockerfile"; \
-		echo "  git add mcp-server/Dockerfile && git commit -m 'chore(mcp-server): bump the Dockerfile bridge pin to $$NEW_VERSION'"; \
+	COMPOSE_PIN=$$(git show HEAD:docker-compose.yml | sed -n -E 's/.*STIGMER_VERSION:-v([0-9A-Za-z.+-]+).*/\1/p' | sort -u | tr '\n' ' ' | sed 's/ $$//'); \
+	ENV_PIN=$$(git show HEAD:.env.example | sed -n -E 's/^#STIGMER_VERSION=v(.*)$$/\1/p'); \
+	if [ "$$PIN" != "$$NEW_VERSION" ] || [ "$$COMPOSE_PIN" != "$$NEW_VERSION" ] || [ "$$ENV_PIN" != "$$NEW_VERSION" ]; then \
+		echo "error: the release pins at HEAD do not all name $$NEW_VERSION:"; \
+		echo "  mcp-server/Dockerfile  MCP_SERVER_VERSION=$$PIN   (release.npm-libs refuses to publish on a mismatch; prod deploys the pin, not the tag)"; \
+		echo "  docker-compose.yml     STIGMER_VERSION:-v$$COMPOSE_PIN   (a fresh clone runs this stack)"; \
+		echo "  .env.example           #STIGMER_VERSION=v$$ENV_PIN"; \
+		echo "Bump them and COMMIT before tagging:"; \
+		echo "  make release-pins version=$$NEW_VERSION"; \
+		echo "  git commit -am 'chore(release): bump the release pins to $$NEW_VERSION'"; \
 		exit 1; \
 	fi; \
-	echo "$$LATEST_TAG -> $$NEW_TAG (bridge pin OK)"; \
+	echo "$$LATEST_TAG -> $$NEW_TAG (release pins OK)"; \
 	git tag -a "sdk/go/$$NEW_TAG" -m "Release sdk/go $$NEW_TAG"; \
 	git tag -a "$$NEW_TAG" -m "Release $$NEW_TAG"; \
 	for t in "sdk/go/$$NEW_TAG" "$$NEW_TAG"; do \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,11 @@
 #                   servers spawn INSIDE this container — they can reach this
 #                   container's filesystem and network, not your host's.
 #
-# Image pins: the STIGMER_VERSION default below is managed by the release
-# lane (release.npm-libs.yaml pushes the bump to main after both published
-# images pass the compose smoke on both architectures). Override in .env to
-# run a different released version.
+# Image pins: the STIGMER_VERSION default below is bumped in the release
+# commit the tag is cut from (`make release` / @release-stigmer-oss refuse
+# to tag without it, alongside the mcp-server bridge pin); release.npm-libs
+# then proves the pinned images with the compose smoke on both
+# architectures. Override in .env to run a different released version.
 #
 # The env blocks below set every load-bearing variable EXPLICITLY, even
 # where the image default would coincide — two independent defaults

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -48,21 +48,28 @@ WORKDIR /app
 # Install the published package globally; this pulls its full runtime dependency
 # tree and exposes the `mcp-server-stigmer` bin on PATH.
 #
-# The install first WAITS for the pinned version to appear on the registry
-# (up to 10 minutes). The prod deploy pipeline fires the moment the tag
-# commit is pushed — ~6 minutes before release.npm-libs finishes publishing
-# that same version — so a bare install raced npm and failed first-try on
-# EVERY release from 3.12.3 through 3.12.8, silently leaving prod on the
-# previous bridge until someone noticed and reran (the v3.12.8 /memory
-# route sat undeployed this way, 2026-08-22). release.mcp-server solves
-# this with a workflow-level wait step; putting the wait here fixes every
-# builder of this file at once.
+# The install RETRIES until the whole pinned tree is installable (up to 10
+# minutes). The prod deploy pipeline fires the moment the tag commit is
+# pushed — minutes before release.npm-libs finishes publishing that same
+# version — so a bare install raced npm and failed first-try on EVERY
+# release from 3.12.3 through 3.12.8, silently leaving prod on the previous
+# bridge until someone noticed and reran (the v3.12.8 /memory route sat
+# undeployed this way, 2026-08-22). Until v3.14.1 the wait polled only the
+# TOP package with `npm view`; the install then failed anyway with
+# ETARGET on @stigmer/sdk@3.14.1 — every @stigmer/* dependency is published
+# by the same run and each becomes visible on its own schedule, so the
+# only reliable signal is the install itself succeeding. Retrying the
+# install (npm install is idempotent on failure: nothing is left half
+# installed under --global) fixes every builder of this file at once.
 RUN for i in $(seq 1 60); do \
-        npm view "@stigmer/mcp-server@${MCP_SERVER_VERSION}" version >/dev/null 2>&1 && break; \
-        echo "attempt $i/60: @stigmer/mcp-server@${MCP_SERVER_VERSION} not on npm yet; retrying in 10s"; \
+        npm install --global --omit=dev "@stigmer/mcp-server@${MCP_SERVER_VERSION}" && break; \
+        if [ "$i" -eq 60 ]; then \
+            echo "@stigmer/mcp-server@${MCP_SERVER_VERSION} and its dependencies did not become installable within 10 minutes" >&2; \
+            exit 1; \
+        fi; \
+        echo "attempt $i/60: @stigmer/mcp-server@${MCP_SERVER_VERSION} (or a dependency) not on npm yet; retrying in 10s"; \
         sleep 10; \
-    done \
-    && npm install --global --omit=dev "@stigmer/mcp-server@${MCP_SERVER_VERSION}"
+    done
 
 # Run as the non-root user shipped with the node:alpine base.
 USER node


### PR DESCRIPTION
## Summary
Ends the three reds that fire on every release and never meant a broken release: the mcp-server bridge image's install race, the dead "Ensure GHCR package is public" steps, and the `bump-compose-pins` push that branch protection refuses.

## Context
On v3.14.1 both release runs went red (`release.mcp-server` and `release.npm-libs`), and the same pattern is visible on v3.14.0. Each red is an alarm with no signal behind it, and the compose pin has had to be applied by hand twice.

## Changes
- `mcp-server/Dockerfile`: the install itself is retried (60 × 10 s) instead of polling only `@stigmer/mcp-server` with `npm view`. The v3.14.1 failure was `ETARGET` on `@stigmer/sdk@3.14.1` — a sibling dependency published by the same run and visible on its own schedule; the only reliable signal is the install succeeding. The loop exits 1 after the budget.
- `.github/workflows/release.npm-libs.yaml`, `release.sandbox-cloud.yaml`: the three "Ensure GHCR package is public" steps are removed. GHCR has no REST endpoint to set visibility; the PUT answered 404 on every run and `continue-on-error` turned it into a permanent error annotation. `stigmer-server`, `stigmer-runner` and `runner` are public (checked); a note at each site says where visibility lives.
- `release.npm-libs.yaml`: the `bump-compose-pins` job is removed, with the history in its place (PR route refused by an org setting, oss#915; direct push refused by branch protection, GH006, on v3.14.0 and v3.14.1).
- `Makefile`: new `release-pins version=X.Y.Z` bumps the mcp-server bridge pin and the compose pins (`docker-compose.yml`, `.env.example`) in one go, portably (perl, not `sed -i`); `make release` now refuses to tag until all three pins name the new version and prints the two commands to fix it.
- `.cursor/rules/release-stigmer-oss.mdc` step 5, `docker-compose.yml` and `.env.example` comments: the compose pin travels in the release commit.

## Implementation notes
- Trade-off made explicit: the compose pin now advances minutes before the published-tag compose smokes prove the images. Those smokes still run and still gate `stigmer-runner:latest`; a red smoke is a broken release a human acts on, and a fresh clone in that window points at images the same run is proving. Both automated write-to-main routes have been tried and refused; a bot token with bypass would be the alternative and is an owner decision.
- No release behaviour changes for consumers; this is lane plumbing.

## Test plan
- `make release bump=patch` at HEAD (pins 3.14.1) refuses with the new three-line message.
- `make release-pins version=9.9.9` on a scratch copy rewrites `mcp-server/Dockerfile`, both `docker-compose.yml` image lines and `.env.example`.
- `docker build -f mcp-server/Dockerfile --build-arg MCP_SERVER_VERSION=3.14.1` succeeds locally from the new Dockerfile; `mcp-server-stigmer` is on PATH in the image; the loop's give-up arm exits 1 (checked in `node:22-alpine`).
- Both workflows parse (`yq`).
- The v3.14.1 runs themselves were repaired by re-running the failed jobs once the packages were visible: `release.mcp-server` is green and the 3.14.1 bridge image exists.

## Risks
- None to published artifacts. If a future release forgets `make release-pins`, `make release` refuses before any tag exists.

## Checklist
- [x] Docs updated (release rule, compose comments)
- [x] Verified locally
- [x] Backward compatible
