### PR TITLE
fix(backend/runner): persist a thrown terminal once; the pause and shutdown rows are no longer doubled

### DIFF
--- a/backend/services/runner/src/__test-utils__/harness-contract/runtime-contract.ts
+++ b/backend/services/runner/src/__test-utils__/harness-contract/runtime-contract.ts
@@ -301,9 +301,9 @@ function hangingTurn(before: string): TurnScenario {
 
 /**
  * A user pause: Temporal's cancellation delivered while the engine hangs
- * persists PAUSED with the pause row written twice (stigmer#1054, reproduced
- * on purpose), no error, no `completedAt`, and THROWS the pause
- * `CancelledFailure` so the workflow knows to wait.
+ * persists PAUSED with the pause row written exactly once, no error, no
+ * `completedAt`, and THROWS the pause `CancelledFailure` so the workflow
+ * knows to wait.
  */
 export async function assertPausePersistsAndThrows(harness: RuntimeContractHarness, label = "rt-pause"): Promise<RuntimeArmResult> {
   const { subject } = harness;
@@ -320,7 +320,7 @@ export async function assertPausePersistsAndThrows(harness: RuntimeContractHarne
   const final = finalStatusOf(harness, driver);
   expect(final.error, `${subject.name}: a pause is not an error`).toBe("");
   expect(final.completedAt, `${subject.name}: a paused turn is not complete`).toBe("");
-  expect(systemMessages(final), `${subject.name}: the pause row, doubled (#1054)`).toEqual([TERMINAL_COPY.pause.row, TERMINAL_COPY.pause.row]);
+  expect(systemMessages(final), `${subject.name}: the pause row, exactly once`).toEqual([TERMINAL_COPY.pause.row]);
   expect(aiMessages(final)).not.toContain(NEVER_SEEN);
   return { driver, invocations: [invocation], final };
 }
@@ -328,7 +328,7 @@ export async function assertPausePersistsAndThrows(harness: RuntimeContractHarne
 /**
  * A worker shutdown: the queue's shutdown signal aborts, then Temporal
  * cancels (the runner-manager's drain). FAILED with the shutdown copy, the
- * row doubled, stamped, and the shutdown `CancelledFailure` thrown.
+ * row exactly once, stamped, and the shutdown `CancelledFailure` thrown.
  */
 export async function assertWorkerShutdownPersistsAndThrows(harness: RuntimeContractHarness, label = "rt-shutdown"): Promise<RuntimeArmResult> {
   const { subject } = harness;
@@ -348,7 +348,7 @@ export async function assertWorkerShutdownPersistsAndThrows(harness: RuntimeCont
   const final = finalStatusOf(harness, driver);
   expect(final.error).toBe(TERMINAL_COPY.workerShutdown.error);
   expect(final.completedAt).not.toBe("");
-  expect(systemMessages(final)).toEqual([TERMINAL_COPY.workerShutdown.row, TERMINAL_COPY.workerShutdown.row]);
+  expect(systemMessages(final), `${subject.name}: the shutdown row, exactly once`).toEqual([TERMINAL_COPY.workerShutdown.row]);
   expect(aiMessages(final)).not.toContain(NEVER_SEEN);
   return { driver, invocations: [invocation], final };
 }
@@ -620,11 +620,11 @@ export function describeHarnessRuntimeContract(harness: RuntimeContractHarness, 
       clock.reset();
       await assertApprovalRoundTrip(harness);
     });
-    it("a user pause persists PAUSED (the #1054 double) and throws the pause CancelledFailure", async () => {
+    it("a user pause persists PAUSED with the pause row once and throws the pause CancelledFailure", async () => {
       clock.reset();
       await assertPausePersistsAndThrows(harness);
     });
-    it("a worker shutdown persists FAILED with the shutdown copy (doubled) and throws the shutdown CancelledFailure", async () => {
+    it("a worker shutdown persists FAILED with the shutdown copy once and throws the shutdown CancelledFailure", async () => {
       clock.reset();
       await assertWorkerShutdownPersistsAndThrows(harness);
     });

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/pause.status.json
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/pause.status.json
@@ -9,11 +9,6 @@
       "type": "MESSAGE_SYSTEM",
       "content": "Execution paused by user. Use resume to continue.",
       "timestamp": "2026-01-01T00:00:03.000Z"
-    },
-    {
-      "type": "MESSAGE_SYSTEM",
-      "content": "Execution paused by user. Use resume to continue.",
-      "timestamp": "2026-01-01T00:00:03.000Z"
     }
   ],
   "phase": "EXECUTION_PAUSED",

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/worker-shutdown.status.json
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/goldens/worker-shutdown.status.json
@@ -9,11 +9,6 @@
       "type": "MESSAGE_SYSTEM",
       "content": "Execution interrupted: the runner worker was shut down while the agent was still running. You can retry or resume.",
       "timestamp": "2026-01-01T00:00:03.000Z"
-    },
-    {
-      "type": "MESSAGE_SYSTEM",
-      "content": "Execution interrupted: the runner worker was shut down while the agent was still running. You can retry or resume.",
-      "timestamp": "2026-01-01T00:00:03.000Z"
     }
   ],
   "phase": "EXECUTION_FAILED",

--- a/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/pause-vs-shutdown.test.ts
+++ b/backend/services/runner/src/activities/execute-cursor/__tests__/hermetic/pause-vs-shutdown.test.ts
@@ -2,8 +2,8 @@
  * Hermetic goldens: USER PAUSE versus WORKER SHUTDOWN — the two interruptions
  * that THROW, and the byte-pinned copy that tells them apart.
  *
- * Invariant pinned (the throw-vs-return table the runtime will own in S2; parent
- * §5c): both interruptions end the activity with a thrown Temporal
+ * Invariant pinned (the throw-vs-return table the runtime owns,
+ * `harness/terminal-table.ts`; parent §5c): both interruptions end the activity with a thrown Temporal
  * `CancelledFailure` (never a return), but they persist DIFFERENT terminal
  * states the control plane keys on:
  *
@@ -22,23 +22,25 @@
  * stream loop sees `isCancelled()` on its next iteration and never processes
  * the event that follows.
  *
- * What the goldens ALSO pin, on purpose: both paths append their system message
- * TWICE — once in `resolvePreBoundaryTerminal` before the throw, once again in
- * the outer `catch (CancelledFailure)`, which re-stamps and re-persists. That is
- * today's production behavior on the wire. S2 must reproduce it byte for byte;
- * whether it is later collapsed to one message is a separate, deliberate change
- * (recorded in the entry's execution log for the owner).
+ * What the goldens ALSO pin: each path appends its system message exactly
+ * ONCE. The orchestrator this net was recorded on appended it twice — once in
+ * `resolvePreBoundaryTerminal` before the throw, once again in the outer
+ * `catch (CancelledFailure)`, which re-stamped and re-persisted — and the
+ * goldens pinned that double on purpose so S2 could reproduce the wire byte
+ * for byte (stigmer#1054, Q-S2-4). The runtime's `settleWith` is now the one
+ * writer of a terminal arm, so a second row has no code path to come from.
  *
- * Parent phase rows exercised: the stream loop's cancellation check; the
- * post-stream `classifyTurnInterruption`; `resolvePreBoundaryTerminal`'s
- * pause and worker-shutdown arms; the outer `CancelledFailure` catch; the
- * `finally` teardown under a thrown exit.
+ * Runtime phases exercised: the adapter's stop-signal cancel; the runtime's
+ * `classifyTurnInterruption`; the terminal table's pause and worker-shutdown
+ * arms through `settleWith`; the `finally` teardown under a thrown exit.
  *
- * Both goldens were regenerated at S2 M3b (entry 20260911.03) with a
- * timestamp-only diff — every terminal stamp one scripted second earlier:
- * the adapter now cancels the SDK run the instant the runtime's stop signal
- * aborts (Q-M3-4), before the SDK double pulls, and the clock ticks on, one
- * more step. The transcript is unchanged, the #1054 double included.
+ * Regeneration history:
+ *  - S2 M3b (entry 20260911.03): timestamp-only diff — every terminal stamp
+ *    one scripted second earlier: the adapter cancels the SDK run the instant
+ *    the runtime's stop signal aborts (Q-M3-4), before the SDK double pulls,
+ *    and the clock ticks on, one more step. Transcript unchanged.
+ *  - 2026-09-12 (stigmer#1054, the PR after S2): one removed system row per
+ *    golden, nothing else. The transcript now carries each terminal row once.
  *
  * Regenerate ONLY after a deliberate behavior change:
  *   npx vitest run src/activities/execute-cursor/__tests__/hermetic -u
@@ -150,10 +152,7 @@ describe("ExecuteCursor hermetic — user pause vs worker shutdown", () => {
     expect(final.completedAt, "a paused turn is not complete").toBe("");
     expect(
       final.messages.filter((m) => m.type === MessageType.MESSAGE_SYSTEM).map((m) => m.content),
-    ).toEqual([
-      "Execution paused by user. Use resume to continue.",
-      "Execution paused by user. Use resume to continue.",
-    ]);
+    ).toEqual(["Execution paused by user. Use resume to continue."]);
     expect(final.messages.some((m) => m.content === NEVER_SEEN), "nothing after the cancel is processed").toBe(false);
 
     const json = JSON.stringify(toJson(AgentExecutionStatusSchema, final), null, 2) + "\n";
@@ -196,7 +195,6 @@ describe("ExecuteCursor hermetic — user pause vs worker shutdown", () => {
     expect(
       final.messages.filter((m) => m.type === MessageType.MESSAGE_SYSTEM).map((m) => m.content),
     ).toEqual([
-      "Execution interrupted: the runner worker was shut down while the agent was still running. You can retry or resume.",
       "Execution interrupted: the runner worker was shut down while the agent was still running. You can retry or resume.",
     ]);
     expect(final.messages.some((m) => m.content === NEVER_SEEN)).toBe(false);

--- a/backend/services/runner/src/harness/run-turn.ts
+++ b/backend/services/runner/src/harness/run-turn.ts
@@ -8,7 +8,8 @@
  * stall watchdog, the cost cap, the platform STOP, Temporal's cancellation);
  * the resolution phases (`turn-context.ts`) composed into the `TurnInput`;
  * the sink the adapter is handed; the terminal table (`terminal-table.ts`)
- * with its throw-vs-return rule; the completion epilogue (final text,
+ * with its throw-vs-return rule, applied by `settleWith`, the one writer of
+ * a terminal; the completion epilogue (final text,
  * structured output, plan artifact, write-back); the finally that releases
  * the workspace lock last. The adapter owns its SDK slice inside `runTurn`
  * and its own teardown inside its own `finally`, which runs BEFORE this
@@ -61,7 +62,6 @@ import {
 import { PersistChokepoint } from "./persist-chokepoint.js";
 import { StopController } from "./stop-controller.js";
 import {
-  appendSystemRows,
   applyTerminalArm,
   costCapArm,
   failedArm,
@@ -127,8 +127,13 @@ export async function runTurnActivity(deps: TurnRuntimeDeps, input: NormalizedAc
   return runWithExecutionContext(executionId, () => runTurn(deps, input));
 }
 
-/** Where the activity ends up once the table has been applied: return the slim status, or throw after the finally. */
-type Settled = { readonly kind: "return"; readonly value: unknown } | { readonly kind: "throw"; readonly error: Error };
+/**
+ * Where the activity ends up once the table has been applied: return the
+ * slim status, or throw after the finally. The thrown value is always a
+ * `CancelledFailure` — the table's rule ("THROW when the workflow must see
+ * the activity as cancelled", `terminal-table.ts`) as a type.
+ */
+type Settled = { readonly kind: "return"; readonly value: unknown } | { readonly kind: "throw"; readonly error: CancelledFailure };
 
 async function runTurn(deps: TurnRuntimeDeps, input: NormalizedActivityInput): Promise<unknown> {
   const { adapter, activityName, client, config } = deps;
@@ -191,20 +196,30 @@ async function runTurn(deps: TurnRuntimeDeps, input: NormalizedActivityInput): P
       shutdownSignalAborted: shutdownSignal?.aborted ?? false,
     });
 
-  /** Write an arm, persist it, and decide how the activity ends. The throw arms do the #1054 double here. */
-  const settleWith = async (arm: TerminalArm): Promise<Settled> => {
+  /**
+   * The one writer of a terminal: apply the arm, persist it ONCE, and end
+   * the activity the way the arm's disposition says. A thrown arm also marks
+   * the in-progress sub-agent rows cancelled before that persist, so the
+   * status the workflow reads back is the whole terminal state in one write.
+   * (The file-review resume in `settleResolution` is the one place that
+   * applies an arm itself: its write-back must land between the arm and the
+   * persist.)
+   *
+   * The table decides what is written and whether the activity throws; the
+   * caller may supply the `CancelledFailure` to throw. The catch does, to
+   * rethrow the failure it caught (the caught failure IS the evidence, #776)
+   * or to throw the after-error variant of the copy; every other caller lets
+   * the arm's own message stand.
+   */
+  const settleWith = async (arm: TerminalArm, failure?: CancelledFailure): Promise<Settled> => {
     applyTerminalArm(status, arm);
-    await chokepoint.write();
     if (arm.disposition.kind === "return") {
+      await chokepoint.write();
       return { kind: "return", value: slimStatus(status) };
     }
-    // stigmer#1054: the orchestrator's throw fell into its own catch, which
-    // appended the row again and re-stamped completion; the goldens pin it.
-    appendSystemRows(status, arm.rows);
-    if (arm.completes) status.completedAt = utcTimestamp();
     cancelInProgressSubAgentProtos(status.subAgentExecutions);
     await chokepoint.write();
-    return { kind: "throw", error: new CancelledFailure(arm.disposition.message) };
+    return { kind: "throw", error: failure ?? new CancelledFailure(arm.disposition.message) };
   };
 
   // ── The turn ended during resolution ──────────────────────────────────────
@@ -490,9 +505,8 @@ async function runTurn(deps: TurnRuntimeDeps, input: NormalizedActivityInput): P
    * the runtime's own: a `CancelledFailure` from a resolution phase (the
    * lock wait), an unexpected error during resolution or the epilogue, or a
    * contract violation. The cancellation arms are the table's throw arms
-   * written once (the runtime did not write them before the throw, so there
-   * is no double here) with a best-effort persist; the generic arm is the
-   * `internal` failure surface, returned.
+   * through `settleWith`, with the failure this catch chooses to throw; the
+   * generic arm is the `internal` failure surface, returned.
    */
   async function settleThrown(err: unknown): Promise<Settled> {
     const cancelledArm = (): TerminalArm | undefined => {
@@ -521,11 +535,7 @@ async function runTurn(deps: TurnRuntimeDeps, input: NormalizedActivityInput): P
       // signal); the caught failure IS the evidence (#776). A thrown
       // cancellation with no delivered cancellation on the signal can only be
       // the runtime's own `checkCancellation`-style throw: infrastructure.
-      const arm = cancelledArm() ?? infrastructureCancelArm();
-      applyTerminalArm(status, arm);
-      cancelInProgressSubAgentProtos(status.subAgentExecutions);
-      await chokepoint.write();
-      return { kind: "throw", error: err };
+      return settleWith(cancelledArm() ?? infrastructureCancelArm(), err);
     }
 
     const errDetail = err instanceof Error ? err.message : String(err);
@@ -537,19 +547,13 @@ async function runTurn(deps: TurnRuntimeDeps, input: NormalizedActivityInput): P
       // else reads as the interruption it was.
       if (arm.phase === ExecutionPhase.EXECUTION_PAUSED) {
         console.log(`${activityName} error during pause (treating as pause): execution=${executionId}, error=${errDetail}`);
-        applyTerminalArm(status, arm);
-        cancelInProgressSubAgentProtos(status.subAgentExecutions);
-        await chokepoint.write();
-        return { kind: "throw", error: new CancelledFailure(TERMINAL_COPY.pause.throwMessageAfterError) };
+        return settleWith(arm, new CancelledFailure(TERMINAL_COPY.pause.throwMessageAfterError));
       }
       console.log(`${activityName} error during infrastructure cancel: execution=${executionId}, error=${errDetail}`);
-      applyTerminalArm(status, {
-        ...infrastructureCancelArm(),
-        error: `Execution interrupted: ${errDetail}`,
-      });
-      cancelInProgressSubAgentProtos(status.subAgentExecutions);
-      await chokepoint.write();
-      return { kind: "throw", error: new CancelledFailure(TERMINAL_COPY.infrastructureCancel.throwMessageAfterError) };
+      return settleWith(
+        { ...infrastructureCancelArm(), error: `Execution interrupted: ${errDetail}` },
+        new CancelledFailure(TERMINAL_COPY.infrastructureCancel.throwMessageAfterError),
+      );
     }
 
     // Unwrap + classify before formatting: a model error arrives
@@ -557,9 +561,7 @@ async function runTurn(deps: TurnRuntimeDeps, input: NormalizedActivityInput): P
     // the root error's own identity.
     const { errorType, errorMessage } = describeExecutionError(err, { proxyMode: !!config.proxyEndpoint });
     console.error(`${activityName} failed: execution=${executionId}, [${errorType}] ${errorMessage}`);
-    applyTerminalArm(status, unexpectedErrorArm(errorType, errorMessage));
-    await chokepoint.write();
-    return { kind: "return", value: slimStatus(status) };
+    return settleWith(unexpectedErrorArm(errorType, errorMessage));
   }
   // ── Drive ─────────────────────────────────────────────────────────────────
 

--- a/backend/services/runner/src/harness/terminal-table.ts
+++ b/backend/services/runner/src/harness/terminal-table.ts
@@ -21,12 +21,13 @@
  *    infrastructure cancel it delivered — with the message the control
  *    planes recognise.
  *
- * The three THROW arms append their row TWICE: once when the runtime writes
- * the terminal status, once more before it throws. That is stigmer#1054,
- * reproduced on purpose (Q-S2-4): the orchestrator's throw fell into its own
- * catch, which appended the copy again, and the goldens pin the double. The
- * fix is a reviewed golden regeneration in the PR after S2, not a silent
- * change inside it.
+ * An arm's rows are appended exactly once, by `applyTerminalArm`, and an arm
+ * is persisted exactly once, by `run-turn.ts`'s `settleWith` — the one
+ * writer of a terminal. The orchestrator this table replaced appended the
+ * three THROW arms' rows twice (its throw fell into its own catch, which
+ * wrote the copy again); S2 reproduced that on purpose so the goldens could
+ * pin the wire byte for byte, and the PR after S2 removed it with a reviewed
+ * golden regeneration (stigmer#1054, Q-S2-4).
  */
 
 import { create } from "@bufbuild/protobuf";
@@ -48,7 +49,7 @@ export interface TerminalArm {
   readonly phase: ExecutionPhase;
   /** `status.error`; absent leaves it as it is (a pause is not an error). */
   readonly error?: string;
-  /** System rows appended in order; the throw arms append them twice (see header). */
+  /** System rows appended in order, each exactly once. */
   readonly rows: readonly string[];
   /** Stamp `completedAt`; a paused turn is not complete. */
   readonly completes: boolean;
@@ -255,8 +256,12 @@ export function unexpectedErrorArm(errorType: string, errorMessage: string): Ter
 
 // ── Applying an arm ─────────────────────────────────────────────────────────
 
-/** Append system rows, each with its own timestamp, in order. */
-export function appendSystemRows(status: AgentExecutionStatus, rows: readonly string[]): void {
+/**
+ * Append system rows, each with its own timestamp, in order. Module-private
+ * on purpose: rows reach a status only through `applyTerminalArm`, so no
+ * caller can append an arm's copy a second time (the shape of stigmer#1054).
+ */
+function appendSystemRows(status: AgentExecutionStatus, rows: readonly string[]): void {
   for (const content of rows) {
     status.messages.push(create(AgentMessageSchema, { type: MessageType.MESSAGE_SYSTEM, content, timestamp: utcTimestamp() }));
   }


### PR DESCRIPTION
## Summary
A paused execution showed "Execution paused by user. Use resume to continue." twice; a worker-shutdown transcript showed its interruption row twice. The turn runtime now persists a thrown terminal exactly once, through one function, and the two goldens that pinned the double lose exactly one row each.

## Context
The Cursor orchestrator's throw fell into its own catch, which appended the terminal copy again, re-stamped `completedAt`, and persisted again (#1054, found while building the hermetic net in #1048). S2 (#1070) reproduced that on purpose so its seventeen goldens could pin today's wire byte for byte (Q-S2-4: "the fix is the next PR after S2 with a reviewed golden regeneration"). This is that PR.

It is sequenced before S3 (`sp.deep-agent-onto-runtime`) deliberately: the runtime contract kit asserted the doubled row as an invariant, so a native adapter brought onto the runtime would have had to reproduce the bug to pass, and P-1's pause-copy alignment would have landed on a doubled row and been regenerated twice.

## Changes
- `harness/run-turn.ts`: `settleWith(arm, failure?)` is the one writer of a terminal arm — apply the arm, mark in-progress sub-agent rows cancelled on a thrown arm, persist ONCE, end the activity per the arm's disposition. The catch's three cancelled branches and its generic branch route through it; the runtime had four hand-written copies of "apply, cancel rows, persist, throw" and now has one. `Settled.throw.error` narrows from `Error` to `CancelledFailure` (the table's throw rule as a type). The `#1054` second append, the `completedAt` re-stamp and the second `write()` are deleted.
- `harness/terminal-table.ts`: header and `rows` doc say rows are appended exactly once; `appendSystemRows` is module-private, so rows reach a status only through `applyTerminalArm` and no caller can append an arm's copy a second time. No code-path change.
- `__test-utils__/harness-contract/runtime-contract.ts`: the pause and worker-shutdown arms assert one row; docs and `it()` titles follow. This runs against the scripted fake (`run-turn.test.ts`) and the real Cursor adapter (`hermetic/harness-contract.test.ts`).
- `execute-cursor/__tests__/hermetic/pause-vs-shutdown.test.ts`: inline assertions to one row; header rewritten to say the goldens pin ONE row and record the double as history; regeneration-history note.
- `goldens/pause.status.json`, `goldens/worker-shutdown.status.json`: one removed `MESSAGE_SYSTEM` object each, nothing else (the review artifact, below).

## Implementation notes
- Verified against the deleted orchestrator (`b3b7ffcaa` `execute-cursor/index.ts`): `resolvePreBoundaryTerminal` persisted the throw arms WITHOUT `cancelInProgressSubAgentProtos` (L1596–1634); only the outer catch cancelled the rows and persisted again, best-effort (L2278/L2297/L2316). `PersistChokepoint.write()` never rejects, so one awaited write with the rows already cancelled loses nothing and fixes the ordering: the first (and only) PAUSED/FAILED write the workflow reads carries the sub-agent rows as cancelled.
- The `failure` override lives on the call, not on `TerminalArm`: the arm is data the goldens pin; the catch supplies the failure it caught (the evidence, #776) or the after-error copy.
- The file-review resume in `settleResolution` remains the one place that applies an arm itself: its write-back must land between the arm and the persist. Stated in `settleWith`'s doc.

## Unchanged
`status.error`, every thrown `CancelledFailure` message (the server's `runner-failure.ts` keys on `WORKER_SHUTDOWN_STATUS_ERROR` and on `"worker shutdown"` / `"shutting down"` in the failure message), `TERMINAL_COPY`, the Cursor adapter, `execute-deep-agent/*` (native already writes its pause row once; P-1's alignment is S3's), the server, protos, activity names, env vars. The other fifteen goldens are byte-identical.

## Test plan
Four runs, each with a stated expectation, all met:
1. Assertions flipped, runtime unfixed: red on exactly the six enumerated cases — the kit's pause and shutdown arms against the fake and against Cursor, and the two hermetic cases — every one `expected [ …(2) ] to deeply equal [ Array(1) ]`.
2. Runtime fixed, no `-u`: red on exactly the two `toMatchFileSnapshot` mismatches; vitest's mismatch output showed one removed object per golden and no `+` lines.
3. `-u` on `pause-vs-shutdown.test.ts` only; `git diff -- '*.status.json'`: 2 files, 10 deletions, the same two hunks.
4. `CI=1 npm test` (the fork-cap posture every S0/S1/S2 full run used): **304 files / 4901 tests passed, 8 skipped, 0 failures** — the exact count S2's M5 recorded. The one "error" is the pre-classified `onTaskUpdate` worker-RPC timeout; the `ResetEventSequence` warnings are the pre-existing `golden-e2e` Temporal smoke. A plain `npm test` (20 forks) produced 12–14 thirty-second timeouts in bash/git-spawning tests, the machine-load behavior S0 documented; none was an assertion failure.
- `CI=1 npx vitest run …/hermetic` twice: 12 files / 43 tests green both runs.
- `npm run typecheck` green. No live-key smoke: the change sits after the engine has stopped; the hermetic arms are the exact scenario.

### The golden diff
```diff
--- a/…/hermetic/goldens/pause.status.json
+++ b/…/hermetic/goldens/pause.status.json
@@ -5,11 +5,6 @@
       "content": "Starting on the parser.",
       "timestamp": "2026-01-01T00:00:02.000Z"
     },
-    {
-      "type": "MESSAGE_SYSTEM",
-      "content": "Execution paused by user. Use resume to continue.",
-      "timestamp": "2026-01-01T00:00:03.000Z"
-    },
     {
       "type": "MESSAGE_SYSTEM",
       "content": "Execution paused by user. Use resume to continue.",
--- a/…/hermetic/goldens/worker-shutdown.status.json
+++ b/…/hermetic/goldens/worker-shutdown.status.json
@@ -5,11 +5,6 @@
       "content": "Starting on the parser.",
       "timestamp": "2026-01-01T00:00:02.000Z"
     },
-    {
-      "type": "MESSAGE_SYSTEM",
-      "content": "Execution interrupted: the runner worker was shut down while the agent was still running. You can retry or resume.",
-      "timestamp": "2026-01-01T00:00:03.000Z"
-    },
     {
       "type": "MESSAGE_SYSTEM",
       "content": "Execution interrupted: the runner worker was shut down while the agent was still running. You can retry or resume.",
```

## Risks
- Low. The change is confined to the runtime's terminal write after the engine has settled; the wire copy and every downstream key are unchanged. Rollback is a revert of one commit.

## Follow-ups recorded, not done (for S3's inheritance)
- The two after-error arms are built inline in `run-turn.ts` (`pauseArm()` with the after-error throw message; `{ ...infrastructureCancelArm(), error }`) rather than as rows of the table.
- No golden or kit arm pins the infrastructure-cancel arm (it needs a hermetic way to deliver a heartbeat-timeout cancellation reason).
- Return arms (stall, cost cap, failed, platform stop) never cancel in-progress sub-agent rows — orchestrator-faithful today; a question for S3 with native's rows in view.

## Checklist
- [x] Docs updated (module headers, kit and hermetic test headers)
- [x] Tests updated (kit invariant flipped; two goldens regenerated with the diff above)
- [x] Backward compatible (wire copy, `status.error`, thrown messages unchanged)

Closes #1054
